### PR TITLE
Fix version_compare to version for ansible 2.9

### DIFF
--- a/ansible/lemmy.yml
+++ b/ansible/lemmy.yml
@@ -33,13 +33,13 @@
     apt:
       pkg:
         - 'python-certbot-nginx'
-    when: ansible_distribution == 'Ubuntu' and ansible_distribution_version|version_compare('20.04', '<')
+    when: ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('20.04', '<')
 
   - name: install certbot-nginx on ubuntu > 20
     apt:
       pkg:
         - 'python3-certbot-nginx'
-    when: ansible_distribution == 'Ubuntu' and ansible_distribution_version|version_compare('20.04', '>=')
+    when: ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('20.04', '>=')
 
   - name: request initial letsencrypt certificate
     command: certbot certonly --nginx --agree-tos -d '{{ domain }}' -m '{{ letsencrypt_contact_email }}'


### PR DESCRIPTION
Turns out that version_compare was deprecated and removed in ansible 2.9.