### PR TITLE
add a user_view fn to return sanitized fields

### DIFF
--- a/server/lemmy_db/src/user_view.rs
+++ b/server/lemmy_db/src/user_view.rs
@@ -223,4 +223,33 @@ impl UserView {
       .filter(banned.eq(true))
       .load::<Self>(conn)
   }
+
+  pub fn get_user_secure(conn: &PgConnection, user_id: i32) -> Result<Self, Error> {
+    use super::user_view::user_fast::dsl::*;
+    use diesel::sql_types::{Nullable, Text};
+    user_fast
+      .select((
+        id,
+        actor_id,
+        name,
+        preferred_username,
+        avatar,
+        banner,
+        "".into_sql::<Nullable<Text>>(),
+        matrix_user_id,
+        bio,
+        local,
+        admin,
+        banned,
+        show_avatars,
+        send_notifications_to_email,
+        published,
+        number_of_posts,
+        post_score,
+        number_of_comments,
+        comment_score,
+      ))
+      .find(user_id)
+      .first::<Self>(conn)
+  }
 }

--- a/server/src/api/user.rs
+++ b/server/src/api/user.rs
@@ -857,7 +857,7 @@ impl Perform for Oper<BanUser> {
     blocking(pool, move |conn| ModBan::create(conn, &form)).await??;
 
     let user_id = data.user_id;
-    let user_view = blocking(pool, move |conn| UserView::read(conn, user_id)).await??;
+    let user_view = blocking(pool, move |conn| UserView::get_user_secure(conn, user_id)).await??;
 
     let res = BanUserResponse {
       user: user_view,


### PR DESCRIPTION
should make it easy to get a selection from the db that doesn't include info we don't want displayed to other users such as email