### PR TITLE
📝 Add macOS-specific instructions for local development.

### DIFF
--- a/docs/src/contributing_local_development.md
+++ b/docs/src/contributing_local_development.md
@@ -1,7 +1,7 @@
 ### Install build requirements
 #### Ubuntu
 ```
-sudo apt install git cargo libssl-dev pkg-config libpq-dev yarn curl gnupg2 git
+sudo apt install git cargo libssl-dev pkg-config libpq-dev yarn curl gnupg2
 # install yarn
 curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
 echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list

--- a/docs/src/contributing_local_development.md
+++ b/docs/src/contributing_local_development.md
@@ -1,7 +1,5 @@
-### Ubuntu
-
-
-#### Build requirements:
+### Install build requirements
+#### Ubuntu
 ```
 sudo apt install git cargo libssl-dev pkg-config libpq-dev yarn curl gnupg2 git
 # install yarn
@@ -10,7 +8,19 @@ echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/source
 sudo apt update && sudo apt install yarn
 ```
 
-#### Get the source code
+#### macOS
+
+Install Rust using [the recommended option on rust-lang.org](https://www.rust-lang.org/tools/install) (rustup).
+
+Then, install [Homebrew](https://brew.sh/) if you don't already have it installed.
+
+Finally, install Node and Yarn.
+
+```
+brew install node yarn
+```
+
+### Get the source code
 ```
 git clone https://github.com/LemmyNet/lemmy.git
 # or alternatively from gitea
@@ -20,36 +30,49 @@ git clone https://github.com/LemmyNet/lemmy.git
 All the following commands need to be run either in `lemmy/server` or `lemmy/ui`, as indicated
 by the `cd` command.
 
-#### Build the backend (Rust)
+### Build the backend (Rust)
 ```
 cd server
 cargo build
 # for development, use `cargo check` instead)
 ```
 
-#### Build the frontend (Typescript)
+### Build the frontend (Typescript)
 ```
 cd ui
 yarn
 yarn build
 ```
 
-#### Setup postgresql
+### Setup postgresql
+#### Ubuntu
 ```
 sudo apt install postgresql
 sudo systemctl start postgresql
-# initialize postgres database
+
+# Either execute server/db-init.sh, or manually initialize the postgres database:
 sudo -u postgres psql -c "create user lemmy with password 'password' superuser;" -U postgres
 sudo -u postgres psql -c 'create database lemmy with owner lemmy;' -U postgres
 export LEMMY_DATABASE_URL=postgres://lemmy:password@localhost:5432/lemmy
-# or execute server/db-init.sh
 ```
 
-#### Run a local development instance
+#### macOS
+```
+brew install postgresql
+brew services start postgresql
+/usr/local/opt/postgres/bin/createuser -s postgres
+
+# Either execute server/db-init.sh, or manually initialize the postgres database:
+psql -c "create user lemmy with password 'password' superuser;" -U postgres
+psql -c 'create database lemmy with owner lemmy;' -U postgres
+export LEMMY_DATABASE_URL=postgres://lemmy:password@localhost:5432/lemmy
+```
+
+### Run a local development instance
 ```
 # run each of these in a seperate terminal
 cd server && cargo run
-ui & yarn start
+cd ui && yarn start
 ```
 
 Then open [localhost:4444](http://localhost:4444) in your browser. It will auto-refresh if you edit


### PR DESCRIPTION
👋

Here are steps that worked to set up the app on my macOS machine. Let me know if I should change any wording!

Just in case this isn't a known issue: I couldn't run `cargo build`. It seems like two packages can't be retrieved because their git repo is offline.

```
Updating git repository `https://git.asonix.dog/asonix/activitystreams-ext`
warning: spurious network error (2 tries remaining): failed to connect to git.asonix.dog: Operation timed out; class=Os (2)
```