### PR TITLE
revert Compose file version from 3.3 to 2.2

### DIFF
--- a/ansible/templates/docker-compose.yml
+++ b/ansible/templates/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: '2.2'
 
 services:
   lemmy:


### PR DESCRIPTION
Version 3.3 is intended for use with Docker Swarm, which is not used here and does not support config option 'mem_limit'. Instead, use Docker Compose version 2.x.