### PR TITLE
Make Ansible overwrite Lemmy config (fixes #1549)

### DIFF
--- a/ansible/lemmy.yml
+++ b/ansible/lemmy.yml
@@ -83,12 +83,11 @@
         pictshare_port: "8537"
         iframely_port: "8538"
 
-    - name:  add config file (only during initial setup)
+    - name:  add config file
       template:
         src: 'templates/config.hjson'
         dest: '{{lemmy_base_dir}}/lemmy.hjson'
         mode: '0600'
-        force: false
         owner: '1000'
         group: '1000'
     vars:

--- a/ansible/templates/config.hjson
+++ b/ansible/templates/config.hjson
@@ -1,6 +1,8 @@
 {
-  # for more info about the config, check out the documentation
+  # For more info about the config, check out the documentation
   # https://join.lemmy.ml/docs/en/administration/configuration.html
+  #
+  # Do not change this file on the server, as rerunning Ansible will overwrite it
 
   # settings related to the postgresql database
   database: {


### PR DESCRIPTION
Do not merge this yet, as most people use Ansible from the main branch, they would accidentally use this version and wipe their config changes on the server. Best only merge it immediately before releasing v0.11.0, and mention it in the changelog.

@the-digital-anarchist You can pull from this branch to try the changed Ansible playbook.