### PR TITLE
Move resolving of activitypub objects to separate api endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1736,10 +1736,13 @@ name = "lemmy_apub_lib"
 version = "0.11.3"
 dependencies = [
  "activitystreams",
+ "anyhow",
  "async-trait",
  "lemmy_apub_lib_derive",
  "lemmy_utils",
  "lemmy_websocket",
+ "log",
+ "reqwest",
  "serde",
  "serde_json",
  "url",
@@ -1836,6 +1839,7 @@ dependencies = [
  "diesel",
  "lazy_static",
  "lemmy_api_common",
+ "lemmy_apub_lib",
  "lemmy_db_queries",
  "lemmy_db_schema",
  "lemmy_db_views",

--- a/api_tests/package.json
+++ b/api_tests/package.json
@@ -16,7 +16,7 @@
     "eslint": "^7.30.0",
     "eslint-plugin-jane": "^9.0.3",
     "jest": "^27.0.6",
-    "lemmy-js-client": "0.11.4-rc.9",
+    "lemmy-js-client": "0.11.4-rc.14",
     "node-fetch": "^2.6.1",
     "prettier": "^2.3.2",
     "ts-jest": "^27.0.3",

--- a/api_tests/src/community.spec.ts
+++ b/api_tests/src/community.spec.ts
@@ -3,7 +3,7 @@ import {
   alpha,
   beta,
   setupLogins,
-  searchForCommunity,
+  resolveCommunity,
   createCommunity,
   deleteCommunity,
   removeCommunity,
@@ -47,9 +47,8 @@ test('Create community', async () => {
 
   // Cache the community on beta, make sure it has the other fields
   let searchShort = `!${prevName}@lemmy-alpha:8541`;
-  let search = await searchForCommunity(beta, searchShort);
-  let communityOnBeta = search.communities[0];
-  assertCommunityFederation(communityOnBeta, communityRes.community_view);
+  let betaCommunity = (await resolveCommunity(beta, searchShort)).community;
+  assertCommunityFederation(betaCommunity, communityRes.community_view);
 });
 
 test('Delete community', async () => {
@@ -57,15 +56,14 @@ test('Delete community', async () => {
 
   // Cache the community on Alpha
   let searchShort = `!${communityRes.community_view.community.name}@lemmy-beta:8551`;
-  let search = await searchForCommunity(alpha, searchShort);
-  let communityOnAlpha = search.communities[0];
-  assertCommunityFederation(communityOnAlpha, communityRes.community_view);
+  let alphaCommunity = (await resolveCommunity(alpha, searchShort)).community;
+  assertCommunityFederation(alphaCommunity, communityRes.community_view);
 
   // Follow the community from alpha
   let follow = await followCommunity(
     alpha,
     true,
-    communityOnAlpha.community.id
+    alphaCommunity.community.id
   );
 
   // Make sure the follow response went through
@@ -82,7 +80,7 @@ test('Delete community', async () => {
   // Make sure it got deleted on A
   let communityOnAlphaDeleted = await getCommunity(
     alpha,
-    communityOnAlpha.community.id
+    alphaCommunity.community.id
   );
   expect(communityOnAlphaDeleted.community_view.community.deleted).toBe(true);
 
@@ -97,7 +95,7 @@ test('Delete community', async () => {
   // Make sure it got undeleted on A
   let communityOnAlphaUnDeleted = await getCommunity(
     alpha,
-    communityOnAlpha.community.id
+    alphaCommunity.community.id
   );
   expect(communityOnAlphaUnDeleted.community_view.community.deleted).toBe(
     false
@@ -109,15 +107,14 @@ test('Remove community', async () => {
 
   // Cache the community on Alpha
   let searchShort = `!${communityRes.community_view.community.name}@lemmy-beta:8551`;
-  let search = await searchForCommunity(alpha, searchShort);
-  let communityOnAlpha = search.communities[0];
-  assertCommunityFederation(communityOnAlpha, communityRes.community_view);
+  let alphaCommunity = (await resolveCommunity(alpha, searchShort)).community;
+  assertCommunityFederation(alphaCommunity, communityRes.community_view);
 
   // Follow the community from alpha
   let follow = await followCommunity(
     alpha,
     true,
-    communityOnAlpha.community.id
+    alphaCommunity.community.id
   );
 
   // Make sure the follow response went through
@@ -134,7 +131,7 @@ test('Remove community', async () => {
   // Make sure it got Removed on A
   let communityOnAlphaRemoved = await getCommunity(
     alpha,
-    communityOnAlpha.community.id
+    alphaCommunity.community.id
   );
   expect(communityOnAlphaRemoved.community_view.community.removed).toBe(true);
 
@@ -149,7 +146,7 @@ test('Remove community', async () => {
   // Make sure it got undeleted on A
   let communityOnAlphaUnRemoved = await getCommunity(
     alpha,
-    communityOnAlpha.community.id
+    alphaCommunity.community.id
   );
   expect(communityOnAlphaUnRemoved.community_view.community.removed).toBe(
     false
@@ -161,7 +158,6 @@ test('Search for beta community', async () => {
   expect(communityRes.community_view.community.name).toBeDefined();
 
   let searchShort = `!${communityRes.community_view.community.name}@lemmy-beta:8551`;
-  let search = await searchForCommunity(alpha, searchShort);
-  let communityOnAlpha = search.communities[0];
-  assertCommunityFederation(communityOnAlpha, communityRes.community_view);
+  let alphaCommunity = (await resolveCommunity(alpha, searchShort)).community;
+  assertCommunityFederation(alphaCommunity, communityRes.community_view);
 });

--- a/api_tests/src/follow.spec.ts
+++ b/api_tests/src/follow.spec.ts
@@ -2,7 +2,7 @@ jest.setTimeout(120000);
 import {
   alpha,
   setupLogins,
-  searchForBetaCommunity,
+  resolveBetaCommunity,
   followCommunity,
   unfollowRemotes,
   getSite,
@@ -17,11 +17,11 @@ afterAll(async () => {
 });
 
 test('Follow federated community', async () => {
-  let search = await searchForBetaCommunity(alpha); // TODO sometimes this is returning null?
+  let betaCommunity = (await resolveBetaCommunity(alpha)).community;
   let follow = await followCommunity(
     alpha,
     true,
-    search.communities[0].community.id
+    betaCommunity.community.id
   );
 
   // Make sure the follow response went through

--- a/api_tests/src/shared.ts
+++ b/api_tests/src/shared.ts
@@ -47,6 +47,8 @@ import {
   BanFromCommunityResponse,
   Post,
   CreatePrivateMessage,
+  ResolveObjectResponse,
+  ResolveObject,
 } from 'lemmy-js-client';
 
 export interface API {
@@ -201,16 +203,14 @@ export async function lockPost(
   return api.client.lockPost(form);
 }
 
-export async function searchPost(
+export async function resolvePost(
   api: API,
   post: Post
-): Promise<SearchResponse> {
-  let form: Search = {
+): Promise<ResolveObjectResponse> {
+  let form: ResolveObject = {
     q: post.ap_id,
-    type_: SearchType.Posts,
-    sort: SortType.TopAll,
   };
-  return api.client.search(form);
+  return api.client.resolveObject(form);
 }
 
 export async function searchPostLocal(
@@ -235,56 +235,44 @@ export async function getPost(
   return api.client.getPost(form);
 }
 
-export async function searchComment(
+export async function resolveComment(
   api: API,
   comment: Comment
-): Promise<SearchResponse> {
-  let form: Search = {
+): Promise<ResolveObjectResponse> {
+  let form: ResolveObject = {
     q: comment.ap_id,
-    type_: SearchType.Comments,
-    sort: SortType.TopAll,
   };
-  return api.client.search(form);
+  return api.client.resolveObject(form);
 }
 
-export async function searchForBetaCommunity(
+export async function resolveBetaCommunity(
   api: API
-): Promise<SearchResponse> {
-  // Make sure lemmy-beta/c/main is cached on lemmy_alpha
+): Promise<ResolveObjectResponse> {
   // Use short-hand search url
-  let form: Search = {
+  let form: ResolveObject = {
     q: '!main@lemmy-beta:8551',
-    type_: SearchType.Communities,
-    sort: SortType.TopAll,
   };
-  return api.client.search(form);
+  return api.client.resolveObject(form);
 }
 
-export async function searchForCommunity(
+export async function resolveCommunity(
   api: API,
   q: string
-): Promise<SearchResponse> {
-  // Use short-hand search url
-  let form: Search = {
+): Promise<ResolveObjectResponse> {
+  let form: ResolveObject = {
     q,
-    type_: SearchType.Communities,
-    sort: SortType.TopAll,
   };
-  return api.client.search(form);
+  return api.client.resolveObject(form);
 }
 
-export async function searchForUser(
+export async function resolvePerson(
   api: API,
   apShortname: string
-): Promise<SearchResponse> {
-  // Make sure lemmy-beta/c/main is cached on lemmy_alpha
-  // Use short-hand search url
-  let form: Search = {
+): Promise<ResolveObjectResponse> {
+  let form: ResolveObject = {
     q: apShortname,
-    type_: SearchType.Users,
-    sort: SortType.TopAll,
   };
-  return api.client.search(form);
+  return api.client.resolveObject(form);
 }
 
 export async function banPersonFromSite(
@@ -293,7 +281,6 @@ export async function banPersonFromSite(
   ban: boolean
 ): Promise<BanPersonResponse> {
   // Make sure lemmy-beta/c/main is cached on lemmy_alpha
-  // Use short-hand search url
   let form: BanPerson = {
     person_id,
     ban,
@@ -310,7 +297,6 @@ export async function banPersonFromCommunity(
   ban: boolean
 ): Promise<BanFromCommunityResponse> {
   // Make sure lemmy-beta/c/main is cached on lemmy_alpha
-  // Use short-hand search url
   let form: BanFromCommunity = {
     person_id,
     community_id,
@@ -591,11 +577,9 @@ export async function unfollowRemotes(
 }
 
 export async function followBeta(api: API): Promise<CommunityResponse> {
-  // Cache it
-  let search = await searchForBetaCommunity(api);
-  let com = search.communities.find(c => c.community.local == false);
-  if (com) {
-    let follow = await followCommunity(api, true, com.community.id);
+  let betaCommunity = (await resolveBetaCommunity(api)).community;
+  if (betaCommunity) {
+    let follow = await followCommunity(api, true, betaCommunity.community.id);
     return follow;
   }
 }

--- a/api_tests/src/user.spec.ts
+++ b/api_tests/src/user.spec.ts
@@ -3,7 +3,7 @@ import {
   alpha,
   beta,
   registerUser,
-  searchForUser,
+  resolvePerson,
   saveUserSettings,
   getSite,
 } from './shared';
@@ -56,9 +56,7 @@ test('Set some user settings, check that they are federated', async () => {
   };
   await saveUserSettings(alpha, form);
 
-  let searchAlpha = await searchForUser(alpha, apShortname);
-  let userOnAlpha = searchAlpha.users[0];
-  let searchBeta = await searchForUser(beta, apShortname);
-  let userOnBeta = searchBeta.users[0];
-  assertUserFederation(userOnAlpha, userOnBeta);
+  let alphaPerson = (await resolvePerson(alpha, apShortname)).person;
+  let betaPerson = (await resolvePerson(beta, apShortname)).person;
+  assertUserFederation(alphaPerson, betaPerson);
 });

--- a/api_tests/yarn.lock
+++ b/api_tests/yarn.lock
@@ -3076,10 +3076,10 @@ language-tags@^1.0.5:
   dependencies:
     language-subtag-registry "~0.3.2"
 
-lemmy-js-client@0.11.4-rc.9:
-  version "0.11.4-rc.9"
-  resolved "https://registry.yarnpkg.com/lemmy-js-client/-/lemmy-js-client-0.11.4-rc.9.tgz#f7b3c73691e4c1600daf3840d22d9cfbddc5f363"
-  integrity sha512-zP8JxWzQU+yuyE8cMG0GzR8aR3lJ++G5zzbynsXwDevzAZXhOm0ObNNtJiA3Q5msStFVKVYa3GwZxBv4XiYshw==
+lemmy-js-client@0.11.4-rc.14:
+  version "0.11.4-rc.14"
+  resolved "https://registry.yarnpkg.com/lemmy-js-client/-/lemmy-js-client-0.11.4-rc.14.tgz#dcac5b8dc78c3b04e6b3630ff9351a94aa73e109"
+  integrity sha512-R8M+myyriNQljQlTweVqtUKGBpgmaM7RI4ebYb7N7sYr5Bk5Ip6v2qTNvKAV6BlsDOCTWANOonfeoz/cIerLEg==
 
 leven@^3.1.0:
   version "3.1.0"

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -87,6 +87,9 @@ pub async fn match_websocket_operation(
       do_websocket_operation::<SaveSiteConfig>(context, id, op, data).await
     }
     UserOperation::Search => do_websocket_operation::<Search>(context, id, op, data).await,
+    UserOperation::ResolveObject => {
+      do_websocket_operation::<ResolveObject>(context, id, op, data).await
+    }
     UserOperation::TransferCommunity => {
       do_websocket_operation::<TransferCommunity>(context, id, op, data).await
     }

--- a/crates/api/src/site.rs
+++ b/crates/api/src/site.rs
@@ -376,7 +376,10 @@ impl Perform for ResolveObject {
     _websocket_id: Option<ConnectionId>,
   ) -> Result<ResolveObjectResponse, LemmyError> {
     let local_user_view = get_local_user_view_from_jwt_opt(&self.auth, context.pool()).await?;
-    search_by_apub_id(&self.q, local_user_view, context).await
+    let res = search_by_apub_id(&self.q, local_user_view, context)
+      .await
+      .map_err(|_| ApiError::err("couldnt_find_object"))?;
+    Ok(res)
   }
 }
 

--- a/crates/api_common/src/lib.rs
+++ b/crates/api_common/src/lib.rs
@@ -46,25 +46,7 @@ use lemmy_utils::{
   LemmyError,
 };
 use log::error;
-use serde::{Deserialize, Serialize};
 use url::Url;
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct WebFingerLink {
-  pub rel: Option<String>,
-  #[serde(rename(serialize = "type", deserialize = "type"))]
-  pub type_: Option<String>,
-  pub href: Option<Url>,
-  #[serde(skip_serializing_if = "Option::is_none")]
-  pub template: Option<String>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct WebFingerResponse {
-  pub subject: String,
-  pub aliases: Vec<Url>,
-  pub links: Vec<WebFingerLink>,
-}
 
 pub async fn blocking<F, T>(pool: &DbPool, f: F) -> Result<T, LemmyError>
 where

--- a/crates/api_common/src/site.rs
+++ b/crates/api_common/src/site.rs
@@ -56,12 +56,12 @@ pub struct ResolveObject {
   pub auth: Option<String>,
 }
 
-#[derive(Serialize, Debug)]
-pub enum ResolveObjectResponse {
-  Comment(CommentView),
-  Post(PostView),
-  Community(CommunityView),
-  Person(PersonViewSafe),
+#[derive(Serialize, Default)]
+pub struct ResolveObjectResponse {
+  pub comment: Option<CommentView>,
+  pub post: Option<PostView>,
+  pub community: Option<CommunityView>,
+  pub person: Option<PersonViewSafe>,
 }
 
 #[derive(Deserialize)]

--- a/crates/api_common/src/site.rs
+++ b/crates/api_common/src/site.rs
@@ -50,6 +50,20 @@ pub struct SearchResponse {
   pub users: Vec<PersonViewSafe>,
 }
 
+#[derive(Deserialize, Debug)]
+pub struct ResolveObject {
+  pub q: String,
+  pub auth: Option<String>,
+}
+
+#[derive(Serialize, Debug)]
+pub enum ResolveObjectResponse {
+  Comment(CommentView),
+  Post(PostView),
+  Community(CommunityView),
+  Person(PersonViewSafe),
+}
+
 #[derive(Deserialize)]
 pub struct GetModlog {
   pub mod_person_id: Option<PersonId>,

--- a/crates/apub/src/activities/comment/mod.rs
+++ b/crates/apub/src/activities/comment/mod.rs
@@ -5,7 +5,8 @@ use activitystreams::{
 };
 use anyhow::anyhow;
 use itertools::Itertools;
-use lemmy_api_common::{blocking, send_local_notifs, WebFingerResponse};
+use lemmy_api_common::{blocking, send_local_notifs};
+use lemmy_apub_lib::webfinger::WebfingerResponse;
 use lemmy_db_queries::{Crud, DbPool};
 use lemmy_db_schema::{
   source::{comment::Comment, community::Community, person::Person, post::Post},
@@ -128,7 +129,7 @@ async fn fetch_webfinger_url(mention: &MentionData, client: &Client) -> Result<U
 
   let response = retry(|| client.get(&fetch_url).send()).await?;
 
-  let res: WebFingerResponse = response
+  let res: WebfingerResponse = response
     .json()
     .await
     .map_err(|e| RecvError(e.to_string()))?;

--- a/crates/apub/src/fetcher/search.rs
+++ b/crates/apub/src/fetcher/search.rs
@@ -1,25 +1,24 @@
 use crate::{
   fetcher::{
+    community::get_or_fetch_and_upsert_community,
     fetch::fetch_remote_object,
-    get_or_fetch_and_upsert_community,
-    get_or_fetch_and_upsert_person,
     is_deleted,
+    person::get_or_fetch_and_upsert_person,
   },
   find_object_by_id,
   objects::{comment::Note, community::Group, person::Person as ApubPerson, post::Page, FromApub},
   Object,
 };
 use anyhow::anyhow;
-use lemmy_api_common::{blocking, site::SearchResponse};
-use lemmy_db_queries::{
-  source::{
-    comment::Comment_,
-    community::Community_,
-    person::Person_,
-    post::Post_,
-    private_message::PrivateMessage_,
-  },
-  SearchType,
+use itertools::Itertools;
+use lemmy_api_common::{blocking, site::ResolveObjectResponse};
+use lemmy_apub_lib::webfinger::{webfinger_resolve_actor, WebfingerType};
+use lemmy_db_queries::source::{
+  comment::Comment_,
+  community::Community_,
+  person::Person_,
+  post::Post_,
+  private_message::PrivateMessage_,
 };
 use lemmy_db_schema::source::{
   comment::Comment,
@@ -28,11 +27,14 @@ use lemmy_db_schema::source::{
   post::Post,
   private_message::PrivateMessage,
 };
-use lemmy_db_views::{comment_view::CommentView, post_view::PostView};
+use lemmy_db_views::{
+  comment_view::CommentView,
+  local_user_view::LocalUserView,
+  post_view::PostView,
+};
 use lemmy_db_views_actor::{community_view::CommunityView, person_view::PersonViewSafe};
-use lemmy_utils::{settings::structs::Settings, LemmyError};
+use lemmy_utils::LemmyError;
 use lemmy_websocket::LemmyContext;
-use log::debug;
 use url::Url;
 
 /// The types of ActivityPub objects that can be fetched directly by searching for their ID.
@@ -54,50 +56,62 @@ enum SearchAcceptedObjects {
 /// http://lemmy_delta:8571/comment/2
 pub async fn search_by_apub_id(
   query: &str,
+  local_user_view: Option<LocalUserView>,
   context: &LemmyContext,
-) -> Result<SearchResponse, LemmyError> {
-  // Parse the shorthand query url
-  let query_url = if query.contains('@') {
-    debug!("Search for {}", query);
-    let split = query.split('@').collect::<Vec<&str>>();
-
-    // Person type will look like ['', username, instance]
-    // Community will look like [!community, instance]
-    let (name, instance) = if split.len() == 3 {
-      (format!("/u/{}", split[1]), split[2])
-    } else if split.len() == 2 {
-      if split[0].contains('!') {
-        let split2 = split[0].split('!').collect::<Vec<&str>>();
-        (format!("/c/{}", split2[1]), split[1])
-      } else {
-        return Err(anyhow!("Invalid search query: {}", query).into());
+) -> Result<ResolveObjectResponse, LemmyError> {
+  let query_url = match Url::parse(query) {
+    Ok(u) => u,
+    Err(_) => {
+      let (kind, name) = query.split_at(1);
+      let kind = match kind {
+        "@" => WebfingerType::Person,
+        "!" => WebfingerType::Group,
+        _ => return Err(anyhow!("invalid query").into()),
+      };
+      // remote actor, use webfinger to resolve url
+      if name.contains('@') {
+        let (name, domain) = name.splitn(2, '@').collect_tuple().expect("invalid query");
+        webfinger_resolve_actor(name, domain, kind, context.client()).await?
       }
-    } else {
-      return Err(anyhow!("Invalid search query: {}", query).into());
-    };
-
-    let url = format!(
-      "{}://{}{}",
-      Settings::get().get_protocol_string(),
-      instance,
-      name
-    );
-    Url::parse(&url)?
-  } else {
-    Url::parse(query)?
+      // local actor, read from database and return
+      else {
+        let name: String = name.into();
+        return match kind {
+          WebfingerType::Group => {
+            let res = blocking(context.pool(), move |conn| {
+              let community = Community::read_from_name(conn, &name)?;
+              CommunityView::read(conn, community.id, local_user_view.map(|l| l.person.id))
+            })
+            .await??;
+            Ok(ResolveObjectResponse::Community(res))
+          }
+          WebfingerType::Person => {
+            let res = blocking(context.pool(), move |conn| {
+              let person = Person::find_by_name(conn, &name)?;
+              PersonViewSafe::read(conn, person.id)
+            })
+            .await??;
+            Ok(ResolveObjectResponse::Person(res))
+          }
+        };
+      }
+    }
   };
 
-  let recursion_counter = &mut 0;
+  let request_counter = &mut 0;
+  // this does a fetch (even for local objects), just to determine its type and fetch it again
+  // below. we need to fix this when rewriting the fetcher.
   let fetch_response =
-    fetch_remote_object::<SearchAcceptedObjects>(context.client(), &query_url, recursion_counter)
+    fetch_remote_object::<SearchAcceptedObjects>(context.client(), &query_url, request_counter)
       .await;
   if is_deleted(&fetch_response) {
     delete_object_locally(&query_url, context).await?;
+    return Err(anyhow!("Object was deleted").into());
   }
 
   // Necessary because we get a stack overflow using FetchError
   let fet_res = fetch_response.map_err(|e| LemmyError::from(e.inner))?;
-  build_response(fet_res, query_url, recursion_counter, context).await
+  build_response(fet_res, query_url, request_counter, context).await
 }
 
 async fn build_response(
@@ -105,58 +119,45 @@ async fn build_response(
   query_url: Url,
   recursion_counter: &mut i32,
   context: &LemmyContext,
-) -> Result<SearchResponse, LemmyError> {
-  let mut response = SearchResponse {
-    type_: SearchType::All.to_string(),
-    comments: vec![],
-    posts: vec![],
-    communities: vec![],
-    users: vec![],
-  };
-
-  match fetch_response {
+) -> Result<ResolveObjectResponse, LemmyError> {
+  use ResolveObjectResponse as ROR;
+  Ok(match fetch_response {
     SearchAcceptedObjects::Person(p) => {
-      let person_id = p.id(&query_url)?;
-      let person = get_or_fetch_and_upsert_person(person_id, context, recursion_counter).await?;
+      let person_uri = p.id(&query_url)?;
 
-      response.users = vec![
+      let person = get_or_fetch_and_upsert_person(person_uri, context, recursion_counter).await?;
+      ROR::Person(
         blocking(context.pool(), move |conn| {
           PersonViewSafe::read(conn, person.id)
         })
         .await??,
-      ];
+      )
     }
     SearchAcceptedObjects::Group(g) => {
       let community_uri = g.id(&query_url)?;
       let community =
         get_or_fetch_and_upsert_community(community_uri, context, recursion_counter).await?;
-
-      response.communities = vec![
+      ROR::Community(
         blocking(context.pool(), move |conn| {
           CommunityView::read(conn, community.id, None)
         })
         .await??,
-      ];
+      )
     }
     SearchAcceptedObjects::Page(p) => {
       let p = Post::from_apub(&p, context, &query_url, recursion_counter).await?;
-
-      response.posts =
-        vec![blocking(context.pool(), move |conn| PostView::read(conn, p.id, None)).await??];
+      ROR::Post(blocking(context.pool(), move |conn| PostView::read(conn, p.id, None)).await??)
     }
     SearchAcceptedObjects::Comment(c) => {
       let c = Comment::from_apub(&c, context, &query_url, recursion_counter).await?;
-
-      response.comments = vec![
+      ROR::Comment(
         blocking(context.pool(), move |conn| {
           CommentView::read(conn, c.id, None)
         })
         .await??,
-      ];
+      )
     }
-  };
-
-  Ok(response)
+  })
 }
 
 async fn delete_object_locally(query_url: &Url, context: &LemmyContext) -> Result<(), LemmyError> {
@@ -194,5 +195,5 @@ async fn delete_object_locally(query_url: &Url, context: &LemmyContext) -> Resul
       .await??;
     }
   }
-  Err(anyhow!("Object was deleted").into())
+  Ok(())
 }

--- a/crates/apub_lib/Cargo.toml
+++ b/crates/apub_lib/Cargo.toml
@@ -14,3 +14,6 @@ serde = { version = "1.0.127", features = ["derive"] }
 async-trait = "0.1.51"
 url = { version = "2.2.2", features = ["serde"] }
 serde_json = { version = "1.0.66", features = ["preserve_order"] }
+anyhow = "1.0.41"
+reqwest = { version = "0.11.4", features = ["json"] }
+log = "0.4.14"

--- a/crates/apub_lib/src/lib.rs
+++ b/crates/apub_lib/src/lib.rs
@@ -6,6 +6,8 @@ use lemmy_utils::LemmyError;
 use lemmy_websocket::LemmyContext;
 use url::Url;
 
+pub mod webfinger;
+
 pub trait ActivityFields {
   fn id_unchecked(&self) -> &Url;
   fn actor(&self) -> &Url;

--- a/crates/apub_lib/src/webfinger.rs
+++ b/crates/apub_lib/src/webfinger.rs
@@ -1,0 +1,72 @@
+use anyhow::anyhow;
+use lemmy_utils::{
+  request::{retry, RecvError},
+  settings::structs::Settings,
+  LemmyError,
+};
+use log::debug;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct WebfingerLink {
+  pub rel: Option<String>,
+  #[serde(rename(serialize = "type", deserialize = "type"))]
+  pub type_: Option<String>,
+  pub href: Option<Url>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub template: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct WebfingerResponse {
+  pub subject: String,
+  pub aliases: Vec<Url>,
+  pub links: Vec<WebfingerLink>,
+}
+
+pub enum WebfingerType {
+  Person,
+  Group,
+}
+
+/// Turns a person id like `@name@example.com` into an apub ID, like `https://example.com/user/name`,
+/// using webfinger.
+pub async fn webfinger_resolve_actor(
+  name: &str,
+  domain: &str,
+  webfinger_type: WebfingerType,
+  client: &Client,
+) -> Result<Url, LemmyError> {
+  let webfinger_type = match webfinger_type {
+    WebfingerType::Person => "acct",
+    WebfingerType::Group => "group",
+  };
+  let fetch_url = format!(
+    "{}://{}/.well-known/webfinger?resource={}:{}@{}",
+    Settings::get().get_protocol_string(),
+    domain,
+    webfinger_type,
+    name,
+    domain
+  );
+  debug!("Fetching webfinger url: {}", &fetch_url);
+
+  let response = retry(|| client.get(&fetch_url).send()).await?;
+
+  let res: WebfingerResponse = response
+    .json()
+    .await
+    .map_err(|e| RecvError(e.to_string()))?;
+
+  let link = res
+    .links
+    .iter()
+    .find(|l| l.type_.eq(&Some("application/activity+json".to_string())))
+    .ok_or_else(|| anyhow!("No application/activity+json link found."))?;
+  link
+    .href
+    .to_owned()
+    .ok_or_else(|| anyhow!("No href found.").into())
+}

--- a/crates/routes/Cargo.toml
+++ b/crates/routes/Cargo.toml
@@ -16,6 +16,7 @@ lemmy_db_views = { version = "=0.11.3", path = "../db_views" }
 lemmy_db_views_actor = { version = "=0.11.3", path = "../db_views_actor" }
 lemmy_db_schema = { version = "=0.11.3", path = "../db_schema" }
 lemmy_api_common = { version = "=0.11.3", path = "../api_common" }
+lemmy_apub_lib = { version = "=0.11.3", path = "../apub_lib" }
 diesel = "1.4.7"
 actix = "0.12.0"
 actix-web = { version = "4.0.0-beta.8", default-features = false, features = ["rustls"] }

--- a/crates/routes/src/webfinger.rs
+++ b/crates/routes/src/webfinger.rs
@@ -1,6 +1,7 @@
 use actix_web::{error::ErrorBadRequest, web::Query, *};
 use anyhow::anyhow;
-use lemmy_api_common::{blocking, WebFingerLink, WebFingerResponse};
+use lemmy_api_common::blocking;
+use lemmy_apub_lib::webfinger::{WebfingerLink, WebfingerResponse};
 use lemmy_db_queries::source::{community::Community_, person::Person_};
 use lemmy_db_schema::source::{community::Community, person::Person};
 use lemmy_utils::{
@@ -68,17 +69,17 @@ async fn get_webfinger_response(
     return Err(ErrorBadRequest(LemmyError::from(anyhow!("not_found"))));
   };
 
-  let json = WebFingerResponse {
+  let json = WebfingerResponse {
     subject: info.resource.to_owned(),
     aliases: vec![url.to_owned().into()],
     links: vec![
-      WebFingerLink {
+      WebfingerLink {
         rel: Some("http://webfinger.net/rel/profile-page".to_string()),
         type_: Some("text/html".to_string()),
         href: Some(url.to_owned().into()),
         template: None,
       },
-      WebFingerLink {
+      WebfingerLink {
         rel: Some("self".to_string()),
         type_: Some("application/activity+json".to_string()),
         href: Some(url.into()),

--- a/crates/websocket/src/lib.rs
+++ b/crates/websocket/src/lib.rs
@@ -110,6 +110,7 @@ pub enum UserOperation {
   AddAdmin,
   BanPerson,
   Search,
+  ResolveObject,
   MarkAllAsRead,
   SaveUserSettings,
   TransferCommunity,

--- a/src/api_routes.rs
+++ b/src/api_routes.rs
@@ -33,6 +33,11 @@ pub fn config(cfg: &mut web::ServiceConfig, rate_limit: &RateLimit) {
           .wrap(rate_limit.message())
           .route(web::get().to(route_get::<Search>)),
       )
+      .service(
+        web::resource("/resolve_object")
+          .wrap(rate_limit.message())
+          .route(web::get().to(route_get::<ResolveObject>)),
+      )
       // Community
       .service(
         web::resource("/community")


### PR DESCRIPTION
Test with:
```
curl -G -X GET -d "q=!main@lemmy-gamma:8561" http://localhost:8540/api/v3/resolve_object | jq
curl -G -X GET -d "q=http://lemmy-beta:8541/post/1" http://localhost:8540/api/v3/resolve_object | jq
etc
```

We can use this opportunity to move the functionality to a separate place in lemmy-ui, which should make it easier to discover and explain. Not sure exactly where that should be though.

This is a breaking change (maybe we should just create a label for that).