### PR TITLE
Adding a configurable config location through an env var.

### DIFF
--- a/docs/src/administration_configuration.md
+++ b/docs/src/administration_configuration.md
@@ -5,6 +5,8 @@ The configuration is based on the file
 This file also contains documentation for all the available options. To override the defaults, you
 can copy the options you want to change into your local `config.hjson` file.
 
+To use a different `config.hjson` location than the current directory, set the environment variable `LEMMY_CONFIG_LOCATION`.
+
 Additionally, you can override any config files with environment variables. These have the same
 name as the config options, and are prefixed with `LEMMY_`. For example, you can override the
 `database.password` with `LEMMY_DATABASE__POOL_SIZE=10`.

--- a/server/lemmy_utils/src/settings.rs
+++ b/server/lemmy_utils/src/settings.rs
@@ -1,9 +1,9 @@
 use config::{Config, ConfigError, Environment, File};
 use serde::Deserialize;
 use std::{fs, io::Error, net::IpAddr, sync::RwLock};
+use std::env;
 
 static CONFIG_FILE_DEFAULTS: &str = "config/defaults.hjson";
-static CONFIG_FILE: &str = "config/config.hjson";
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Settings {
@@ -83,7 +83,7 @@ impl Settings {
 
     s.merge(File::with_name(CONFIG_FILE_DEFAULTS))?;
 
-    s.merge(File::with_name(CONFIG_FILE).required(false))?;
+    s.merge(File::with_name(&Self::get_config_location()).required(false))?;
 
     // Add in settings from the environment (with a prefix of LEMMY)
     // Eg.. `LEMMY_DEBUG=1 ./target/app` would set the `debug` key
@@ -115,12 +115,16 @@ impl Settings {
     format!("{}/api/v1", self.hostname)
   }
 
+  pub fn get_config_location() -> String {
+    env::var("LEMMY_CONFIG_LOCATION").unwrap_or("config/config.hjson".to_string())
+  }
+
   pub fn read_config_file() -> Result<String, Error> {
-    fs::read_to_string(CONFIG_FILE)
+    fs::read_to_string(Self::get_config_location())
   }
 
   pub fn save_config_file(data: &str) -> Result<String, Error> {
-    fs::write(CONFIG_FILE, data)?;
+    fs::write(Self::get_config_location(), data)?;
 
     // Reload the new settings
     // From https://stackoverflow.com/questions/29654927/how-do-i-assign-a-string-to-a-mutable-static-variable/47181804#47181804

--- a/server/lemmy_utils/src/settings.rs
+++ b/server/lemmy_utils/src/settings.rs
@@ -4,6 +4,7 @@ use std::{fs, io::Error, net::IpAddr, sync::RwLock};
 use std::env;
 
 static CONFIG_FILE_DEFAULTS: &str = "config/defaults.hjson";
+static CONFIG_FILE: &str = "config/config.hjson";
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Settings {
@@ -116,7 +117,7 @@ impl Settings {
   }
 
   pub fn get_config_location() -> String {
-    env::var("LEMMY_CONFIG_LOCATION").unwrap_or("config/config.hjson".to_string())
+    env::var("LEMMY_CONFIG_LOCATION").unwrap_or(CONFIG_FILE.to_string())
   }
 
   pub fn read_config_file() -> Result<String, Error> {

--- a/server/lemmy_utils/src/settings.rs
+++ b/server/lemmy_utils/src/settings.rs
@@ -117,7 +117,7 @@ impl Settings {
   }
 
   pub fn get_config_location() -> String {
-    env::var("LEMMY_CONFIG_LOCATION").unwrap_or(CONFIG_FILE.to_string())
+    env::var("LEMMY_CONFIG_LOCATION").unwrap_or_else(|_| CONFIG_FILE.to_string())
   }
 
   pub fn read_config_file() -> Result<String, Error> {


### PR DESCRIPTION
- Its `LEMMY_CONFIG_LOCATION`
- Fixes #764