### PR TITLE
Fixed sponsor_message

### DIFF
--- a/ui/translations/en.json
+++ b/ui/translations/en.json
@@ -187,7 +187,7 @@
     "sponsors": "Sponsors",
     "sponsors_of_lemmy": "Sponsors of Lemmy",
     "sponsor_message":
-      "Lemmy is free, <1>open-source</1> software, meaning no advertising, monetizing, or venture capital, ever. Your donations directly support full-time development of the project. Thank you to the following people:",
+      "Lemmy is a <a href="https://en.wikipedia.org/wiki/Free_and_open-source_software">free and open-source</a> software. The <a href="https://github.com/LemmyNet/lemmy">source code</a> is available for everyone to see and modify it. Lemmy is also decentralized and complies with the <a href="https://en.wikipedia.org/wiki/Fediverse">fediverse</a>, meaning there is no venture capital, and anyone is free to host their own instance with their own sets of rules and modifications. Your donations directly support the full-time development of the project. Thank you to the following people:",
     "support_on_patreon": "Support on Patreon",
     "support_on_liberapay": "Support on Liberapay",
     "support_on_open_collective": "Support on OpenCollective",


### PR DESCRIPTION
Fixed sponsor_message due to a bad description of what FOSS is as well as misinformation

i read the file, but i did not understand anything about the `<1>open source</1>`, since it's a tag that i have never seen, so i used HTML instead. i would appreciate if you fix it