### PR TITLE
Dont show total karma in search results Closes #883

### DIFF
--- a/ui/src/components/search.tsx
+++ b/ui/src/components/search.tsx
@@ -282,9 +282,6 @@ export class Search extends Component<any, SearchState> {
                       }}
                     />
                   </span>
-                  <span>{` - ${
-                    (i.data as UserView).comment_score
-                  } comment karma`}</span>
                 </div>
               )}
             </div>
@@ -359,12 +356,13 @@ export class Search extends Component<any, SearchState> {
           <div class="row">
             <div class="col-12">
               <span>
-                <Link
-                  className="text-info"
-                  to={`/u/${user.name}`}
-                >{`/u/${user.name}`}</Link>
+                <UserListing
+                  user={{
+                    name: user.name,
+                    avatar: user.avatar,
+                  }}
+                />
               </span>
-              <span>{` - ${user.comment_score} comment karma`}</span>
             </div>
           </div>
         ))}

--- a/ui/src/components/user-listing.tsx
+++ b/ui/src/components/user-listing.tsx
@@ -52,7 +52,7 @@ export class UserListing extends Component<UserListingProps, any> {
               class="rounded-circle mr-2"
             />
           )}
-          <span>{name_}</span>
+          <span>{`/u/${name_}`}</span>
         </Link>
 
         {isCakeDay(user.published) && <CakeDay creatorName={name_} />}


### PR DESCRIPTION
Removed span that renders a users comment karma in the search results.  

**Before**
<img width="326" alt="Screen Shot 2020-07-01 at 9 58 40 PM" src="https://user-images.githubusercontent.com/5953350/86311769-b7dfef80-bbe6-11ea-9bb6-78f1004c80fc.png">
<img width="321" alt="Screen Shot 2020-07-01 at 9 58 08 PM" src="https://user-images.githubusercontent.com/5953350/86311778-badae000-bbe6-11ea-9d81-fb8a58db07ca.png">


**After**
<img width="329" alt="Screen Shot 2020-07-01 at 9 58 25 PM" src="https://user-images.githubusercontent.com/5953350/86311747-af87b480-bbe6-11ea-9933-b93ab5e85a62.png">
<img width="324" alt="Screen Shot 2020-07-01 at 9 58 18 PM" src="https://user-images.githubusercontent.com/5953350/86311750-b1517800-bbe6-11ea-9386-9f6de59bdb9d.png">



