### PR TITLE
feat: hide deleted comments on a user's profile

### DIFF
--- a/ui/src/components/comment-node.tsx
+++ b/ui/src/components/comment-node.tsx
@@ -78,6 +78,7 @@ interface CommentNodeProps {
   sort?: CommentSortType;
   sortType?: SortType;
   enableDownvotes: boolean;
+  hideDeletedComment?: boolean;
 }
 
 export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
@@ -129,6 +130,13 @@ export class CommentNode extends Component<CommentNodeProps, CommentNodeState> {
 
   render() {
     let node = this.props.node;
+    const hideDeletedComment = this.props.hideDeletedComment;
+    const {
+      comment: { deleted: commentIsDeleted },
+    } = node;
+
+    if (commentIsDeleted && hideDeletedComment) return null;
+
     return (
       <div
         className={`comment ${

--- a/ui/src/components/comment-nodes.tsx
+++ b/ui/src/components/comment-nodes.tsx
@@ -26,6 +26,7 @@ interface CommentNodesProps {
   sort?: CommentSortType;
   sortType?: SortType;
   enableDownvotes: boolean;
+  hideDeletedComments?: boolean;
 }
 
 export class CommentNodes extends Component<
@@ -56,6 +57,7 @@ export class CommentNodes extends Component<
             sort={this.props.sort}
             sortType={this.props.sortType}
             enableDownvotes={this.props.enableDownvotes}
+            hideDeletedComment={this.props.hideDeletedComments}
           />
         ))}
       </div>

--- a/ui/src/components/user-details.tsx
+++ b/ui/src/components/user-details.tsx
@@ -167,6 +167,7 @@ export class UserDetails extends Component<UserDetailsProps, UserDetailsState> {
                   showCommunity
                   showContext
                   enableDownvotes={this.props.enableDownvotes}
+                  hideDeletedComments={true}
                 />
               )}
             </div>


### PR DESCRIPTION
Work for #1053 

I'm not sure if Lemmy wants this, but this allows for the hiding of deleted comments on a user's profile. Imo, the deleted comments shouldn't be returned from the server because a super-curious user might inspect the traffic of another user's profile and see the deleted comments, but that might be overkill. Plus, it would further complicate when and how to retrieve the deleted comments for restoration. Just a thought.