### PR TITLE
archive-org instead of archive-is

### DIFF
--- a/ui/src/components/post-form.tsx
+++ b/ui/src/components/post-form.tsx
@@ -214,7 +214,7 @@ export class PostForm extends Component<PostFormProps, PostFormState> {
               </form>
               {validURL(this.state.postForm.url) && (
                 <a
-                  href={`${archiveUrl}/?run=1&url=${encodeURIComponent(
+                  href={`${archiveUrl}/save/${encodeURIComponent(
                     this.state.postForm.url
                   )}`}
                   target="_blank"

--- a/ui/src/utils.ts
+++ b/ui/src/utils.ts
@@ -52,7 +52,7 @@ export const repoUrl = 'https://github.com/LemmyNet/lemmy';
 export const helpGuideUrl = '/docs/about_guide.html';
 export const markdownHelpUrl = `${helpGuideUrl}#markdown-guide`;
 export const sortingHelpUrl = `${helpGuideUrl}#sorting`;
-export const archiveUrl = 'https://archive.is';
+export const archiveUrl = 'https://web.archive.org';
 
 export const postRefetchSeconds: number = 60 * 1000;
 export const fetchLimit: number = 20;


### PR DESCRIPTION
From dev.lemmy.ml:  
*archive.is is a Tor-hostile CloudFlare site, and it cannot be circumvented by using Tor Browser or by using archive.org (which gives: “This page is not available on the web because of server error”).*