### PR TITLE
Fix docker build hang from IPv6 / Alpine issues

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -47,10 +47,14 @@ RUN cp ./target/$CARGO_BUILD_TARGET/$RUSTRELEASEDIR/lemmy_server /app/lemmy_serv
 FROM alpine:3.12 as lemmy
 
 # Install libpq for postgres
-RUN apk add libpq
+# DNS overrides are needed to work around IPv6 issues in some environments
+# see https://github.com/gliderlabs/docker-alpine/issues/307
+RUN printf "nameserver 208.67.222.222\nnameserver 8.8.4.4\nnameserver 1.1.1.1\nnameserver 9.9.9.9\nnameserver 8.8.8"> /etc/resolv.conf \
+      && apk add libpq
 
 # Install Espeak for captchas
-RUN apk add espeak
+RUN printf "nameserver 208.67.222.222\nnameserver 8.8.4.4\nnameserver 1.1.1.1\nnameserver 9.9.9.9\nnameserver 8.8.8"> /etc/resolv.conf \
+      && apk add espeak
 
 RUN addgroup -g 1000 lemmy
 RUN adduser -D -s /bin/sh -u 1000 -G lemmy lemmy


### PR DESCRIPTION
In my environment (Arch Linux using docker installed with pacman),
the `docker_update.sh` script hung when querying the APK repos.
Some digging around revealed this is some IPv6-related issue others
have encountered - https://github.com/moby/moby/issues/20569

This change works around the issue by overriding the DNS config
on the `apk add` steps, fixing the issue on my machine.