### PR TITLE
Wrap each inbox route individually with digest verifier

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1422,9 +1422,9 @@ dependencies = [
 
 [[package]]
 name = "http-signature-normalization-actix"
-version = "0.4.0-alpha.0"
+version = "0.4.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09afff6987c7edbed101d1cddd2185786fb0af0dd9c06b654aca73a0a763680f"
+checksum = "131fc982391a6b37847888b568cbe0e9cd302f1b0015f4f6f4a50234bebd049c"
 dependencies = [
  "actix-http",
  "actix-web",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -44,7 +44,7 @@ url = { version = "2.1.1", features = ["serde"] }
 percent-encoding = "2.1.0"
 openssl = "0.10"
 http = "0.2.1"
-http-signature-normalization-actix = { version = "0.4.0-alpha.0", default-features = false, features = ["sha-2"] }
+http-signature-normalization-actix = { version = "0.4.0-alpha.2", default-features = false, features = ["sha-2"] }
 base64 = "0.12.1"
 tokio = "0.2.21"
 futures = "0.3.5"

--- a/server/src/routes/federation.rs
+++ b/server/src/routes/federation.rs
@@ -9,11 +9,15 @@ use crate::apub::{
   APUB_JSON_CONTENT_TYPE,
 };
 use actix_web::*;
+use http_signature_normalization_actix::digest::middleware::VerifyDigest;
 use lemmy_utils::settings::Settings;
+use sha2::{Digest, Sha256};
 
 pub fn config(cfg: &mut web::ServiceConfig) {
   if Settings::get().federation.enabled {
     println!("federation enabled, host is {}", Settings::get().hostname);
+    let digest_verifier = VerifyDigest::new(Sha256::new());
+
     cfg
       .service(
         web::scope("/")
@@ -36,8 +40,20 @@ pub fn config(cfg: &mut web::ServiceConfig) {
           .route("/comment/{comment_id}", web::get().to(get_apub_comment)),
       )
       // Inboxes dont work with the header guard for some reason.
-      .route("/c/{community_name}/inbox", web::post().to(community_inbox))
-      .route("/u/{user_name}/inbox", web::post().to(user_inbox))
-      .route("/inbox", web::post().to(shared_inbox));
+      .service(
+        web::resource("/c/{community_name}/inbox")
+          .wrap(digest_verifier.clone())
+          .route(web::post().to(community_inbox)),
+      )
+      .service(
+        web::resource("/u/{user_name}/inbox")
+          .wrap(digest_verifier.clone())
+          .route(web::post().to(user_inbox)),
+      )
+      .service(
+        web::resource("/inbox")
+          .wrap(digest_verifier)
+          .route(web::post().to(shared_inbox)),
+      );
   }
 }


### PR DESCRIPTION
Since the last try with `scope("/")` didn't work out. Here's a version that won't accidentally apply to every route.

Another possible fix would be to guard where content-type is `application/activity+json` but I don't trust other AP servers to actually do things properly tbh