### PR TITLE
Migrate comment inReplyTo field to single value (ref #1454)

### DIFF
--- a/crates/apub/src/lib.rs
+++ b/crates/apub/src/lib.rs
@@ -6,6 +6,7 @@ pub mod activity_queue;
 pub mod extensions;
 pub mod fetcher;
 pub mod http;
+pub mod migrations;
 pub mod objects;
 
 use crate::{

--- a/crates/apub/src/migrations.rs
+++ b/crates/apub/src/migrations.rs
@@ -1,0 +1,17 @@
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+/// Migrate comment.in_reply_to field from containing post and parent comment ID, to only containing
+/// the direct parent (whether its a post or comment). This is for compatibility with Pleroma and
+/// Smithereen.
+/// [https://github.com/LemmyNet/lemmy/issues/1454]
+///
+/// v0.12: receive both, send old (compatible with v0.11)
+/// v0.13 receive both, send new (compatible with v0.12+, incompatible with v0.11)
+/// v0.14: only send and receive new, remove migration (compatible with v0.13+)
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum CommentInReplyToMigration {
+  Old(Vec<Url>),
+  New(Url),
+}


### PR DESCRIPTION
This is how we can do protocol migrations now with the new way of sending and receiving apub objects. I think its very elegant.

Tested by inspecting the json, and by temporarily changing the code to send the new variant (works fine).