### PR TITLE
Support container configuration changes at runtime

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -48,7 +48,15 @@ COPY --from=node /app/ui/dist /app/dist
 
 RUN addgroup -g 1000 lemmy
 RUN adduser -D -s /bin/sh -u 1000 -G lemmy lemmy
-RUN chown lemmy:lemmy /app/lemmy
+
+# Set up entrypoint
+COPY docker/docker-entrypoint.sh /usr/local/bin/
+
+RUN chown -R lemmy:lemmy /app/lemmy \
+    && chown -R lemmy:lemmy /config \
+    && chown -R lemmy:lemmy /app/dist
+
 USER lemmy
 EXPOSE 8536
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["/app/lemmy"]

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+set -e
+
+if [ "$1" = '/app/lemmy' ]; then
+    # Default database settings
+    : "${DB_USER:=lemmy}"
+    : "${DB_PASSWORD:=password}"
+    : "${DB_HOST:=localhost}"
+    : "${DB_PORT:=5432}"
+    : "${DB_DATABASE:=lemmy}"
+    : "${DB_POOL_SIZE:=5}"
+
+    # Default app settings
+    : "${LEMMY_HOSTNAME:=localhost}"
+    : "${BIND_ADDR:=0.0.0.0}"
+    : "${PORT:=8536}"
+    : "${JWT_SECRET:=changeme}"
+    : "${FRONT_END_DIR:=/app/dist}"
+
+    # Default rate_limit settings
+    : "${RATE_LIMIT_MESSAGE:=180}"
+    : "${RATE_LIMIT_MESSAGE_PER_SECOND:=60}"
+    : "${RATE_LIMIT_POST:=6}"
+    : "${RATE_LIMIT_POST_PER_SECOND:=600}"
+    : "${RATE_LIMIT_REGISTER:=3}"
+    : "${RATE_LIMIT_REGISTER_PER_SECOND:=3600}"
+
+    # Default federation settings
+    : "${FEDERATION_ENABLED:=false}"
+    : "${FEDERATION_TLS_ENABLED:=true}"
+    : "${FEDERATION_ALLOWED_INSTANCES:=}"
+
+    cat << EOF > /config/config.hjson
+{
+  database: {
+    user: "${DB_USER}"
+    password: "${DB_PASSWORD}"
+    host: "${DB_HOST}"
+    port: ${DB_PORT}
+    database: "${DB_DATABASE}"
+    pool_size: ${DB_POOL_SIZE}
+  }
+  hostname: "${LEMMY_HOSTNAME}"
+  bind: "${BIND_ADDR}"
+  port: ${PORT}
+  jwt_secret: "${JWT_SECRET}"
+  front_end_dir: "${FRONT_END_DIR}"
+  rate_limit: {
+    message: ${RATE_LIMIT_MESSAGE}
+    message_per_second: ${RATE_LIMIT_MESSAGE_PER_SECOND}
+    post: ${RATE_LIMIT_POST}
+    post_per_second: ${RATE_LIMIT_POST_PER_SECOND}
+    register: ${RATE_LIMIT_REGISTER}
+    register_per_second: ${RATE_LIMIT_REGISTER_PER_SECOND}
+  }
+  federation: {
+    enabled: ${FEDERATION_ENABLED}
+    tls_enabled: ${FEDERATION_TLS_ENABLED}
+    allowed_instances: "${FEDERATION_ALLOWED_INSTANCES}"
+  }
+}
+EOF
+fi
+
+exec "$@"
+

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -58,7 +58,14 @@ COPY --chown=lemmy:lemmy --from=rust /app/server/lemmy_server /app/lemmy
 COPY --chown=lemmy:lemmy --from=docs /app/docs/book/ /app/dist/documentation/
 COPY --chown=lemmy:lemmy --from=node /app/ui/dist /app/dist
 
-RUN chown lemmy:lemmy /app/lemmy
+# Set up entrypoint
+COPY docker/docker-entrypoint.sh /usr/local/bin/
+
+RUN chown -R lemmy:lemmy /app/lemmy \
+    && chown -R lemmy:lemmy /config \
+    && chown -R lemmy:lemmy /app/dist
+
 USER lemmy
 EXPOSE 8536
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["/app/lemmy"]


### PR DESCRIPTION
### Description

Enables runtime configuration of Lemmy containers through the use of environment variables set on the container itself.

Relates to #843.

### Approach

Used the docker-entrypoint.sh pattern to add a shell script that dynamically writes configuration files whenever the container starts. More information on this approach can be found at the following link:

https://success.docker.com/article/use-a-script-to-initialize-stateful-container-data

`$HOSTNAME` tends to conflict with the Linux env var of the same name, so I opted for `$LEMMY_HOSTNAME` to resolve the conflict. Furthermore, to avoid users needing to specify LEMMY_HOSTNAME whenever they run the container, I opted to use a default value of "localhost".

### Testing

This was tested with the production Dockerfile like so:

```bash
cd lemmy
podman build -f docker/prod/Dockerfile -t lemmy:test .
podman run -it --rm -d -e FRONT_END_DIR=/app/nonexistent --name lemmy localhost/lemmy:test
podman exec -it lemmy /bin/sh
```

Inside the container, I verified that changes took effect:

```
/ $ cat /config/config.hjson 
{
  database: {
    user: "lemmy"
    password: "password"
    host: "localhost"
    port: 5432
    database: "lemmy"
    pool_size: 5
  }
  hostname: "localhost"
  bind: "0.0.0.0"
  port: 8536
  jwt_secret: "changeme"
  front_end_dir: "/app/nonexistent"
  rate_limit: {
    message: 180
    message_per_second: 60
    post: 6
    post_per_second: 600
    register: 3
    register_per_second: 3600
  }
  federation: {
    enabled: false
    tls_enabled: true
    allowed_instances: ""
  }
}
```

(I use `podman` on my laptop instead of `docker`, but the commands are equivalent)