### PR TITLE
fixed screenshot paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 Front Page|Post
 ---|---
-![main screen](https://raw.githubusercontent.com/LemmyNet/lemmy/main/docs/img/main_screen.png)|![chat screen](https://raw.githubusercontent.com/LemmyNet/lemmy/main/docs/img/chat_screen.png)
+![main screen](./docs/img/main_screen.png)|![chat screen](./docs/img/chat_screen.png)
 
 [Lemmy](https://github.com/LemmyNet/lemmy) is similar to sites like [Reddit](https://reddit.com), [Lobste.rs](https://lobste.rs), or [Hacker News](https://news.ycombinator.com/): you subscribe to forums you're interested in, post links and discussions, then vote, and comment on them. Behind the scenes, it is very different; anyone can easily run a server, and all these servers are federated (think email), and connected to the same universe, called the [Fediverse](https://en.wikipedia.org/wiki/Fediverse).
 


### PR DESCRIPTION
They aren't showing, as the links point to nothing. This makes them use relative links, which work.

Before this PR:
![grafik](https://user-images.githubusercontent.com/19350749/104776979-39f6c680-577b-11eb-83d0-c7b699d5bd56.png)
