### PR TITLE
Update lemmy_council.md

### DIFF
--- a/docs/src/lemmy_council.md
+++ b/docs/src/lemmy_council.md
@@ -1,7 +1,6 @@
 # Lemmy Council
 
-- A group of lemmy developers and users that use a well-defined democratic process to steer the project in a positive direction, keep it aligned to community goals, and resolve conflicts. 
-- Council members are also added as administrators to any official Lemmy instances.
+- A group of lemmy developers and users that use a well-defined democratic process to steer the project in a positive direction, keep it aligned to community goals, and resolve conflicts.
 
 ## 1. What gets voted on
 


### PR DESCRIPTION
Removed line saying that council members are administrators on official instances, as it is unclear that currently only https://lemmy.ml is a official instance.