### PR TITLE
fix shell quotation error of server db-init.sh

### DIFF
--- a/server/db-init.sh
+++ b/server/db-init.sh
@@ -37,7 +37,7 @@ done
 
 
 psql -c "CREATE USER $username WITH PASSWORD '$password' SUPERUSER;" -U postgres
-psql -c 'CREATE DATABASE $dbname WITH OWNER $username;' -U postgres
+psql -c "CREATE DATABASE $dbname WITH OWNER $username;" -U postgres
 export LEMMY_DATABASE_URL=postgres://$username:$password@localhost:$port/$dbname
 
 echo $LEMMY_DATABASE_URL


### PR DESCRIPTION
In server/db-init.sh, it should use ", and not ', else will cause varible replace fail.