### PR TITLE
add on_conflict clauses to common unique constraint failures

### DIFF
--- a/lemmy_db/src/comment.rs
+++ b/lemmy_db/src/comment.rs
@@ -206,6 +206,9 @@ impl Likeable<CommentLikeForm> for CommentLike {
     use crate::schema::comment_like::dsl::*;
     insert_into(comment_like)
       .values(comment_like_form)
+      .on_conflict((comment_id, user_id))
+      .do_update()
+      .set(comment_like_form)
       .get_result::<Self>(conn)
   }
   fn remove(conn: &PgConnection, user_id: i32, comment_id: i32) -> Result<usize, Error> {
@@ -241,6 +244,9 @@ impl Saveable<CommentSavedForm> for CommentSaved {
     use crate::schema::comment_saved::dsl::*;
     insert_into(comment_saved)
       .values(comment_saved_form)
+      .on_conflict((comment_id, user_id))
+      .do_update()
+      .set(comment_saved_form)
       .get_result::<Self>(conn)
   }
   fn unsave(conn: &PgConnection, comment_saved_form: &CommentSavedForm) -> Result<usize, Error> {

--- a/lemmy_db/src/community.rs
+++ b/lemmy_db/src/community.rs
@@ -295,6 +295,9 @@ impl Followable<CommunityFollowerForm> for CommunityFollower {
     use crate::schema::community_follower::dsl::*;
     insert_into(community_follower)
       .values(community_follower_form)
+      .on_conflict((community_id, user_id))
+      .do_update()
+      .set(community_follower_form)
       .get_result::<Self>(conn)
   }
   fn follow_accepted(conn: &PgConnection, community_id_: i32, user_id_: i32) -> Result<Self, Error>

--- a/lemmy_db/src/post.rs
+++ b/lemmy_db/src/post.rs
@@ -237,6 +237,9 @@ impl Likeable<PostLikeForm> for PostLike {
     use crate::schema::post_like::dsl::*;
     insert_into(post_like)
       .values(post_like_form)
+      .on_conflict((post_id, user_id))
+      .do_update()
+      .set(post_like_form)
       .get_result::<Self>(conn)
   }
   fn remove(conn: &PgConnection, user_id: i32, post_id: i32) -> Result<usize, Error> {
@@ -272,6 +275,9 @@ impl Saveable<PostSavedForm> for PostSaved {
     use crate::schema::post_saved::dsl::*;
     insert_into(post_saved)
       .values(post_saved_form)
+      .on_conflict((post_id, user_id))
+      .do_update()
+      .set(post_saved_form)
       .get_result::<Self>(conn)
   }
   fn unsave(conn: &PgConnection, post_saved_form: &PostSavedForm) -> Result<usize, Error> {

--- a/lemmy_db/src/user_mention.rs
+++ b/lemmy_db/src/user_mention.rs
@@ -29,8 +29,11 @@ impl Crud<UserMentionForm> for UserMention {
 
   fn create(conn: &PgConnection, user_mention_form: &UserMentionForm) -> Result<Self, Error> {
     use crate::schema::user_mention::dsl::*;
+    // since the return here isnt utilized, we dont need to do an update
+    // but get_result doesnt return the existing row here
     insert_into(user_mention)
       .values(user_mention_form)
+      .on_conflict_do_nothing()
       .get_result::<Self>(conn)
   }
 

--- a/lemmy_db/src/user_mention.rs
+++ b/lemmy_db/src/user_mention.rs
@@ -33,7 +33,9 @@ impl Crud<UserMentionForm> for UserMention {
     // but get_result doesnt return the existing row here
     insert_into(user_mention)
       .values(user_mention_form)
-      .on_conflict_do_nothing()
+      .on_conflict((recipient_id, comment_id))
+      .do_update()
+      .set(user_mention_form)
       .get_result::<Self>(conn)
   }
 

--- a/lemmy_structs/src/lib.rs
+++ b/lemmy_structs/src/lib.rs
@@ -98,10 +98,7 @@ fn do_send_local_notifs(
 
       // Allow this to fail softly, since comment edits might re-update or replace it
       // Let the uniqueness handle this fail
-      match UserMention::create(&conn, &user_mention_form) {
-        Ok(_mention) => (),
-        Err(_e) => (),
-      };
+      let _ = UserMention::create(&conn, &user_mention_form);
 
       // Send an email to those users that have notifications on
       if do_send_email && mention_user.send_notifications_to_email {

--- a/lemmy_structs/src/lib.rs
+++ b/lemmy_structs/src/lib.rs
@@ -100,7 +100,7 @@ fn do_send_local_notifs(
       // Let the uniqueness handle this fail
       match UserMention::create(&conn, &user_mention_form) {
         Ok(_mention) => (),
-        Err(_e) => error!("{}", &_e),
+        Err(_e) => (),
       };
 
       // Send an email to those users that have notifications on


### PR DESCRIPTION
this cleans up the postgres logs a bit. good for client-side handling and helps with idempotency