### PR TITLE
Blank out extra info for deleted or removed content. Fixes #1679

### DIFF
--- a/api_tests/src/comment.spec.ts
+++ b/api_tests/src/comment.spec.ts
@@ -115,6 +115,7 @@ test('Delete a comment', async () => {
     commentRes.comment_view.comment.id
   );
   expect(deleteCommentRes.comment_view.comment.deleted).toBe(true);
+  expect(deleteCommentRes.comment_view.comment.content).toBe("");
 
   // Make sure that comment is undefined on beta
   let searchBeta = await searchComment(beta, commentRes.comment_view.comment);
@@ -149,6 +150,7 @@ test('Remove a comment from admin and community on the same instance', async () 
   // The beta admin removes it (the community lives on beta)
   let removeCommentRes = await removeComment(beta, true, betaCommentId);
   expect(removeCommentRes.comment_view.comment.removed).toBe(true);
+  expect(removeCommentRes.comment_view.comment.content).toBe("");
 
   // Make sure that comment is removed on alpha (it gets pushed since an admin from beta removed it)
   let refetchedPost = await getPost(alpha, postRes.post_view.post.id);

--- a/api_tests/src/community.spec.ts
+++ b/api_tests/src/community.spec.ts
@@ -77,6 +77,7 @@ test('Delete community', async () => {
     communityRes.community_view.community.id
   );
   expect(deleteCommunityRes.community_view.community.deleted).toBe(true);
+  expect(deleteCommunityRes.community_view.community.title).toBe("");
 
   // Make sure it got deleted on A
   let communityOnAlphaDeleted = await getCommunity(
@@ -128,6 +129,7 @@ test('Remove community', async () => {
     communityRes.community_view.community.id
   );
   expect(removeCommunityRes.community_view.community.removed).toBe(true);
+  expect(removeCommunityRes.community_view.community.title).toBe("");
 
   // Make sure it got Removed on A
   let communityOnAlphaRemoved = await getCommunity(

--- a/api_tests/src/post.spec.ts
+++ b/api_tests/src/post.spec.ts
@@ -210,6 +210,7 @@ test('Delete a post', async () => {
 
   let deletedPost = await deletePost(alpha, true, postRes.post_view.post);
   expect(deletedPost.post_view.post.deleted).toBe(true);
+  expect(deletedPost.post_view.post.name).toBe("");
 
   // Make sure lemmy beta sees post is deleted
   let searchBeta = await searchPost(beta, postRes.post_view.post);
@@ -237,6 +238,7 @@ test('Remove a post from admin and community on different instance', async () =>
 
   let removedPost = await removePost(alpha, true, postRes.post_view.post);
   expect(removedPost.post_view.post.removed).toBe(true);
+  expect(removedPost.post_view.post.name).toBe("");
 
   // Make sure lemmy beta sees post is NOT removed
   let searchBeta = await searchPost(beta, postRes.post_view.post);

--- a/api_tests/src/private_message.spec.ts
+++ b/api_tests/src/private_message.spec.ts
@@ -64,6 +64,7 @@ test('Delete a private message', async () => {
     pmRes.private_message_view.private_message.id
   );
   expect(deletedPmRes.private_message_view.private_message.deleted).toBe(true);
+  expect(deletedPmRes.private_message_view.private_message.content).toBe("");
 
   // The GetPrivateMessages filters out deleted,
   // even though they are in the actual database.

--- a/crates/api/src/site.rs
+++ b/crates/api/src/site.rs
@@ -15,6 +15,7 @@ use lemmy_db_queries::{
   from_opt_str_to_opt_enum,
   source::site::Site_,
   Crud,
+  DeleteableOrRemoveable,
   ListingType,
   SearchType,
   SortType,
@@ -331,6 +332,28 @@ impl Perform for Search {
         .await??;
       }
     };
+
+    // Blank out deleted or removed info
+    for cv in comments
+      .iter_mut()
+      .filter(|cv| cv.comment.deleted || cv.comment.removed)
+    {
+      cv.comment = cv.to_owned().comment.blank_out_deleted_or_removed_info();
+    }
+
+    for cv in communities
+      .iter_mut()
+      .filter(|cv| cv.community.deleted || cv.community.removed)
+    {
+      cv.community = cv.to_owned().community.blank_out_deleted_or_removed_info();
+    }
+
+    for pv in posts
+      .iter_mut()
+      .filter(|p| p.post.deleted || p.post.removed)
+    {
+      pv.post = pv.to_owned().post.blank_out_deleted_or_removed_info();
+    }
 
     // Return the jwt
     Ok(SearchResponse {

--- a/crates/api_crud/src/community/delete.rs
+++ b/crates/api_crud/src/community/delete.rs
@@ -2,7 +2,7 @@ use crate::{community::send_community_websocket, PerformCrud};
 use actix_web::web::Data;
 use lemmy_api_common::{blocking, community::*, get_local_user_view_from_jwt, is_admin};
 use lemmy_apub::CommunityType;
-use lemmy_db_queries::{source::community::Community_, Crud};
+use lemmy_db_queries::{source::community::Community_, Crud, DeleteableOrRemoveable};
 use lemmy_db_schema::source::{
   community::*,
   moderator::{ModRemoveCommunity, ModRemoveCommunityForm},
@@ -50,6 +50,7 @@ impl PerformCrud for DeleteCommunity {
     // Send apub messages
     if deleted {
       updated_community
+        .blank_out_deleted_or_removed_info()
         .send_delete(local_user_view.person.to_owned(), context)
         .await?;
     } else {
@@ -60,10 +61,15 @@ impl PerformCrud for DeleteCommunity {
 
     let community_id = data.community_id;
     let person_id = local_user_view.person.id;
-    let community_view = blocking(context.pool(), move |conn| {
+    let mut community_view = blocking(context.pool(), move |conn| {
       CommunityView::read(conn, community_id, Some(person_id))
     })
     .await??;
+
+    // Blank out deleted or removed info
+    if deleted {
+      community_view.community = community_view.community.blank_out_deleted_or_removed_info();
+    }
 
     let res = CommunityResponse { community_view };
 
@@ -118,17 +124,25 @@ impl PerformCrud for RemoveCommunity {
 
     // Apub messages
     if removed {
-      updated_community.send_remove(context).await?;
+      updated_community
+        .blank_out_deleted_or_removed_info()
+        .send_remove(context)
+        .await?;
     } else {
       updated_community.send_undo_remove(context).await?;
     }
 
     let community_id = data.community_id;
     let person_id = local_user_view.person.id;
-    let community_view = blocking(context.pool(), move |conn| {
+    let mut community_view = blocking(context.pool(), move |conn| {
       CommunityView::read(conn, community_id, Some(person_id))
     })
     .await??;
+
+    // Blank out deleted or removed info
+    if removed {
+      community_view.community = community_view.community.blank_out_deleted_or_removed_info();
+    }
 
     let res = CommunityResponse { community_view };
 

--- a/crates/api_crud/src/post/delete.rs
+++ b/crates/api_crud/src/post/delete.rs
@@ -8,7 +8,7 @@ use lemmy_api_common::{
   post::*,
 };
 use lemmy_apub::ApubObjectType;
-use lemmy_db_queries::{source::post::Post_, Crud};
+use lemmy_db_queries::{source::post::Post_, Crud, DeleteableOrRemoveable};
 use lemmy_db_schema::source::{moderator::*, post::*};
 use lemmy_db_views::post_view::PostView;
 use lemmy_utils::{ApiError, ConnectionId, LemmyError};
@@ -52,6 +52,7 @@ impl PerformCrud for DeletePost {
     // apub updates
     if deleted {
       updated_post
+        .blank_out_deleted_or_removed_info()
         .send_delete(&local_user_view.person, context)
         .await?;
     } else {
@@ -62,10 +63,14 @@ impl PerformCrud for DeletePost {
 
     // Refetch the post
     let post_id = data.post_id;
-    let post_view = blocking(context.pool(), move |conn| {
+    let mut post_view = blocking(context.pool(), move |conn| {
       PostView::read(conn, post_id, Some(local_user_view.person.id))
     })
     .await??;
+
+    if deleted {
+      post_view.post = post_view.post.blank_out_deleted_or_removed_info();
+    }
 
     let res = PostResponse { post_view };
 
@@ -132,6 +137,7 @@ impl PerformCrud for RemovePost {
     // apub updates
     if removed {
       updated_post
+        .blank_out_deleted_or_removed_info()
         .send_remove(&local_user_view.person, context)
         .await?;
     } else {
@@ -143,10 +149,15 @@ impl PerformCrud for RemovePost {
     // Refetch the post
     let post_id = data.post_id;
     let person_id = local_user_view.person.id;
-    let post_view = blocking(context.pool(), move |conn| {
+    let mut post_view = blocking(context.pool(), move |conn| {
       PostView::read(conn, post_id, Some(person_id))
     })
     .await??;
+
+    // Blank out deleted or removed info
+    if removed {
+      post_view.post = post_view.post.blank_out_deleted_or_removed_info();
+    }
 
     let res = PostResponse { post_view };
 

--- a/crates/api_crud/src/private_message/update.rs
+++ b/crates/api_crud/src/private_message/update.rs
@@ -6,7 +6,7 @@ use lemmy_api_common::{
   person::{EditPrivateMessage, PrivateMessageResponse},
 };
 use lemmy_apub::ApubObjectType;
-use lemmy_db_queries::{source::private_message::PrivateMessage_, Crud};
+use lemmy_db_queries::{source::private_message::PrivateMessage_, Crud, DeleteableOrRemoveable};
 use lemmy_db_schema::source::private_message::PrivateMessage;
 use lemmy_db_views::{local_user_view::LocalUserView, private_message_view::PrivateMessageView};
 use lemmy_utils::{utils::remove_slurs, ApiError, ConnectionId, LemmyError};
@@ -49,10 +49,17 @@ impl PerformCrud for EditPrivateMessage {
       .await?;
 
     let private_message_id = data.private_message_id;
-    let private_message_view = blocking(context.pool(), move |conn| {
+    let mut private_message_view = blocking(context.pool(), move |conn| {
       PrivateMessageView::read(conn, private_message_id)
     })
     .await??;
+
+    // Blank out deleted or removed info
+    if private_message_view.private_message.deleted {
+      private_message_view.private_message = private_message_view
+        .private_message
+        .blank_out_deleted_or_removed_info();
+    }
 
     let res = PrivateMessageResponse {
       private_message_view,

--- a/crates/db_queries/src/lib.rs
+++ b/crates/db_queries/src/lib.rs
@@ -117,6 +117,10 @@ pub trait Reportable<Form> {
     Self: Sized;
 }
 
+pub trait DeleteableOrRemoveable {
+  fn blank_out_deleted_or_removed_info(self) -> Self;
+}
+
 pub trait ApubObject<Form> {
   fn read_from_apub_id(conn: &PgConnection, object_id: &DbUrl) -> Result<Self, Error>
   where

--- a/crates/db_queries/src/source/comment.rs
+++ b/crates/db_queries/src/source/comment.rs
@@ -1,4 +1,4 @@
-use crate::{ApubObject, Crud, Likeable, Saveable};
+use crate::{ApubObject, Crud, DeleteableOrRemoveable, Likeable, Saveable};
 use diesel::{dsl::*, result::Error, *};
 use lemmy_db_schema::{
   naive_now,
@@ -225,6 +225,13 @@ impl Saveable<CommentSavedForm> for CommentSaved {
         .filter(person_id.eq(comment_saved_form.person_id)),
     )
     .execute(conn)
+  }
+}
+
+impl DeleteableOrRemoveable for Comment {
+  fn blank_out_deleted_or_removed_info(mut self) -> Self {
+    self.content = "".into();
+    self
   }
 }
 

--- a/crates/db_queries/src/source/community.rs
+++ b/crates/db_queries/src/source/community.rs
@@ -1,4 +1,4 @@
-use crate::{ApubObject, Bannable, Crud, Followable, Joinable};
+use crate::{ApubObject, Bannable, Crud, DeleteableOrRemoveable, Followable, Joinable};
 use diesel::{dsl::*, result::Error, *};
 use lemmy_db_schema::{
   naive_now,
@@ -11,6 +11,7 @@ use lemmy_db_schema::{
     CommunityModeratorForm,
     CommunityPersonBan,
     CommunityPersonBanForm,
+    CommunitySafe,
   },
   CommunityId,
   DbUrl,
@@ -196,6 +197,26 @@ impl Joinable<CommunityModeratorForm> for CommunityModerator {
         .filter(person_id.eq(community_moderator_form.person_id)),
     )
     .execute(conn)
+  }
+}
+
+impl DeleteableOrRemoveable for CommunitySafe {
+  fn blank_out_deleted_or_removed_info(mut self) -> Self {
+    self.title = "".into();
+    self.description = None;
+    self.icon = None;
+    self.banner = None;
+    self
+  }
+}
+
+impl DeleteableOrRemoveable for Community {
+  fn blank_out_deleted_or_removed_info(mut self) -> Self {
+    self.title = "".into();
+    self.description = None;
+    self.icon = None;
+    self.banner = None;
+    self
   }
 }
 

--- a/crates/db_queries/src/source/post.rs
+++ b/crates/db_queries/src/source/post.rs
@@ -1,4 +1,4 @@
-use crate::{ApubObject, Crud, Likeable, Readable, Saveable};
+use crate::{ApubObject, Crud, DeleteableOrRemoveable, Likeable, Readable, Saveable};
 use diesel::{dsl::*, result::Error, *};
 use lemmy_db_schema::{
   naive_now,
@@ -257,6 +257,20 @@ impl Readable<PostReadForm> for PostRead {
         .filter(person_id.eq(post_read_form.person_id)),
     )
     .execute(conn)
+  }
+}
+
+impl DeleteableOrRemoveable for Post {
+  fn blank_out_deleted_or_removed_info(mut self) -> Self {
+    self.name = "".into();
+    self.url = None;
+    self.body = None;
+    self.embed_title = None;
+    self.embed_description = None;
+    self.embed_html = None;
+    self.thumbnail_url = None;
+
+    self
   }
 }
 

--- a/crates/db_queries/src/source/private_message.rs
+++ b/crates/db_queries/src/source/private_message.rs
@@ -1,4 +1,4 @@
-use crate::{ApubObject, Crud};
+use crate::{ApubObject, Crud, DeleteableOrRemoveable};
 use diesel::{dsl::*, result::Error, *};
 use lemmy_db_schema::{naive_now, source::private_message::*, DbUrl, PersonId, PrivateMessageId};
 
@@ -134,6 +134,13 @@ impl PrivateMessage_ for PrivateMessage {
     )
     .set(read.eq(true))
     .get_results::<Self>(conn)
+  }
+}
+
+impl DeleteableOrRemoveable for PrivateMessage {
+  fn blank_out_deleted_or_removed_info(mut self) -> Self {
+    self.content = "".into();
+    self
   }
 }
 


### PR DESCRIPTION
I don't *particularly* like this solution, as this blanking happens after the database calls, so requires some in-code manipulation, when I'd really rather have the DB be able to do it. But there's no way that I can think of to do that, IE blanking other columns if one is a certain result.

The vector looping if probably fast enough that it's not an issue.