### PR TITLE
Replacing dogbin/iframely docker image with jolt one.

### DIFF
--- a/ansible/templates/docker-compose.yml
+++ b/ansible/templates/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     restart: always
 
   iframely:
-    image: dogbin/iframely:latest
+    image: jolt/iframely:latest
     ports:
       - "127.0.0.1:8061:80"
     volumes:

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     restart: always
 
   iframely:
-    image: dogbin/iframely:latest
+    image: jolt/iframely:v1.4.3
     ports:
       - "127.0.0.1:8061:80"
     volumes:

--- a/docker/federation/docker-compose.yml
+++ b/docker/federation/docker-compose.yml
@@ -117,6 +117,6 @@ services:
       - ./volumes/pictrs_gamma:/mnt
 
   iframely:
-    image: dogbin/iframely:latest
+    image: jolt/iframely:v1.4.3
     volumes:
       - ../iframely.config.local.js:/iframely/config.local.js:ro

--- a/docker/prod/docker-compose.yml
+++ b/docker/prod/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     restart: always
 
   iframely:
-    image: dogbin/iframely:latest
+    image: jolt/iframely:v1.4.3
     ports:
       - "127.0.0.1:8061:80"
     volumes:


### PR DESCRIPTION
Its a more updated iframely image that's actually versioned.