### PR TITLE
Remove brotli, zstd dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,12 +81,10 @@ dependencies = [
  "ahash 0.7.4",
  "base64 0.13.0",
  "bitflags",
- "brotli2",
  "bytes",
  "bytestring",
  "derive_more",
  "encoding_rs",
- "flate2",
  "futures-core",
  "futures-util",
  "h2",
@@ -108,7 +106,6 @@ dependencies = [
  "smallvec",
  "time 0.2.27",
  "tokio",
- "zstd",
 ]
 
 [[package]]
@@ -398,7 +395,6 @@ dependencies = [
  "base64 0.13.0",
  "bytes",
  "cfg-if",
- "cookie",
  "derive_more",
  "futures-core",
  "itoa",
@@ -566,26 +562,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "brotli-sys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4445dea95f4c2b41cde57cc9fee236ae4dbae88d8fcbdb4750fc1bb5d86aaecd"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "brotli2"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb036c3eade309815c15ddbacec5b22c4d1f3983a774ab2eac2e3e9ea85568e"
-dependencies = [
- "brotli-sys",
- "libc",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,9 +625,6 @@ name = "cc"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
-dependencies = [
- "jobserver",
-]
 
 [[package]]
 name = "cfg-if"
@@ -729,9 +702,9 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cookie"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf8865bac3d9a3bde5bde9088ca431b11f5d37c7a578b8086af77248b76627"
+checksum = "d5f1c7727e460397e56abc4bddc1d49e07a1ad78fc98eb2e1c8f032a58a2f80d"
 dependencies = [
  "percent-encoding",
  "time 0.2.27",
@@ -1376,9 +1349,9 @@ dependencies = [
 
 [[package]]
 name = "http-signature-normalization-actix"
-version = "0.5.0-beta.6"
+version = "0.5.0-beta.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fddb5f0de5059c337a00cfe5b224768e1821327da9df4b6f27762cbf305126d"
+checksum = "aa7cf7b03512ba7341b4252794751c5ff46635e0ff33eb864a929a5b7381e17a"
 dependencies = [
  "actix-web",
  "awc",
@@ -1539,15 +1512,6 @@ name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
-
-[[package]]
-name = "jobserver"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "jpeg-decoder"
@@ -3703,32 +3667,3 @@ name = "xdg"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57"
-
-[[package]]
-name = "zstd"
-version = "0.7.0+zstd.1.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9428752481d8372e15b1bf779ea518a179ad6c771cca2d2c60e4fbff3cc2cd52"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "3.1.0+zstd.1.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa1926623ad7fe406e090555387daf73db555b948134b4d73eac5eb08fb666d"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "1.5.0+zstd.1.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e6c094340240369025fc6b731b054ee2a834328fa584310ac96aa4baebdc465"
-dependencies = [
- "cc",
- "libc",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ env_logger = "0.8.4"
 strum = "0.21.0"
 url = { version = "2.2.2", features = ["serde"] }
 openssl = "0.10.35"
-http-signature-normalization-actix = { version = "0.5.0-beta.6", default-features = false, features = ["sha-2"] }
+http-signature-normalization-actix = { version = "0.5.0-beta.7", default-features = false, features = ["sha-2"] }
 tokio = { version = "1.8.0", features = ["sync"] }
 anyhow = "1.0.41"
 reqwest = { version = "0.11.4", features = ["json"] }

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -35,7 +35,7 @@ lazy_static = "1.4.0"
 url = { version = "2.2.2", features = ["serde"] }
 openssl = "0.10.35"
 http = "0.2.4"
-http-signature-normalization-actix = { version = "0.5.0-beta.6", default-features = false, features = ["sha-2"] }
+http-signature-normalization-actix = { version = "0.5.0-beta.7", default-features = false, features = ["sha-2"] }
 base64 = "0.13.0"
 tokio = "1.8.0"
 futures = "0.3.15"

--- a/crates/api_common/Cargo.toml
+++ b/crates/api_common/Cargo.toml
@@ -18,7 +18,7 @@ lemmy_utils = { path = "../utils" }
 serde = { version = "1.0.126", features = ["derive"] }
 log = "0.4.14"
 diesel = "1.4.7"
-actix-web = "4.0.0-beta.8"
+actix-web = {version = "4.0.0-beta.8", default-features = false, features = ["cookies"] }
 chrono = { version = "0.4.19", features = ["serde"] }
 serde_json = { version = "1.0.64", features = ["preserve_order"] }
 url = "2.2.2"

--- a/crates/api_crud/Cargo.toml
+++ b/crates/api_crud/Cargo.toml
@@ -30,7 +30,7 @@ lazy_static = "1.4.0"
 url = { version = "2.2.2", features = ["serde"] }
 openssl = "0.10.35"
 http = "0.2.4"
-http-signature-normalization-actix = { version = "0.5.0-beta.6", default-features = false, features = ["sha-2"] }
+http-signature-normalization-actix = { version = "0.5.0-beta.7", default-features = false, features = ["sha-2"] }
 base64 = "0.13.0"
 tokio = "1.8.0"
 futures = "0.3.15"

--- a/crates/apub/Cargo.toml
+++ b/crates/apub/Cargo.toml
@@ -36,7 +36,7 @@ url = { version = "2.2.2", features = ["serde"] }
 percent-encoding = "2.1.0"
 openssl = "0.10.35"
 http = "0.2.4"
-http-signature-normalization-actix = { version = "0.5.0-beta.6", default-features = false, features = ["sha-2"] }
+http-signature-normalization-actix = { version = "0.5.0-beta.7", default-features = false, features = ["sha-2"] }
 http-signature-normalization-reqwest = { version = "0.2.0", default-features = false, features = ["sha-2"] }
 base64 = "0.13.0"
 tokio = "1.8.0"


### PR DESCRIPTION
These are for http compression which we dont need. They take 141s and 124s to compile on my laptop, respectively. So this is gonna give a big compilation speedup especially on slower devices. I also added a CI check so we dont accidentally pull them in again.