### PR TITLE
Parameterize config file location

### DIFF
--- a/docs/src/administration_configuration.md
+++ b/docs/src/administration_configuration.md
@@ -1,22 +1,17 @@
 # Configuration
 
-The configuration is based on the file
-[defaults.hjson](https://yerbamate.dev/LemmyNet/lemmy/src/branch/main/config/defaults.hjson).
-This file also contains documentation for all the available options. To override the defaults, you
-can copy the options you want to change into your local `config.hjson` file.
+The configuration is based on the file [defaults.hjson](https://yerbamate.dev/LemmyNet/lemmy/src/branch/main/config/defaults.hjson). This file also contains documentation for all the available options. To override the defaults, you can copy the options you want to change into your local `config.hjson` file.
 
-To use a different `config.hjson` location than the current directory, set the environment variable `LEMMY_CONFIG_LOCATION`. Make sure you copy the `defaults.hjson` if you do this, otherwise you will be missing settings.
+The `defaults.hjson` and `config.hjson` files are located at `config/defaults.hjson` and`config/config.hjson`, respectively. To change these default locations, you can set these two environment variables:
 
-Additionally, you can override any config files with environment variables. These have the same
-name as the config options, and are prefixed with `LEMMY_`. For example, you can override the
-`database.password` with `LEMMY_DATABASE__POOL_SIZE=10`.
+    LEMMY_CONFIG_LOCATION           # config.hjson
+    LEMMY_CONFIG_DEFAULTS_LOCATION  # defaults.hjson
 
-An additional option `LEMMY_DATABASE_URL` is available, which can be used with a PostgreSQL
-connection string like `postgres://lemmy:password@lemmy_db:5432/lemmy`, passing all connection
-details at once.
+Additionally, you can override any config files with environment variables. These have the same name as the config options, and are prefixed with `LEMMY_`. For example, you can override the `database.password` with `LEMMY_DATABASE__POOL_SIZE=10`.
 
-If the Docker container is not used, manually create the database specified above by running the
-following commands:
+An additional option `LEMMY_DATABASE_URL` is available, which can be used with a PostgreSQL connection string like `postgres://lemmy:password@lemmy_db:5432/lemmy`, passing all connection details at once.
+
+If the Docker container is not used, manually create the database specified above by running the following commands:
 
 ```bash
 cd server

--- a/lemmy_utils/src/settings.rs
+++ b/lemmy_utils/src/settings.rs
@@ -93,7 +93,7 @@ impl Settings {
 
     s.merge(File::with_name(&Self::get_config_defaults_location()))?;
 
-    s.merge(File::with_name(CONFIG_FILE).required(false))?;
+    s.merge(File::with_name(&Self::get_config_location()).required(false))?;
 
     // Add in settings from the environment (with a prefix of LEMMY)
     // Eg.. `LEMMY_DEBUG=1 ./target/app` would set the `debug` key
@@ -122,11 +122,15 @@ impl Settings {
   }
 
   pub fn get_config_defaults_location() -> String {
-    env::var("LEMMY_CONFIG_LOCATION").unwrap_or_else(|_| CONFIG_FILE_DEFAULTS.to_string())
+    env::var("LEMMY_CONFIG_DEFAULTS_LOCATION").unwrap_or_else(|_| CONFIG_FILE_DEFAULTS.to_string())
+  }
+
+  pub fn get_config_location() -> String {
+    env::var("LEMMY_CONFIG_LOCATION").unwrap_or_else(|_| CONFIG_FILE.to_string())
   }
 
   pub fn read_config_file() -> Result<String, Error> {
-    fs::read_to_string(CONFIG_FILE)
+    fs::read_to_string(Self::get_config_location())
   }
 
   pub fn get_allowed_instances(&self) -> Vec<String> {


### PR DESCRIPTION
Allows `config.hjson` to be located on a configurable path.

Split off from #1130 