### PR TITLE
Add option to disable strict allowlist (fixes #1486)

### DIFF
--- a/config/config.hjson
+++ b/config/config.hjson
@@ -66,10 +66,13 @@
     # https://join.lemmy.ml/docs/en/federation/administration.html#instance-allowlist-and-blocklist
     #
     # comma separated list of instances with which federation is allowed
-    # Only one of these blocks should be uncommented
     # allowed_instances: ["instance1.tld","instance2.tld"]
     # comma separated list of instances which are blocked from federating
     # blocked_instances: []
+    # By default, the instance allowlist only applies for federating remote communities, and for
+    # posts/comments made in local communities. If you also want the allowlist to filter
+    # posts/comments in remote instance, set this to true.
+    # strict_allowlist: false
   }
   captcha: {
     enabled: true

--- a/config/config.hjson
+++ b/config/config.hjson
@@ -65,14 +65,13 @@
     # Allows and blocks are described here:
     # https://join.lemmy.ml/docs/en/federation/administration.html#instance-allowlist-and-blocklist
     #
-    # comma separated list of instances with which federation is allowed
+    # list of instances with which federation is allowed
     # allowed_instances: ["instance1.tld","instance2.tld"]
-    # comma separated list of instances which are blocked from federating
+    # instances which we never federate anything with (but previously federated objects are unaffected)
     # blocked_instances: []
-    # By default, the instance allowlist only applies for federating remote communities, and for
-    # posts/comments made in local communities. If you also want the allowlist to filter
-    # posts/comments in remote instance, set this to true.
-    # strict_allowlist: false
+    # If true, only federate with instances on the allowlist and block everything else. If false,
+    # use allowlist only for remote communities, and posts/comments in local communities.
+    # strict_allowlist: true
   }
   captcha: {
     enabled: true

--- a/crates/apub/src/activities/send/community.rs
+++ b/crates/apub/src/activities/send/community.rs
@@ -290,7 +290,7 @@ impl CommunityType for Community {
       .map(|i| i.into_inner())
       .unique()
       // Don't send to blocked instances
-      .filter(|inbox| check_is_apub_id_valid(inbox).is_ok())
+      .filter(|inbox| check_is_apub_id_valid(inbox, false).is_ok())
       .collect();
 
     Ok(inboxes)

--- a/crates/apub/src/activity_queue.rs
+++ b/crates/apub/src/activity_queue.rs
@@ -46,7 +46,7 @@ where
   Kind: Serialize,
   <T as Extends<Kind>>::Error: From<serde_json::Error> + Send + Sync + 'static,
 {
-  if check_is_apub_id_valid(&inbox).is_ok() {
+  if check_is_apub_id_valid(&inbox, false).is_ok() {
     debug!(
       "Sending activity {:?} to {}",
       &activity.id_unchecked(),
@@ -83,7 +83,7 @@ where
   .flatten()
   .unique()
   .filter(|inbox| inbox.host_str() != Some(&Settings::get().hostname()))
-  .filter(|inbox| check_is_apub_id_valid(inbox).is_ok())
+  .filter(|inbox| check_is_apub_id_valid(inbox, false).is_ok())
   .map(|inbox| inbox.to_owned())
   .collect();
   debug!(
@@ -124,7 +124,7 @@ where
       .await?;
   } else {
     let inbox = community.get_shared_inbox_or_inbox_url();
-    check_is_apub_id_valid(&inbox)?;
+    check_is_apub_id_valid(&inbox, false)?;
     debug!(
       "Sending activity {:?} to community {}",
       &activity.id_unchecked(),
@@ -160,7 +160,7 @@ where
   );
   let mentions = mentions
     .iter()
-    .filter(|inbox| check_is_apub_id_valid(inbox).is_ok())
+    .filter(|inbox| check_is_apub_id_valid(inbox, false).is_ok())
     .map(|i| i.to_owned())
     .collect();
   send_activity_internal(

--- a/crates/apub/src/fetcher/fetch.rs
+++ b/crates/apub/src/fetcher/fetch.rs
@@ -59,7 +59,7 @@ where
   if *recursion_counter > MAX_REQUEST_NUMBER {
     return Err(LemmyError::from(anyhow!("Maximum recursion depth reached")).into());
   }
-  check_is_apub_id_valid(&url)?;
+  check_is_apub_id_valid(&url, false)?;
 
   let timeout = Duration::from_secs(60);
 

--- a/crates/apub/src/objects/comment.rs
+++ b/crates/apub/src/objects/comment.rs
@@ -1,6 +1,7 @@
 use crate::{
   extensions::context::lemmy_context,
   fetcher::objects::{get_or_fetch_and_insert_comment, get_or_fetch_and_insert_post},
+  get_community_from_to_or_cc,
   objects::{
     check_object_domain,
     check_object_for_community_or_site_ban,
@@ -145,6 +146,8 @@ impl FromApubToForm<NoteExt> for CommentForm {
     request_counter: &mut i32,
     _mod_action_allowed: bool,
   ) -> Result<CommentForm, LemmyError> {
+    let community = get_community_from_to_or_cc(note, context, request_counter).await?;
+    let ap_id = Some(check_object_domain(note, expected_domain, community.local)?);
     let creator_actor_id = &note
       .attributed_to()
       .context(location_info!())?
@@ -202,7 +205,7 @@ impl FromApubToForm<NoteExt> for CommentForm {
       published: note.published().map(|u| u.to_owned().naive_local()),
       updated: note.updated().map(|u| u.to_owned().naive_local()),
       deleted: None,
-      ap_id: Some(check_object_domain(note, expected_domain)?),
+      ap_id,
       local: Some(false),
     })
   }

--- a/crates/apub/src/objects/community.rs
+++ b/crates/apub/src/objects/community.rs
@@ -203,7 +203,7 @@ impl FromApubToForm<GroupExt> for CommunityForm {
       updated: group.inner.updated().map(|u| u.to_owned().naive_local()),
       deleted: None,
       nsfw: Some(group.ext_one.sensitive.unwrap_or(false)),
-      actor_id: Some(check_object_domain(group, expected_domain)?),
+      actor_id: Some(check_object_domain(group, expected_domain, true)?),
       local: Some(false),
       private_key: None,
       public_key: Some(group.ext_two.to_owned().public_key.public_key_pem),

--- a/crates/apub/src/objects/mod.rs
+++ b/crates/apub/src/objects/mod.rs
@@ -98,13 +98,14 @@ where
 pub(in crate::objects) fn check_object_domain<T, Kind>(
   apub: &T,
   expected_domain: Url,
+  use_strict_allowlist: bool,
 ) -> Result<DbUrl, LemmyError>
 where
   T: Base + AsBase<Kind>,
 {
   let domain = expected_domain.domain().context(location_info!())?;
   let object_id = apub.id(domain)?.context(location_info!())?;
-  check_is_apub_id_valid(object_id)?;
+  check_is_apub_id_valid(object_id, use_strict_allowlist)?;
   Ok(object_id.to_owned().into())
 }
 

--- a/crates/apub/src/objects/person.rs
+++ b/crates/apub/src/objects/person.rs
@@ -189,7 +189,7 @@ impl FromApubToForm<PersonExt> for PersonForm {
       banner: banner.map(|o| o.map(|i| i.into())),
       published: person.inner.published().map(|u| u.to_owned().naive_local()),
       updated: person.updated().map(|u| u.to_owned().naive_local()),
-      actor_id: Some(check_object_domain(person, expected_domain)?),
+      actor_id: Some(check_object_domain(person, expected_domain, false)?),
       bio: Some(bio),
       local: Some(false),
       admin: Some(false),

--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -143,12 +143,13 @@ impl FromApubToForm<PageExt> for PostForm {
     request_counter: &mut i32,
     mod_action_allowed: bool,
   ) -> Result<PostForm, LemmyError> {
+    let community = get_community_from_to_or_cc(page, context, request_counter).await?;
     let ap_id = if mod_action_allowed {
       let id = page.id_unchecked().context(location_info!())?;
-      check_is_apub_id_valid(id)?;
+      check_is_apub_id_valid(id, community.local)?;
       id.to_owned().into()
     } else {
-      check_object_domain(page, expected_domain)?
+      check_object_domain(page, expected_domain, community.local)?
     };
     let ext = &page.ext_one;
     let creator_actor_id = page
@@ -161,8 +162,6 @@ impl FromApubToForm<PageExt> for PostForm {
 
     let creator =
       get_or_fetch_and_upsert_person(creator_actor_id, context, request_counter).await?;
-
-    let community = get_community_from_to_or_cc(page, context, request_counter).await?;
 
     let thumbnail_url: Option<Url> = match &page.inner.image() {
       Some(any_image) => Image::from_any_base(

--- a/crates/apub/src/objects/private_message.rs
+++ b/crates/apub/src/objects/private_message.rs
@@ -1,5 +1,4 @@
 use crate::{
-  check_is_apub_id_valid,
   extensions::context::lemmy_context,
   fetcher::person::get_or_fetch_and_upsert_person,
   objects::{
@@ -116,8 +115,7 @@ impl FromApubToForm<NoteExt> for PrivateMessageForm {
       .context(location_info!())?;
     let recipient =
       get_or_fetch_and_upsert_person(&recipient_actor_id, context, request_counter).await?;
-    let ap_id = note.id_unchecked().context(location_info!())?.to_string();
-    check_is_apub_id_valid(&Url::parse(&ap_id)?)?;
+    let ap_id = Some(check_object_domain(note, expected_domain, false)?);
 
     let content = get_source_markdown_value(note)?.context(location_info!())?;
 
@@ -129,7 +127,7 @@ impl FromApubToForm<NoteExt> for PrivateMessageForm {
       updated: note.updated().map(|u| u.to_owned().naive_local()),
       deleted: None,
       read: None,
-      ap_id: Some(check_object_domain(note, expected_domain)?),
+      ap_id,
       local: Some(false),
     })
   }

--- a/crates/apub_receive/src/activities/receive/private_message.rs
+++ b/crates/apub_receive/src/activities/receive/private_message.rs
@@ -220,7 +220,7 @@ where
     .to_owned()
     .single_xsd_any_uri()
     .context(location_info!())?;
-  check_is_apub_id_valid(&person_id)?;
+  check_is_apub_id_valid(&person_id, false)?;
   // check that the sender is a person, not a community
   get_or_fetch_and_upsert_person(&person_id, &context, request_counter).await?;
 

--- a/crates/apub_receive/src/inbox/mod.rs
+++ b/crates/apub_receive/src/inbox/mod.rs
@@ -85,7 +85,7 @@ where
     .to_owned()
     .single_xsd_any_uri()
     .context(location_info!())?;
-  check_is_apub_id_valid(&actor_id)?;
+  check_is_apub_id_valid(&actor_id, false)?;
   let actor = get_or_fetch_and_upsert_actor(&actor_id, &context, request_counter).await?;
   verify_signature(&request, actor.as_ref())?;
   Ok(actor)

--- a/crates/apub_receive/src/inbox/person_inbox.rs
+++ b/crates/apub_receive/src/inbox/person_inbox.rs
@@ -302,7 +302,7 @@ pub async fn receive_announce(
     .context(location_info!())?;
 
   let inner_id = inner_activity.id().context(location_info!())?.to_owned();
-  check_is_apub_id_valid(&inner_id)?;
+  check_is_apub_id_valid(&inner_id, false)?;
   if is_activity_already_known(context.pool(), &inner_id).await? {
     return Ok(());
   }

--- a/crates/utils/src/settings/defaults.rs
+++ b/crates/utils/src/settings/defaults.rs
@@ -49,6 +49,7 @@ impl Default for FederationConfig {
       enabled: false,
       allowed_instances: None,
       blocked_instances: None,
+      strict_allowlist: Some(true),
     }
   }
 }

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -77,6 +77,7 @@ pub struct FederationConfig {
   pub enabled: bool,
   pub allowed_instances: Option<Vec<String>>,
   pub blocked_instances: Option<Vec<String>>,
+  pub strict_allowlist: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, Clone)]


### PR DESCRIPTION
This is not something I would enable on a big instance like lemmy.ml, but it should be useful for smaller instances which want to see more content. Consider the case of a new, small instance which only federates with lemmy.ml. That instance can follow lemmy.ml communities, and see posts/comments made by lemmy.ml users. However it will not see any posts/comments made by users on third instances in lemmy.ml communities. So far the only way to see every content in a remote community was to use blocklist mode, but now the same can be achieved by disabling `strict_allowlist`.

Effectively we have the following federation modes now:

- Using allowlist, strict_allowlist = true (will only federate with instances in the allowlist, everything else is blocked)
- Using allowlist and blocklist, strict_allowlist = false (will federate with instances on allowlist, plus some other instances which are not blocked)
- Using only blocklist (will federate with all instances which are not blocked)

If `strict_allowlist == true` (which is the default), Lemmy behaviour is identical to previous versions. So this can be released in a patch version without any problem.

Edit: I still need to test this.

Edit 2: Did a quick test and it works as expected.