### PR TITLE
For untagged commits, include hash in version name (fixes #1563)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,5 +4,4 @@ docker
 api_tests
 ansible
 tests
-.git
 *.sh

--- a/crates/utils/src/version.rs
+++ b/crates/utils/src/version.rs
@@ -1,1 +1,1 @@
-pub const VERSION: &str = "0.10.3";
+pub const VERSION: &str = "unknown version";

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -36,6 +36,7 @@ COPY --from=cacher /home/rust/.cargo /home/rust/.cargo
 COPY ./ ./
 
 RUN sudo chown -R rust:rust .
+RUN echo "pub const VERSION: &str = \"$(git describe --tag)\";" > "crates/utils/src/version.rs"
 RUN cargo build
 
 # reduce binary size

--- a/docker/dev/volume_mount.dockerfile
+++ b/docker/dev/volume_mount.dockerfile
@@ -9,6 +9,7 @@ WORKDIR /app
 
 # Copy the source folders
 COPY . ./
+RUN echo "pub const VERSION: &str = \"$(git describe --tag)\";" > "crates/utils/src/version.rs"
 
 # Build for debug
 RUN --mount=type=cache,target=/usr/local/cargo/registry \

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /app
 COPY ./ ./
 
 RUN sudo chown -R rust:rust .
+RUN echo "pub const VERSION: &str = \"$(git describe --tag)\";" > "crates/utils/src/version.rs"
 RUN cargo build --release
 
 # reduce binary size

--- a/docker/prod/Dockerfile.arm
+++ b/docker/prod/Dockerfile.arm
@@ -11,6 +11,7 @@ RUN apt-get update \
 WORKDIR /app
 
 COPY ./ ./
+RUN echo "pub const VERSION: &str = \"$(git describe --tag)\";" > "crates/utils/src/version.rs"
 
 RUN cargo build --release
 

--- a/docker/prod/deploy.sh
+++ b/docker/prod/deploy.sh
@@ -6,12 +6,6 @@ set -e
 new_tag="$1"
 third_semver=$(echo $new_tag | cut -d "." -f 3)
 
-# Setting the version on the backend
-pushd ../../
-echo "pub const VERSION: &str = \"$new_tag\";" > "crates/utils/src/version.rs"
-git add "crates/utils/src/version.rs"
-popd
-
 # The ansible and docker installs should only update for non release-candidates
 # IE, when the third semver is a number, not '2-rc'
 if [ ! -z "${third_semver##*[!0-9]*}" ]; then


### PR DESCRIPTION
We can simply write the version name as part of the Docker build, instead of doing it during the release. One disadvantage of this approach is that builds made without Docker wont have a version name (unless it is manually set), but anyway we dont support that.

We should do the same for lemmy-ui, and if the versions for frontend and backend differ, show both of them.

This is how it looks now:

![Screenshot_20210412_135636](https://user-images.githubusercontent.com/1044450/114390751-2d211d80-9b86-11eb-92d4-7b62c91ceeea.jpg)
