### PR TITLE
Swap name and preferredUsername apub fields

### DIFF
--- a/docs/src/contributing_apub_api_outline.md
+++ b/docs/src/contributing_apub_api_outline.md
@@ -52,8 +52,8 @@ Receives activities from user: `Follow`, `Undo/Follow`, `Create`, `Update`, `Lik
     "@context": "https://www.w3.org/ns/activitystreams",
     "id": "https://enterprise.lemmy.ml/c/main",
     "type": "Group",
-    "name": "main",
-    "preferredUsername": "The Main Community",
+    "preferredUsername": "main",
+    "name": "The Main Community",
     "category": { 
         "identifier": "1",
         "name": "Discussion"
@@ -90,8 +90,8 @@ Receives activities from user: `Follow`, `Undo/Follow`, `Create`, `Update`, `Lik
 
 | Field Name | Mandatory | Description |
 |---|---|---|
-| `name` | yes | Name of the actor |
-| `preferredUsername` | yes | Displayname |
+| `preferredUsername` | yes | Name of the actor |
+| `name` | yes | Title of the community |
 | `category` | yes | Hardcoded list of categories, see https://dev.lemmy.ml/api/v1/categories |
 | `sensitive` | yes | True indicates that all posts in the community are nsfw |
 | `attributedTo` | yes | First the community creator, then all the remaining moderators |
@@ -121,8 +121,8 @@ Sends and receives activities from/to other users: `Create/Note`, `Update/Note`,
     "@context": "https://www.w3.org/ns/activitystreams",
     "id": "https://enterprise.lemmy.ml/u/picard",
     "type": "Person",
-    "name": "riker",
-    "preferredUsername": "Jean-Luc Picard",
+    "preferredUsername": "picard",
+    "name": "Jean-Luc Picard",
     "summary": "The user bio",
     "icon": {
         "type": "Image",
@@ -148,8 +148,8 @@ Sends and receives activities from/to other users: `Create/Note`, `Update/Note`,
 
 | Field Name | Mandatory | Description |
 |---|---|---|
-| `name` | yes | Name of the actor |
-| `preferredUsername` | no | Displayname |
+| `preferredUsername` | yes | Name of the actor |
+| `name` | no | The user's displayname |
 | `summary` | no | User bio |
 | `icon` | no | The user's avatar, shown next to the username |
 | `image` | no | The user's banner, shown on top of the profile |

--- a/lemmy_apub/src/objects/community.rs
+++ b/lemmy_apub/src/objects/community.rs
@@ -51,7 +51,7 @@ impl ToApub for Community {
     group
       .set_context(activitystreams::context())
       .set_id(Url::parse(&self.actor_id)?)
-      .set_name(self.name.to_owned())
+      .set_name(self.title.to_owned())
       .set_published(convert_datetime(self.published))
       .set_many_attributed_tos(moderators);
 
@@ -78,7 +78,7 @@ impl ToApub for Community {
 
     let mut ap_actor = ApActor::new(self.get_inbox_url()?, group);
     ap_actor
-      .set_preferred_username(self.title.to_owned())
+      .set_preferred_username(self.name.to_owned())
       .set_outbox(self.get_outbox_url()?)
       .set_followers(self.get_followers_url()?)
       .set_endpoints(Endpoints {
@@ -127,16 +127,16 @@ impl FromApub for CommunityForm {
     let creator = get_or_fetch_and_upsert_user(creator_uri, context).await?;
     let name = group
       .inner
+      .preferred_username()
+      .context(location_info!())?
+      .to_string();
+    let title = group
+      .inner
       .name()
       .context(location_info!())?
       .as_one()
       .context(location_info!())?
       .as_xsd_string()
-      .context(location_info!())?
-      .to_string();
-    let title = group
-      .inner
-      .preferred_username()
       .context(location_info!())?
       .to_string();
     // TODO: should be parsed as html and tags like <script> removed (or use markdown source)

--- a/lemmy_apub/src/objects/user.rs
+++ b/lemmy_apub/src/objects/user.rs
@@ -30,7 +30,6 @@ impl ToApub for User_ {
     person
       .set_context(activitystreams::context())
       .set_id(Url::parse(&self.actor_id)?)
-      .set_name(self.name.to_owned())
       .set_published(convert_datetime(self.published));
 
     if let Some(u) = self.updated {
@@ -53,15 +52,16 @@ impl ToApub for User_ {
       person.set_summary(bio.to_owned());
     }
 
+    if let Some(i) = self.preferred_username.to_owned() {
+      person.set_name(i);
+    }
+
     let mut ap_actor = ApActor::new(self.get_inbox_url()?, person);
+    ap_actor.set_preferred_username(self.name.to_owned());
     ap_actor.set_endpoints(Endpoints {
       shared_inbox: Some(self.get_shared_inbox_url()?),
       ..Default::default()
     });
-
-    if let Some(i) = &self.preferred_username {
-      ap_actor.set_preferred_username(i.to_owned());
-    }
 
     Ok(Ext1::new(ap_actor, self.get_public_key_ext()?))
   }
@@ -104,15 +104,17 @@ impl FromApub for UserForm {
       None => None,
     };
 
-    let name = person
-      .name()
-      .context(location_info!())?
-      .one()
-      .context(location_info!())?
-      .as_xsd_string()
+    let name: String = person
+      .inner
+      .preferred_username()
       .context(location_info!())?
       .to_string();
-    let preferred_username = person.inner.preferred_username().map(|u| u.to_string());
+    let preferred_username: Option<String> = person
+      .name()
+      .map(|n| n.one())
+      .flatten()
+      .map(|n| n.to_owned().xsd_string())
+      .flatten();
 
     // TODO a limit check (like the API does) might need to be done
     // here when we federate to other platforms. Same for preferred_username


### PR DESCRIPTION
Turns out that these fields are used in a completely counterintuitive way, at least by Mastodon and Peertube.

We should also rename the related database fields and variables, because right now its very confusing.