### PR TITLE
Replace search button to input field at navbar.

### DIFF
--- a/ui/assets/css/main.css
+++ b/ui/assets/css/main.css
@@ -249,3 +249,11 @@ pre {
   white-space: pre-wrap;
   word-break: keep-all;
 }
+
+.search-bar {
+  flex-basis: 10%;
+  flex-shrink: 3;
+  flex-grow: 0.3;
+  max-width: 33%;
+  min-width: 11em;
+}

--- a/ui/assets/css/main.css
+++ b/ui/assets/css/main.css
@@ -250,10 +250,17 @@ pre {
   word-break: keep-all;
 }
 
-.search-bar {
-  flex-basis: 10%;
-  flex-shrink: 3;
-  flex-grow: 0.3;
-  max-width: 33%;
-  min-width: 11em;
+.form-control.search-input {
+  float: right !important;
+  transition: width 0.5s ease-out 0s !important;
 }
+
+.show-input {
+  width: 13em !important;
+
+}
+.hide-input {
+  background: transparent !important;
+  width: 0px !important;
+  padding: 0 !important;
+ }

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -2,7 +2,7 @@ import { render, Component } from 'inferno';
 import { BrowserRouter, Route, Switch } from 'inferno-router';
 import { Provider } from 'inferno-i18next';
 import { Main } from './components/main';
-import Navbar from './components/navbar';
+import { Navbar } from './components/navbar';
 import { Footer } from './components/footer';
 import { Login } from './components/login';
 import { CreatePost } from './components/create-post';

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -2,7 +2,7 @@ import { render, Component } from 'inferno';
 import { BrowserRouter, Route, Switch } from 'inferno-router';
 import { Provider } from 'inferno-i18next';
 import { Main } from './components/main';
-import { Navbar } from './components/navbar';
+import Navbar from './components/navbar';
 import { Footer } from './components/footer';
 import { Login } from './components/login';
 import { CreatePost } from './components/create-post';


### PR DESCRIPTION
Replace the Search button element to Input field, that redirect to search path with search parameter set to default.


Issue #814 


* Search input not rendered at /search path.

* Navbar wrapped with withRouter for accessing history props.

* Flex-grow/shrink control the width of the input element dynamically.


![gif](https://media.giphy.com/media/j78FvRXB8bEngnjoXS/giphy.gif)