### PR TITLE
validate post URLs on the backend

### DIFF
--- a/server/src/api/post.rs
+++ b/server/src/api/post.rs
@@ -163,8 +163,8 @@ impl Perform for Oper<CreatePost> {
       return Err(APIError::err("site_ban").into());
     }
 
-    if data.url.is_some() {
-      match Url::parse(data.url.as_ref().unwrap()) {
+    if let Some(url) = data.url.as_ref() {
+      match Url::parse(url) {
         Ok(_t) => (),
         Err(_e) => return Err(APIError::err("invalid_url").into()),
       }

--- a/server/src/api/post.rs
+++ b/server/src/api/post.rs
@@ -37,6 +37,7 @@ use lemmy_utils::{
 };
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
+use url::Url;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CreatePost {
@@ -160,6 +161,13 @@ impl Perform for Oper<CreatePost> {
     let user = blocking(pool, move |conn| User_::read(conn, user_id)).await??;
     if user.banned {
       return Err(APIError::err("site_ban").into());
+    }
+
+    if data.url.is_some() {
+      match Url::parse(data.url.as_ref().unwrap()) {
+        Ok(_t) => (),
+        Err(_e) => return Err(APIError::err("invalid_url").into()),
+      }
     }
 
     // Fetch Iframely and pictrs cached image

--- a/ui/translations/en.json
+++ b/ui/translations/en.json
@@ -277,5 +277,6 @@
     "what_is": "What is",
     "cake_day_title": "Cake day:",
     "cake_day_info": "It's {{ creator_name }}'s cake day today!",
-    "invalid_post_title": "Invalid post title"
+    "invalid_post_title": "Invalid post title",
+    "invalid_url": "Invalid URL."
 }


### PR DESCRIPTION
we were getting an error on our FE: "Uncaught TypeError: URL constructor: google.com is not a valid URL." which was breaking the FE when accessing a specific user's profile.

since the API will also be used for third party access, we should probably reject URLs missing the protocol specifier. i assume it's possible someone may want to link to something utilizing a different protocol, so if the FE (or a third party app) were to assume https, it could be incorrect.

i've cherrypicked the commit that added this to our backend, but if you'd like it fixed in a different manner, please let me know :)