### PR TITLE
Fix husky fmt hook.

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-cargo +nightly fmt
+cargo +nightly fmt -- --check
 
 cargo +nightly clippy --workspace --tests --all-targets --all-features -- \
     -D warnings -D deprecated -D clippy::perf -D clippy::complexity -D clippy::dbg_macro

--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-cargo fmt -- --check
+cargo +nightly fmt -- --check
 
 cargo clippy --workspace --tests --all-targets --all-features -- \
     -D warnings -D deprecated -D clippy::perf -D clippy::complexity -D clippy::dbg_macro

--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -e
 
-cargo +nightly fmt -- --check
+cargo fmt -- --check
 
-cargo +nightly clippy --workspace --tests --all-targets --all-features -- \
+cargo clippy --workspace --tests --all-targets --all-features -- \
     -D warnings -D deprecated -D clippy::perf -D clippy::complexity -D clippy::dbg_macro
 
 ./scripts/update_config_defaults.sh


### PR DESCRIPTION
This one shouldn't have slipped in. cargo-husky has no lint-staged like node, so running `fmt` on these doesn't stage the files at all, and will let you commit unformatted files. Making this a format check again to fix.