### PR TITLE
Add additional slurs configuration option. Closes #1464.

### DIFF
--- a/config/config.hjson
+++ b/config/config.hjson
@@ -90,4 +90,8 @@
 #    # whether or not smtp connections should use tls
 #    use_tls: true
 #  }
+  # additional_slurs:
+  #  '''
+  #  (\bThis\b)|(\bis\b)|(\bsample\b)
+  #  '''
 }

--- a/crates/utils/src/settings/defaults.rs
+++ b/crates/utils/src/settings/defaults.rs
@@ -17,6 +17,7 @@ impl Default for Settings {
       jwt_secret: Some("changeme".into()),
       pictrs_url: Some("http://pictrs:8080".into()),
       iframely_url: Some("http://iframely".into()),
+      additional_slurs: None,
     }
   }
 }

--- a/crates/utils/src/settings/mod.rs
+++ b/crates/utils/src/settings/mod.rs
@@ -27,10 +27,10 @@ lazy_static! {
 }
 
 impl Settings {
-  /// Reads config from the files and environment.
-  /// First, defaults are loaded from CONFIG_FILE_DEFAULTS, then these values can be overwritten
-  /// from CONFIG_FILE (optional). Finally, values from the environment (with prefix LEMMY) are
-  /// added to the config.
+  /// Reads config from configuration file.
+  /// Then values from the environment (with prefix LEMMY) are added to the config.
+  /// And then default values are merged into config.
+  /// Defaults are controlled by Default trait implemntation for Settings structs.
   ///
   /// Note: The env var `LEMMY_DATABASE_URL` is parsed in
   /// `lemmy_db_queries/src/lib.rs::get_database_url_from_env()`

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -17,6 +17,7 @@ pub struct Settings {
   pub(crate) captcha: Option<CaptchaConfig>,
   pub(crate) email: Option<EmailConfig>,
   pub(crate) setup: Option<SetupConfig>,
+  pub(crate) additional_slurs: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/crates/utils/src/utils.rs
+++ b/crates/utils/src/utils.rs
@@ -7,7 +7,16 @@ use regex::{Regex, RegexBuilder};
 
 lazy_static! {
   static ref EMAIL_REGEX: Regex = Regex::new(r"^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$").expect("compile regex");
-  static ref SLUR_REGEX: Regex = RegexBuilder::new(r"(fag(g|got|tard)?\b|cock\s?sucker(s|ing)?|ni((g{2,}|q)+|[gq]{2,})[e3r]+(s|z)?|mudslime?s?|kikes?|\bspi(c|k)s?\b|\bchinks?|gooks?|bitch(es|ing|y)?|whor(es?|ing)|\btr(a|@)nn?(y|ies?)|\b(b|re|r)tard(ed)?s?)").case_insensitive(true).build().expect("compile regex");
+  static ref SLUR_REGEX: Regex = {
+    let mut slurs = r"(fag(g|got|tard)?\b|cock\s?sucker(s|ing)?|ni((g{2,}|q)+|[gq]{2,})[e3r]+(s|z)?|mudslime?s?|kikes?|\bspi(c|k)s?\b|\bchinks?|gooks?|bitch(es|ing|y)?|whor(es?|ing)|\btr(a|@)nn?(y|ies?)|\b(b|re|r)tard(ed)?s?)".to_string();
+    if let Some(additional_slurs) = Settings::get().additional_slurs {
+        slurs.push('|');
+        slurs.push_str(&additional_slurs);
+    };
+    RegexBuilder::new(&&slurs).case_insensitive(true).build().expect("compile regex")
+  };
+
+
   static ref USERNAME_MATCHES_REGEX: Regex = Regex::new(r"/u/[a-zA-Z][0-9a-zA-Z_]*").expect("compile regex");
   // TODO keep this old one, it didn't work with port well tho
   // static ref MENTIONS_REGEX: Regex = Regex::new(r"@(?P<name>[\w.]+)@(?P<domain>[a-zA-Z0-9._-]+\.[a-zA-Z0-9_-]+)").expect("compile regex");


### PR DESCRIPTION
Greetings!
Implemented #1464.
Without a test :( I don't know how to test this gracefully. I don't like the idea of config file modification at runtime. Maybe it's okay to fill in `additional_slurs` option by default with some slurs and rely on them in test.
If someone has a suggestion about the proper test implementation I will be happy to implement it :)
