### PR TITLE
Quick fix: Trailing slash causes 404

### DIFF
--- a/ansible/templates/nginx.conf
+++ b/ansible/templates/nginx.conf
@@ -60,6 +60,9 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
+        # Cuts off the trailing slash on URLs to make them valid
+        rewrite ^(.+)/+$ $1 permanent;
+
         # WebSocket support
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/docker/federation/nginx.conf
+++ b/docker/federation/nginx.conf
@@ -17,6 +17,9 @@ http {
             proxy_set_header Host $host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
+            # Cuts off the trailing slash on URLs to make them valid
+            rewrite ^(.+)/+$ $1 permanent;
+
             # WebSocket support
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
@@ -57,6 +60,9 @@ http {
             proxy_set_header Host $host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
+            # Cuts off the trailing slash on URLs to make them valid
+            rewrite ^(.+)/+$ $1 permanent;
+
             # WebSocket support
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
@@ -96,6 +102,9 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header Host $host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+            # Cuts off the trailing slash on URLs to make them valid
+            rewrite ^(.+)/+$ $1 permanent;
 
             # WebSocket support
             proxy_http_version 1.1;


### PR DESCRIPTION
Currently, posts on the dev instance (as well as on chapo) have a format like this:

https://dev.lemmy.ml/post/38305

However, if you add a trailing slash to the URL, it gives a 404.

https://dev.lemmy.ml/post/38305/

This fix adds a `rewrite` block to the `location /` block in `nginx.conf` to strip the trailing slash, allowing the URL to direct and work properly.