### PR TITLE
bump memory limit of iframely

### DIFF
--- a/docker/prod/docker-compose.yml
+++ b/docker/prod/docker-compose.yml
@@ -53,4 +53,4 @@ services:
     volumes:
       - ./iframely.config.local.js:/iframely/config.local.js:ro
     restart: always
-    mem_limit: 100m
+    mem_limit: 200m


### PR DESCRIPTION
Fixes #1476

On some systems, the 100m memory ceiling for iframely isn't enough, causing the process to die and restart endlessly (this was tested on my local computer, a 2018 Intel 6-Core MacBook Pro running macOS 11.2.1)

## Steps to reproduce:

Run this command (replacing `$LEMMY_DIR` with the absolute path to the folder container the iframely config files).

```
docker run --rm --name iframely --volume "$LEMMY_DIR/iframely.config.local.js:/iframely/config.local.js:ro" -p 127.0.0.1:8061:80 -m 100m dogbin/iframely:latest
```

On my machine, you see the process constantly rebooting. This may not occur for all systems because iframely creates one worker process for each CPU core on your machine. More CPU cores means more parallel processes, which consume more memory.