### PR TITLE
Fix post thumbnail_url to use full urls. Fixes #632

### DIFF
--- a/server/lemmy_db/src/community.rs
+++ b/server/lemmy_db/src/community.rs
@@ -133,10 +133,7 @@ impl Community {
       .get_result::<Self>(conn)
   }
 
-  fn community_mods_and_admins(
-    conn: &PgConnection,
-    community_id: i32,
-  ) -> Result<Vec<i32>, Error> {
+  fn community_mods_and_admins(conn: &PgConnection, community_id: i32) -> Result<Vec<i32>, Error> {
     use crate::{community_view::CommunityModeratorView, user_view::UserView};
     let mut mods_and_admins: Vec<i32> = Vec::new();
     mods_and_admins.append(

--- a/server/src/apub/post.rs
+++ b/server/src/apub/post.rs
@@ -33,7 +33,7 @@ use lemmy_db::{
   user::User_,
   Crud,
 };
-use lemmy_utils::{convert_datetime, get_apub_protocol_string, settings::Settings};
+use lemmy_utils::convert_datetime;
 use serde::Deserialize;
 use url::Url;
 
@@ -114,15 +114,8 @@ impl ToApub for Post {
     }
 
     if let Some(thumbnail_url) = &self.thumbnail_url {
-      let full_url = format!(
-        "{}://{}/pictshare/{}",
-        get_apub_protocol_string(),
-        Settings::get().hostname,
-        thumbnail_url
-      );
-
       let mut image = Image::new();
-      image.set_url(full_url);
+      image.set_url(thumbnail_url.to_string());
       page.set_image(image.into_any_base()?);
     }
 


### PR DESCRIPTION
Realized I should actually say what this is doing. 

In the post table, the `thumbnail_url` column is currently incorrectly using just the hash from pictshare, IE `E9bEh.png`. It should use the full URL, since federated posts don't have that picture locally.