### PR TITLE
Verify activity domains 2

### DIFF
--- a/docs/src/contributing_apub_api_outline.md
+++ b/docs/src/contributing_apub_api_outline.md
@@ -597,7 +597,7 @@ Sent to: User
     "type": "Delete",
     "actor": "https://ds9.lemmy.ml/u/sisko",
     "to": "https://enterprise.lemmy.ml/u/riker/inbox",
-    "object": "https://enterprise.lemmy.ml/private_message/341"
+    "object": "https://ds9.lemmy.ml/private_message/341"
 }
 ```
 

--- a/lemmy_apub/src/activities/receive/announce.rs
+++ b/lemmy_apub/src/activities/receive/announce.rs
@@ -1,48 +1,50 @@
-use crate::activities::receive::{
-  create::receive_create,
-  delete::receive_delete,
-  dislike::receive_dislike,
-  like::receive_like,
-  receive_unhandled_activity,
-  remove::receive_remove,
-  undo::receive_undo,
-  update::receive_update,
+use crate::{
+  activities::receive::{
+    create::receive_create,
+    delete::receive_delete,
+    dislike::receive_dislike,
+    like::receive_like,
+    receive_unhandled_activity,
+    remove::receive_remove,
+    undo::receive_undo,
+    update::receive_update,
+    verify_activity_domains_valid,
+  },
+  check_is_apub_id_valid,
+  ActorType,
 };
-use activitystreams::{
-  activity::*,
-  base::{AnyBase, BaseExt},
-  prelude::ExtendsExt,
-};
+use activitystreams::{activity::*, base::AnyBase, prelude::ExtendsExt};
 use actix_web::HttpResponse;
 use anyhow::Context;
 use lemmy_utils::{location_info, LemmyError};
 use lemmy_websocket::LemmyContext;
 
 pub async fn receive_announce(
-  activity: AnyBase,
   context: &LemmyContext,
+  activity: AnyBase,
+  actor: &dyn ActorType,
 ) -> Result<HttpResponse, LemmyError> {
   let announce = Announce::from_any_base(activity)?.context(location_info!())?;
-
-  // ensure that announce and community come from the same instance
-  let community_id = announce
-    .actor()?
-    .to_owned()
-    .single_xsd_any_uri()
-    .context(location_info!())?;
-  announce.id(community_id.domain().context(location_info!())?)?;
+  verify_activity_domains_valid(&announce, actor.actor_id()?, false)?;
 
   let kind = announce.object().as_single_kind_str();
-  let object = announce.object();
-  let object2 = object.clone().one().context(location_info!())?;
+  let object = announce
+    .object()
+    .to_owned()
+    .one()
+    .context(location_info!())?;
+
+  let inner_id = object.id().context(location_info!())?.to_owned();
+  check_is_apub_id_valid(&inner_id)?;
+
   match kind {
-    Some("Create") => receive_create(object2, context).await,
-    Some("Update") => receive_update(object2, context).await,
-    Some("Like") => receive_like(object2, context).await,
-    Some("Dislike") => receive_dislike(object2, context).await,
-    Some("Delete") => receive_delete(object2, context).await,
-    Some("Remove") => receive_remove(object2, context).await,
-    Some("Undo") => receive_undo(object2, context).await,
+    Some("Create") => receive_create(context, object, inner_id).await,
+    Some("Update") => receive_update(context, object, inner_id).await,
+    Some("Like") => receive_like(context, object, inner_id).await,
+    Some("Dislike") => receive_dislike(context, object, inner_id).await,
+    Some("Delete") => receive_delete(context, object, inner_id).await,
+    Some("Remove") => receive_remove(context, object, inner_id).await,
+    Some("Undo") => receive_undo(context, object, inner_id).await,
     _ => receive_unhandled_activity(announce),
   }
 }

--- a/lemmy_apub/src/activities/receive/create.rs
+++ b/lemmy_apub/src/activities/receive/create.rs
@@ -3,6 +3,7 @@ use crate::{
     announce_if_community_is_local,
     get_actor_as_user,
     receive_unhandled_activity,
+    verify_activity_domains_valid,
   },
   ActorType,
   FromApub,
@@ -24,16 +25,15 @@ use lemmy_websocket::{
   LemmyContext,
   UserOperation,
 };
+use url::Url;
 
 pub async fn receive_create(
-  activity: AnyBase,
   context: &LemmyContext,
+  activity: AnyBase,
+  expected_domain: Url,
 ) -> Result<HttpResponse, LemmyError> {
   let create = Create::from_any_base(activity)?.context(location_info!())?;
-
-  // ensure that create and actor come from the same instance
-  let user = get_actor_as_user(&create, context).await?;
-  create.id(user.actor_id()?.domain().context(location_info!())?)?;
+  verify_activity_domains_valid(&create, expected_domain, true)?;
 
   match create.object().as_single_kind_str() {
     Some("Page") => receive_create_post(create, context).await,

--- a/lemmy_apub/src/extensions/signatures.rs
+++ b/lemmy_apub/src/extensions/signatures.rs
@@ -63,7 +63,7 @@ pub async fn sign_and_send(
   Ok(response)
 }
 
-pub fn verify(request: &HttpRequest, actor: &dyn ActorType) -> Result<(), LemmyError> {
+pub fn verify_signature(request: &HttpRequest, actor: &dyn ActorType) -> Result<(), LemmyError> {
   let public_key = actor.public_key().context(location_info!())?;
   let verified = CONFIG2
     .begin_verify(

--- a/lemmy_apub/src/fetcher.rs
+++ b/lemmy_apub/src/fetcher.rs
@@ -93,7 +93,7 @@ pub async fn search_by_apub_id(
 ) -> Result<SearchResponse, LemmyError> {
   // Parse the shorthand query url
   let query_url = if query.contains('@') {
-    debug!("{}", query);
+    debug!("Search for {}", query);
     let split = query.split('@').collect::<Vec<&str>>();
 
     // User type will look like ['', username, instance]

--- a/lemmy_apub/src/inbox/shared_inbox.rs
+++ b/lemmy_apub/src/inbox/shared_inbox.rs
@@ -10,7 +10,7 @@ use crate::{
     update::receive_update,
   },
   check_is_apub_id_valid,
-  extensions::signatures::verify,
+  extensions::signatures::verify_signature,
   fetcher::get_or_fetch_and_upsert_actor,
   insert_activity,
 };
@@ -62,7 +62,7 @@ pub async fn shared_inbox(
   check_is_apub_id_valid(&actor)?;
 
   let actor = get_or_fetch_and_upsert_actor(&actor, &context).await?;
-  verify(&request, actor.as_ref())?;
+  verify_signature(&request, actor.as_ref())?;
 
   let any_base = activity.clone().into_any_base()?;
   let kind = activity.kind().context(location_info!())?;

--- a/lemmy_apub/src/lib.rs
+++ b/lemmy_apub/src/lib.rs
@@ -17,10 +17,8 @@ use crate::extensions::{
 use activitystreams::{
   activity::Follow,
   actor::{ApActor, Group, Person},
-  base::{AnyBase, AsBase},
-  markers::Base,
+  base::AnyBase,
   object::{Page, Tombstone},
-  prelude::*,
 };
 use activitystreams_ext::{Ext1, Ext2};
 use anyhow::{anyhow, Context};
@@ -130,24 +128,6 @@ pub trait ApubObjectType {
   ) -> Result<(), LemmyError>;
   async fn send_remove(&self, mod_: &User_, context: &LemmyContext) -> Result<(), LemmyError>;
   async fn send_undo_remove(&self, mod_: &User_, context: &LemmyContext) -> Result<(), LemmyError>;
-}
-
-pub(in crate) fn check_actor_domain<T, Kind>(
-  apub: &T,
-  expected_domain: Option<Url>,
-) -> Result<String, LemmyError>
-where
-  T: Base + AsBase<Kind>,
-{
-  let actor_id = if let Some(url) = expected_domain {
-    let domain = url.domain().context(location_info!())?;
-    apub.id(domain)?.context(location_info!())?
-  } else {
-    let actor_id = apub.id_unchecked().context(location_info!())?;
-    check_is_apub_id_valid(&actor_id)?;
-    actor_id
-  };
-  Ok(actor_id.to_string())
 }
 
 #[async_trait::async_trait(?Send)]

--- a/lemmy_apub/src/objects/comment.rs
+++ b/lemmy_apub/src/objects/comment.rs
@@ -1,11 +1,10 @@
 use crate::{
-  check_actor_domain,
   fetcher::{
     get_or_fetch_and_insert_comment,
     get_or_fetch_and_insert_post,
     get_or_fetch_and_upsert_user,
   },
-  objects::create_tombstone,
+  objects::{check_object_domain, create_tombstone},
   FromApub,
   ToApub,
 };
@@ -140,7 +139,7 @@ impl FromApub for CommentForm {
       published: note.published().map(|u| u.to_owned().naive_local()),
       updated: note.updated().map(|u| u.to_owned().naive_local()),
       deleted: None,
-      ap_id: Some(check_actor_domain(note, expected_domain)?),
+      ap_id: Some(check_object_domain(note, expected_domain)?),
       local: false,
     })
   }

--- a/lemmy_apub/src/objects/community.rs
+++ b/lemmy_apub/src/objects/community.rs
@@ -1,8 +1,7 @@
 use crate::{
-  check_actor_domain,
   extensions::group_extensions::GroupExtension,
   fetcher::get_or_fetch_and_upsert_user,
-  objects::create_tombstone,
+  objects::{check_object_domain, create_tombstone},
   ActorType,
   FromApub,
   GroupExt,
@@ -189,7 +188,7 @@ impl FromApub for CommunityForm {
       updated: group.inner.updated().map(|u| u.to_owned().naive_local()),
       deleted: None,
       nsfw: group.ext_one.sensitive,
-      actor_id: Some(check_actor_domain(group, expected_domain)?),
+      actor_id: Some(check_object_domain(group, expected_domain)?),
       local: false,
       private_key: None,
       public_key: Some(group.ext_two.to_owned().public_key.public_key_pem),

--- a/lemmy_apub/src/objects/post.rs
+++ b/lemmy_apub/src/objects/post.rs
@@ -1,8 +1,7 @@
 use crate::{
-  check_actor_domain,
   extensions::page_extension::PageExtension,
   fetcher::{get_or_fetch_and_upsert_community, get_or_fetch_and_upsert_user},
-  objects::create_tombstone,
+  objects::{check_object_domain, create_tombstone},
   FromApub,
   PageExt,
   ToApub,
@@ -193,7 +192,7 @@ impl FromApub for PostForm {
       embed_description: iframely_description,
       embed_html: iframely_html,
       thumbnail_url: pictrs_thumbnail,
-      ap_id: Some(check_actor_domain(page, expected_domain)?),
+      ap_id: Some(check_object_domain(page, expected_domain)?),
       local: false,
     })
   }

--- a/lemmy_apub/src/objects/private_message.rs
+++ b/lemmy_apub/src/objects/private_message.rs
@@ -1,8 +1,7 @@
 use crate::{
-  check_actor_domain,
   check_is_apub_id_valid,
   fetcher::get_or_fetch_and_upsert_user,
-  objects::create_tombstone,
+  objects::{check_object_domain, create_tombstone},
   FromApub,
   ToApub,
 };
@@ -96,7 +95,7 @@ impl FromApub for PrivateMessageForm {
       updated: note.updated().map(|u| u.to_owned().naive_local()),
       deleted: None,
       read: None,
-      ap_id: Some(check_actor_domain(note, expected_domain)?),
+      ap_id: Some(check_object_domain(note, expected_domain)?),
       local: false,
     })
   }

--- a/lemmy_apub/src/objects/user.rs
+++ b/lemmy_apub/src/objects/user.rs
@@ -1,4 +1,4 @@
-use crate::{check_actor_domain, ActorType, FromApub, PersonExt, ToApub};
+use crate::{objects::check_object_domain, ActorType, FromApub, PersonExt, ToApub};
 use activitystreams::{
   actor::{ApActor, Endpoints, Person},
   object::{Image, Tombstone},
@@ -145,7 +145,7 @@ impl FromApub for UserForm {
       show_avatars: false,
       send_notifications_to_email: false,
       matrix_user_id: None,
-      actor_id: Some(check_actor_domain(person, expected_domain)?),
+      actor_id: Some(check_object_domain(person, expected_domain)?),
       bio: Some(bio),
       local: false,
       private_key: None,


### PR DESCRIPTION
This is much easier now, as a rule we need to call `verify_activity_domains_valid()` after every invocation of `Activity::from_any_base()`.