### PR TITLE
"icon-bell" adjustments

### DIFF
--- a/ui/src/components/navbar.tsx
+++ b/ui/src/components/navbar.tsx
@@ -107,7 +107,7 @@ export class Navbar extends Component<any, NavbarState> {
         </Link>
         {this.state.isLoggedIn && (
           <Link
-            class="ml-auto p-0 navbar-toggler nav-link"
+            class="ml-auto mr-1 navbar-toggler nav-link"
             to="/inbox"
             title={i18n.t('inbox')}
           >

--- a/ui/src/components/navbar.tsx
+++ b/ui/src/components/navbar.tsx
@@ -183,7 +183,7 @@ export class Navbar extends Component<any, NavbarState> {
           </ul>
           <ul class="navbar-nav ml-auto">
             {this.canAdmin && (
-              <li className="nav-item mt-1">
+              <li className="nav-item">
                 <Link
                   class="nav-link"
                   to={`/admin`}
@@ -197,7 +197,7 @@ export class Navbar extends Component<any, NavbarState> {
             )}
             {this.state.isLoggedIn ? (
               <>
-                <li className="nav-item mt-1">
+                <li className="nav-item">
                   <Link class="nav-link" to="/inbox" title={i18n.t('inbox')}>
                     <svg class="icon">
                       <use xlinkHref="#icon-bell"></use>


### PR DESCRIPTION
### Expanded nav bar

Removing the `mt-1` class from the bell fixes misalignment on the right side of the nav bar. If the icon sized seem problematic, let me know and I can change them in `ui/src/components/navbar.tsx`.

![screenshot-20200611130629](https://user-images.githubusercontent.com/7846060/84391320-77f4a080-ac16-11ea-82c9-9b43fa1d7eee.png)

### Collapsed nav bar

Removed `p-0` class from the icon and added `mr-1`.

![screenshot-20200611133207](https://user-images.githubusercontent.com/7846060/84391629-de79be80-ac16-11ea-9926-a0017ad4a0e1.png)