### PR TITLE
Remote mods can update/delete/undelete communities

### DIFF
--- a/crates/api_crud/src/community/delete.rs
+++ b/crates/api_crud/src/community/delete.rs
@@ -52,9 +52,13 @@ impl PerformCrud for DeleteCommunity {
 
     // Send apub messages
     if deleted {
-      updated_community.send_delete(context).await?;
+      updated_community
+        .send_delete(local_user_view.person.to_owned(), context)
+        .await?;
     } else {
-      updated_community.send_undo_delete(context).await?;
+      updated_community
+        .send_undo_delete(local_user_view.person.to_owned(), context)
+        .await?;
     }
 
     let community_id = data.community_id;

--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -2,11 +2,11 @@ use crate::{
   check_is_apub_id_valid,
   extensions::{context::lemmy_context, page_extension::PageExtension},
   fetcher::person::get_or_fetch_and_upsert_person,
+  get_community_from_to_or_cc,
   objects::{
     check_object_domain,
     check_object_for_community_or_site_ban,
     create_tombstone,
-    get_community_from_to_or_cc,
     get_object_from_apub,
     get_source_markdown_value,
     set_content_and_source,

--- a/crates/apub_receive/src/activities/receive/community.rs
+++ b/crates/apub_receive/src/activities/receive/community.rs
@@ -1,9 +1,85 @@
+use crate::{
+  activities::receive::get_actor_as_person,
+  inbox::receive_for_community::verify_actor_is_community_mod,
+};
+use activitystreams::{
+  activity::{ActorAndObjectRefExt, Delete, Undo, Update},
+  base::ExtendsExt,
+};
+use anyhow::{anyhow, Context};
 use lemmy_api_common::{blocking, community::CommunityResponse};
-use lemmy_db_queries::source::community::Community_;
-use lemmy_db_schema::source::community::Community;
-use lemmy_db_views_actor::community_view::CommunityView;
-use lemmy_utils::LemmyError;
+use lemmy_apub::{
+  get_community_from_to_or_cc,
+  objects::FromApubToForm,
+  ActorType,
+  CommunityType,
+  GroupExt,
+};
+use lemmy_db_queries::{source::community::Community_, Crud};
+use lemmy_db_schema::source::{
+  community::{Community, CommunityForm},
+  person::Person,
+};
+use lemmy_db_views_actor::{
+  community_moderator_view::CommunityModeratorView,
+  community_view::CommunityView,
+};
+use lemmy_utils::{location_info, LemmyError};
 use lemmy_websocket::{messages::SendCommunityRoomMessage, LemmyContext, UserOperationCrud};
+
+/// This activity is received from a remote community mod, and updates the description or other
+/// fields of a local community.
+pub(crate) async fn receive_remote_mod_update_community(
+  update: Update,
+  context: &LemmyContext,
+  request_counter: &mut i32,
+) -> Result<(), LemmyError> {
+  let community = get_community_from_to_or_cc(&update, context, request_counter).await?;
+  verify_actor_is_community_mod(&update, &community, context).await?;
+  let group = GroupExt::from_any_base(update.object().to_owned().one().context(location_info!())?)?
+    .context(location_info!())?;
+  let updated_community = CommunityForm::from_apub(
+    &group,
+    context,
+    community.actor_id(),
+    request_counter,
+    false,
+  )
+  .await?;
+  let cf = CommunityForm {
+    name: updated_community.name,
+    title: updated_community.title,
+    description: updated_community.description,
+    nsfw: updated_community.nsfw,
+    // TODO: icon and banner would be hosted on the other instance, ideally we would copy it to ours
+    icon: updated_community.icon,
+    banner: updated_community.banner,
+    ..CommunityForm::default()
+  };
+  blocking(context.pool(), move |conn| {
+    Community::update(conn, community.id, &cf)
+  })
+  .await??;
+
+  Ok(())
+}
+
+pub(crate) async fn receive_remote_mod_delete_community(
+  delete: Delete,
+  community: Community,
+  context: &LemmyContext,
+  request_counter: &mut i32,
+) -> Result<(), LemmyError> {
+  verify_actor_is_community_mod(&delete, &community, context).await?;
+  let actor = get_actor_as_person(&delete, context, request_counter).await?;
+  verify_is_remote_community_creator(&actor, &community, context).await?;
+  let community_id = community.id;
+  blocking(context.pool(), move |conn| {
+    Community::update_deleted(conn, community_id, true)
+  })
+  .await??;
+  community.send_delete(actor, context).await
+}
 
 pub(crate) async fn receive_delete_community(
   context: &LemmyContext,
@@ -61,6 +137,23 @@ pub(crate) async fn receive_remove_community(
   Ok(())
 }
 
+pub(crate) async fn receive_remote_mod_undo_delete_community(
+  undo: Undo,
+  community: Community,
+  context: &LemmyContext,
+  request_counter: &mut i32,
+) -> Result<(), LemmyError> {
+  verify_actor_is_community_mod(&undo, &community, context).await?;
+  let actor = get_actor_as_person(&undo, context, request_counter).await?;
+  verify_is_remote_community_creator(&actor, &community, context).await?;
+  let community_id = community.id;
+  blocking(context.pool(), move |conn| {
+    Community::update_deleted(conn, community_id, false)
+  })
+  .await??;
+  community.send_undo_delete(actor, context).await
+}
+
 pub(crate) async fn receive_undo_delete_community(
   context: &LemmyContext,
   community: Community,
@@ -116,4 +209,24 @@ pub(crate) async fn receive_undo_remove_community(
   });
 
   Ok(())
+}
+
+/// Checks if the remote user is creator of the local community. This can only happen if a community
+/// is created by a local user, and then transferred to a remote user.
+async fn verify_is_remote_community_creator(
+  user: &Person,
+  community: &Community,
+  context: &LemmyContext,
+) -> Result<(), LemmyError> {
+  let community_id = community.id;
+  let community_mods = blocking(context.pool(), move |conn| {
+    CommunityModeratorView::for_community(conn, community_id)
+  })
+  .await??;
+
+  if user.id != community_mods[0].moderator.id {
+    Err(anyhow!("Actor is not community creator").into())
+  } else {
+    Ok(())
+  }
 }

--- a/crates/apub_receive/src/inbox/receive_for_community.rs
+++ b/crates/apub_receive/src/inbox/receive_for_community.rs
@@ -14,6 +14,11 @@ use crate::{
       receive_undo_like_comment,
       receive_undo_remove_comment,
     },
+    community::{
+      receive_remote_mod_delete_community,
+      receive_remote_mod_undo_delete_community,
+      receive_remote_mod_update_community,
+    },
     post::{
       receive_create_post,
       receive_delete_post,
@@ -60,9 +65,12 @@ use lemmy_apub::{
     objects::{get_or_fetch_and_insert_comment, get_or_fetch_and_insert_post},
     person::get_or_fetch_and_upsert_person,
   },
+  find_object_by_id,
   find_post_or_comment_by_id,
   generate_moderators_url,
+  ActorType,
   CommunityType,
+  Object,
   PostOrComment,
 };
 use lemmy_db_queries::{
@@ -101,6 +109,14 @@ enum PageOrNote {
   Note,
 }
 
+#[derive(EnumString)]
+enum ObjectTypes {
+  Page,
+  Note,
+  Group,
+  Person,
+}
+
 /// This file is for post/comment activities received by the community, and for post/comment
 ///       activities announced by the community and received by the person.
 
@@ -120,8 +136,8 @@ pub(in crate::inbox) async fn receive_create_for_community(
     .as_single_kind_str()
     .and_then(|s| s.parse().ok());
   match kind {
-    Some(PageOrNote::Page) => receive_create_post(create, context, request_counter).await,
-    Some(PageOrNote::Note) => receive_create_comment(create, context, request_counter).await,
+    Some(ObjectTypes::Page) => receive_create_post(create, context, request_counter).await,
+    Some(ObjectTypes::Note) => receive_create_comment(create, context, request_counter).await,
     _ => receive_unhandled_activity(create),
   }
 }
@@ -134,7 +150,7 @@ pub(in crate::inbox) async fn receive_update_for_community(
   expected_domain: &Url,
   request_counter: &mut i32,
 ) -> Result<(), LemmyError> {
-  let update = Update::from_any_base(activity)?.context(location_info!())?;
+  let update = Update::from_any_base(activity.to_owned())?.context(location_info!())?;
   verify_activity_domains_valid(&update, &expected_domain, false)?;
   verify_is_addressed_to_public(&update)?;
   verify_modification_actor_instance(&update, &announce, context, request_counter).await?;
@@ -144,8 +160,13 @@ pub(in crate::inbox) async fn receive_update_for_community(
     .as_single_kind_str()
     .and_then(|s| s.parse().ok());
   match kind {
-    Some(PageOrNote::Page) => receive_update_post(update, announce, context, request_counter).await,
-    Some(PageOrNote::Note) => receive_update_comment(update, context, request_counter).await,
+    Some(ObjectTypes::Page) => {
+      receive_update_post(update, announce, context, request_counter).await
+    }
+    Some(ObjectTypes::Note) => receive_update_comment(update, context, request_counter).await,
+    Some(ObjectTypes::Group) => {
+      receive_remote_mod_update_community(update, context, request_counter).await
+    }
     _ => receive_unhandled_activity(update),
   }
 }
@@ -215,7 +236,7 @@ pub(in crate::inbox) async fn receive_delete_for_community(
   request_counter: &mut i32,
 ) -> Result<(), LemmyError> {
   let delete = Delete::from_any_base(activity)?.context(location_info!())?;
-  verify_activity_domains_valid(&delete, &expected_domain, true)?;
+  // TODO: skip this check if action is done by remote mod
   verify_is_addressed_to_public(&delete)?;
   verify_modification_actor_instance(&delete, &announce, context, request_counter).await?;
 
@@ -225,11 +246,20 @@ pub(in crate::inbox) async fn receive_delete_for_community(
     .single_xsd_any_uri()
     .context(location_info!())?;
 
-  match find_post_or_comment_by_id(context, object).await {
-    Ok(PostOrComment::Post(p)) => receive_delete_post(context, *p).await,
-    Ok(PostOrComment::Comment(c)) => receive_delete_comment(context, *c).await,
-    // if we dont have the object, no need to do anything
-    Err(_) => Ok(()),
+  match find_object_by_id(context, object).await {
+    Ok(Object::Post(p)) => {
+      verify_activity_domains_valid(&delete, &expected_domain, true)?;
+      receive_delete_post(context, *p).await
+    }
+    Ok(Object::Comment(c)) => {
+      verify_activity_domains_valid(&delete, &expected_domain, true)?;
+      receive_delete_comment(context, *c).await
+    }
+    Ok(Object::Community(c)) => {
+      receive_remote_mod_delete_community(delete, *c, context, request_counter).await
+    }
+    // if we dont have the object or dont support its deletion, no need to do anything
+    _ => Ok(()),
   }
 }
 
@@ -314,7 +344,9 @@ pub(in crate::inbox) async fn receive_undo_for_community(
     .as_single_kind_str()
     .and_then(|s| s.parse().ok())
   {
-    Some(Delete) => receive_undo_delete_for_community(context, undo, expected_domain).await,
+    Some(Delete) => {
+      receive_undo_delete_for_community(context, undo, expected_domain, request_counter).await
+    }
     Some(Remove) => {
       receive_undo_remove_for_community(context, undo, announce, expected_domain).await
     }
@@ -338,15 +370,15 @@ pub(in crate::inbox) async fn receive_undo_for_community(
   }
 }
 
-/// A post or comment deletion being reverted
+/// A post, comment or community deletion being reverted
 pub(in crate::inbox) async fn receive_undo_delete_for_community(
   context: &LemmyContext,
   undo: Undo,
   expected_domain: &Url,
+  request_counter: &mut i32,
 ) -> Result<(), LemmyError> {
   let delete = Delete::from_any_base(undo.object().to_owned().one().context(location_info!())?)?
     .context(location_info!())?;
-  verify_activity_domains_valid(&delete, &expected_domain, true)?;
   verify_is_addressed_to_public(&delete)?;
 
   let object = delete
@@ -354,11 +386,21 @@ pub(in crate::inbox) async fn receive_undo_delete_for_community(
     .to_owned()
     .single_xsd_any_uri()
     .context(location_info!())?;
-  match find_post_or_comment_by_id(context, object).await {
-    Ok(PostOrComment::Post(p)) => receive_undo_delete_post(context, *p).await,
-    Ok(PostOrComment::Comment(c)) => receive_undo_delete_comment(context, *c).await,
-    // if we dont have the object, no need to do anything
-    Err(_) => Ok(()),
+  match find_object_by_id(context, object).await {
+    Ok(Object::Post(p)) => {
+      verify_activity_domains_valid(&delete, &expected_domain, true)?;
+      receive_undo_delete_post(context, *p).await
+    }
+    Ok(Object::Comment(c)) => {
+      verify_activity_domains_valid(&delete, &expected_domain, true)?;
+      receive_undo_delete_comment(context, *c).await
+    }
+    Ok(Object::Community(c)) => {
+      verify_actor_is_community_mod(&undo, &c, context).await?;
+      receive_remote_mod_undo_delete_community(undo, *c, context, request_counter).await
+    }
+    // if we dont have the object or dont support its deletion, no need to do anything
+    _ => Ok(()),
   }
 }
 
@@ -617,7 +659,7 @@ where
 ///
 /// This method should only be used for activities received by the community, not for activities
 /// used by community followers.
-async fn verify_actor_is_community_mod<T, Kind>(
+pub(crate) async fn verify_actor_is_community_mod<T, Kind>(
   activity: &T,
   community: &Community,
   context: &LemmyContext,
@@ -722,9 +764,18 @@ where
     .map(|o| o.id())
     .flatten()
     .context(location_info!())?;
-  let original_id = match fetch_post_or_comment_by_id(object_id, context, request_counter).await? {
-    PostOrComment::Post(p) => p.ap_id.into_inner(),
-    PostOrComment::Comment(c) => c.ap_id.into_inner(),
+  let original_id = match fetch_post_or_comment_by_id(object_id, context, request_counter).await {
+    Ok(PostOrComment::Post(p)) => p.ap_id.into_inner(),
+    Ok(PostOrComment::Comment(c)) => c.ap_id.into_inner(),
+    Err(_) => {
+      // We can also receive Update activity from remote mod for local activity
+      let object_id = object_id.to_owned().into();
+      blocking(context.pool(), move |conn| {
+        Community::read_from_apub_id(conn, &object_id)
+      })
+      .await??
+      .actor_id()
+    }
   };
   if actor_id.domain() != original_id.domain() {
     let community = extract_community_from_cc(activity, context).await?;


### PR DESCRIPTION
Works as expected in my testing. This doesnt change any existing behaviour, only adds new functionality so it should be fully backwards compatible, and could be released as part of v0.10.x. But it might be better to leave it for v0.11, to give time for more thorough testing.

This works as following:
- Update: remote mod sends `Update/Community` activity to community, community receives and verifies, updates the community in database, other instances will refetch it (so the community itself doesnt send any Update activity
- Delete: remote mod sends `Delete/Community` to community, community receives and verifies, deletes itself and sends a newly generated `Delete/Community` activity (this is identical to the activity that is sent in the current Lemmy version)
- Undelete: same as delete
- Remove and Unremove: unchanged, as it can only be triggered by admins on the same instance as community

Instead of the above behaviour, it would also be possible to treat Delete/Community and other activities equivalently to Delete/Post etc, by having the community simply announce the user activity. That might be more logical, and would mean that the community only sends activity types Announce and Follow, nothing else. It would require a breaking change though.

I also need to update the federation docs for this.