### PR TITLE
Don't show cake day indicator on the same year / day of user registration, instead show it the following years

### DIFF
--- a/ui/src/utils.ts
+++ b/ui/src/utils.ts
@@ -496,7 +496,8 @@ export function isCakeDay(published: string): boolean {
 
   return (
     userCreationDate.date() === currentDate.date() &&
-    userCreationDate.month() === currentDate.month()
+    userCreationDate.month() === currentDate.month() &&
+    userCreationDate.year() !== currentDate.year()
   );
 }
 


### PR DESCRIPTION
Fixes #934 