### PR TITLE
Fix federation of initial post/comment vote (fixes #1824)

### DIFF
--- a/crates/apub/src/fetcher/post_or_comment.rs
+++ b/crates/apub/src/fetcher/post_or_comment.rs
@@ -23,6 +23,7 @@ pub enum PostOrCommentForm {
 }
 
 #[derive(Deserialize)]
+#[serde(untagged)]
 pub enum PageOrNote {
   Page(Box<Page>),
   Note(Box<Note>),


### PR DESCRIPTION
It was missing this one line, which meant that it failed to parse the object json. The fix is working correctly in manual testing

What i cant figure out is why the api test "create a comment" was still passing. Its testing the exact same scenario where the bug is happening, as far as I can tell. But for some reason the vote always gets federated correctly in the tests.