### PR TITLE
Set local for apub objects

### DIFF
--- a/docs/src/about_ranking.md
+++ b/docs/src/about_ranking.md
@@ -1,17 +1,16 @@
 # Trending / Hot / Best Sorting algorithm
-
-An expected feature in link aggregators is a kind of "Trending" sort which shows users a mixture of new posts / comments and popular ones, making for a display order which highlights the most currently active parts of the site / thread.  This keeps the experience fresh and makes sure the site stays moving.  Various flaws can be found in the ways that popular link aggregators like Reddit have implemented "Hot" or "Trending" sorts, so Lemmy has its own algorithm.
-
-## Goals and Considerations
+## Goals
 - During the day, new posts and comments should be near the top, so they can be voted on.
 - After a day or so, the time factor should go away.
 - Use a log scale, since votes tend to snowball, and so the first 10 votes are just as important as the next hundred.
 
-| Reddit | Hacker News | Lemmy |
-|-|-|-|
-| Does not take the lifetime of the thread into account, [giving early comments an overwhelming advantage over later ones,](https://minimaxir.com/2016/11/first-comment/) with the effect being even worse in small communities. New comments pool at the bottom of the thread, effectively killing off discussion and making each thread a race to comment early.  This lowers the quality of conversation and rewards comments that are repetitive and spammy. | While far superior to Reddit's implementation for its decay of scores over time, [Hacker News' ranking algorithm](https://medium.com/hacking-and-gonzo/how-hacker-news-ranking-algorithm-works-1d9b0cf2c08d) does not use a logarithmic scale for scores. | Counterbalances the snowballing effect of votes over time with a logarithmic scale.  Negates the inherent advantage of early comments while still ensuring that votes still matter in the long-term, not nuking older popular comments. |
+## Reddit Sorting
+[Reddit's comment sorting algorithm](https://medium.com/hacking-and-gonzo/how-reddit-ranking-algorithms-work-ef111e33d0d9), the wilson confidence sort, is inadequate, because it completely ignores time. What ends up happening, especially in smaller subreddits, is that the early comments end up getting upvoted, and newer comments stay at the bottom, never to be seen. Research showed that nearly all top comments are just the [first ones posted.](https://minimaxir.com/2016/11/first-comment/)
 
-## Additional Details
+## Hacker News Sorting
+The [Hacker New's ranking algorithm](https://medium.com/hacking-and-gonzo/how-hacker-news-ranking-algorithm-works-1d9b0cf2c08d) is great, but it doesn't use a log scale for the scores.
+
+## My Algorithm
 ```
 Rank = ScaleFactor * log(Max(1, 3 + Score)) / (Time + 2)^Gravity
 

--- a/lemmy_apub/src/activities/receive/private_message.rs
+++ b/lemmy_apub/src/activities/receive/private_message.rs
@@ -194,7 +194,7 @@ async fn check_private_message_activity_valid<T, Kind>(
 where
   T: AsBase<Kind> + AsObject<Kind> + ActorAndObjectRefExt,
 {
-  let to_and_cc = get_activity_to_and_cc(activity)?;
+  let to_and_cc = get_activity_to_and_cc(activity);
   if to_and_cc.len() != 1 {
     return Err(anyhow!("Private message can only be addressed to one user").into());
   }

--- a/lemmy_apub/src/inbox/community_inbox.rs
+++ b/lemmy_apub/src/inbox/community_inbox.rs
@@ -80,7 +80,7 @@ pub async fn community_inbox(
     Community::read_from_name(&conn, &path)
   })
   .await??;
-  let to_and_cc = get_activity_to_and_cc(&activity)?;
+  let to_and_cc = get_activity_to_and_cc(&activity);
   if !to_and_cc.contains(&&community.actor_id()?) {
     return Err(anyhow!("Activity delivered to wrong community").into());
   }

--- a/lemmy_apub/src/inbox/mod.rs
+++ b/lemmy_apub/src/inbox/mod.rs
@@ -50,7 +50,7 @@ pub(crate) async fn is_activity_already_known(
   }
 }
 
-pub(crate) fn get_activity_to_and_cc<T, Kind>(activity: &T) -> Result<Vec<Url>, LemmyError>
+pub(crate) fn get_activity_to_and_cc<T, Kind>(activity: &T) -> Vec<Url>
 where
   T: AsBase<Kind> + AsObject<Kind> + ActorAndObjectRefExt,
 {
@@ -75,14 +75,14 @@ where
       .collect();
     to_and_cc.append(&mut cc);
   }
-  Ok(to_and_cc)
+  to_and_cc
 }
 
 pub(crate) fn is_addressed_to_public<T, Kind>(activity: &T) -> Result<(), LemmyError>
 where
   T: AsBase<Kind> + AsObject<Kind> + ActorAndObjectRefExt,
 {
-  let to_and_cc = get_activity_to_and_cc(activity)?;
+  let to_and_cc = get_activity_to_and_cc(activity);
   if to_and_cc.contains(&public()) {
     Ok(())
   } else {

--- a/lemmy_apub/src/inbox/shared_inbox.rs
+++ b/lemmy_apub/src/inbox/shared_inbox.rs
@@ -64,7 +64,7 @@ pub async fn shared_inbox(
 
   let activity_any_base = activity.clone().into_any_base()?;
   let mut res: Option<HttpResponse> = None;
-  let to_and_cc = get_activity_to_and_cc(&activity)?;
+  let to_and_cc = get_activity_to_and_cc(&activity);
   // Handle community first, so in case the sender is banned by the community, it will error out.
   // If we handled the user receive first, the activity would be inserted to the database before the
   // community could check for bans.

--- a/lemmy_apub/src/inbox/user_inbox.rs
+++ b/lemmy_apub/src/inbox/user_inbox.rs
@@ -100,7 +100,7 @@ pub async fn user_inbox(
     User_::read_from_name(&conn, &username)
   })
   .await??;
-  let to_and_cc = get_activity_to_and_cc(&activity)?;
+  let to_and_cc = get_activity_to_and_cc(&activity);
   // TODO: we should also accept activities that are sent to community followers
   if !to_and_cc.contains(&&user.actor_id()?) {
     return Err(anyhow!("Activity delivered to wrong user").into());
@@ -170,7 +170,7 @@ async fn is_for_user_inbox(
   context: &LemmyContext,
   activity: &UserAcceptedActivities,
 ) -> Result<(), LemmyError> {
-  let to_and_cc = get_activity_to_and_cc(activity)?;
+  let to_and_cc = get_activity_to_and_cc(activity);
   // Check if it is addressed directly to any local user
   if is_addressed_to_local_user(&to_and_cc, context.pool()).await? {
     return Ok(());

--- a/lemmy_apub/src/objects/comment.rs
+++ b/lemmy_apub/src/objects/comment.rs
@@ -6,6 +6,7 @@ use crate::{
     get_or_fetch_and_upsert_user,
   },
   objects::{
+    apub_id_is_local,
     check_object_domain,
     create_tombstone,
     get_source_markdown_value,
@@ -147,7 +148,7 @@ impl FromApub for CommentForm {
       updated: note.updated().map(|u| u.to_owned().naive_local()),
       deleted: None,
       ap_id: Some(check_object_domain(note, expected_domain)?),
-      local: false,
+      local: apub_id_is_local(&&note.id_unchecked().context(location_info!())?)?,
     })
   }
 }

--- a/lemmy_apub/src/objects/community.rs
+++ b/lemmy_apub/src/objects/community.rs
@@ -2,6 +2,7 @@ use crate::{
   extensions::{context::lemmy_context, group_extensions::GroupExtension},
   fetcher::get_or_fetch_and_upsert_user,
   objects::{
+    apub_id_is_local,
     check_object_domain,
     create_tombstone,
     get_source_markdown_value,
@@ -186,7 +187,7 @@ impl FromApub for CommunityForm {
       deleted: None,
       nsfw: group.ext_one.sensitive,
       actor_id: Some(check_object_domain(group, expected_domain)?),
-      local: false,
+      local: apub_id_is_local(&&group.id_unchecked().context(location_info!())?)?,
       private_key: None,
       public_key: Some(group.ext_two.to_owned().public_key.public_key_pem),
       last_refreshed_at: Some(naive_now()),

--- a/lemmy_apub/src/objects/mod.rs
+++ b/lemmy_apub/src/objects/mod.rs
@@ -7,7 +7,7 @@ use activitystreams::{
 };
 use anyhow::{anyhow, Context};
 use chrono::NaiveDateTime;
-use lemmy_utils::{location_info, utils::convert_datetime, LemmyError};
+use lemmy_utils::{location_info, settings::Settings, utils::convert_datetime, LemmyError};
 use url::Url;
 
 pub(crate) mod comment;
@@ -126,4 +126,20 @@ pub(in crate::objects) fn check_is_markdown(mime: Option<&Mime>) -> Result<(), L
   } else {
     Ok(())
   }
+}
+
+/// Checks if the apub id is local
+pub(in crate::objects) fn apub_id_is_local(apub_id: &Url) -> Result<bool, LemmyError> {
+  let settings = Settings::get();
+  let local_instance = settings
+    .hostname
+    .split(':')
+    .collect::<Vec<&str>>()
+    .first()
+    .context(location_info!())?
+    .to_string();
+
+  let domain = apub_id.domain().context(location_info!())?.to_string();
+
+  Ok(domain == local_instance)
 }

--- a/lemmy_apub/src/objects/post.rs
+++ b/lemmy_apub/src/objects/post.rs
@@ -2,6 +2,7 @@ use crate::{
   extensions::{context::lemmy_context, page_extension::PageExtension},
   fetcher::{get_or_fetch_and_upsert_community, get_or_fetch_and_upsert_user},
   objects::{
+    apub_id_is_local,
     check_object_domain,
     create_tombstone,
     get_source_markdown_value,
@@ -208,7 +209,7 @@ impl FromApub for PostForm {
       embed_html: iframely_html,
       thumbnail_url: pictrs_thumbnail,
       ap_id: Some(check_object_domain(page, expected_domain)?),
-      local: false,
+      local: apub_id_is_local(&&page.id_unchecked().context(location_info!())?)?,
     })
   }
 }

--- a/lemmy_apub/src/objects/private_message.rs
+++ b/lemmy_apub/src/objects/private_message.rs
@@ -3,6 +3,7 @@ use crate::{
   extensions::context::lemmy_context,
   fetcher::get_or_fetch_and_upsert_user,
   objects::{
+    apub_id_is_local,
     check_object_domain,
     create_tombstone,
     get_source_markdown_value,
@@ -102,7 +103,7 @@ impl FromApub for PrivateMessageForm {
       deleted: None,
       read: None,
       ap_id: Some(check_object_domain(note, expected_domain)?),
-      local: false,
+      local: apub_id_is_local(&&note.id_unchecked().context(location_info!())?)?,
     })
   }
 }

--- a/lemmy_apub/src/objects/user.rs
+++ b/lemmy_apub/src/objects/user.rs
@@ -1,6 +1,11 @@
 use crate::{
   extensions::context::lemmy_context,
-  objects::{check_object_domain, get_source_markdown_value, set_content_and_source},
+  objects::{
+    apub_id_is_local,
+    check_object_domain,
+    get_source_markdown_value,
+    set_content_and_source,
+  },
   ActorType,
   FromApub,
   PersonExt,
@@ -154,7 +159,7 @@ impl FromApub for UserForm {
       matrix_user_id: None,
       actor_id: Some(check_object_domain(person, expected_domain)?),
       bio: Some(bio),
-      local: false,
+      local: apub_id_is_local(&&person.id_unchecked().context(location_info!())?)?,
       private_key: None,
       public_key: Some(person.ext_one.public_key.to_owned().public_key_pem),
       last_refreshed_at: Some(naive_now()),

--- a/lemmy_db/src/user.rs
+++ b/lemmy_db/src/user.rs
@@ -265,6 +265,7 @@ mod tests {
       private_key: None,
       public_key: None,
       last_refreshed_at: inserted_user.published,
+      deleted: false,
     };
 
     let read_user = User_::read(&conn, inserted_user.id).unwrap();


### PR DESCRIPTION
Setting the local at the `from_apub` object level is much better than adding apub logic to the db folder.