### PR TITLE
Implement instance actor

### DIFF
--- a/api_tests/src/post.spec.ts
+++ b/api_tests/src/post.spec.ts
@@ -298,28 +298,43 @@ test('A and G subscribe to B (center) A posts, it gets announced to G', async ()
 
 test('Enforce site ban for federated user', async () => {
   let alphaShortname = `@lemmy_alpha@lemmy-alpha:8541`;
-  let alphaPerson = (await resolvePerson(beta, alphaShortname)).person;
+  let alphaPerson = (await resolvePerson(alpha, alphaShortname)).person;
   expect(alphaPerson).toBeDefined();
 
-  // ban alpha from beta site
-  let banAlpha = await banPersonFromSite(beta, alphaPerson.person.id, true);
+  let postRes1 = await createPost(alpha, betaCommunity.community.id);
+  let searchBeta1 = await searchPostLocal(beta, postRes1.post_view.post);
+  expect(searchBeta1.posts[0]).toBeDefined();
+
+  // ban alpha from site
+  let banAlpha = await banPersonFromSite(alpha, alphaPerson.person.id, true, true);
   expect(banAlpha.banned).toBe(true);
 
-  // Alpha makes post on beta
-  let postRes = await createPost(alpha, betaCommunity.community.id);
-  expect(postRes.post_view.post).toBeDefined();
-  expect(postRes.post_view.community.local).toBe(false);
-  expect(postRes.post_view.creator.local).toBe(true);
-  expect(postRes.post_view.counts.score).toBe(1);
+  // alpha ban should be federated to beta
+  let alphaUserOnBeta1 = await resolvePerson(beta, alphaPerson.person.actor_id);
+  console.debug(alphaUserOnBeta1);
+  expect(alphaUserOnBeta1.person.person.banned).toBe(true);
+
+  // post should be removed
+  let searchBeta2 = await searchPostLocal(beta, postRes1.post_view.post);
+  expect(searchBeta2.posts[0]).toBeUndefined();
+
+  // Alpha makes new post on beta
+  let postRes2 = await createPost(alpha, betaCommunity.community.id);
+  expect(postRes2.post_view.post).toBeDefined();
+  expect(postRes2.post_view.community.local).toBe(false);
+  expect(postRes2.post_view.creator.local).toBe(true);
+  expect(postRes2.post_view.counts.score).toBe(1);
 
   // Make sure that post doesn't make it to beta
-  let searchBeta = await searchPostLocal(beta, postRes.post_view.post);
-  let betaPost = searchBeta.posts[0];
-  expect(betaPost).toBeUndefined();
+  let searchBeta = await searchPostLocal(beta, postRes2.post_view.post);
+  expect(searchBeta.posts[0]).toBeUndefined();
 
   // Unban alpha
-  let unBanAlpha = await banPersonFromSite(beta, alphaPerson.person.id, false);
+  let unBanAlpha = await banPersonFromSite(alpha, alphaPerson.person.id, false, false);
   expect(unBanAlpha.banned).toBe(false);
+
+  let alphaUserOnBeta2 = await resolvePerson(beta, alphaPerson.person.actor_id)
+  expect(alphaUserOnBeta2.person.person.banned).toBe(false);
 });
 
 test('Enforce community ban for federated user', async () => {
@@ -327,33 +342,41 @@ test('Enforce community ban for federated user', async () => {
   let alphaPerson = (await resolvePerson(beta, alphaShortname)).person;
   expect(alphaPerson).toBeDefined();
 
-  // ban alpha from beta site
-  await banPersonFromCommunity(beta, alphaPerson.person.id, 2, false);
-  let banAlpha = await banPersonFromCommunity(beta, alphaPerson.person.id, 2, true);
+  // make a post in beta, it goes through
+  let postRes1 = await createPost(alpha, betaCommunity.community.id);
+  let searchBeta1 = await searchPostLocal(beta, postRes1.post_view.post);
+  expect(searchBeta1.posts[0]).toBeDefined();
+
+  // ban alpha from beta community
+  let banAlpha = await banPersonFromCommunity(beta, alphaPerson.person.id, 2, true, true);
   expect(banAlpha.banned).toBe(true);
 
+  // ensure that the post by alpha got removed
+  let searchAlpha1 = await searchPostLocal(alpha, postRes1.post_view.post);
+  expect(searchAlpha1.posts[0]).toBeUndefined();
+
   // Alpha tries to make post on beta, but it fails because of ban
-  let postRes = await createPost(alpha, betaCommunity.community.id);
-  expect(postRes.post_view).toBeUndefined();
+  let postRes2 = await createPost(alpha, betaCommunity.community.id);
+  expect(postRes2.post_view).toBeUndefined();
 
   // Unban alpha
   let unBanAlpha = await banPersonFromCommunity(
     beta,
     alphaPerson.person.id,
     2,
+    false,
     false
   );
   expect(unBanAlpha.banned).toBe(false);
-  let postRes2 = await createPost(alpha, betaCommunity.community.id);
-  expect(postRes2.post_view.post).toBeDefined();
-  expect(postRes2.post_view.community.local).toBe(false);
-  expect(postRes2.post_view.creator.local).toBe(true);
-  expect(postRes2.post_view.counts.score).toBe(1);
+  let postRes3 = await createPost(alpha, betaCommunity.community.id);
+  expect(postRes3.post_view.post).toBeDefined();
+  expect(postRes3.post_view.community.local).toBe(false);
+  expect(postRes3.post_view.creator.local).toBe(true);
+  expect(postRes3.post_view.counts.score).toBe(1);
 
   // Make sure that post makes it to beta community
-  let searchBeta = await searchPostLocal(beta, postRes2.post_view.post);
-  let betaPost = searchBeta.posts[0];
-  expect(betaPost).toBeDefined();
+  let searchBeta2 = await searchPostLocal(beta, postRes3.post_view.post);
+  expect(searchBeta2.posts[0]).toBeDefined();
 });
 
 test('Report a post', async () => {

--- a/api_tests/src/shared.ts
+++ b/api_tests/src/shared.ts
@@ -66,23 +66,23 @@ export interface API {
 }
 
 export let alpha: API = {
-  client: new LemmyHttp('http://localhost:8541'),
+  client: new LemmyHttp('http://127.0.0.1:8541'),
 };
 
 export let beta: API = {
-  client: new LemmyHttp('http://localhost:8551'),
+  client: new LemmyHttp('http://127.0.0.1:8551'),
 };
 
 export let gamma: API = {
-  client: new LemmyHttp('http://localhost:8561'),
+  client: new LemmyHttp('http://127.0.0.1:8561'),
 };
 
 export let delta: API = {
-  client: new LemmyHttp('http://localhost:8571'),
+  client: new LemmyHttp('http://127.0.0.1:8571'),
 };
 
 export let epsilon: API = {
-  client: new LemmyHttp('http://localhost:8581'),
+  client: new LemmyHttp('http://127.0.0.1:8581'),
 };
 
 const password = 'lemmylemmy'
@@ -289,13 +289,14 @@ export async function resolvePerson(
 export async function banPersonFromSite(
   api: API,
   person_id: number,
-  ban: boolean
+  ban: boolean,
+  remove_data: boolean,
 ): Promise<BanPersonResponse> {
   // Make sure lemmy-beta/c/main is cached on lemmy_alpha
   let form: BanPerson = {
     person_id,
     ban,
-    remove_data: false,
+    remove_data,
     auth: api.auth,
   };
   return api.client.banPerson(form);
@@ -305,13 +306,13 @@ export async function banPersonFromCommunity(
   api: API,
   person_id: number,
   community_id: number,
+  remove_data: boolean,
   ban: boolean
 ): Promise<BanFromCommunityResponse> {
-  // Make sure lemmy-beta/c/main is cached on lemmy_alpha
   let form: BanFromCommunity = {
     person_id,
     community_id,
-    remove_data: false,
+    remove_data,
     ban,
     auth: api.auth,
   };

--- a/crates/api/src/community.rs
+++ b/crates/api/src/community.rs
@@ -540,6 +540,7 @@ impl Perform for TransferCommunity {
       community_view,
       moderators,
       online: 0,
+      site: None,
     })
   }
 }

--- a/crates/api/src/community.rs
+++ b/crates/api/src/community.rs
@@ -257,6 +257,7 @@ impl Perform for BanFromCommunity {
         &banned_person,
         &local_user_view.person.clone().into(),
         remove_data,
+        data.reason.clone(),
         expires,
         context,
       )
@@ -271,6 +272,7 @@ impl Perform for BanFromCommunity {
         &SiteOrCommunity::Community(community),
         &banned_person,
         &local_user_view.person.clone().into(),
+        data.reason.clone(),
         context,
       )
       .await?;

--- a/crates/api/src/community.rs
+++ b/crates/api/src/community.rs
@@ -516,7 +516,6 @@ impl Perform for TransferCommunity {
       community_view,
       moderators,
       online: 0,
-      site: None,
     })
   }
 }

--- a/crates/api/src/local_user.rs
+++ b/crates/api/src/local_user.rs
@@ -478,26 +478,29 @@ impl Perform for BanPerson {
         .await??
         .into(),
     );
-    if ban {
-      BlockUser::send(
-        &site,
-        &person.into(),
-        &local_user_view.person.into(),
-        remove_data,
-        data.reason.clone(),
-        expires,
-        context,
-      )
-      .await?;
-    } else {
-      UndoBlockUser::send(
-        &site,
-        &person.into(),
-        &local_user_view.person.into(),
-        data.reason.clone(),
-        context,
-      )
-      .await?;
+    // if the action affects a local user, federate to other instances
+    if person.local {
+      if ban {
+        BlockUser::send(
+          &site,
+          &person.into(),
+          &local_user_view.person.into(),
+          remove_data,
+          data.reason.clone(),
+          expires,
+          context,
+        )
+        .await?;
+      } else {
+        UndoBlockUser::send(
+          &site,
+          &person.into(),
+          &local_user_view.person.into(),
+          data.reason.clone(),
+          context,
+        )
+        .await?;
+      }
     }
 
     let res = BanPersonResponse {

--- a/crates/api/src/local_user.rs
+++ b/crates/api/src/local_user.rs
@@ -91,7 +91,7 @@ impl Perform for Login {
       return Err(LemmyError::from_message("password_incorrect"));
     }
 
-    let site = blocking(context.pool(), Site::read_simple).await??;
+    let site = blocking(context.pool(), Site::read_local_site).await??;
     if site.require_email_verification && !local_user_view.local_user.email_verified {
       return Err(LemmyError::from_message("email_not_verified"));
     }
@@ -200,7 +200,7 @@ impl Perform for SaveUserSettings {
 
     // When the site requires email, make sure email is not Some(None). IE, an overwrite to a None value
     if let Some(email) = &email {
-      let site_fut = blocking(context.pool(), Site::read_simple);
+      let site_fut = blocking(context.pool(), Site::read_local_site);
       if email.is_none() && site_fut.await??.require_email_verification {
         return Err(LemmyError::from_message("email_required"));
       }

--- a/crates/api/src/site.rs
+++ b/crates/api/src/site.rs
@@ -583,7 +583,7 @@ impl Perform for ListRegistrationApplications {
     is_admin(&local_user_view)?;
 
     let unread_only = data.unread_only;
-    let verified_email_only = blocking(context.pool(), Site::read_simple)
+    let verified_email_only = blocking(context.pool(), Site::read_local_site)
       .await??
       .require_email_verification;
 
@@ -689,7 +689,7 @@ impl Perform for GetUnreadRegistrationApplicationCount {
     // Only let admins do this
     is_admin(&local_user_view)?;
 
-    let verified_email_only = blocking(context.pool(), Site::read_simple)
+    let verified_email_only = blocking(context.pool(), Site::read_local_site)
       .await??
       .require_email_verification;
 

--- a/crates/api_common/src/community.rs
+++ b/crates/api_common/src/community.rs
@@ -1,7 +1,4 @@
-use lemmy_db_schema::{
-  newtypes::{CommunityId, PersonId},
-  source::site::Site,
-};
+use lemmy_db_schema::newtypes::{CommunityId, PersonId};
 use lemmy_db_views_actor::{
   community_moderator_view::CommunityModeratorView,
   community_view::CommunityView,
@@ -23,12 +20,6 @@ pub struct GetCommunityResponse {
   pub community_view: CommunityView,
   pub moderators: Vec<CommunityModeratorView>,
   pub online: usize,
-  /// Metadata of the instance where the community is located. Only fields name, sidebar,
-  /// description, icon, banner, actor_id, last_refreshed_at get federated, everything else uses
-  /// default values. May be null if the community is hosted on an older Lemmy version, or on
-  /// another software.
-  /// TODO: this should probably be SiteView
-  pub site: Option<Site>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/api_common/src/community.rs
+++ b/crates/api_common/src/community.rs
@@ -1,4 +1,7 @@
-use lemmy_db_schema::newtypes::{CommunityId, PersonId};
+use lemmy_db_schema::{
+  newtypes::{CommunityId, PersonId},
+  source::site::Site,
+};
 use lemmy_db_views_actor::{
   community_moderator_view::CommunityModeratorView,
   community_view::CommunityView,
@@ -20,6 +23,12 @@ pub struct GetCommunityResponse {
   pub community_view: CommunityView,
   pub moderators: Vec<CommunityModeratorView>,
   pub online: usize,
+  /// Metadata of the instance where the community is located. Only fields name, sidebar,
+  /// description, icon, banner, actor_id, last_refreshed_at get federated, everything else uses
+  /// default values. May be null if the community is hosted on an older Lemmy version, or on
+  /// another software.
+  /// TODO: this should probably be SiteView
+  pub site: Option<Site>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/api_common/src/lib.rs
+++ b/crates/api_common/src/lib.rs
@@ -35,7 +35,6 @@ use lemmy_utils::{
   LemmyError,
   Sensitive,
 };
-use url::Url;
 
 pub async fn blocking<F, T>(pool: &DbPool, f: F) -> Result<T, LemmyError>
 where
@@ -311,7 +310,7 @@ pub async fn build_federated_instances(
 
     let mut linked = distinct_communities
       .iter()
-      .map(|actor_id| Ok(Url::parse(actor_id)?.host_str().unwrap_or("").to_string()))
+      .map(|actor_id| Ok(actor_id.host_str().unwrap_or("").to_string()))
       .collect::<Result<Vec<String>, LemmyError>>()?;
 
     if let Some(allowed) = allowed.as_ref() {

--- a/crates/api_common/src/lib.rs
+++ b/crates/api_common/src/lib.rs
@@ -267,7 +267,7 @@ pub async fn check_person_block(
 #[tracing::instrument(skip_all)]
 pub async fn check_downvotes_enabled(score: i16, pool: &DbPool) -> Result<(), LemmyError> {
   if score == -1 {
-    let site = blocking(pool, Site::read_simple).await??;
+    let site = blocking(pool, Site::read_local_site).await??;
     if !site.enable_downvotes {
       return Err(LemmyError::from_message("downvotes_disabled"));
     }
@@ -281,7 +281,7 @@ pub async fn check_private_instance(
   pool: &DbPool,
 ) -> Result<(), LemmyError> {
   if local_user_view.is_none() {
-    let site = blocking(pool, Site::read_simple).await?;
+    let site = blocking(pool, Site::read_local_site).await?;
 
     // The site might not be set up yet
     if let Ok(site) = site {
@@ -511,7 +511,7 @@ pub async fn check_private_instance_and_federation_enabled(
   pool: &DbPool,
   settings: &Settings,
 ) -> Result<(), LemmyError> {
-  let site_opt = blocking(pool, Site::read_simple).await?;
+  let site_opt = blocking(pool, Site::read_local_site).await?;
 
   if let Ok(site) = site_opt {
     if site.private_instance && settings.federation.enabled {

--- a/crates/api_crud/src/community/create.rs
+++ b/crates/api_crud/src/community/create.rs
@@ -53,7 +53,7 @@ impl PerformCrud for CreateCommunity {
     let local_user_view =
       get_local_user_view_from_jwt(&data.auth, context.pool(), context.secret()).await?;
 
-    let site = blocking(context.pool(), move |conn| Site::read(conn, 0)).await??;
+    let site = blocking(context.pool(), Site::read_local_site).await??;
     if site.community_creation_admin_only && is_admin(&local_user_view).is_err() {
       return Err(LemmyError::from_message(
         "only_admins_can_create_communities",

--- a/crates/api_crud/src/community/read.rs
+++ b/crates/api_crud/src/community/read.rs
@@ -7,10 +7,9 @@ use lemmy_api_common::{
   get_local_user_view_from_jwt_opt,
   resolve_actor_identifier,
 };
-use lemmy_apub::objects::instance::instance_actor_id_from_url;
 use lemmy_db_schema::{
   from_opt_str_to_opt_enum,
-  source::{community::Community, site::Site},
+  source::community::Community,
   traits::DeleteableOrRemoveable,
   ListingType,
   SortType,
@@ -79,21 +78,10 @@ impl PerformCrud for GetCommunity {
       .await
       .unwrap_or(1);
 
-    let site_id = instance_actor_id_from_url(community_view.community.actor_id.clone().into());
-    let site = blocking(context.pool(), move |conn| {
-      Site::read_from_apub_id(conn, site_id)
-    })
-    .await
-    .map(|s| s.ok())
-    .ok()
-    .flatten()
-    .flatten();
-
     let res = GetCommunityResponse {
       community_view,
       moderators,
       online,
-      site,
     };
 
     // Return the jwt

--- a/crates/api_crud/src/community/read.rs
+++ b/crates/api_crud/src/community/read.rs
@@ -7,9 +7,10 @@ use lemmy_api_common::{
   get_local_user_view_from_jwt_opt,
   resolve_actor_identifier,
 };
+use lemmy_apub::objects::instance::instance_actor_id_from_url;
 use lemmy_db_schema::{
   from_opt_str_to_opt_enum,
-  source::community::Community,
+  source::{community::Community, site::Site},
   traits::DeleteableOrRemoveable,
   ListingType,
   SortType,
@@ -78,10 +79,21 @@ impl PerformCrud for GetCommunity {
       .await
       .unwrap_or(1);
 
+    let site_id = instance_actor_id_from_url(community_view.community.actor_id.clone().into());
+    let site = blocking(context.pool(), move |conn| {
+      Site::read_from_apub_id(conn, site_id)
+    })
+    .await
+    .map(|s| s.ok())
+    .ok()
+    .flatten()
+    .flatten();
+
     let res = GetCommunityResponse {
       community_view,
       moderators,
       online,
+      site,
     };
 
     // Return the jwt

--- a/crates/api_crud/src/site/create.rs
+++ b/crates/api_crud/src/site/create.rs
@@ -63,6 +63,7 @@ impl PerformCrud for CreateSite {
     }
 
     let actor_id: DbUrl = Url::parse(&Settings::get().get_protocol_and_hostname())?.into();
+    let inbox_url = Some(generate_site_inbox_url(&actor_id)?);
     let keypair = generate_actor_keypair()?;
     let site_form = SiteForm {
       name: data.name.to_owned(),
@@ -74,8 +75,9 @@ impl PerformCrud for CreateSite {
       open_registration: data.open_registration,
       enable_nsfw: data.enable_nsfw,
       community_creation_admin_only: data.community_creation_admin_only,
+      actor_id: Some(actor_id),
       last_refreshed_at: Some(naive_now()),
-      inbox_url: Some(generate_site_inbox_url(&actor_id)?),
+      inbox_url,
       private_key: Some(Some(keypair.private_key)),
       public_key: Some(keypair.public_key),
       ..SiteForm::default()

--- a/crates/api_crud/src/site/create.rs
+++ b/crates/api_crud/src/site/create.rs
@@ -7,19 +7,25 @@ use lemmy_api_common::{
   site::*,
   site_description_length_check,
 };
+use lemmy_apub::generate_inbox_url;
 use lemmy_db_schema::{
   diesel_option_overwrite,
   diesel_option_overwrite_to_url,
+  naive_now,
+  newtypes::DbUrl,
   source::site::{Site, SiteForm},
   traits::Crud,
 };
 use lemmy_db_views::site_view::SiteView;
 use lemmy_utils::{
+  apub::generate_actor_keypair,
+  settings::structs::Settings,
   utils::{check_slurs, check_slurs_opt},
   ConnectionId,
   LemmyError,
 };
 use lemmy_websocket::LemmyContext;
+use url::Url;
 
 #[async_trait::async_trait(?Send)]
 impl PerformCrud for CreateSite {
@@ -33,7 +39,7 @@ impl PerformCrud for CreateSite {
   ) -> Result<SiteResponse, LemmyError> {
     let data: &CreateSite = self;
 
-    let read_site = Site::read_simple;
+    let read_site = Site::read_local_site;
     if blocking(context.pool(), read_site).await?.is_ok() {
       return Err(LemmyError::from_message("site_already_exists"));
     };
@@ -56,6 +62,8 @@ impl PerformCrud for CreateSite {
       site_description_length_check(desc)?;
     }
 
+    let actor_id: DbUrl = Url::parse(&Settings::get().get_protocol_and_hostname())?.into();
+    let keypair = generate_actor_keypair()?;
     let site_form = SiteForm {
       name: data.name.to_owned(),
       sidebar,
@@ -66,6 +74,10 @@ impl PerformCrud for CreateSite {
       open_registration: data.open_registration,
       enable_nsfw: data.enable_nsfw,
       community_creation_admin_only: data.community_creation_admin_only,
+      last_refreshed_at: Some(naive_now()),
+      inbox_url: Some(generate_inbox_url(&actor_id)?),
+      private_key: Some(Some(keypair.private_key)),
+      public_key: Some(keypair.public_key),
       ..SiteForm::default()
     };
 

--- a/crates/api_crud/src/site/create.rs
+++ b/crates/api_crud/src/site/create.rs
@@ -7,7 +7,7 @@ use lemmy_api_common::{
   site::*,
   site_description_length_check,
 };
-use lemmy_apub::generate_inbox_url;
+use lemmy_apub::generate_site_inbox_url;
 use lemmy_db_schema::{
   diesel_option_overwrite,
   diesel_option_overwrite_to_url,
@@ -75,7 +75,7 @@ impl PerformCrud for CreateSite {
       enable_nsfw: data.enable_nsfw,
       community_creation_admin_only: data.community_creation_admin_only,
       last_refreshed_at: Some(naive_now()),
-      inbox_url: Some(generate_inbox_url(&actor_id)?),
+      inbox_url: Some(generate_site_inbox_url(&actor_id)?),
       private_key: Some(Some(keypair.private_key)),
       public_key: Some(keypair.public_key),
       ..SiteForm::default()

--- a/crates/api_crud/src/site/update.rs
+++ b/crates/api_crud/src/site/update.rs
@@ -20,6 +20,7 @@ use lemmy_db_schema::{
 use lemmy_db_views::site_view::SiteView;
 use lemmy_utils::{utils::check_slurs_opt, ConnectionId, LemmyError};
 use lemmy_websocket::{messages::SendAllMessage, LemmyContext, UserOperationCrud};
+use std::default::Default;
 
 #[async_trait::async_trait(?Send)]
 impl PerformCrud for EditSite {
@@ -41,7 +42,7 @@ impl PerformCrud for EditSite {
     // Make sure user is an admin
     is_admin(&local_user_view)?;
 
-    let found_site = blocking(context.pool(), Site::read_simple).await??;
+    let found_site = blocking(context.pool(), Site::read_local_site).await??;
 
     let sidebar = diesel_option_overwrite(&data.sidebar);
     let description = diesel_option_overwrite(&data.description);
@@ -68,6 +69,7 @@ impl PerformCrud for EditSite {
       require_application: data.require_application,
       application_question,
       private_instance: data.private_instance,
+      ..SiteForm::default()
     };
 
     let update_site = blocking(context.pool(), move |conn| {

--- a/crates/api_crud/src/user/create.rs
+++ b/crates/api_crud/src/user/create.rs
@@ -58,7 +58,7 @@ impl PerformCrud for Register {
     let (mut email_verification, mut require_application) = (false, false);
 
     // Make sure site has open registration
-    if let Ok(site) = blocking(context.pool(), Site::read_simple).await? {
+    if let Ok(site) = blocking(context.pool(), Site::read_local_site).await? {
       if !site.open_registration {
         return Err(LemmyError::from_message("registration_closed"));
       }

--- a/crates/apub/assets/lemmy/activities/block/block_user.json
+++ b/crates/apub/assets/lemmy/activities/block/block_user.json
@@ -9,6 +9,8 @@
   ],
   "target": "http://enterprise.lemmy.ml/c/main",
   "type": "Block",
+  "remove_data": "true",
+  "summary": "spam post",
   "expires": "2021-11-01T12:23:50.151874+00:00",
   "id": "http://enterprise.lemmy.ml/activities/block/5d42fffb-0903-4625-86d4-0b39bb344fc2"
 }

--- a/crates/apub/assets/lemmy/activities/block/undo_block_user.json
+++ b/crates/apub/assets/lemmy/activities/block/undo_block_user.json
@@ -14,6 +14,9 @@
     ],
     "target": "http://enterprise.lemmy.ml/c/main",
     "type": "Block",
+    "remove_data": "true",
+    "summary": "spam post",
+    "expires": "2021-11-01T12:23:50.151874+00:00",
     "id": "http://enterprise.lemmy.ml/activities/block/726f43ab-bd0e-4ab3-89c8-627e976f553c"
   },
   "cc": [

--- a/crates/apub/assets/lemmy/objects/instance.json
+++ b/crates/apub/assets/lemmy/objects/instance.json
@@ -1,0 +1,39 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    {
+      "stickied": "as:stickied",
+      "pt": "https://join-lemmy.org#",
+      "sc": "http://schema.org#",
+      "matrixUserId": {
+        "type": "sc:Text",
+        "id": "as:alsoKnownAs"
+      },
+      "sensitive": "as:sensitive",
+      "comments_enabled": {
+        "type": "sc:Boolean",
+        "id": "pt:commentsEnabled"
+      },
+      "moderators": "as:moderators"
+    },
+    "https://w3id.org/security/v1"
+  ],
+  "type": "Service",
+  "id": "https://enterprise.lemmy.ml/",
+  "name": "Enterprise",
+  "summary": "A test instance",
+  "content": "<p>Enterprise sidebar</p>\\n",
+  "mediaType": "text/html",
+  "source": {
+    "content": "Enterprise sidebar",
+    "mediaType": "text/markdown"
+  },
+  "inbox": "https://enterprise.lemmy.ml/inbox",
+  "outbox": "https://enterprise.lemmy.ml/outbox",
+  "publicKey": {
+    "id": "https://enterprise.lemmy.ml/#main-key",
+    "owner": "https://enterprise.lemmy.ml/",
+    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAupcK0xTw5yQb/fnztAmb\n9LfPbhJJP1+1GwUaOXGYiDJD6uYJhl9CLmgztLl3RyV9ltOYoN8/NLNDfOMmgOjd\nrsNWEjDI9IcVPmiZnhU7hsi6KgQvJzzv8O5/xYjAGhDfrGmtdpL+lyG0B5fQod8J\n/V5VWvTQ0B0qFrLSBBuhOrp8/fTtDskdtElDPtnNfH2jn6FgtLOijidWwf9ekFo4\n0I1JeuEw6LuD/CzKVJTPoztzabUV1DQF/DnFJm+8y7SCJa9jEO56Uf9eVfa1jF6f\ndH6ZvNJMiafstVuLMAw7C/eNJy3ufXgtZ4403oOKA0aRSYf1cc9pHSZ9gDE/mevH\nLwIDAQAB\n-----END PUBLIC KEY-----\n"
+  },
+  "published": "2022-01-19T21:52:11.110741+00:00"
+}

--- a/crates/apub/src/activities/block/mod.rs
+++ b/crates/apub/src/activities/block/mod.rs
@@ -1,0 +1,144 @@
+use crate::{
+  objects::{community::ApubCommunity, instance::ApubSite, person::ApubPerson},
+  protocol::objects::{group::Group, instance::Instance},
+};
+use chrono::NaiveDateTime;
+use lemmy_api_common::blocking;
+use lemmy_apub_lib::{
+  object_id::ObjectId,
+  traits::{ActorType, ApubObject},
+};
+use lemmy_db_schema::{source::site::Site, DbPool};
+use lemmy_utils::LemmyError;
+use lemmy_websocket::LemmyContext;
+use serde::Deserialize;
+use url::Url;
+
+pub mod block_user;
+pub mod undo_block_user;
+
+#[derive(Clone, Debug)]
+pub enum SiteOrCommunity {
+  Site(ApubSite),
+  Community(ApubCommunity),
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+pub enum InstanceOrGroup {
+  Instance(Instance),
+  Group(Group),
+}
+
+#[async_trait::async_trait(?Send)]
+impl ApubObject for SiteOrCommunity {
+  type DataType = LemmyContext;
+  type ApubType = InstanceOrGroup;
+  type TombstoneType = ();
+
+  #[tracing::instrument(skip_all)]
+  fn last_refreshed_at(&self) -> Option<NaiveDateTime> {
+    Some(match self {
+      SiteOrCommunity::Site(i) => i.last_refreshed_at,
+      SiteOrCommunity::Community(c) => c.last_refreshed_at,
+    })
+  }
+
+  #[tracing::instrument(skip_all)]
+  async fn read_from_apub_id(
+    object_id: Url,
+    data: &Self::DataType,
+  ) -> Result<Option<Self>, LemmyError>
+  where
+    Self: Sized,
+  {
+    let site = ApubSite::read_from_apub_id(object_id.clone(), data).await?;
+    Ok(match site {
+      Some(o) => Some(SiteOrCommunity::Site(o)),
+      None => ApubCommunity::read_from_apub_id(object_id, data)
+        .await?
+        .map(SiteOrCommunity::Community),
+    })
+  }
+
+  async fn delete(self, _data: &Self::DataType) -> Result<(), LemmyError> {
+    unimplemented!()
+  }
+
+  async fn into_apub(self, _data: &Self::DataType) -> Result<Self::ApubType, LemmyError> {
+    unimplemented!()
+  }
+
+  fn to_tombstone(&self) -> Result<Self::TombstoneType, LemmyError> {
+    unimplemented!()
+  }
+
+  #[tracing::instrument(skip_all)]
+  async fn verify(
+    apub: &Self::ApubType,
+    expected_domain: &Url,
+    data: &Self::DataType,
+    request_counter: &mut i32,
+  ) -> Result<(), LemmyError> {
+    match apub {
+      InstanceOrGroup::Instance(i) => {
+        ApubSite::verify(i, expected_domain, data, request_counter).await
+      }
+      InstanceOrGroup::Group(g) => {
+        ApubCommunity::verify(g, expected_domain, data, request_counter).await
+      }
+    }
+  }
+
+  #[tracing::instrument(skip_all)]
+  async fn from_apub(
+    apub: Self::ApubType,
+    data: &Self::DataType,
+    request_counter: &mut i32,
+  ) -> Result<Self, LemmyError>
+  where
+    Self: Sized,
+  {
+    Ok(match apub {
+      InstanceOrGroup::Instance(p) => {
+        SiteOrCommunity::Site(ApubSite::from_apub(p, data, request_counter).await?)
+      }
+      InstanceOrGroup::Group(n) => {
+        SiteOrCommunity::Community(ApubCommunity::from_apub(n, data, request_counter).await?)
+      }
+    })
+  }
+}
+
+impl SiteOrCommunity {
+  fn id(&self) -> ObjectId<SiteOrCommunity> {
+    match self {
+      SiteOrCommunity::Site(s) => ObjectId::new(s.actor_id.clone()),
+      SiteOrCommunity::Community(c) => ObjectId::new(c.actor_id.clone()),
+    }
+  }
+}
+
+async fn generate_cc(target: &SiteOrCommunity, pool: &DbPool) -> Result<Vec<Url>, LemmyError> {
+  Ok(match target {
+    SiteOrCommunity::Site(_) => blocking(pool, Site::read_remote_sites)
+      .await??
+      .into_iter()
+      .map(|s| s.actor_id.into())
+      .collect(),
+    SiteOrCommunity::Community(c) => vec![c.actor_id()],
+  })
+}
+
+async fn generate_instance_inboxes(
+  blocked_user: &ApubPerson,
+  pool: &DbPool,
+) -> Result<Vec<Url>, LemmyError> {
+  let mut inboxes: Vec<Url> = blocking(pool, Site::read_remote_sites)
+    .await??
+    .into_iter()
+    .map(|s| s.inbox_url.into())
+    .collect();
+  inboxes.push(blocked_user.shared_inbox_or_inbox_url());
+  Ok(inboxes)
+}

--- a/crates/apub/src/activities/community/mod.rs
+++ b/crates/apub/src/activities/community/mod.rs
@@ -11,10 +11,8 @@ use url::Url;
 
 pub mod add_mod;
 pub mod announce;
-pub mod block_user;
 pub mod remove_mod;
 pub mod report;
-pub mod undo_block_user;
 pub mod update;
 
 #[tracing::instrument(skip_all)]

--- a/crates/apub/src/activities/mod.rs
+++ b/crates/apub/src/activities/mod.rs
@@ -25,6 +25,7 @@ use tracing::info;
 use url::{ParseError, Url};
 use uuid::Uuid;
 
+pub mod block;
 pub mod comment;
 pub mod community;
 pub mod deletion;

--- a/crates/apub/src/activity_lists.rs
+++ b/crates/apub/src/activity_lists.rs
@@ -3,13 +3,12 @@ use crate::{
   objects::community::ApubCommunity,
   protocol::{
     activities::{
+      block::{block_user::BlockUser, undo_block_user::UndoBlockUser},
       community::{
         add_mod::AddMod,
         announce::AnnounceActivity,
-        block_user::BlockUserFromCommunity,
         remove_mod::RemoveMod,
         report::Report,
-        undo_block_user::UndoBlockUserFromCommunity,
         update::UpdateCommunity,
       },
       create_or_update::{comment::CreateOrUpdateComment, post::CreateOrUpdatePost},
@@ -78,12 +77,20 @@ pub enum AnnouncableActivities {
   Delete(Delete),
   UndoDelete(UndoDelete),
   UpdateCommunity(UpdateCommunity),
-  BlockUserFromCommunity(BlockUserFromCommunity),
-  UndoBlockUserFromCommunity(UndoBlockUserFromCommunity),
+  BlockUser(BlockUser),
+  UndoBlockUser(UndoBlockUser),
   AddMod(AddMod),
   RemoveMod(RemoveMod),
   // For compatibility with Pleroma/Mastodon (send only)
   Page(Page),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, ActivityHandler)]
+#[serde(untagged)]
+#[activity_handler(LemmyContext)]
+pub enum SiteInboxActivities {
+  BlockUser(BlockUser),
+  UndoBlockUser(UndoBlockUser),
 }
 
 #[async_trait::async_trait(?Send)]
@@ -103,8 +110,8 @@ impl GetCommunity for AnnouncableActivities {
       Delete(a) => a.get_community(context, request_counter).await?,
       UndoDelete(a) => a.get_community(context, request_counter).await?,
       UpdateCommunity(a) => a.get_community(context, request_counter).await?,
-      BlockUserFromCommunity(a) => a.get_community(context, request_counter).await?,
-      UndoBlockUserFromCommunity(a) => a.get_community(context, request_counter).await?,
+      BlockUser(a) => a.get_community(context, request_counter).await?,
+      UndoBlockUser(a) => a.get_community(context, request_counter).await?,
       AddMod(a) => a.get_community(context, request_counter).await?,
       RemoveMod(a) => a.get_community(context, request_counter).await?,
       Page(_) => unimplemented!(),

--- a/crates/apub/src/collections/community_moderators.rs
+++ b/crates/apub/src/collections/community_moderators.rs
@@ -140,7 +140,6 @@ mod tests {
   use super::*;
   use crate::objects::{
     community::tests::parse_lemmy_community,
-    instance::tests::parse_lemmy_instance,
     person::tests::parse_lemmy_person,
     tests::{file_to_json_object, init_context},
   };
@@ -161,7 +160,7 @@ mod tests {
     let client = reqwest::Client::new().into();
     let manager = create_activity_queue(client);
     let context = init_context(manager.queue_handle().clone());
-    let site = parse_lemmy_instance(&context).await;
+    let (new_mod, site) = parse_lemmy_person(&context).await;
     let community = parse_lemmy_community(&context).await;
     let community_id = community.id;
 
@@ -177,7 +176,7 @@ mod tests {
 
     CommunityModerator::join(&context.pool().get().unwrap(), &community_moderator_form).unwrap();
 
-    let new_mod = parse_lemmy_person(&context).await;
+    assert_eq!(site.actor_id.to_string(), "https://enterprise.lemmy.ml/");
 
     let json: GroupModerators =
       file_to_json_object("assets/lemmy/collections/group_moderators.json").unwrap();

--- a/crates/apub/src/collections/community_moderators.rs
+++ b/crates/apub/src/collections/community_moderators.rs
@@ -140,6 +140,7 @@ mod tests {
   use super::*;
   use crate::objects::{
     community::tests::parse_lemmy_community,
+    instance::tests::parse_lemmy_instance,
     person::tests::parse_lemmy_person,
     tests::{file_to_json_object, init_context},
   };
@@ -148,6 +149,7 @@ mod tests {
     source::{
       community::Community,
       person::{Person, PersonForm},
+      site::Site,
     },
     traits::Crud,
   };
@@ -159,6 +161,7 @@ mod tests {
     let client = reqwest::Client::new().into();
     let manager = create_activity_queue(client);
     let context = init_context(manager.queue_handle().clone());
+    let site = parse_lemmy_instance(&context).await;
     let community = parse_lemmy_community(&context).await;
     let community_id = community.id;
 
@@ -209,5 +212,6 @@ mod tests {
       community_context.0.id,
     )
     .unwrap();
+    Site::delete(&*community_context.1.pool().get().unwrap(), site.id).unwrap();
   }
 }

--- a/crates/apub/src/fetcher/deletable_apub_object.rs
+++ b/crates/apub/src/fetcher/deletable_apub_object.rs
@@ -1,0 +1,99 @@
+use crate::fetcher::post_or_comment::PostOrComment;
+use lemmy_api_common::blocking;
+use lemmy_db_queries::source::{
+  comment::Comment_,
+  community::Community_,
+  person::Person_,
+  post::Post_,
+};
+use lemmy_db_schema::source::{
+  comment::Comment,
+  community::Community,
+  person::Person,
+  post::Post,
+  site::Site,
+};
+use lemmy_utils::LemmyError;
+use lemmy_websocket::LemmyContext;
+
+// TODO: merge this trait with ApubObject (means that db_schema needs to depend on apub_lib)
+#[async_trait::async_trait(?Send)]
+pub trait DeletableApubObject {
+  // TODO: pass in tombstone with summary field, to decide between remove/delete
+  async fn delete(self, context: &LemmyContext) -> Result<(), LemmyError>;
+}
+
+#[async_trait::async_trait(?Send)]
+impl DeletableApubObject for Community {
+  async fn delete(self, context: &LemmyContext) -> Result<(), LemmyError> {
+    let id = self.id;
+    blocking(context.pool(), move |conn| {
+      Community::update_deleted(conn, id, true)
+    })
+    .await??;
+    Ok(())
+  }
+}
+
+#[async_trait::async_trait(?Send)]
+impl DeletableApubObject for Person {
+  async fn delete(self, context: &LemmyContext) -> Result<(), LemmyError> {
+    let id = self.id;
+    blocking(context.pool(), move |conn| Person::delete_account(conn, id)).await??;
+    Ok(())
+  }
+}
+
+#[async_trait::async_trait(?Send)]
+impl DeletableApubObject for Post {
+  async fn delete(self, context: &LemmyContext) -> Result<(), LemmyError> {
+    let id = self.id;
+    blocking(context.pool(), move |conn| {
+      Post::update_deleted(conn, id, true)
+    })
+    .await??;
+    Ok(())
+  }
+}
+
+#[async_trait::async_trait(?Send)]
+impl DeletableApubObject for Comment {
+  async fn delete(self, context: &LemmyContext) -> Result<(), LemmyError> {
+    let id = self.id;
+    blocking(context.pool(), move |conn| {
+      Comment::update_deleted(conn, id, true)
+    })
+    .await??;
+    Ok(())
+  }
+}
+
+#[async_trait::async_trait(?Send)]
+impl DeletableApubObject for PostOrComment {
+  async fn delete(self, context: &LemmyContext) -> Result<(), LemmyError> {
+    match self {
+      PostOrComment::Comment(c) => {
+        blocking(context.pool(), move |conn| {
+          Comment::update_deleted(conn, c.id, true)
+        })
+        .await??;
+      }
+      PostOrComment::Post(p) => {
+        blocking(context.pool(), move |conn| {
+          Post::update_deleted(conn, p.id, true)
+        })
+        .await??;
+      }
+    }
+
+    Ok(())
+  }
+}
+
+#[async_trait::async_trait(?Send)]
+impl DeletableApubObject for Site {
+  async fn delete(self, _context: &LemmyContext) -> Result<(), LemmyError> {
+    // not implemented, ignore
+    Ok(())
+  }
+}

--- a/crates/apub/src/http/mod.rs
+++ b/crates/apub/src/http/mod.rs
@@ -36,6 +36,7 @@ mod community;
 mod person;
 mod post;
 pub mod routes;
+pub mod site;
 
 #[tracing::instrument(skip_all)]
 pub async fn shared_inbox(

--- a/crates/apub/src/http/person.rs
+++ b/crates/apub/src/http/person.rs
@@ -1,6 +1,7 @@
 use crate::{
   activity_lists::PersonInboxActivities,
   context::WithContext,
+  generate_outbox_url,
   http::{
     create_apub_response,
     create_apub_tombstone_response,
@@ -9,7 +10,7 @@ use crate::{
     ActivityCommonFields,
   },
   objects::person::ApubPerson,
-  protocol::collections::person_outbox::PersonOutbox,
+  protocol::collections::empty_outbox::EmptyOutbox,
 };
 use actix_web::{web, web::Payload, HttpRequest, HttpResponse};
 use lemmy_api_common::blocking;
@@ -80,6 +81,7 @@ pub(crate) async fn get_apub_person_outbox(
     Person::read_from_name(conn, &info.user_name)
   })
   .await??;
-  let outbox = PersonOutbox::new(person).await?;
+  let outbox_id = generate_outbox_url(&person.actor_id)?.into();
+  let outbox = EmptyOutbox::new(outbox_id).await?;
   Ok(create_apub_response(&outbox))
 }

--- a/crates/apub/src/http/routes.rs
+++ b/crates/apub/src/http/routes.rs
@@ -29,7 +29,6 @@ pub fn config(cfg: &mut web::ServiceConfig, settings: &Settings) {
     cfg
       .route("/", web::get().to(get_apub_site_http))
       .route("/site_outbox", web::get().to(get_apub_site_outbox))
-      .route("/site_inbox", web::get().to(get_apub_site_inbox))
       .route(
         "/c/{community_name}",
         web::get().to(get_apub_community_http),
@@ -61,7 +60,8 @@ pub fn config(cfg: &mut web::ServiceConfig, settings: &Settings) {
         .guard(InboxRequestGuard)
         .route("/c/{community_name}/inbox", web::post().to(community_inbox))
         .route("/u/{user_name}/inbox", web::post().to(person_inbox))
-        .route("/inbox", web::post().to(shared_inbox)),
+        .route("/inbox", web::post().to(shared_inbox))
+        .route("/site_inbox", web::post().to(get_apub_site_inbox)),
     );
   }
 }

--- a/crates/apub/src/http/routes.rs
+++ b/crates/apub/src/http/routes.rs
@@ -11,6 +11,7 @@ use crate::http::{
   person::{get_apub_person_http, get_apub_person_outbox, person_inbox},
   post::get_apub_post,
   shared_inbox,
+  site::get_apub_site_http,
 };
 use actix_web::{
   guard::{Guard, GuardContext},
@@ -26,6 +27,8 @@ pub fn config(cfg: &mut web::ServiceConfig, settings: &Settings) {
     println!("federation enabled, host is {}", settings.hostname);
 
     cfg
+      .route("/", web::get().to(get_apub_site_http))
+      .route("/site_outbox", web::get().to(get_apub_site_http))
       .route(
         "/c/{community_name}",
         web::get().to(get_apub_community_http),

--- a/crates/apub/src/http/routes.rs
+++ b/crates/apub/src/http/routes.rs
@@ -11,7 +11,7 @@ use crate::http::{
   person::{get_apub_person_http, get_apub_person_outbox, person_inbox},
   post::get_apub_post,
   shared_inbox,
-  site::get_apub_site_http,
+  site::{get_apub_site_http, get_apub_site_inbox, get_apub_site_outbox},
 };
 use actix_web::{
   guard::{Guard, GuardContext},
@@ -28,7 +28,8 @@ pub fn config(cfg: &mut web::ServiceConfig, settings: &Settings) {
 
     cfg
       .route("/", web::get().to(get_apub_site_http))
-      .route("/site_outbox", web::get().to(get_apub_site_http))
+      .route("/site_outbox", web::get().to(get_apub_site_outbox))
+      .route("/site_inbox", web::get().to(get_apub_site_inbox))
       .route(
         "/c/{community_name}",
         web::get().to(get_apub_community_http),

--- a/crates/apub/src/http/site.rs
+++ b/crates/apub/src/http/site.rs
@@ -1,14 +1,17 @@
 use crate::{
-  http::create_apub_response,
+  activity_lists::SiteInboxActivities,
+  context::WithContext,
+  http::{create_apub_response, payload_to_string, receive_activity, ActivityCommonFields},
   objects::instance::ApubSite,
   protocol::collections::empty_outbox::EmptyOutbox,
 };
-use actix_web::{web, HttpResponse};
+use actix_web::{web, web::Payload, HttpRequest, HttpResponse};
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::traits::ApubObject;
 use lemmy_db_schema::source::site::Site;
 use lemmy_utils::{settings::structs::Settings, LemmyError};
 use lemmy_websocket::LemmyContext;
+use tracing::info;
 use url::Url;
 
 pub(crate) async fn get_apub_site_http(
@@ -30,4 +33,18 @@ pub(crate) async fn get_apub_site_outbox() -> Result<HttpResponse, LemmyError> {
   );
   let outbox = EmptyOutbox::new(Url::parse(&outbox_id)?).await?;
   Ok(create_apub_response(&outbox))
+}
+
+#[tracing::instrument(skip_all)]
+pub async fn get_apub_site_inbox(
+  request: HttpRequest,
+  payload: Payload,
+  _path: web::Path<String>,
+  context: web::Data<LemmyContext>,
+) -> Result<HttpResponse, LemmyError> {
+  let unparsed = payload_to_string(payload).await?;
+  info!("Received site inbox activity {}", unparsed);
+  let activity_data: ActivityCommonFields = serde_json::from_str(&unparsed)?;
+  let activity = serde_json::from_str::<WithContext<SiteInboxActivities>>(&unparsed)?;
+  receive_activity(request, activity.inner(), activity_data, &context).await
 }

--- a/crates/apub/src/http/site.rs
+++ b/crates/apub/src/http/site.rs
@@ -39,7 +39,6 @@ pub(crate) async fn get_apub_site_outbox() -> Result<HttpResponse, LemmyError> {
 pub async fn get_apub_site_inbox(
   request: HttpRequest,
   payload: Payload,
-  _path: web::Path<String>,
   context: web::Data<LemmyContext>,
 ) -> Result<HttpResponse, LemmyError> {
   let unparsed = payload_to_string(payload).await?;

--- a/crates/apub/src/lib.rs
+++ b/crates/apub/src/lib.rs
@@ -164,6 +164,10 @@ pub fn generate_inbox_url(actor_id: &DbUrl) -> Result<DbUrl, ParseError> {
   Ok(Url::parse(&format!("{}/inbox", actor_id))?.into())
 }
 
+pub fn generate_site_inbox_url(actor_id: &DbUrl) -> Result<DbUrl, ParseError> {
+  Ok(Url::parse(&format!("{}/site_inbox", actor_id))?.into())
+}
+
 pub fn generate_shared_inbox_url(actor_id: &DbUrl) -> Result<DbUrl, LemmyError> {
   let actor_id: Url = actor_id.clone().into();
   let url = format!(

--- a/crates/apub/src/lib.rs
+++ b/crates/apub/src/lib.rs
@@ -165,7 +165,9 @@ pub fn generate_inbox_url(actor_id: &DbUrl) -> Result<DbUrl, ParseError> {
 }
 
 pub fn generate_site_inbox_url(actor_id: &DbUrl) -> Result<DbUrl, ParseError> {
-  Ok(Url::parse(&format!("{}/site_inbox", actor_id))?.into())
+  let mut actor_id: Url = actor_id.clone().into();
+  actor_id.set_path("site_inbox");
+  Ok(actor_id.into())
 }
 
 pub fn generate_shared_inbox_url(actor_id: &DbUrl) -> Result<DbUrl, LemmyError> {

--- a/crates/apub/src/objects/comment.rs
+++ b/crates/apub/src/objects/comment.rs
@@ -210,7 +210,7 @@ pub(crate) mod tests {
   use super::*;
   use crate::objects::{
     community::{tests::parse_lemmy_community, ApubCommunity},
-    instance::{tests::parse_lemmy_instance, ApubSite},
+    instance::ApubSite,
     person::{tests::parse_lemmy_person, ApubPerson},
     post::ApubPost,
     tests::{file_to_json_object, init_context},
@@ -224,8 +224,7 @@ pub(crate) mod tests {
     url: &Url,
     context: &LemmyContext,
   ) -> (ApubPerson, ApubCommunity, ApubPost, ApubSite) {
-    let person = parse_lemmy_person(context).await;
-    let site = parse_lemmy_instance(context).await;
+    let (person, site) = parse_lemmy_person(context).await;
     let community = parse_lemmy_community(context).await;
     let post_json = file_to_json_object("assets/lemmy/objects/page.json").unwrap();
     ApubPost::verify(&post_json, url, context, &mut 0)

--- a/crates/apub/src/objects/community.rs
+++ b/crates/apub/src/objects/community.rs
@@ -3,6 +3,7 @@ use crate::{
   collections::{community_moderators::ApubCommunityModerators, CommunityContext},
   generate_moderators_url,
   generate_outbox_url,
+  objects::instance::{instance_actor_id_from_url, ApubSite},
   protocol::{
     objects::{group::Group, tombstone::Tombstone, Endpoints},
     ImageObject,
@@ -16,7 +17,6 @@ use lemmy_api_common::blocking;
 use lemmy_apub_lib::{
   object_id::ObjectId,
   traits::{ActorType, ApubObject},
-  values::MediaTypeMarkdown,
 };
 use lemmy_db_schema::{source::community::Community, traits::ApubActor};
 use lemmy_db_views_actor::community_follower_view::CommunityFollowerView;
@@ -26,7 +26,7 @@ use lemmy_utils::{
 };
 use lemmy_websocket::LemmyContext;
 use std::ops::Deref;
-use tracing::debug;
+use tracing::{debug, info};
 use url::Url;
 
 #[derive(Clone, Debug)]
@@ -80,22 +80,15 @@ impl ApubObject for ApubCommunity {
 
   #[tracing::instrument(skip_all)]
   async fn into_apub(self, _context: &LemmyContext) -> Result<Group, LemmyError> {
-    let source = self.description.clone().map(|bio| Source {
-      content: bio,
-      media_type: MediaTypeMarkdown::Markdown,
-    });
-    let icon = self.icon.clone().map(ImageObject::new);
-    let image = self.banner.clone().map(ImageObject::new);
-
     let group = Group {
       kind: GroupType::Group,
       id: ObjectId::new(self.actor_id()),
       preferred_username: self.name.clone(),
       name: self.title.clone(),
       summary: self.description.as_ref().map(|b| markdown_to_html(b)),
-      source,
-      icon,
-      image,
+      source: self.description.clone().map(Source::new),
+      icon: self.icon.clone().map(ImageObject::new),
+      image: self.banner.clone().map(ImageObject::new),
       sensitive: Some(self.nsfw),
       moderators: Some(ObjectId::<ApubCommunityModerators>::new(
         generate_moderators_url(&self.actor_id)?,
@@ -160,6 +153,15 @@ impl ApubObject for ApubCommunity {
         .ok();
     }
 
+    // try to fetch the instance actor (to make things like instance rules available)
+    let instance_id = instance_actor_id_from_url(community.actor_id.clone().into());
+    let site = ObjectId::<ApubSite>::new(instance_id.clone())
+      .dereference(context, context.client(), request_counter)
+      .await;
+    if let Err(e) = site {
+      info!("Failed to dereference site for {}: {}", instance_id, e);
+    }
+
     Ok(community)
   }
 }
@@ -219,9 +221,12 @@ impl ApubCommunity {
 #[cfg(test)]
 pub(crate) mod tests {
   use super::*;
-  use crate::objects::tests::{file_to_json_object, init_context};
+  use crate::objects::{
+    instance::tests::parse_lemmy_instance,
+    tests::{file_to_json_object, init_context},
+  };
   use lemmy_apub_lib::activity_queue::create_activity_queue;
-  use lemmy_db_schema::traits::Crud;
+  use lemmy_db_schema::{source::site::Site, traits::Crud};
   use serial_test::serial;
 
   pub(crate) async fn parse_lemmy_community(context: &LemmyContext) -> ApubCommunity {
@@ -239,7 +244,7 @@ pub(crate) mod tests {
     let community = ApubCommunity::from_apub(json, context, &mut request_counter)
       .await
       .unwrap();
-    // this makes two requests to the (intentionally) broken outbox/moderators collections
+    // this makes one requests to the (intentionally broken) outbox collection
     assert_eq!(request_counter, 1);
     community
   }
@@ -250,6 +255,7 @@ pub(crate) mod tests {
     let client = reqwest::Client::new().into();
     let manager = create_activity_queue(client);
     let context = init_context(manager.queue_handle().clone());
+    let site = parse_lemmy_instance(&context).await;
     let community = parse_lemmy_community(&context).await;
 
     assert_eq!(community.title, "Ten Forward");
@@ -257,5 +263,6 @@ pub(crate) mod tests {
     assert_eq!(community.description.as_ref().unwrap().len(), 132);
 
     Community::delete(&*context.pool().get().unwrap(), community.id).unwrap();
+    Site::delete(&*context.pool().get().unwrap(), site.id).unwrap();
   }
 }

--- a/crates/apub/src/objects/community.rs
+++ b/crates/apub/src/objects/community.rs
@@ -3,7 +3,7 @@ use crate::{
   collections::{community_moderators::ApubCommunityModerators, CommunityContext},
   generate_moderators_url,
   generate_outbox_url,
-  objects::instance::{instance_actor_id_from_url, ApubSite},
+  objects::instance::fetch_instance_actor_for_object,
   protocol::{
     objects::{group::Group, tombstone::Tombstone, Endpoints},
     ImageObject,
@@ -26,7 +26,7 @@ use lemmy_utils::{
 };
 use lemmy_websocket::LemmyContext;
 use std::ops::Deref;
-use tracing::{debug, info};
+use tracing::debug;
 use url::Url;
 
 #[derive(Clone, Debug)]
@@ -153,14 +153,7 @@ impl ApubObject for ApubCommunity {
         .ok();
     }
 
-    // try to fetch the instance actor (to make things like instance rules available)
-    let instance_id = instance_actor_id_from_url(community.actor_id.clone().into());
-    let site = ObjectId::<ApubSite>::new(instance_id.clone())
-      .dereference(context, context.client(), request_counter)
-      .await;
-    if let Err(e) = site {
-      info!("Failed to dereference site for {}: {}", instance_id, e);
-    }
+    fetch_instance_actor_for_object(community.actor_id(), context, request_counter).await;
 
     Ok(community)
   }

--- a/crates/apub/src/objects/instance.rs
+++ b/crates/apub/src/objects/instance.rs
@@ -1,0 +1,205 @@
+use crate::{
+  check_is_apub_id_valid,
+  generate_outbox_url,
+  objects::get_summary_from_string_or_source,
+  protocol::{objects::instance::Instance, ImageObject, Source, Unparsed},
+};
+use activitystreams_kinds::actor::ServiceType;
+use chrono::NaiveDateTime;
+use lemmy_api_common::blocking;
+use lemmy_apub_lib::{
+  object_id::ObjectId,
+  traits::{ActorType, ApubObject},
+  values::MediaTypeHtml,
+  verify::verify_domains_match,
+};
+use lemmy_db_schema::{
+  naive_now,
+  source::site::{Site, SiteForm},
+};
+use lemmy_utils::{
+  utils::{check_slurs, check_slurs_opt, convert_datetime, markdown_to_html},
+  LemmyError,
+};
+use lemmy_websocket::LemmyContext;
+use std::ops::Deref;
+use url::Url;
+
+#[derive(Clone, Debug)]
+pub struct ApubSite(Site);
+
+impl Deref for ApubSite {
+  type Target = Site;
+  fn deref(&self) -> &Self::Target {
+    &self.0
+  }
+}
+
+impl From<Site> for ApubSite {
+  fn from(s: Site) -> Self {
+    ApubSite { 0: s }
+  }
+}
+
+#[async_trait::async_trait(?Send)]
+impl ApubObject for ApubSite {
+  type DataType = LemmyContext;
+  type ApubType = Instance;
+  type TombstoneType = ();
+
+  fn last_refreshed_at(&self) -> Option<NaiveDateTime> {
+    Some(self.last_refreshed_at)
+  }
+
+  #[tracing::instrument(skip_all)]
+  async fn read_from_apub_id(
+    object_id: Url,
+    data: &Self::DataType,
+  ) -> Result<Option<Self>, LemmyError> {
+    Ok(
+      blocking(data.pool(), move |conn| {
+        Site::read_from_apub_id(conn, object_id)
+      })
+      .await??
+      .map(Into::into),
+    )
+  }
+
+  async fn delete(self, _data: &Self::DataType) -> Result<(), LemmyError> {
+    unimplemented!()
+  }
+
+  #[tracing::instrument(skip_all)]
+  async fn into_apub(self, _data: &Self::DataType) -> Result<Self::ApubType, LemmyError> {
+    let instance = Instance {
+      kind: ServiceType::Service,
+      id: ObjectId::new(self.actor_id()),
+      name: self.name.clone(),
+      content: self.sidebar.as_ref().map(|d| markdown_to_html(d)),
+      source: self.sidebar.clone().map(Source::new),
+      summary: self.description.clone(),
+      media_type: self.sidebar.as_ref().map(|_| MediaTypeHtml::Html),
+      icon: self.icon.clone().map(ImageObject::new),
+      image: self.banner.clone().map(ImageObject::new),
+      inbox: self.inbox_url.clone().into(),
+      outbox: generate_outbox_url(&self.actor_id)?.into(),
+      public_key: self.get_public_key()?,
+      published: convert_datetime(self.published),
+      updated: self.updated.map(convert_datetime),
+      unparsed: Unparsed::default(),
+    };
+    Ok(instance)
+  }
+
+  fn to_tombstone(&self) -> Result<Self::TombstoneType, LemmyError> {
+    unimplemented!()
+  }
+
+  #[tracing::instrument(skip_all)]
+  async fn verify(
+    apub: &Self::ApubType,
+    expected_domain: &Url,
+    data: &Self::DataType,
+    _request_counter: &mut i32,
+  ) -> Result<(), LemmyError> {
+    check_is_apub_id_valid(apub.id.inner(), true, &data.settings())?;
+    verify_domains_match(expected_domain, apub.id.inner())?;
+
+    let slur_regex = &data.settings().slur_regex();
+    check_slurs(&apub.name, slur_regex)?;
+    check_slurs_opt(&apub.summary, slur_regex)?;
+    Ok(())
+  }
+
+  #[tracing::instrument(skip_all)]
+  async fn from_apub(
+    apub: Self::ApubType,
+    data: &Self::DataType,
+    _request_counter: &mut i32,
+  ) -> Result<Self, LemmyError> {
+    let site_form = SiteForm {
+      name: apub.name.clone(),
+      sidebar: Some(get_summary_from_string_or_source(
+        &apub.content,
+        &apub.source,
+      )),
+      updated: apub.updated.map(|u| u.clone().naive_local()),
+      icon: Some(apub.icon.clone().map(|i| i.url.into())),
+      banner: Some(apub.image.clone().map(|i| i.url.into())),
+      description: Some(apub.summary.clone()),
+      actor_id: Some(apub.id.clone().into()),
+      last_refreshed_at: Some(naive_now()),
+      inbox_url: Some(apub.inbox.clone().into()),
+      public_key: Some(apub.public_key.public_key_pem.clone()),
+      ..SiteForm::default()
+    };
+    let site = blocking(data.pool(), move |conn| Site::upsert(conn, &site_form)).await??;
+    Ok(site.into())
+  }
+}
+
+impl ActorType for ApubSite {
+  fn actor_id(&self) -> Url {
+    self.actor_id.to_owned().into()
+  }
+  fn public_key(&self) -> String {
+    self.public_key.to_owned()
+  }
+  fn private_key(&self) -> Option<String> {
+    self.private_key.to_owned()
+  }
+
+  fn inbox_url(&self) -> Url {
+    self.inbox_url.clone().into()
+  }
+
+  fn shared_inbox_url(&self) -> Option<Url> {
+    None
+  }
+}
+
+/// Instance actor is at the root path, so we simply need to clear the path and other unnecessary
+/// parts of the url.
+pub fn instance_actor_id_from_url(mut url: Url) -> Url {
+  url.set_fragment(None);
+  url.set_path("");
+  url.set_query(None);
+  url
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+  use super::*;
+  use crate::objects::tests::{file_to_json_object, init_context};
+  use lemmy_apub_lib::activity_queue::create_activity_queue;
+  use lemmy_db_schema::traits::Crud;
+  use serial_test::serial;
+
+  pub(crate) async fn parse_lemmy_instance(context: &LemmyContext) -> ApubSite {
+    let json: Instance = file_to_json_object("assets/lemmy/objects/instance.json").unwrap();
+    let id = Url::parse("https://enterprise.lemmy.ml/").unwrap();
+    let mut request_counter = 0;
+    ApubSite::verify(&json, &id, context, &mut request_counter)
+      .await
+      .unwrap();
+    let site = ApubSite::from_apub(json, context, &mut request_counter)
+      .await
+      .unwrap();
+    assert_eq!(request_counter, 0);
+    site
+  }
+
+  #[actix_rt::test]
+  #[serial]
+  async fn test_parse_lemmy_instance() {
+    let client = reqwest::Client::new().into();
+    let manager = create_activity_queue(client);
+    let context = init_context(manager.queue_handle().clone());
+    let site = parse_lemmy_instance(&context).await;
+
+    assert_eq!(site.name, "Enterprise");
+    assert_eq!(site.description.as_ref().unwrap().len(), 15);
+
+    Site::delete(&*context.pool().get().unwrap(), site.id).unwrap();
+  }
+}

--- a/crates/apub/src/objects/mod.rs
+++ b/crates/apub/src/objects/mod.rs
@@ -3,6 +3,7 @@ use html2md::parse_html;
 
 pub mod comment;
 pub mod community;
+pub mod instance;
 pub mod person;
 pub mod post;
 pub mod private_message;

--- a/crates/apub/src/objects/person.rs
+++ b/crates/apub/src/objects/person.rs
@@ -201,12 +201,19 @@ impl ActorType for ApubPerson {
 #[cfg(test)]
 pub(crate) mod tests {
   use super::*;
-  use crate::objects::tests::{file_to_json_object, init_context};
+  use crate::{
+    objects::{
+      instance::{tests::parse_lemmy_instance, ApubSite},
+      tests::{file_to_json_object, init_context},
+    },
+    protocol::objects::instance::Instance,
+  };
   use lemmy_apub_lib::activity_queue::create_activity_queue;
-  use lemmy_db_schema::traits::Crud;
+  use lemmy_db_schema::{source::site::Site, traits::Crud};
   use serial_test::serial;
 
-  pub(crate) async fn parse_lemmy_person(context: &LemmyContext) -> ApubPerson {
+  pub(crate) async fn parse_lemmy_person(context: &LemmyContext) -> (ApubPerson, ApubSite) {
+    let site = parse_lemmy_instance(context).await;
     let json = file_to_json_object("assets/lemmy/objects/person.json").unwrap();
     let url = Url::parse("https://enterprise.lemmy.ml/u/picard").unwrap();
     let mut request_counter = 0;
@@ -217,7 +224,7 @@ pub(crate) mod tests {
       .await
       .unwrap();
     assert_eq!(request_counter, 0);
-    person
+    (person, site)
   }
 
   #[actix_rt::test]
@@ -226,13 +233,14 @@ pub(crate) mod tests {
     let client = reqwest::Client::new().into();
     let manager = create_activity_queue(client);
     let context = init_context(manager.queue_handle().clone());
-    let person = parse_lemmy_person(&context).await;
+    let (person, site) = parse_lemmy_person(&context).await;
 
     assert_eq!(person.display_name, Some("Jean-Luc Picard".to_string()));
     assert!(!person.local);
     assert_eq!(person.bio.as_ref().unwrap().len(), 39);
 
     DbPerson::delete(&*context.pool().get().unwrap(), person.id).unwrap();
+    Site::delete(&*context.pool().get().unwrap(), site.id).unwrap();
   }
 
   #[actix_rt::test]
@@ -241,6 +249,16 @@ pub(crate) mod tests {
     let client = reqwest::Client::new().into();
     let manager = create_activity_queue(client);
     let context = init_context(manager.queue_handle().clone());
+
+    // create and parse a fake pleroma instance actor, to avoid network request during test
+    let mut json: Instance = file_to_json_object("assets/lemmy/objects/instance.json").unwrap();
+    let id = Url::parse("https://queer.hacktivis.me/").unwrap();
+    json.id = ObjectId::new(id);
+    let mut request_counter = 0;
+    let site = ApubSite::from_apub(json, &context, &mut request_counter)
+      .await
+      .unwrap();
+
     let json = file_to_json_object("assets/pleroma/objects/person.json").unwrap();
     let url = Url::parse("https://queer.hacktivis.me/users/lanodan").unwrap();
     let mut request_counter = 0;
@@ -258,5 +276,6 @@ pub(crate) mod tests {
     assert_eq!(person.bio.as_ref().unwrap().len(), 873);
 
     DbPerson::delete(&*context.pool().get().unwrap(), person.id).unwrap();
+    Site::delete(&*context.pool().get().unwrap(), site.id).unwrap();
   }
 }

--- a/crates/apub/src/objects/person.rs
+++ b/crates/apub/src/objects/person.rs
@@ -16,7 +16,6 @@ use lemmy_api_common::blocking;
 use lemmy_apub_lib::{
   object_id::ObjectId,
   traits::{ActorType, ApubObject},
-  values::MediaTypeMarkdown,
   verify::verify_domains_match,
 };
 use lemmy_db_schema::{
@@ -88,12 +87,6 @@ impl ApubObject for ApubPerson {
     } else {
       UserTypes::Person
     };
-    let source = self.bio.clone().map(|bio| Source {
-      content: bio,
-      media_type: MediaTypeMarkdown::Markdown,
-    });
-    let icon = self.avatar.clone().map(ImageObject::new);
-    let image = self.banner.clone().map(ImageObject::new);
 
     let person = Person {
       kind,
@@ -101,9 +94,9 @@ impl ApubObject for ApubPerson {
       preferred_username: self.name.clone(),
       name: self.display_name.clone(),
       summary: self.bio.as_ref().map(|b| markdown_to_html(b)),
-      source,
-      icon,
-      image,
+      source: self.bio.clone().map(Source::new),
+      icon: self.avatar.clone().map(ImageObject::new),
+      image: self.banner.clone().map(ImageObject::new),
       matrix_user_id: self.matrix_user_id.clone(),
       published: Some(convert_datetime(self.published)),
       outbox: generate_outbox_url(&self.actor_id)?.into(),

--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -209,7 +209,6 @@ mod tests {
   use super::*;
   use crate::objects::{
     community::tests::parse_lemmy_community,
-    instance::tests::parse_lemmy_instance,
     person::tests::parse_lemmy_person,
     post::ApubPost,
     tests::{file_to_json_object, init_context},
@@ -224,9 +223,8 @@ mod tests {
     let client = reqwest::Client::new().into();
     let manager = create_activity_queue(client);
     let context = init_context(manager.queue_handle().clone());
-    let site = parse_lemmy_instance(&context).await;
+    let (person, site) = parse_lemmy_person(&context).await;
     let community = parse_lemmy_community(&context).await;
-    let person = parse_lemmy_person(&context).await;
 
     let json = file_to_json_object("assets/lemmy/objects/page.json").unwrap();
     let url = Url::parse("https://enterprise.lemmy.ml/post/55143").unwrap();

--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -209,11 +209,13 @@ mod tests {
   use super::*;
   use crate::objects::{
     community::tests::parse_lemmy_community,
+    instance::tests::parse_lemmy_instance,
     person::tests::parse_lemmy_person,
     post::ApubPost,
     tests::{file_to_json_object, init_context},
   };
   use lemmy_apub_lib::activity_queue::create_activity_queue;
+  use lemmy_db_schema::source::site::Site;
   use serial_test::serial;
 
   #[actix_rt::test]
@@ -222,6 +224,7 @@ mod tests {
     let client = reqwest::Client::new().into();
     let manager = create_activity_queue(client);
     let context = init_context(manager.queue_handle().clone());
+    let site = parse_lemmy_instance(&context).await;
     let community = parse_lemmy_community(&context).await;
     let person = parse_lemmy_person(&context).await;
 
@@ -246,5 +249,6 @@ mod tests {
     Post::delete(&*context.pool().get().unwrap(), post.id).unwrap();
     Person::delete(&*context.pool().get().unwrap(), person.id).unwrap();
     Community::delete(&*context.pool().get().unwrap(), community.id).unwrap();
+    Site::delete(&*context.pool().get().unwrap(), site.id).unwrap();
   }
 }

--- a/crates/apub/src/objects/private_message.rs
+++ b/crates/apub/src/objects/private_message.rs
@@ -8,7 +8,7 @@ use lemmy_api_common::blocking;
 use lemmy_apub_lib::{
   object_id::ObjectId,
   traits::ApubObject,
-  values::{MediaTypeHtml, MediaTypeMarkdown},
+  values::MediaTypeHtml,
   verify::verify_domains_match,
 };
 use lemmy_db_schema::{
@@ -87,10 +87,7 @@ impl ApubObject for ApubPrivateMessage {
       to: [ObjectId::new(recipient.actor_id)],
       content: markdown_to_html(&self.content),
       media_type: Some(MediaTypeHtml::Html),
-      source: Some(Source {
-        content: self.content.clone(),
-        media_type: MediaTypeMarkdown::Markdown,
-      }),
+      source: Some(Source::new(self.content.clone())),
       published: Some(convert_datetime(self.published)),
       updated: self.updated.map(convert_datetime),
       unparsed: Default::default(),

--- a/crates/apub/src/protocol/activities/block/block_user.rs
+++ b/crates/apub/src/protocol/activities/block/block_user.rs
@@ -1,24 +1,27 @@
-use crate::{
-  objects::person::ApubPerson,
-  protocol::{activities::community::block_user::BlockUserFromCommunity, Unparsed},
-};
-use activitystreams_kinds::activity::UndoType;
+use crate::{activities::block::SiteOrCommunity, objects::person::ApubPerson, protocol::Unparsed};
+use activitystreams_kinds::activity::BlockType;
+use chrono::{DateTime, FixedOffset};
 use lemmy_apub_lib::object_id::ObjectId;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct UndoBlockUserFromCommunity {
+pub struct BlockUser {
   pub(crate) actor: ObjectId<ApubPerson>,
   #[serde(deserialize_with = "crate::deserialize_one_or_many")]
   pub(crate) to: Vec<Url>,
-  pub(crate) object: BlockUserFromCommunity,
+  pub(crate) object: ObjectId<ApubPerson>,
   #[serde(deserialize_with = "crate::deserialize_one_or_many")]
   pub(crate) cc: Vec<Url>,
+  pub(crate) target: ObjectId<SiteOrCommunity>,
   #[serde(rename = "type")]
-  pub(crate) kind: UndoType,
+  pub(crate) kind: BlockType,
+  /// Quick and dirty solution.
+  /// TODO: send a separate Delete activity instead
+  pub(crate) remove_data: Option<bool>,
   pub(crate) id: Url,
   #[serde(flatten)]
   pub(crate) unparsed: Unparsed,
+  pub(crate) expires: Option<DateTime<FixedOffset>>,
 }

--- a/crates/apub/src/protocol/activities/block/block_user.rs
+++ b/crates/apub/src/protocol/activities/block/block_user.rs
@@ -20,6 +20,8 @@ pub struct BlockUser {
   /// Quick and dirty solution.
   /// TODO: send a separate Delete activity instead
   pub(crate) remove_data: Option<bool>,
+  /// block reason, written to mod log
+  pub(crate) summary: Option<String>,
   pub(crate) id: Url,
   #[serde(flatten)]
   pub(crate) unparsed: Unparsed,

--- a/crates/apub/src/protocol/activities/block/mod.rs
+++ b/crates/apub/src/protocol/activities/block/mod.rs
@@ -10,11 +10,8 @@ mod tests {
 
   #[actix_rt::test]
   async fn test_parse_lemmy_block() {
-    test_parse_lemmy_item::<BlockUser>("assets/lemmy/activities/community/block_user.json")
+    test_parse_lemmy_item::<BlockUser>("assets/lemmy/activities/block/block_user.json").unwrap();
+    test_parse_lemmy_item::<UndoBlockUser>("assets/lemmy/activities/block/undo_block_user.json")
       .unwrap();
-    test_parse_lemmy_item::<UndoBlockUser>(
-      "assets/lemmy/activities/community/undo_block_user.json",
-    )
-    .unwrap();
   }
 }

--- a/crates/apub/src/protocol/activities/block/mod.rs
+++ b/crates/apub/src/protocol/activities/block/mod.rs
@@ -1,0 +1,20 @@
+pub mod block_user;
+pub mod undo_block_user;
+
+#[cfg(test)]
+mod tests {
+  use crate::protocol::{
+    activities::block::{block_user::BlockUser, undo_block_user::UndoBlockUser},
+    tests::test_parse_lemmy_item,
+  };
+
+  #[actix_rt::test]
+  async fn test_parse_lemmy_block() {
+    test_parse_lemmy_item::<BlockUser>("assets/lemmy/activities/community/block_user.json")
+      .unwrap();
+    test_parse_lemmy_item::<UndoBlockUser>(
+      "assets/lemmy/activities/community/undo_block_user.json",
+    )
+    .unwrap();
+  }
+}

--- a/crates/apub/src/protocol/activities/block/undo_block_user.rs
+++ b/crates/apub/src/protocol/activities/block/undo_block_user.rs
@@ -1,27 +1,24 @@
 use crate::{
-  objects::{community::ApubCommunity, person::ApubPerson},
-  protocol::Unparsed,
+  objects::person::ApubPerson,
+  protocol::{activities::block::block_user::BlockUser, Unparsed},
 };
-use activitystreams_kinds::activity::BlockType;
-use chrono::{DateTime, FixedOffset};
+use activitystreams_kinds::activity::UndoType;
 use lemmy_apub_lib::object_id::ObjectId;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct BlockUserFromCommunity {
+pub struct UndoBlockUser {
   pub(crate) actor: ObjectId<ApubPerson>,
   #[serde(deserialize_with = "crate::deserialize_one_or_many")]
   pub(crate) to: Vec<Url>,
-  pub(crate) object: ObjectId<ApubPerson>,
+  pub(crate) object: BlockUser,
   #[serde(deserialize_with = "crate::deserialize_one_or_many")]
   pub(crate) cc: Vec<Url>,
-  pub(crate) target: ObjectId<ApubCommunity>,
   #[serde(rename = "type")]
-  pub(crate) kind: BlockType,
+  pub(crate) kind: UndoType,
   pub(crate) id: Url,
   #[serde(flatten)]
   pub(crate) unparsed: Unparsed,
-  pub(crate) expires: Option<DateTime<FixedOffset>>,
 }

--- a/crates/apub/src/protocol/activities/community/mod.rs
+++ b/crates/apub/src/protocol/activities/community/mod.rs
@@ -7,15 +7,12 @@ pub mod update;
 #[cfg(test)]
 mod tests {
   use crate::protocol::{
-    activities::{
-      block::{block_user::BlockUser, undo_block_user::UndoBlockUser},
-      community::{
-        add_mod::AddMod,
-        announce::AnnounceActivity,
-        remove_mod::RemoveMod,
-        report::Report,
-        update::UpdateCommunity,
-      },
+    activities::community::{
+      add_mod::AddMod,
+      announce::AnnounceActivity,
+      remove_mod::RemoveMod,
+      report::Report,
+      update::UpdateCommunity,
     },
     tests::test_parse_lemmy_item,
   };
@@ -30,13 +27,6 @@ mod tests {
     test_parse_lemmy_item::<AddMod>("assets/lemmy/activities/community/add_mod.json").unwrap();
     test_parse_lemmy_item::<RemoveMod>("assets/lemmy/activities/community/remove_mod.json")
       .unwrap();
-
-    test_parse_lemmy_item::<BlockUser>("assets/lemmy/activities/community/block_user.json")
-      .unwrap();
-    test_parse_lemmy_item::<UndoBlockUser>(
-      "assets/lemmy/activities/community/undo_block_user.json",
-    )
-    .unwrap();
 
     test_parse_lemmy_item::<UpdateCommunity>(
       "assets/lemmy/activities/community/update_community.json",

--- a/crates/apub/src/protocol/activities/community/mod.rs
+++ b/crates/apub/src/protocol/activities/community/mod.rs
@@ -1,22 +1,21 @@
 pub mod add_mod;
 pub mod announce;
-pub mod block_user;
 pub mod remove_mod;
 pub mod report;
-pub mod undo_block_user;
 pub mod update;
 
 #[cfg(test)]
 mod tests {
   use crate::protocol::{
-    activities::community::{
-      add_mod::AddMod,
-      announce::AnnounceActivity,
-      block_user::BlockUserFromCommunity,
-      remove_mod::RemoveMod,
-      report::Report,
-      undo_block_user::UndoBlockUserFromCommunity,
-      update::UpdateCommunity,
+    activities::{
+      block::{block_user::BlockUser, undo_block_user::UndoBlockUser},
+      community::{
+        add_mod::AddMod,
+        announce::AnnounceActivity,
+        remove_mod::RemoveMod,
+        report::Report,
+        update::UpdateCommunity,
+      },
     },
     tests::test_parse_lemmy_item,
   };
@@ -32,11 +31,9 @@ mod tests {
     test_parse_lemmy_item::<RemoveMod>("assets/lemmy/activities/community/remove_mod.json")
       .unwrap();
 
-    test_parse_lemmy_item::<BlockUserFromCommunity>(
-      "assets/lemmy/activities/community/block_user.json",
-    )
-    .unwrap();
-    test_parse_lemmy_item::<UndoBlockUserFromCommunity>(
+    test_parse_lemmy_item::<BlockUser>("assets/lemmy/activities/community/block_user.json")
+      .unwrap();
+    test_parse_lemmy_item::<UndoBlockUser>(
       "assets/lemmy/activities/community/undo_block_user.json",
     )
     .unwrap();

--- a/crates/apub/src/protocol/activities/mod.rs
+++ b/crates/apub/src/protocol/activities/mod.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use strum_macros::Display;
 
+pub mod block;
 pub mod community;
 pub mod create_or_update;
 pub mod deletion;

--- a/crates/apub/src/protocol/collections/empty_outbox.rs
+++ b/crates/apub/src/protocol/collections/empty_outbox.rs
@@ -1,24 +1,23 @@
-use crate::generate_outbox_url;
 use activitystreams_kinds::collection::OrderedCollectionType;
-use lemmy_db_schema::source::person::Person;
 use lemmy_utils::LemmyError;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
+/// Empty placeholder outbox used for Person, Instance, which dont implement a proper outbox yet.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct PersonOutbox {
+pub(crate) struct EmptyOutbox {
   r#type: OrderedCollectionType,
   id: Url,
   ordered_items: Vec<()>,
   total_items: i32,
 }
 
-impl PersonOutbox {
-  pub(crate) async fn new(user: Person) -> Result<PersonOutbox, LemmyError> {
-    Ok(PersonOutbox {
+impl EmptyOutbox {
+  pub(crate) async fn new(outbox_id: Url) -> Result<EmptyOutbox, LemmyError> {
+    Ok(EmptyOutbox {
       r#type: OrderedCollectionType::OrderedCollection,
-      id: generate_outbox_url(&user.actor_id)?.into(),
+      id: outbox_id,
       ordered_items: vec![],
       total_items: 0,
     })

--- a/crates/apub/src/protocol/collections/mod.rs
+++ b/crates/apub/src/protocol/collections/mod.rs
@@ -1,16 +1,16 @@
+pub(crate) mod empty_outbox;
 pub(crate) mod group_followers;
 pub(crate) mod group_moderators;
 pub(crate) mod group_outbox;
-pub(crate) mod person_outbox;
 
 #[cfg(test)]
 mod tests {
   use crate::protocol::{
     collections::{
+      empty_outbox::EmptyOutbox,
       group_followers::GroupFollowers,
       group_moderators::GroupModerators,
       group_outbox::GroupOutbox,
-      person_outbox::PersonOutbox,
     },
     tests::test_parse_lemmy_item,
   };
@@ -24,6 +24,6 @@ mod tests {
     assert_eq!(outbox.ordered_items.len() as i32, outbox.total_items);
     test_parse_lemmy_item::<GroupModerators>("assets/lemmy/collections/group_moderators.json")
       .unwrap();
-    test_parse_lemmy_item::<PersonOutbox>("assets/lemmy/collections/person_outbox.json").unwrap();
+    test_parse_lemmy_item::<EmptyOutbox>("assets/lemmy/collections/person_outbox.json").unwrap();
   }
 }

--- a/crates/apub/src/protocol/mod.rs
+++ b/crates/apub/src/protocol/mod.rs
@@ -17,6 +17,15 @@ pub struct Source {
   pub(crate) media_type: MediaTypeMarkdown,
 }
 
+impl Source {
+  pub(crate) fn new(content: String) -> Self {
+    Source {
+      content,
+      media_type: MediaTypeMarkdown::Markdown,
+    }
+  }
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ImageObject {

--- a/crates/apub/src/protocol/objects/instance.rs
+++ b/crates/apub/src/protocol/objects/instance.rs
@@ -1,0 +1,39 @@
+use crate::{
+  objects::instance::ApubSite,
+  protocol::{ImageObject, Source, Unparsed},
+};
+use activitystreams_kinds::actor::ServiceType;
+use chrono::{DateTime, FixedOffset};
+use lemmy_apub_lib::{object_id::ObjectId, signatures::PublicKey, values::MediaTypeHtml};
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+use url::Url;
+
+#[skip_serializing_none]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Instance {
+  #[serde(rename = "type")]
+  pub(crate) kind: ServiceType,
+  pub(crate) id: ObjectId<ApubSite>,
+  // site name
+  pub(crate) name: String,
+  // sidebar
+  pub(crate) content: Option<String>,
+  pub(crate) source: Option<Source>,
+  // short instance description
+  pub(crate) summary: Option<String>,
+  pub(crate) media_type: Option<MediaTypeHtml>,
+  /// instance icon
+  pub(crate) icon: Option<ImageObject>,
+  /// instance banner
+  pub(crate) image: Option<ImageObject>,
+  pub(crate) inbox: Url,
+  /// mandatory field in activitypub, currently empty in lemmy
+  pub(crate) outbox: Url,
+  pub(crate) public_key: PublicKey,
+  pub(crate) published: DateTime<FixedOffset>,
+  pub(crate) updated: Option<DateTime<FixedOffset>>,
+  #[serde(flatten)]
+  pub(crate) unparsed: Unparsed,
+}

--- a/crates/apub/src/protocol/objects/mod.rs
+++ b/crates/apub/src/protocol/objects/mod.rs
@@ -3,6 +3,7 @@ use url::Url;
 
 pub(crate) mod chat_message;
 pub(crate) mod group;
+pub(crate) mod instance;
 pub(crate) mod note;
 pub(crate) mod page;
 pub(crate) mod person;
@@ -23,6 +24,7 @@ mod tests {
       objects::{
         chat_message::ChatMessage,
         group::Group,
+        instance::Instance,
         note::Note,
         page::Page,
         person::Person,
@@ -33,9 +35,10 @@ mod tests {
   };
 
   #[actix_rt::test]
-  async fn test_parse_object_lemmy() {
-    test_parse_lemmy_item::<Person>("assets/lemmy/objects/person.json").unwrap();
+  async fn test_parse_objects_lemmy() {
+    test_parse_lemmy_item::<Instance>("assets/lemmy/objects/instance.json").unwrap();
     test_parse_lemmy_item::<Group>("assets/lemmy/objects/group.json").unwrap();
+    test_parse_lemmy_item::<Person>("assets/lemmy/objects/person.json").unwrap();
     test_parse_lemmy_item::<Page>("assets/lemmy/objects/page.json").unwrap();
     test_parse_lemmy_item::<Note>("assets/lemmy/objects/note.json").unwrap();
     test_parse_lemmy_item::<ChatMessage>("assets/lemmy/objects/chat_message.json").unwrap();
@@ -43,7 +46,7 @@ mod tests {
   }
 
   #[actix_rt::test]
-  async fn test_parse_object_pleroma() {
+  async fn test_parse_objects_pleroma() {
     file_to_json_object::<WithContext<Person>>("assets/pleroma/objects/person.json").unwrap();
     file_to_json_object::<WithContext<Note>>("assets/pleroma/objects/note.json").unwrap();
     file_to_json_object::<WithContext<ChatMessage>>("assets/pleroma/objects/chat_message.json")
@@ -51,19 +54,19 @@ mod tests {
   }
 
   #[actix_rt::test]
-  async fn test_parse_object_smithereen() {
+  async fn test_parse_objects_smithereen() {
     file_to_json_object::<WithContext<Person>>("assets/smithereen/objects/person.json").unwrap();
     file_to_json_object::<Note>("assets/smithereen/objects/note.json").unwrap();
   }
 
   #[actix_rt::test]
-  async fn test_parse_object_mastodon() {
+  async fn test_parse_objects_mastodon() {
     file_to_json_object::<WithContext<Person>>("assets/mastodon/objects/person.json").unwrap();
     file_to_json_object::<WithContext<Note>>("assets/mastodon/objects/note.json").unwrap();
   }
 
   #[actix_rt::test]
-  async fn test_parse_object_lotide() {
+  async fn test_parse_objects_lotide() {
     file_to_json_object::<WithContext<Group>>("assets/lotide/objects/group.json").unwrap();
     file_to_json_object::<WithContext<Person>>("assets/lotide/objects/person.json").unwrap();
     file_to_json_object::<WithContext<Note>>("assets/lotide/objects/note.json").unwrap();

--- a/crates/db_schema/src/aggregates/site_aggregates.rs
+++ b/crates/db_schema/src/aggregates/site_aggregates.rs
@@ -55,19 +55,7 @@ mod tests {
 
     let site_form = SiteForm {
       name: "test_site".into(),
-      sidebar: None,
-      description: None,
-      icon: None,
-      banner: None,
-      enable_downvotes: None,
-      open_registration: None,
-      enable_nsfw: None,
-      updated: None,
-      community_creation_admin_only: Some(false),
-      require_email_verification: None,
-      require_application: None,
-      application_question: None,
-      private_instance: None,
+      ..Default::default()
     };
 
     Site::create(&conn, &site_form).unwrap();
@@ -136,7 +124,8 @@ mod tests {
     let after_delete_creator = SiteAggregates::read(&conn);
     assert!(after_delete_creator.is_ok());
 
-    Site::delete(&conn, 1).unwrap();
+    let site_id = after_delete_creator.unwrap().id;
+    Site::delete(&conn, site_id).unwrap();
     let after_delete_site = SiteAggregates::read(&conn);
     assert!(after_delete_site.is_err());
   }

--- a/crates/db_schema/src/impls/community.rs
+++ b/crates/db_schema/src/impls/community.rs
@@ -122,9 +122,9 @@ impl Community {
       .get_result::<Self>(conn)
   }
 
-  pub fn distinct_federated_communities(conn: &PgConnection) -> Result<Vec<String>, Error> {
+  pub fn distinct_federated_communities(conn: &PgConnection) -> Result<Vec<DbUrl>, Error> {
     use crate::schema::community::dsl::*;
-    community.select(actor_id).distinct().load::<String>(conn)
+    community.select(actor_id).distinct().load::<DbUrl>(conn)
   }
 
   pub fn upsert(conn: &PgConnection, community_form: &CommunityForm) -> Result<Community, Error> {

--- a/crates/db_schema/src/impls/site.rs
+++ b/crates/db_schema/src/impls/site.rs
@@ -54,4 +54,9 @@ impl Site {
         .map(Into::into),
     )
   }
+
+  pub fn read_remote_sites(conn: &PgConnection) -> Result<Vec<Self>, Error> {
+    use crate::schema::site::dsl::*;
+    site.order_by(id).offset(1).get_results::<Self>(conn)
+  }
 }

--- a/crates/db_schema/src/impls/site.rs
+++ b/crates/db_schema/src/impls/site.rs
@@ -1,5 +1,6 @@
-use crate::{source::site::*, traits::Crud};
+use crate::{source::site::*, traits::Crud, DbUrl};
 use diesel::{dsl::*, result::Error, *};
+use url::Url;
 
 impl Crud for Site {
   type Form = SiteForm;
@@ -27,8 +28,30 @@ impl Crud for Site {
 }
 
 impl Site {
-  pub fn read_simple(conn: &PgConnection) -> Result<Self, Error> {
+  pub fn read_local_site(conn: &PgConnection) -> Result<Self, Error> {
     use crate::schema::site::dsl::*;
-    site.first::<Self>(conn)
+    site.order_by(id).first::<Self>(conn)
+  }
+
+  pub fn upsert(conn: &PgConnection, site_form: &SiteForm) -> Result<Site, Error> {
+    use crate::schema::site::dsl::*;
+    insert_into(site)
+      .values(site_form)
+      .on_conflict(actor_id)
+      .do_update()
+      .set(site_form)
+      .get_result::<Self>(conn)
+  }
+
+  pub fn read_from_apub_id(conn: &PgConnection, object_id: Url) -> Result<Option<Self>, Error> {
+    use crate::schema::site::dsl::*;
+    let object_id: DbUrl = object_id.into();
+    Ok(
+      site
+        .filter(actor_id.eq(object_id))
+        .first::<Site>(conn)
+        .ok()
+        .map(Into::into),
+    )
   }
 }

--- a/crates/db_schema/src/newtypes.rs
+++ b/crates/db_schema/src/newtypes.rs
@@ -10,6 +10,7 @@ use std::{
   fmt,
   fmt::{Display, Formatter},
   io::Write,
+  ops::Deref,
 };
 use url::Url;
 
@@ -123,5 +124,13 @@ where
 {
   fn from(id: ObjectId<Kind>) -> Self {
     DbUrl(id.into())
+  }
+}
+
+impl Deref for DbUrl {
+  type Target = Url;
+
+  fn deref(&self) -> &Self::Target {
+    &self.0
   }
 }

--- a/crates/db_schema/src/schema.rs
+++ b/crates/db_schema/src/schema.rs
@@ -454,6 +454,11 @@ table! {
         require_application -> Bool,
         application_question -> Nullable<Text>,
         private_instance -> Bool,
+        actor_id -> Text,
+        last_refreshed_at -> Timestamp,
+        inbox_url -> Text,
+        private_key -> Nullable<Text>,
+        public_key -> Text,
     }
 }
 

--- a/crates/db_schema/src/source/site.rs
+++ b/crates/db_schema/src/source/site.rs
@@ -20,6 +20,11 @@ pub struct Site {
   pub require_application: bool,
   pub application_question: Option<String>,
   pub private_instance: bool,
+  pub actor_id: DbUrl,
+  pub last_refreshed_at: chrono::NaiveDateTime,
+  pub inbox_url: DbUrl,
+  pub private_key: Option<String>,
+  pub public_key: String,
 }
 
 #[derive(Insertable, AsChangeset, Default)]
@@ -40,4 +45,9 @@ pub struct SiteForm {
   pub require_application: Option<bool>,
   pub application_question: Option<Option<String>>,
   pub private_instance: Option<bool>,
+  pub actor_id: Option<DbUrl>,
+  pub last_refreshed_at: Option<chrono::NaiveDateTime>,
+  pub inbox_url: Option<DbUrl>,
+  pub private_key: Option<Option<String>>,
+  pub public_key: Option<String>,
 }

--- a/crates/db_views/src/site_view.rs
+++ b/crates/db_views/src/site_view.rs
@@ -14,11 +14,12 @@ pub struct SiteView {
 
 impl SiteView {
   pub fn read(conn: &PgConnection) -> Result<Self, Error> {
-    let (site, counts) = site::table
+    let (mut site, counts) = site::table
       .inner_join(site_aggregates::table)
       .select((site::all_columns, site_aggregates::all_columns))
       .first::<(Site, SiteAggregates)>(conn)?;
 
+    site.private_key = None;
     Ok(SiteView { site, counts })
   }
 }

--- a/migrations/2022-01-28-104106_instance-actor/down.sql
+++ b/migrations/2022-01-28-104106_instance-actor/down.sql
@@ -1,0 +1,6 @@
+alter table site
+    drop column actor_id,
+    drop column last_refreshed_at,
+    drop column inbox_url,
+    drop column private_key,
+    drop column public_key;

--- a/migrations/2022-01-28-104106_instance-actor/up.sql
+++ b/migrations/2022-01-28-104106_instance-actor/up.sql
@@ -1,0 +1,6 @@
+alter table site
+    add column actor_id varchar(255) not null unique default generate_unique_changeme(),
+    add column last_refreshed_at Timestamp not null default now(),
+    add column inbox_url varchar(255) not null default generate_unique_changeme(),
+    add column private_key text,
+    add column public_key text not null default generate_unique_changeme();

--- a/src/code_migrations.rs
+++ b/src/code_migrations.rs
@@ -18,11 +18,13 @@ use lemmy_db_schema::{
     person::{Person, PersonForm},
     post::Post,
     private_message::PrivateMessage,
+    site::{Site, SiteForm},
   },
   traits::Crud,
 };
 use lemmy_utils::{apub::generate_actor_keypair, LemmyError};
 use tracing::info;
+use url::Url;
 
 pub fn run_advanced_migrations(
   conn: &PgConnection,
@@ -35,6 +37,7 @@ pub fn run_advanced_migrations(
   private_message_updates_2020_05_05(conn, protocol_and_hostname)?;
   post_thumbnail_url_updates_2020_07_27(conn, protocol_and_hostname)?;
   apub_columns_2021_02_02(conn)?;
+  instance_actor_2022_01_28(conn, protocol_and_hostname)?;
 
   Ok(())
 }
@@ -282,5 +285,31 @@ fn apub_columns_2021_02_02(conn: &PgConnection) -> Result<(), LemmyError> {
     }
   }
 
+  Ok(())
+}
+
+/// Site object turns into an actor, so that things like instance description can be federated. This
+/// means we need to add actor columns to the site table, and initialize them with correct values.
+/// Before this point, there is only a single value in the site table which refers to the local
+/// Lemmy instance, so thats all we need to update.
+fn instance_actor_2022_01_28(
+  conn: &PgConnection,
+  protocol_and_hostname: &str,
+) -> Result<(), LemmyError> {
+  info!("Running instance_actor_2021_09_29");
+  if let Ok(site) = Site::read_local_site(conn) {
+    let key_pair = generate_actor_keypair()?;
+    let actor_id = Url::parse(protocol_and_hostname)?;
+    let site_form = SiteForm {
+      name: site.name,
+      actor_id: Some(actor_id.clone().into()),
+      last_refreshed_at: Some(naive_now()),
+      inbox_url: Some(generate_inbox_url(&actor_id.into())?),
+      private_key: Some(Some(key_pair.private_key)),
+      public_key: Some(key_pair.public_key),
+      ..Default::default()
+    };
+    Site::update(conn, site.id, &site_form)?;
+  }
   Ok(())
 }

--- a/src/code_migrations.rs
+++ b/src/code_migrations.rs
@@ -8,6 +8,7 @@ use lemmy_apub::{
   generate_inbox_url,
   generate_local_apub_endpoint,
   generate_shared_inbox_url,
+  generate_site_inbox_url,
   EndpointType,
 };
 use lemmy_db_schema::{
@@ -304,7 +305,7 @@ fn instance_actor_2022_01_28(
       name: site.name,
       actor_id: Some(actor_id.clone().into()),
       last_refreshed_at: Some(naive_now()),
-      inbox_url: Some(generate_inbox_url(&actor_id.into())?),
+      inbox_url: Some(generate_site_inbox_url(&actor_id.into())?),
       private_key: Some(Some(key_pair.private_key)),
       public_key: Some(key_pair.public_key),
       ..Default::default()


### PR DESCRIPTION
This will allow us to federate things like instance description and site bans. It is also a prerequisite for https://github.com/LemmyNet/lemmy/issues/1487.

Todo:
- [x] write db migrations
- [x] fetch the instance actor when parsing a remote community (make it optional if possible for compatibility)
- [x] implement site inbox/outbox
- [x] create api for retrieving info for remote instances
- [x] write federation test