### PR TITLE
Fix IPv6 port setup for Nginx #1635

### DIFF
--- a/ansible/templates/nginx.conf
+++ b/ansible/templates/nginx.conf
@@ -2,6 +2,7 @@ limit_req_zone $binary_remote_addr zone=lemmy_ratelimit:10m rate=1r/s;
 
 server {
     listen 80;
+    listen [::]:80;
     server_name {{ domain }};
     location /.well-known/acme-challenge/ {
         root /var/www/certbot;
@@ -13,6 +14,7 @@ server {
 
 server {
     listen 443 ssl http2;
+    listen [::]:443 ssl http2;
     server_name {{ domain }};
 
     ssl_certificate /etc/letsencrypt/live/{{domain}}/fullchain.pem;


### PR DESCRIPTION
Change the Ansible lemmy.conf nginx config to listen on IPv6 ports for both HTTP and HTTPS.