### PR TITLE
Ignore other test which causes stack overflow

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -173,7 +173,7 @@ fn create_http_request() -> HttpRequest {
     .to_http_request()
 }
 
-// TODO: this fails with a stack overflow for some reason
+// This fails with a mysterious stack overflow - see #1449
 #[actix_rt::test]
 #[ignore]
 async fn test_shared_inbox_expired_signature() {
@@ -191,7 +191,9 @@ async fn test_shared_inbox_expired_signature() {
   User_::delete(connection, user.id).unwrap();
 }
 
+// This fails with a mysterious stack overflow - see #1449
 #[actix_rt::test]
+#[ignore]
 async fn test_user_inbox_expired_signature() {
   let request = create_http_request();
   let context = create_context();


### PR DESCRIPTION
Like the previously-identified `test_shared_inbox_expired_signature`,
`test_user_inbox_expired_signature` also causes a stack overflow
in my environment. This change disables that test as well, and updates
the comments on both to point to the tracking issue I opened at #1449.