### PR TITLE
Fixes regression from #848

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -325,7 +325,7 @@ pub fn markdown_to_html(text: &str) -> String {
 
 pub fn get_ip(conn_info: &ConnectionInfo) -> String {
   conn_info
-    .remote_addr()
+    .realip_remote_addr()
     .unwrap_or("127.0.0.1:12345")
     .split(':')
     .next()


### PR DESCRIPTION
The api for actix_web::dev::ConnectionInfo changed from 2.0.0 to 3.0.0. The equivalent of 2.0.0's remote() in 3.0.0 is realip_remote_addr(), not remote_addr().

https://docs.rs/actix-web/2.0.0/actix_web/dev/struct.ConnectionInfo.html#method.remote
https://docs.rs/actix-web/3.0.0-alpha.3/actix_web/dev/struct.ConnectionInfo.html#method.realip_remote_addr