### PR TITLE
Fixing docker caching.

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -17,14 +17,19 @@ WORKDIR /app
 RUN sudo chown -R rust:rust .
 RUN USER=root cargo new server
 WORKDIR /app/server
+RUN mkdir -p lemmy_db/src/ lemmy_utils/src/
 COPY server/Cargo.toml server/Cargo.lock ./
-COPY server/lemmy_db ./lemmy_db
-COPY server/lemmy_utils ./lemmy_utils
+COPY server/lemmy_db/Cargo.toml ./lemmy_db/
+COPY server/lemmy_utils/Cargo.toml ./lemmy_utils/
 RUN mkdir -p ./src/bin \
-   && echo 'fn main() { println!("Dummy") }' > ./src/bin/main.rs
+   && echo 'fn main() { println!("Dummy")  }' > ./src/bin/main.rs \
+   && cp ./src/bin/main.rs ./lemmy_db/src/main.rs \
+   && cp ./src/bin/main.rs ./lemmy_utils/src/main.rs
 RUN cargo build
-RUN find target/debug -type f -name "$(echo "lemmy_server" | tr '-' '_')*" -exec touch -t 200001010000 {} +
+RUN rm -f ./target/x86_64-unknown-linux-musl/debug/deps/lemmy_server*
 COPY server/src ./src/
+COPY server/lemmy_db ./lemmy_db/
+COPY server/lemmy_utils ./lemmy_utils/
 COPY server/migrations ./migrations/
 
 # Build for debug

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -10,32 +10,36 @@ RUN yarn install --pure-lockfile
 COPY ui /app/ui
 RUN yarn build
 
-FROM ekidd/rust-musl-builder:1.42.0-openssl11 as rust
+FROM ekidd/rust-musl-builder:nightly-2020-05-07 as rust
 
 # Cache deps
 WORKDIR /app
 RUN sudo chown -R rust:rust .
 RUN USER=root cargo new server
+
+# Install cargo-build-deps
+RUN cargo install --git https://github.com/romac/cargo-build-deps.git
 WORKDIR /app/server
 RUN mkdir -p lemmy_db/src/ lemmy_utils/src/
+
+# Copy the cargo tomls
 COPY server/Cargo.toml server/Cargo.lock ./
 COPY server/lemmy_db/Cargo.toml ./lemmy_db/
 COPY server/lemmy_utils/Cargo.toml ./lemmy_utils/
-RUN mkdir -p ./src/bin \
-   && echo 'fn main() { println!("Dummy")  }' > ./src/bin/main.rs \
-   && cp ./src/bin/main.rs ./lemmy_db/src/main.rs \
-   && cp ./src/bin/main.rs ./lemmy_utils/src/main.rs
-RUN cargo build
-RUN rm -f ./target/x86_64-unknown-linux-musl/debug/deps/lemmy_server*
+
+# Cache the deps
+RUN cargo build-deps
+
+# Copy the src folders
 COPY server/src ./src/
-COPY server/lemmy_db ./lemmy_db/
-COPY server/lemmy_utils ./lemmy_utils/
+COPY server/lemmy_db/src ./lemmy_db/src/
+COPY server/lemmy_utils/src/ ./lemmy_utils/src/
 COPY server/migrations ./migrations/
 
 # Build for debug
 RUN cargo build
 
-FROM ekidd/rust-musl-builder:1.42.0-openssl11 as docs
+FROM ekidd/rust-musl-builder:nightly-2020-05-07 as docs
 WORKDIR /app
 COPY docs ./docs
 RUN sudo chown -R rust:rust .

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -3,9 +3,7 @@ version: '3.3'
 services:
 
   lemmy:
-    build: 
-      context: ../../
-      dockerfile: docker/dev/Dockerfile
+    image: lemmy-dev:latest
     ports:
       - "8536:8536"
     restart: always

--- a/docker/dev/docker_update.sh
+++ b/docker/dev/docker_update.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 set -e
 
-export COMPOSE_DOCKER_CLI_BUILD=1
-export DOCKER_BUILDKIT=1
 sudo chown -R 991:991 volumes/pictrs
-sudo docker-compose up -d --no-deps --build
+sudo docker build ../../ --file ../dev/Dockerfile -t lemmy-dev:latest
+sudo docker-compose up -d

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -10,14 +10,19 @@ WORKDIR /app
 RUN sudo chown -R rust:rust .
 RUN USER=root cargo new server
 WORKDIR /app/server
+RUN mkdir -p lemmy_db/src/ lemmy_utils/src/
 COPY server/Cargo.toml server/Cargo.lock ./
-COPY server/lemmy_db ./lemmy_db
-COPY server/lemmy_utils ./lemmy_utils
+COPY server/lemmy_db/Cargo.toml ./lemmy_db/
+COPY server/lemmy_utils/Cargo.toml ./lemmy_utils/
 RUN mkdir -p ./src/bin \
-   && echo 'fn main() { println!("Dummy") }' > ./src/bin/main.rs
+   && echo 'fn main() { println!("Dummy")  }' > ./src/bin/main.rs \
+   && cp ./src/bin/main.rs ./lemmy_db/src/main.rs \
+   && cp ./src/bin/main.rs ./lemmy_utils/src/main.rs
 RUN cargo build --release
 RUN find target/$CARGO_BUILD_TARGET/$RUSTRELEASEDIR -type f -name "$(echo "lemmy_server" | tr '-' '_')*" -exec touch -t 200001010000 {} +
 COPY server/src ./src/
+COPY server/lemmy_db ./lemmy_db/
+COPY server/lemmy_utils ./lemmy_utils/
 COPY server/migrations ./migrations/
 
 # build for release

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -10,19 +10,14 @@ WORKDIR /app
 RUN sudo chown -R rust:rust .
 RUN USER=root cargo new server
 WORKDIR /app/server
-RUN mkdir -p lemmy_db/src/ lemmy_utils/src/
 COPY server/Cargo.toml server/Cargo.lock ./
-COPY server/lemmy_db/Cargo.toml ./lemmy_db/
-COPY server/lemmy_utils/Cargo.toml ./lemmy_utils/
+COPY server/lemmy_db ./lemmy_db
+COPY server/lemmy_utils ./lemmy_utils
 RUN mkdir -p ./src/bin \
-   && echo 'fn main() { println!("Dummy")  }' > ./src/bin/main.rs \
-   && cp ./src/bin/main.rs ./lemmy_db/src/main.rs \
-   && cp ./src/bin/main.rs ./lemmy_utils/src/main.rs
+   && echo 'fn main() { println!("Dummy") }' > ./src/bin/main.rs
 RUN cargo build --release
 RUN find target/$CARGO_BUILD_TARGET/$RUSTRELEASEDIR -type f -name "$(echo "lemmy_server" | tr '-' '_')*" -exec touch -t 200001010000 {} +
 COPY server/src ./src/
-COPY server/lemmy_db ./lemmy_db/
-COPY server/lemmy_utils ./lemmy_utils/
 COPY server/migrations ./migrations/
 
 # build for release

--- a/server/lemmy_db/Cargo.toml
+++ b/server/lemmy_db/Cargo.toml
@@ -3,6 +3,10 @@ name = "lemmy_db"
 version = "0.1.0"
 edition = "2018"
 
+[lib]
+name = "lemmy_db"
+path = "src/lib.rs"
+
 [dependencies]
 diesel = { version = "1.4.4", features = ["postgres","chrono","r2d2","64-column-tables","serde_json"] }
 chrono = { version = "0.4.7", features = ["serde"] }

--- a/server/lemmy_utils/Cargo.toml
+++ b/server/lemmy_utils/Cargo.toml
@@ -3,6 +3,10 @@ name = "lemmy_utils"
 version = "0.1.0"
 edition = "2018"
 
+[lib]
+name = "lemmy_utils"
+path = "src/lib.rs"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
Using your old docker caching method, it works better. Still not as ideal as having a `cargo build --cache-deps`