### PR TITLE
Fetch git tags manually in CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,11 +8,12 @@ platform:
 
 steps:
 
-  - name: chown repo
+  - name: prepare repo
     image: ekidd/rust-musl-builder:1.50.0
     user: root
     commands:
       - chown 1000:1000 . -R
+      - git fetch --tags
 
   - name: check formatting
     image: rustdocker/rust:nightly
@@ -135,6 +136,15 @@ platform:
   arch: arm64
 
 steps:
+
+  - name: prepare repo
+    image: rust:1.50-slim-buster
+    user: root
+    commands:
+      - chown 1000:1000 . -R
+      - apt update
+      - apt install --no-install-recommends --yes git
+      - git fetch --tags
 
   - name: cargo test
     image: rust:1.50-slim-buster

--- a/.drone.yml
+++ b/.drone.yml
@@ -35,7 +35,7 @@ steps:
       RUST_TEST_THREADS: 1
     commands:
       - sudo apt-get update
-      - sudo apt-get -y install --no-install-recommends espeak postgresql-client
+      - sudo apt-get -y install --no-install-recommends postgresql-client
       - cargo test --workspace --no-fail-fast
 
   - name: cargo build
@@ -155,7 +155,7 @@ steps:
       RUST_TEST_THREADS: 1
     commands:
       - apt-get update
-      - apt-get -y install --no-install-recommends espeak postgresql-client libssl-dev pkg-config libpq-dev
+      - apt-get -y install --no-install-recommends postgresql-client libssl-dev pkg-config libpq-dev
       - cargo test --workspace --no-fail-fast
       - cargo build
 


### PR DESCRIPTION
Drone CI doesnt fetch git tags by default, which results in empty version names in dev builds (and probably in release builds as well). To avoid this, we need to fetch the tags manually.

![Screenshot_20210415_135913](https://user-images.githubusercontent.com/1044450/115746222-ae955e80-a383-11eb-8ec1-9f6c092e6fa4.jpg)

https://discourse.drone.io/t/how-can-i-remove-the-no-tags-parameter-of-the-git-fetch-command/2156
