### PR TITLE
Add both (De)Serialize to all models

### DIFF
--- a/crates/api_common/src/comment.rs
+++ b/crates/api_common/src/comment.rs
@@ -2,7 +2,7 @@ use lemmy_db_schema::{CommentId, CommentReportId, CommunityId, LocalUserId, Post
 use lemmy_db_views::{comment_report_view::CommentReportView, comment_view::CommentView};
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct CreateComment {
   pub content: String,
   pub post_id: PostId,
@@ -11,7 +11,7 @@ pub struct CreateComment {
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct EditComment {
   pub content: String,
   pub comment_id: CommentId,
@@ -19,14 +19,14 @@ pub struct EditComment {
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct DeleteComment {
   pub comment_id: CommentId,
   pub deleted: bool,
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct RemoveComment {
   pub comment_id: CommentId,
   pub removed: bool,
@@ -34,35 +34,35 @@ pub struct RemoveComment {
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct MarkCommentAsRead {
   pub comment_id: CommentId,
   pub read: bool,
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct SaveComment {
   pub comment_id: CommentId,
   pub save: bool,
   pub auth: String,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct CommentResponse {
   pub comment_view: CommentView,
   pub recipient_ids: Vec<LocalUserId>,
   pub form_id: Option<String>, // An optional front end ID, to tell which is coming back
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct CreateCommentLike {
   pub comment_id: CommentId,
   pub score: i16,
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GetComments {
   pub type_: Option<String>,
   pub sort: Option<String>,
@@ -74,31 +74,31 @@ pub struct GetComments {
   pub auth: Option<String>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GetCommentsResponse {
   pub comments: Vec<CommentView>,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct CreateCommentReport {
   pub comment_id: CommentId,
   pub reason: String,
   pub auth: String,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct CommentReportResponse {
   pub comment_report_view: CommentReportView,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct ResolveCommentReport {
   pub report_id: CommentReportId,
   pub resolved: bool,
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct ListCommentReports {
   pub page: Option<i64>,
   pub limit: Option<i64>,
@@ -109,7 +109,7 @@ pub struct ListCommentReports {
   pub auth: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct ListCommentReportsResponse {
   pub comment_reports: Vec<CommentReportView>,
 }

--- a/crates/api_common/src/community.rs
+++ b/crates/api_common/src/community.rs
@@ -6,7 +6,7 @@ use lemmy_db_views_actor::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GetCommunity {
   pub id: Option<CommunityId>,
   /// Example: star_trek , or star_trek@xyz.tld
@@ -14,14 +14,14 @@ pub struct GetCommunity {
   pub auth: Option<String>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GetCommunityResponse {
   pub community_view: CommunityView,
   pub moderators: Vec<CommunityModeratorView>,
   pub online: usize,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct CreateCommunity {
   pub name: String,
   pub title: String,
@@ -32,12 +32,12 @@ pub struct CreateCommunity {
   pub auth: String,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct CommunityResponse {
   pub community_view: CommunityView,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct ListCommunities {
   pub type_: Option<String>,
   pub sort: Option<String>,
@@ -46,12 +46,12 @@ pub struct ListCommunities {
   pub auth: Option<String>,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct ListCommunitiesResponse {
   pub communities: Vec<CommunityView>,
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct BanFromCommunity {
   pub community_id: CommunityId,
   pub person_id: PersonId,
@@ -62,13 +62,13 @@ pub struct BanFromCommunity {
   pub auth: String,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct BanFromCommunityResponse {
   pub person_view: PersonViewSafe,
   pub banned: bool,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct AddModToCommunity {
   pub community_id: CommunityId,
   pub person_id: PersonId,
@@ -76,12 +76,12 @@ pub struct AddModToCommunity {
   pub auth: String,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct AddModToCommunityResponse {
   pub moderators: Vec<CommunityModeratorView>,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct EditCommunity {
   pub community_id: CommunityId,
   pub title: Option<String>,
@@ -92,14 +92,14 @@ pub struct EditCommunity {
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct DeleteCommunity {
   pub community_id: CommunityId,
   pub deleted: bool,
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct RemoveCommunity {
   pub community_id: CommunityId,
   pub removed: bool,
@@ -108,27 +108,27 @@ pub struct RemoveCommunity {
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct FollowCommunity {
   pub community_id: CommunityId,
   pub follow: bool,
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct BlockCommunity {
   pub community_id: CommunityId,
   pub block: bool,
   pub auth: String,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct BlockCommunityResponse {
   pub community_view: CommunityView,
   pub blocked: bool,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct TransferCommunity {
   pub community_id: CommunityId,
   pub person_id: PersonId,

--- a/crates/api_common/src/person.rs
+++ b/crates/api_common/src/person.rs
@@ -10,14 +10,14 @@ use lemmy_db_views_actor::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct Login {
   pub username_or_email: String,
   pub password: String,
 }
 use lemmy_db_schema::{CommunityId, PersonId, PersonMentionId, PrivateMessageId};
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct Register {
   pub username: String,
   pub password: String,
@@ -29,22 +29,22 @@ pub struct Register {
   pub honeypot: Option<String>,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GetCaptcha {}
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GetCaptchaResponse {
   pub ok: Option<CaptchaResponse>, // Will be None if captchas are disabled
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct CaptchaResponse {
   pub png: String, // A Base64 encoded png
   pub wav: String, // A Base64 encoded wav audio
   pub uuid: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct SaveUserSettings {
   pub show_nsfw: Option<bool>,
   pub show_scores: Option<bool>,
@@ -67,7 +67,7 @@ pub struct SaveUserSettings {
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct ChangePassword {
   pub new_password: String,
   pub new_password_verify: String,
@@ -75,12 +75,12 @@ pub struct ChangePassword {
   pub auth: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct LoginResponse {
   pub jwt: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GetPersonDetails {
   pub person_id: Option<PersonId>, // One of these two are required
   /// Example: dessalines , or dessalines@xyz.tld
@@ -93,7 +93,7 @@ pub struct GetPersonDetails {
   pub auth: Option<String>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GetPersonDetailsResponse {
   pub person_view: PersonViewSafe,
   pub comments: Vec<CommentView>,
@@ -101,34 +101,34 @@ pub struct GetPersonDetailsResponse {
   pub moderates: Vec<CommunityModeratorView>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GetRepliesResponse {
   pub replies: Vec<CommentView>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GetPersonMentionsResponse {
   pub mentions: Vec<PersonMentionView>,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct MarkAllAsRead {
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct AddAdmin {
   pub person_id: PersonId,
   pub added: bool,
   pub auth: String,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct AddAdminResponse {
   pub admins: Vec<PersonViewSafe>,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct BanPerson {
   pub person_id: PersonId,
   pub ban: bool,
@@ -138,26 +138,26 @@ pub struct BanPerson {
   pub auth: String,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct BanPersonResponse {
   pub person_view: PersonViewSafe,
   pub banned: bool,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct BlockPerson {
   pub person_id: PersonId,
   pub block: bool,
   pub auth: String,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct BlockPersonResponse {
   pub person_view: PersonViewSafe,
   pub blocked: bool,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GetReplies {
   pub sort: Option<String>,
   pub page: Option<i64>,
@@ -166,7 +166,7 @@ pub struct GetReplies {
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GetPersonMentions {
   pub sort: Option<String>,
   pub page: Option<i64>,
@@ -175,68 +175,68 @@ pub struct GetPersonMentions {
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct MarkPersonMentionAsRead {
   pub person_mention_id: PersonMentionId,
   pub read: bool,
   pub auth: String,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct PersonMentionResponse {
   pub person_mention_view: PersonMentionView,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct DeleteAccount {
   pub password: String,
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct PasswordReset {
   pub email: String,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct PasswordResetResponse {}
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct PasswordChange {
   pub token: String,
   pub password: String,
   pub password_verify: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct CreatePrivateMessage {
   pub content: String,
   pub recipient_id: PersonId,
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct EditPrivateMessage {
   pub private_message_id: PrivateMessageId,
   pub content: String,
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct DeletePrivateMessage {
   pub private_message_id: PrivateMessageId,
   pub deleted: bool,
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct MarkPrivateMessageAsRead {
   pub private_message_id: PrivateMessageId,
   pub read: bool,
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GetPrivateMessages {
   pub unread_only: Option<bool>,
   pub page: Option<i64>,
@@ -244,35 +244,35 @@ pub struct GetPrivateMessages {
   pub auth: String,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct PrivateMessagesResponse {
   pub private_messages: Vec<PrivateMessageView>,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct PrivateMessageResponse {
   pub private_message_view: PrivateMessageView,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GetReportCount {
   pub community_id: Option<CommunityId>,
   pub auth: String,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct GetReportCountResponse {
   pub community_id: Option<CommunityId>,
   pub comment_reports: i64,
   pub post_reports: i64,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GetUnreadCount {
   pub auth: String,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct GetUnreadCountResponse {
   pub replies: i64,
   pub mentions: i64,

--- a/crates/api_common/src/post.rs
+++ b/crates/api_common/src/post.rs
@@ -12,7 +12,7 @@ use lemmy_utils::request::SiteMetadata;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct CreatePost {
   pub name: String,
   pub community_id: CommunityId,
@@ -23,18 +23,18 @@ pub struct CreatePost {
   pub auth: String,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct PostResponse {
   pub post_view: PostView,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GetPost {
   pub id: PostId,
   pub auth: Option<String>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GetPostResponse {
   pub post_view: PostView,
   pub community_view: CommunityView,
@@ -43,7 +43,7 @@ pub struct GetPostResponse {
   pub online: usize,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct GetPosts {
   pub type_: Option<String>,
   pub sort: Option<String>,
@@ -55,19 +55,19 @@ pub struct GetPosts {
   pub auth: Option<String>,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct GetPostsResponse {
   pub posts: Vec<PostView>,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct CreatePostLike {
   pub post_id: PostId,
   pub score: i16,
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct EditPost {
   pub post_id: PostId,
   pub name: Option<String>,
@@ -77,14 +77,14 @@ pub struct EditPost {
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct DeletePost {
   pub post_id: PostId,
   pub deleted: bool,
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct RemovePost {
   pub post_id: PostId,
   pub removed: bool,
@@ -92,47 +92,47 @@ pub struct RemovePost {
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct LockPost {
   pub post_id: PostId,
   pub locked: bool,
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct StickyPost {
   pub post_id: PostId,
   pub stickied: bool,
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct SavePost {
   pub post_id: PostId,
   pub save: bool,
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct CreatePostReport {
   pub post_id: PostId,
   pub reason: String,
   pub auth: String,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct PostReportResponse {
   pub post_report_view: PostReportView,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct ResolvePostReport {
   pub report_id: PostReportId,
   pub resolved: bool,
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct ListPostReports {
   pub page: Option<i64>,
   pub limit: Option<i64>,
@@ -143,17 +143,17 @@ pub struct ListPostReports {
   pub auth: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct ListPostReportsResponse {
   pub post_reports: Vec<PostReportView>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct GetSiteMetadata {
   pub url: Url,
 }
 
-#[derive(Serialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct GetSiteMetadataResponse {
   pub metadata: SiteMetadata,
 }

--- a/crates/api_common/src/site.rs
+++ b/crates/api_common/src/site.rs
@@ -27,7 +27,7 @@ use lemmy_db_views_moderator::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct Search {
   pub q: String,
   pub community_id: Option<CommunityId>,
@@ -41,7 +41,7 @@ pub struct Search {
   pub auth: Option<String>,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct SearchResponse {
   pub type_: String,
   pub comments: Vec<CommentView>,
@@ -50,13 +50,13 @@ pub struct SearchResponse {
   pub users: Vec<PersonViewSafe>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct ResolveObject {
   pub q: String,
   pub auth: Option<String>,
 }
 
-#[derive(Serialize, Default)]
+#[derive(Serialize, Deserialize, Default)]
 pub struct ResolveObjectResponse {
   pub comment: Option<CommentView>,
   pub post: Option<PostView>,
@@ -64,7 +64,7 @@ pub struct ResolveObjectResponse {
   pub person: Option<PersonViewSafe>,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GetModlog {
   pub mod_person_id: Option<PersonId>,
   pub community_id: Option<CommunityId>,
@@ -72,7 +72,7 @@ pub struct GetModlog {
   pub limit: Option<i64>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GetModlogResponse {
   pub removed_posts: Vec<ModRemovePostView>,
   pub locked_posts: Vec<ModLockPostView>,
@@ -86,7 +86,7 @@ pub struct GetModlogResponse {
   pub added: Vec<ModAddView>,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct CreateSite {
   pub name: String,
   pub sidebar: Option<String>,
@@ -100,7 +100,7 @@ pub struct CreateSite {
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct EditSite {
   pub name: Option<String>,
   pub sidebar: Option<String>,
@@ -114,17 +114,17 @@ pub struct EditSite {
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GetSite {
   pub auth: Option<String>,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct SiteResponse {
   pub site_view: SiteView,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GetSiteResponse {
   pub site_view: Option<SiteView>, // Because the site might not be set up yet
   pub admins: Vec<PersonViewSafe>,
@@ -135,7 +135,7 @@ pub struct GetSiteResponse {
   pub federated_instances: Option<FederatedInstances>, // Federation may be disabled
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct MyUserInfo {
   pub local_user_view: LocalUserSettingsView,
   pub follows: Vec<CommunityFollowerView>,
@@ -144,29 +144,29 @@ pub struct MyUserInfo {
   pub person_blocks: Vec<PersonBlockView>,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct TransferSite {
   pub person_id: PersonId,
   pub auth: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GetSiteConfig {
   pub auth: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GetSiteConfigResponse {
   pub config_hjson: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct SaveSiteConfig {
   pub config_hjson: String,
   pub auth: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct FederatedInstances {
   pub linked: Vec<String>,
   pub allowed: Option<Vec<String>>,

--- a/crates/api_common/src/websocket.rs
+++ b/crates/api_common/src/websocket.rs
@@ -1,42 +1,42 @@
 use lemmy_db_schema::{CommunityId, PostId};
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct UserJoin {
   pub auth: String,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct UserJoinResponse {
   pub joined: bool,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct CommunityJoin {
   pub community_id: CommunityId,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct CommunityJoinResponse {
   pub joined: bool,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct ModJoin {
   pub community_id: CommunityId,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct ModJoinResponse {
   pub joined: bool,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct PostJoin {
   pub post_id: PostId,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct PostJoinResponse {
   pub joined: bool,
 }

--- a/crates/db_queries/src/aggregates/comment_aggregates.rs
+++ b/crates/db_queries/src/aggregates/comment_aggregates.rs
@@ -1,8 +1,10 @@
 use diesel::{result::Error, *};
 use lemmy_db_schema::{schema::comment_aggregates, CommentId};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Queryable, Associations, Identifiable, PartialEq, Debug, Serialize, Clone)]
+#[derive(
+  Queryable, Associations, Identifiable, PartialEq, Debug, Serialize, Deserialize, Clone,
+)]
 #[table_name = "comment_aggregates"]
 pub struct CommentAggregates {
   pub id: i32,

--- a/crates/db_queries/src/aggregates/community_aggregates.rs
+++ b/crates/db_queries/src/aggregates/community_aggregates.rs
@@ -1,8 +1,10 @@
 use diesel::{result::Error, *};
 use lemmy_db_schema::{schema::community_aggregates, CommunityId};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Queryable, Associations, Identifiable, PartialEq, Debug, Serialize, Clone)]
+#[derive(
+  Queryable, Associations, Identifiable, PartialEq, Debug, Serialize, Deserialize, Clone,
+)]
 #[table_name = "community_aggregates"]
 pub struct CommunityAggregates {
   pub id: i32,

--- a/crates/db_queries/src/aggregates/person_aggregates.rs
+++ b/crates/db_queries/src/aggregates/person_aggregates.rs
@@ -1,8 +1,10 @@
 use diesel::{result::Error, *};
 use lemmy_db_schema::{schema::person_aggregates, PersonId};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Queryable, Associations, Identifiable, PartialEq, Debug, Serialize, Clone)]
+#[derive(
+  Queryable, Associations, Identifiable, PartialEq, Debug, Serialize, Deserialize, Clone,
+)]
 #[table_name = "person_aggregates"]
 pub struct PersonAggregates {
   pub id: i32,

--- a/crates/db_queries/src/aggregates/post_aggregates.rs
+++ b/crates/db_queries/src/aggregates/post_aggregates.rs
@@ -1,8 +1,10 @@
 use diesel::{result::Error, *};
 use lemmy_db_schema::{schema::post_aggregates, PostId};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Queryable, Associations, Identifiable, PartialEq, Debug, Serialize, Clone)]
+#[derive(
+  Queryable, Associations, Identifiable, PartialEq, Debug, Serialize, Deserialize, Clone,
+)]
 #[table_name = "post_aggregates"]
 pub struct PostAggregates {
   pub id: i32,

--- a/crates/db_queries/src/aggregates/site_aggregates.rs
+++ b/crates/db_queries/src/aggregates/site_aggregates.rs
@@ -1,8 +1,10 @@
 use diesel::{result::Error, *};
 use lemmy_db_schema::schema::site_aggregates;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Queryable, Associations, Identifiable, PartialEq, Debug, Serialize, Clone)]
+#[derive(
+  Queryable, Associations, Identifiable, PartialEq, Debug, Serialize, Deserialize, Clone,
+)]
 #[table_name = "site_aggregates"]
 pub struct SiteAggregates {
   pub id: i32,

--- a/crates/db_schema/src/source/comment.rs
+++ b/crates/db_schema/src/source/comment.rs
@@ -10,7 +10,7 @@ use chrono::NaiveDateTime;
 use diesel::{ExpressionMethods, PgConnection, QueryDsl, RunQueryDsl};
 use lemmy_apub_lib::traits::ApubObject;
 use lemmy_utils::LemmyError;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use url::Url;
 
 // WITH RECURSIVE MyTree AS (
@@ -20,7 +20,9 @@ use url::Url;
 // )
 // SELECT * FROM MyTree;
 
-#[derive(Clone, Queryable, Associations, Identifiable, PartialEq, Debug, Serialize)]
+#[derive(
+  Clone, Queryable, Associations, Identifiable, PartialEq, Debug, Serialize, Deserialize,
+)]
 #[belongs_to(Post)]
 #[table_name = "comment"]
 pub struct Comment {
@@ -38,7 +40,9 @@ pub struct Comment {
   pub local: bool,
 }
 
-#[derive(Clone, Queryable, Associations, Identifiable, PartialEq, Debug, Serialize)]
+#[derive(
+  Clone, Queryable, Associations, Identifiable, PartialEq, Debug, Serialize, Deserialize,
+)]
 #[belongs_to(Post)]
 #[table_name = "comment_alias_1"]
 pub struct CommentAlias1 {

--- a/crates/db_schema/src/source/community.rs
+++ b/crates/db_schema/src/source/community.rs
@@ -8,10 +8,10 @@ use chrono::NaiveDateTime;
 use diesel::{ExpressionMethods, PgConnection, QueryDsl, RunQueryDsl};
 use lemmy_apub_lib::traits::{ActorType, ApubObject};
 use lemmy_utils::LemmyError;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use url::Url;
 
-#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize)]
+#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize, Deserialize)]
 #[table_name = "community"]
 pub struct Community {
   pub id: CommunityId,
@@ -36,7 +36,7 @@ pub struct Community {
 }
 
 /// A safe representation of community, without the sensitive info
-#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize)]
+#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize, Deserialize)]
 #[table_name = "community"]
 pub struct CommunitySafe {
   pub id: CommunityId,

--- a/crates/db_schema/src/source/community_block.rs
+++ b/crates/db_schema/src/source/community_block.rs
@@ -5,9 +5,11 @@ use crate::{
   CommunityId,
   PersonId,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Queryable, Associations, Identifiable, PartialEq, Debug, Serialize)]
+#[derive(
+  Clone, Queryable, Associations, Identifiable, PartialEq, Debug, Serialize, Deserialize,
+)]
 #[table_name = "community_block"]
 #[belongs_to(Community)]
 pub struct CommunityBlock {

--- a/crates/db_schema/src/source/local_user.rs
+++ b/crates/db_schema/src/source/local_user.rs
@@ -1,7 +1,7 @@
 use crate::{schema::local_user, LocalUserId, PersonId};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize)]
+#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize, Deserialize)]
 #[table_name = "local_user"]
 pub struct LocalUser {
   pub id: LocalUserId,
@@ -43,7 +43,7 @@ pub struct LocalUserForm {
 }
 
 /// A local user view that removes password encrypted
-#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize)]
+#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize, Deserialize)]
 #[table_name = "local_user"]
 pub struct LocalUserSettings {
   pub id: LocalUserId,

--- a/crates/db_schema/src/source/moderator.rs
+++ b/crates/db_schema/src/source/moderator.rs
@@ -16,9 +16,9 @@ use crate::{
   PersonId,
   PostId,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize)]
+#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize, Deserialize)]
 #[table_name = "mod_remove_post"]
 pub struct ModRemovePost {
   pub id: i32,
@@ -38,7 +38,7 @@ pub struct ModRemovePostForm {
   pub removed: Option<bool>,
 }
 
-#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize)]
+#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize, Deserialize)]
 #[table_name = "mod_lock_post"]
 pub struct ModLockPost {
   pub id: i32,
@@ -56,7 +56,7 @@ pub struct ModLockPostForm {
   pub locked: Option<bool>,
 }
 
-#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize)]
+#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize, Deserialize)]
 #[table_name = "mod_sticky_post"]
 pub struct ModStickyPost {
   pub id: i32,
@@ -74,7 +74,7 @@ pub struct ModStickyPostForm {
   pub stickied: Option<bool>,
 }
 
-#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize)]
+#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize, Deserialize)]
 #[table_name = "mod_remove_comment"]
 pub struct ModRemoveComment {
   pub id: i32,
@@ -94,7 +94,7 @@ pub struct ModRemoveCommentForm {
   pub removed: Option<bool>,
 }
 
-#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize)]
+#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize, Deserialize)]
 #[table_name = "mod_remove_community"]
 pub struct ModRemoveCommunity {
   pub id: i32,
@@ -116,7 +116,7 @@ pub struct ModRemoveCommunityForm {
   pub expires: Option<chrono::NaiveDateTime>,
 }
 
-#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize)]
+#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize, Deserialize)]
 #[table_name = "mod_ban_from_community"]
 pub struct ModBanFromCommunity {
   pub id: i32,
@@ -140,7 +140,7 @@ pub struct ModBanFromCommunityForm {
   pub expires: Option<chrono::NaiveDateTime>,
 }
 
-#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize)]
+#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize, Deserialize)]
 #[table_name = "mod_ban"]
 pub struct ModBan {
   pub id: i32,
@@ -162,7 +162,7 @@ pub struct ModBanForm {
   pub expires: Option<chrono::NaiveDateTime>,
 }
 
-#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize)]
+#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize, Deserialize)]
 #[table_name = "mod_add_community"]
 pub struct ModAddCommunity {
   pub id: i32,
@@ -182,7 +182,7 @@ pub struct ModAddCommunityForm {
   pub removed: Option<bool>,
 }
 
-#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize)]
+#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize, Deserialize)]
 #[table_name = "mod_transfer_community"]
 pub struct ModTransferCommunity {
   pub id: i32,
@@ -202,7 +202,7 @@ pub struct ModTransferCommunityForm {
   pub removed: Option<bool>,
 }
 
-#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize)]
+#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize, Deserialize)]
 #[table_name = "mod_add"]
 pub struct ModAdd {
   pub id: i32,

--- a/crates/db_schema/src/source/person.rs
+++ b/crates/db_schema/src/source/person.rs
@@ -7,10 +7,10 @@ use chrono::NaiveDateTime;
 use diesel::{ExpressionMethods, PgConnection, QueryDsl, RunQueryDsl};
 use lemmy_apub_lib::traits::{ActorType, ApubObject};
 use lemmy_utils::LemmyError;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use url::Url;
 
-#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize)]
+#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize, Deserialize)]
 #[table_name = "person"]
 pub struct Person {
   pub id: PersonId,
@@ -36,7 +36,7 @@ pub struct Person {
 }
 
 /// A safe representation of person, without the sensitive info
-#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize)]
+#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize, Deserialize)]
 #[table_name = "person"]
 pub struct PersonSafe {
   pub id: PersonId,
@@ -58,7 +58,7 @@ pub struct PersonSafe {
   pub bot_account: bool,
 }
 
-#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize)]
+#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize, Deserialize)]
 #[table_name = "person_alias_1"]
 pub struct PersonAlias1 {
   pub id: PersonId,
@@ -83,7 +83,7 @@ pub struct PersonAlias1 {
   pub bot_account: bool,
 }
 
-#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize)]
+#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize, Deserialize)]
 #[table_name = "person_alias_1"]
 pub struct PersonSafeAlias1 {
   pub id: PersonId,
@@ -105,7 +105,7 @@ pub struct PersonSafeAlias1 {
   pub bot_account: bool,
 }
 
-#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize)]
+#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize, Deserialize)]
 #[table_name = "person_alias_2"]
 pub struct PersonAlias2 {
   pub id: PersonId,
@@ -130,7 +130,7 @@ pub struct PersonAlias2 {
   pub bot_account: bool,
 }
 
-#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize)]
+#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize, Deserialize)]
 #[table_name = "person_alias_1"]
 pub struct PersonSafeAlias2 {
   pub id: PersonId,

--- a/crates/db_schema/src/source/person_block.rs
+++ b/crates/db_schema/src/source/person_block.rs
@@ -1,7 +1,9 @@
 use crate::{schema::person_block, PersonBlockId, PersonId};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Queryable, Associations, Identifiable, PartialEq, Debug, Serialize)]
+#[derive(
+  Clone, Queryable, Associations, Identifiable, PartialEq, Debug, Serialize, Deserialize,
+)]
 #[table_name = "person_block"]
 pub struct PersonBlock {
   pub id: PersonBlockId,

--- a/crates/db_schema/src/source/person_mention.rs
+++ b/crates/db_schema/src/source/person_mention.rs
@@ -5,9 +5,11 @@ use crate::{
   PersonId,
   PersonMentionId,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Queryable, Associations, Identifiable, PartialEq, Debug, Serialize)]
+#[derive(
+  Clone, Queryable, Associations, Identifiable, PartialEq, Debug, Serialize, Deserialize,
+)]
 #[belongs_to(Comment)]
 #[table_name = "person_mention"]
 pub struct PersonMention {

--- a/crates/db_schema/src/source/post.rs
+++ b/crates/db_schema/src/source/post.rs
@@ -9,10 +9,10 @@ use chrono::NaiveDateTime;
 use diesel::{ExpressionMethods, PgConnection, QueryDsl, RunQueryDsl};
 use lemmy_apub_lib::traits::ApubObject;
 use lemmy_utils::LemmyError;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use url::Url;
 
-#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize)]
+#[derive(Clone, Queryable, Identifiable, PartialEq, Debug, Serialize, Deserialize)]
 #[table_name = "post"]
 pub struct Post {
   pub id: PostId,

--- a/crates/db_schema/src/source/private_message.rs
+++ b/crates/db_schema/src/source/private_message.rs
@@ -3,10 +3,12 @@ use chrono::NaiveDateTime;
 use diesel::{ExpressionMethods, PgConnection, QueryDsl, RunQueryDsl};
 use lemmy_apub_lib::traits::ApubObject;
 use lemmy_utils::LemmyError;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use url::Url;
 
-#[derive(Clone, Queryable, Associations, Identifiable, PartialEq, Debug, Serialize)]
+#[derive(
+  Clone, Queryable, Associations, Identifiable, PartialEq, Debug, Serialize, Deserialize,
+)]
 #[table_name = "private_message"]
 pub struct PrivateMessage {
   pub id: PrivateMessageId,

--- a/crates/db_schema/src/source/site.rs
+++ b/crates/db_schema/src/source/site.rs
@@ -1,7 +1,7 @@
 use crate::{schema::site, DbUrl, PersonId};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Queryable, Identifiable, PartialEq, Debug, Clone, Serialize)]
+#[derive(Queryable, Identifiable, PartialEq, Debug, Clone, Serialize, Deserialize)]
 #[table_name = "site"]
 pub struct Site {
   pub id: i32,

--- a/crates/db_views/src/comment_report_view.rs
+++ b/crates/db_views/src/comment_report_view.rs
@@ -31,9 +31,9 @@ use lemmy_db_schema::{
   CommunityId,
   PersonId,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, PartialEq, Serialize, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct CommentReportView {
   pub comment_report: CommentReport,
   pub comment: Comment,

--- a/crates/db_views/src/comment_view.rs
+++ b/crates/db_views/src/comment_view.rs
@@ -39,9 +39,9 @@ use lemmy_db_schema::{
   PersonId,
   PostId,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, PartialEq, Serialize, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct CommentView {
   pub comment: Comment,
   pub creator: PersonSafe,

--- a/crates/db_views/src/local_user_view.rs
+++ b/crates/db_views/src/local_user_view.rs
@@ -9,9 +9,9 @@ use lemmy_db_schema::{
   LocalUserId,
   PersonId,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct LocalUserView {
   pub local_user: LocalUser,
   pub person: Person,
@@ -117,7 +117,7 @@ impl LocalUserView {
   }
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct LocalUserSettingsView {
   pub local_user: LocalUserSettings,
   pub person: PersonSafe,

--- a/crates/db_views/src/post_report_view.rs
+++ b/crates/db_views/src/post_report_view.rs
@@ -29,9 +29,9 @@ use lemmy_db_schema::{
   PersonId,
   PostReportId,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, PartialEq, Serialize, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct PostReportView {
   pub post_report: PostReport,
   pub post: Post,

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -36,9 +36,9 @@ use lemmy_db_schema::{
   PostId,
 };
 use log::debug;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, PartialEq, Serialize, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct PostView {
   pub post: Post,
   pub creator: PersonSafe,

--- a/crates/db_views/src/private_message_view.rs
+++ b/crates/db_views/src/private_message_view.rs
@@ -10,9 +10,9 @@ use lemmy_db_schema::{
   PrivateMessageId,
 };
 use log::debug;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, PartialEq, Serialize, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct PrivateMessageView {
   pub private_message: PrivateMessage,
   pub creator: PersonSafe,

--- a/crates/db_views/src/site_view.rs
+++ b/crates/db_views/src/site_view.rs
@@ -7,9 +7,9 @@ use lemmy_db_schema::{
     site::Site,
   },
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SiteView {
   pub site: Site,
   pub creator: PersonSafe,

--- a/crates/db_views_actor/src/community_block_view.rs
+++ b/crates/db_views_actor/src/community_block_view.rs
@@ -8,9 +8,9 @@ use lemmy_db_schema::{
   },
   PersonId,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CommunityBlockView {
   pub person: PersonSafe,
   pub community: CommunitySafe,

--- a/crates/db_views_actor/src/community_follower_view.rs
+++ b/crates/db_views_actor/src/community_follower_view.rs
@@ -9,9 +9,9 @@ use lemmy_db_schema::{
   CommunityId,
   PersonId,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CommunityFollowerView {
   pub community: CommunitySafe,
   pub follower: PersonSafe,

--- a/crates/db_views_actor/src/community_moderator_view.rs
+++ b/crates/db_views_actor/src/community_moderator_view.rs
@@ -9,9 +9,9 @@ use lemmy_db_schema::{
   CommunityId,
   PersonId,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CommunityModeratorView {
   pub community: CommunitySafe,
   pub moderator: PersonSafe,

--- a/crates/db_views_actor/src/community_person_ban_view.rs
+++ b/crates/db_views_actor/src/community_person_ban_view.rs
@@ -9,9 +9,9 @@ use lemmy_db_schema::{
   CommunityId,
   PersonId,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CommunityPersonBanView {
   pub community: CommunitySafe,
   pub person: PersonSafe,

--- a/crates/db_views_actor/src/community_view.rs
+++ b/crates/db_views_actor/src/community_view.rs
@@ -20,9 +20,9 @@ use lemmy_db_schema::{
   CommunityId,
   PersonId,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CommunityView {
   pub community: CommunitySafe,
   pub subscribed: bool,

--- a/crates/db_views_actor/src/person_block_view.rs
+++ b/crates/db_views_actor/src/person_block_view.rs
@@ -5,9 +5,9 @@ use lemmy_db_schema::{
   source::person::{Person, PersonAlias1, PersonSafe, PersonSafeAlias1},
   PersonId,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PersonBlockView {
   pub person: PersonSafe,
   pub target: PersonSafeAlias1,

--- a/crates/db_views_actor/src/person_mention_view.rs
+++ b/crates/db_views_actor/src/person_mention_view.rs
@@ -34,9 +34,9 @@ use lemmy_db_schema::{
   PersonId,
   PersonMentionId,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, PartialEq, Serialize, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct PersonMentionView {
   pub person_mention: PersonMention,
   pub comment: Comment,

--- a/crates/db_views_actor/src/person_view.rs
+++ b/crates/db_views_actor/src/person_view.rs
@@ -13,9 +13,9 @@ use lemmy_db_schema::{
   source::person::{Person, PersonSafe},
   PersonId,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PersonViewSafe {
   pub person: PersonSafe,
   pub counts: PersonAggregates,

--- a/crates/db_views_moderator/src/mod_add_community_view.rs
+++ b/crates/db_views_moderator/src/mod_add_community_view.rs
@@ -10,9 +10,9 @@ use lemmy_db_schema::{
   CommunityId,
   PersonId,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ModAddCommunityView {
   pub mod_add_community: ModAddCommunity,
   pub moderator: PersonSafe,

--- a/crates/db_views_moderator/src/mod_add_view.rs
+++ b/crates/db_views_moderator/src/mod_add_view.rs
@@ -8,9 +8,9 @@ use lemmy_db_schema::{
   },
   PersonId,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ModAddView {
   pub mod_add: ModAdd,
   pub moderator: PersonSafe,

--- a/crates/db_views_moderator/src/mod_ban_from_community_view.rs
+++ b/crates/db_views_moderator/src/mod_ban_from_community_view.rs
@@ -10,9 +10,9 @@ use lemmy_db_schema::{
   CommunityId,
   PersonId,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ModBanFromCommunityView {
   pub mod_ban_from_community: ModBanFromCommunity,
   pub moderator: PersonSafe,

--- a/crates/db_views_moderator/src/mod_ban_view.rs
+++ b/crates/db_views_moderator/src/mod_ban_view.rs
@@ -8,9 +8,9 @@ use lemmy_db_schema::{
   },
   PersonId,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ModBanView {
   pub mod_ban: ModBan,
   pub moderator: PersonSafe,

--- a/crates/db_views_moderator/src/mod_lock_post_view.rs
+++ b/crates/db_views_moderator/src/mod_lock_post_view.rs
@@ -11,9 +11,9 @@ use lemmy_db_schema::{
   CommunityId,
   PersonId,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ModLockPostView {
   pub mod_lock_post: ModLockPost,
   pub moderator: PersonSafe,

--- a/crates/db_views_moderator/src/mod_remove_comment_view.rs
+++ b/crates/db_views_moderator/src/mod_remove_comment_view.rs
@@ -12,9 +12,9 @@ use lemmy_db_schema::{
   CommunityId,
   PersonId,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ModRemoveCommentView {
   pub mod_remove_comment: ModRemoveComment,
   pub moderator: PersonSafe,

--- a/crates/db_views_moderator/src/mod_remove_community_view.rs
+++ b/crates/db_views_moderator/src/mod_remove_community_view.rs
@@ -9,9 +9,9 @@ use lemmy_db_schema::{
   },
   PersonId,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ModRemoveCommunityView {
   pub mod_remove_community: ModRemoveCommunity,
   pub moderator: PersonSafe,

--- a/crates/db_views_moderator/src/mod_remove_post_view.rs
+++ b/crates/db_views_moderator/src/mod_remove_post_view.rs
@@ -11,9 +11,9 @@ use lemmy_db_schema::{
   CommunityId,
   PersonId,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ModRemovePostView {
   pub mod_remove_post: ModRemovePost,
   pub moderator: PersonSafe,

--- a/crates/db_views_moderator/src/mod_sticky_post_view.rs
+++ b/crates/db_views_moderator/src/mod_sticky_post_view.rs
@@ -11,9 +11,9 @@ use lemmy_db_schema::{
   CommunityId,
   PersonId,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ModStickyPostView {
   pub mod_sticky_post: ModStickyPost,
   pub moderator: PersonSafe,

--- a/crates/db_views_moderator/src/mod_transfer_community_view.rs
+++ b/crates/db_views_moderator/src/mod_transfer_community_view.rs
@@ -10,9 +10,9 @@ use lemmy_db_schema::{
   CommunityId,
   PersonId,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ModTransferCommunityView {
   pub mod_transfer_community: ModTransferCommunity,
   pub moderator: PersonSafe,


### PR DESCRIPTION
As discussed in the dev Matrix channel, I'm adding both `Serialize` and `Deserialize` to all models, so that clients can pull them from these crates instead of implementing everything themselves.