### PR TITLE
Verify activitypub payload digests

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1413,9 +1413,9 @@ dependencies = [
 
 [[package]]
 name = "http-signature-normalization-actix"
-version = "0.4.0-alpha.0"
+version = "0.4.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09afff6987c7edbed101d1cddd2185786fb0af0dd9c06b654aca73a0a763680f"
+checksum = "1c6efbc3e600cdd617585f4f15be3726c6942fb2eba3c8c79474c5d3159ad7c0"
 dependencies = [
  "actix-http",
  "actix-web",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -43,7 +43,7 @@ percent-encoding = "2.1.0"
 comrak = "0.7"
 openssl = "0.10"
 http = "0.2.1"
-http-signature-normalization-actix = { version = "0.4.0-alpha.0", default-features = false, features = ["sha-2"] }
+http-signature-normalization-actix = { version = "0.4.0-alpha.1", default-features = false, features = ["sha-2"] }
 base64 = "0.12.1"
 tokio = "0.2.21"
 futures = "0.3.5"


### PR DESCRIPTION
In my previous PR, I added digest headers to outbound activities. This PR verifies those digest headers for inbound activities.