### PR TITLE
Remove root prefix for docker, added volumes dir

### DIFF
--- a/docs/src/contributing_docker_development.md
+++ b/docs/src/contributing_docker_development.md
@@ -11,7 +11,9 @@ git clone https://github.com/LemmyNet/lemmy
 ## Running
 
 ```bash
-cd /docker/dev
+cd docker/dev
+mkdir -p volumes/pictrs
+sudo chown -R 991:991 volumes/pictrs
 ./docker_update.sh
 ```
 


### PR DESCRIPTION
- `cd /docker/dev` is incorrect, changed to `cd docker/dev`
- `./docker_update.sh` expects a `volumes` dir and will fail if none exists.