### PR TITLE
Remove tracking params from post url (fixes #768)

### DIFF
--- a/crates/api_crud/src/post/create.rs
+++ b/crates/api_crud/src/post/create.rs
@@ -13,7 +13,7 @@ use lemmy_db_schema::source::post::*;
 use lemmy_db_views::post_view::PostView;
 use lemmy_utils::{
   request::fetch_iframely_and_pictrs_data,
-  utils::{check_slurs, check_slurs_opt, is_valid_post_title},
+  utils::{check_slurs, check_slurs_opt, clean_url_params, is_valid_post_title},
   ApiError,
   ConnectionId,
   LemmyError,
@@ -48,7 +48,7 @@ impl PerformCrud for CreatePost {
 
     let post_form = PostForm {
       name: data.name.trim().to_owned(),
-      url: data_url.map(|u| u.to_owned().into()),
+      url: data_url.map(|u| clean_url_params(u.to_owned()).into()),
       body: data.body.to_owned(),
       community_id: data.community_id,
       creator_id: local_user_view.person.id,

--- a/crates/api_crud/src/post/update.rs
+++ b/crates/api_crud/src/post/update.rs
@@ -7,7 +7,7 @@ use lemmy_db_schema::{naive_now, source::post::*};
 use lemmy_db_views::post_view::PostView;
 use lemmy_utils::{
   request::fetch_iframely_and_pictrs_data,
-  utils::{check_slurs_opt, is_valid_post_title},
+  utils::{check_slurs_opt, clean_url_params, is_valid_post_title},
   ApiError,
   ConnectionId,
   LemmyError,
@@ -59,7 +59,7 @@ impl PerformCrud for EditPost {
       creator_id: orig_post.creator_id.to_owned(),
       community_id: orig_post.community_id,
       name: data.name.to_owned().unwrap_or(orig_post.name),
-      url: data_url.map(|u| u.to_owned().into()),
+      url: data_url.map(|u| clean_url_params(u.to_owned()).into()),
       body: data.body.to_owned(),
       nsfw: data.nsfw,
       updated: Some(naive_now()),


### PR DESCRIPTION
Later we could use the same method to remove tracking params from links in the post body, and in comments, PMs and user/community descriptions. But that would be a bit more complicated cause we'd have to parse the markdown.

Btw latest Rust nightly is showing dozens of warnings like this, and there seems to be no automatic fix.

`warning: this expression borrows a reference (`&diesel::PgConnection`) that is immediately dereferenced by the compiler`