### PR TITLE
Make some of the database config values optional (fixes #1550)

### DIFF
--- a/crates/utils/src/settings/defaults.rs
+++ b/crates/utils/src/settings/defaults.rs
@@ -21,15 +21,20 @@ impl Default for Settings {
   }
 }
 
+pub(in crate::settings) static DEFAULT_DATABASE_USER: &str = "lemmy";
+pub(in crate::settings) static DEFAULT_DATABASE_PORT: i32 = 5432;
+pub(in crate::settings) static DEFAULT_DATABASE_DB: &str = "lemmy";
+pub static DEFAULT_DATABASE_POOL_SIZE: u32 = 5;
+
 impl Default for DatabaseConfig {
   fn default() -> Self {
     Self {
-      user: "lemmy".into(),
+      user: Some(DEFAULT_DATABASE_USER.to_string()),
       password: "password".into(),
       host: "localhost".into(),
-      port: 5432,
-      database: "lemmy".into(),
-      pool_size: 5,
+      port: Some(DEFAULT_DATABASE_PORT),
+      database: Some(DEFAULT_DATABASE_DB.to_string()),
+      pool_size: Some(DEFAULT_DATABASE_POOL_SIZE),
     }
   }
 }

--- a/crates/utils/src/settings/mod.rs
+++ b/crates/utils/src/settings/mod.rs
@@ -1,13 +1,16 @@
 use crate::{
   location_info,
-  settings::structs::{
-    CaptchaConfig,
-    DatabaseConfig,
-    EmailConfig,
-    FederationConfig,
-    RateLimitConfig,
-    Settings,
-    SetupConfig,
+  settings::{
+    defaults::{DEFAULT_DATABASE_DB, DEFAULT_DATABASE_PORT, DEFAULT_DATABASE_USER},
+    structs::{
+      CaptchaConfig,
+      DatabaseConfig,
+      EmailConfig,
+      FederationConfig,
+      RateLimitConfig,
+      Settings,
+      SetupConfig,
+    },
   },
   LemmyError,
 };
@@ -16,7 +19,7 @@ use deser_hjson::from_str;
 use merge::Merge;
 use std::{env, fs, io::Error, net::IpAddr, sync::RwLock};
 
-pub(crate) mod defaults;
+pub mod defaults;
 pub mod structs;
 
 static CONFIG_FILE: &str = "config/config.hjson";
@@ -60,7 +63,15 @@ impl Settings {
     let conf = self.database();
     format!(
       "postgres://{}:{}@{}:{}/{}",
-      conf.user, conf.password, conf.host, conf.port, conf.database,
+      conf
+        .user
+        .unwrap_or_else(|| DEFAULT_DATABASE_USER.to_string()),
+      conf.password,
+      conf.host,
+      conf.port.unwrap_or(DEFAULT_DATABASE_PORT),
+      conf
+        .database
+        .unwrap_or_else(|| DEFAULT_DATABASE_DB.to_string()),
     )
   }
 

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -27,12 +27,12 @@ pub struct CaptchaConfig {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct DatabaseConfig {
-  pub user: String,
+  pub user: Option<String>,
   pub password: String,
   pub host: String,
-  pub port: i32,
-  pub database: String,
-  pub pool_size: u32,
+  pub port: Option<i32>,
+  pub database: Option<String>,
+  pub pool_size: Option<u32>,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/docker/dev/docker_update_volume_mount.sh
+++ b/docker/dev/docker_update_volume_mount.sh
@@ -8,4 +8,4 @@ set -e
 mkdir -p volumes/pictrs
 sudo chown -R 991:991 volumes/pictrs
 sudo docker build ../../ --file ../dev/volume_mount.dockerfile -t lemmy-dev:latest
-sudo docker-compose up -d
+sudo docker-compose up

--- a/docker/dev/volume_mount.dockerfile
+++ b/docker/dev/volume_mount.dockerfile
@@ -24,7 +24,6 @@ RUN apt-get update -y
 RUN apt-get install -y libpq-dev espeak 
 
 # Copy resources
-COPY config/defaults.hjson /config/defaults.hjson
 COPY --from=rust /app/lemmy_server /app/lemmy
 
 EXPOSE 8536

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use lemmy_routes::{feeds, images, nodeinfo, webfinger};
 use lemmy_server::{api_routes, code_migrations::run_advanced_migrations, scheduled_tasks};
 use lemmy_utils::{
   rate_limit::{rate_limiter::RateLimiter, RateLimit},
-  settings::structs::Settings,
+  settings::{defaults::DEFAULT_DATABASE_POOL_SIZE, structs::Settings},
   LemmyError,
 };
 use lemmy_websocket::{chat_server::ChatServer, LemmyContext};
@@ -38,7 +38,12 @@ async fn main() -> Result<(), LemmyError> {
   };
   let manager = ConnectionManager::<PgConnection>::new(&db_url);
   let pool = Pool::builder()
-    .max_size(settings.database().pool_size)
+    .max_size(
+      settings
+        .database()
+        .pool_size
+        .unwrap_or(DEFAULT_DATABASE_POOL_SIZE),
+    )
     .build(manager)
     .unwrap_or_else(|_| panic!("Error connecting to {}", db_url));
 


### PR DESCRIPTION
Tested locally that Lemmy starts fine after these changes, with the default config we use for Ansible.

This should be backported to the v0.10 branch to fix Ansible installations.