### PR TITLE
More federation compat

### DIFF
--- a/crates/apub/src/activities/community/mod.rs
+++ b/crates/apub/src/activities/community/mod.rs
@@ -28,7 +28,7 @@ pub(crate) async fn send_to_community<T: ActorType>(
 ) -> Result<(), LemmyError> {
   // if this is a local community, we need to do an announce from the community instead
   if community.local {
-    insert_activity(activity_id, activity.clone(), true, false, context.pool()).await?;
+    insert_activity(activity_id, &activity, true, false, context.pool()).await?;
     AnnounceActivity::send(activity, community, additional_inboxes, context).await?;
   } else {
     let mut inboxes = additional_inboxes;

--- a/crates/apub/src/activities/mod.rs
+++ b/crates/apub/src/activities/mod.rs
@@ -173,7 +173,7 @@ async fn send_lemmy_activity<T: Serialize>(
 
   insert_activity(
     activity_id,
-    serialised_activity.clone(),
+    &serialised_activity,
     true,
     sensitive,
     context.pool(),

--- a/crates/apub/src/activities/post/create_or_update.rs
+++ b/crates/apub/src/activities/post/create_or_update.rs
@@ -59,6 +59,7 @@ impl CreateOrUpdatePost {
     })
     .await??
     .into();
+
     let create_or_update = CreateOrUpdatePost::new(post, actor, &community, kind, context).await?;
     let id = create_or_update.id.clone();
     let activity = AnnouncableActivities::CreateOrUpdatePost(create_or_update);

--- a/crates/apub/src/activity_lists.rs
+++ b/crates/apub/src/activity_lists.rs
@@ -108,8 +108,8 @@ impl GetCommunity for AnnouncableActivities {
       UndoBlockUserFromCommunity(a) => a.get_community(context, request_counter).await?,
       AddMod(a) => a.get_community(context, request_counter).await?,
       RemoveMod(a) => a.get_community(context, request_counter).await?,
-      Page(a) => a.get_community(context, request_counter).await?,
-      Note(a) => a.get_community(context, request_counter).await?,
+      Page(_) => unimplemented!(),
+      Note(_) => unimplemented!(),
     };
     Ok(community)
   }

--- a/crates/apub/src/activity_lists.rs
+++ b/crates/apub/src/activity_lists.rs
@@ -1,29 +1,32 @@
 use crate::{
   activities::community::announce::GetCommunity,
   objects::community::ApubCommunity,
-  protocol::activities::{
-    community::{
-      add_mod::AddMod,
-      announce::AnnounceActivity,
-      block_user::BlockUserFromCommunity,
-      remove_mod::RemoveMod,
-      report::Report,
-      undo_block_user::UndoBlockUserFromCommunity,
-      update::UpdateCommunity,
+  protocol::{
+    activities::{
+      community::{
+        add_mod::AddMod,
+        announce::AnnounceActivity,
+        block_user::BlockUserFromCommunity,
+        remove_mod::RemoveMod,
+        report::Report,
+        undo_block_user::UndoBlockUserFromCommunity,
+        update::UpdateCommunity,
+      },
+      create_or_update::{comment::CreateOrUpdateComment, post::CreateOrUpdatePost},
+      deletion::{delete::Delete, undo_delete::UndoDelete},
+      following::{
+        accept::AcceptFollowCommunity,
+        follow::FollowCommunity,
+        undo_follow::UndoFollowCommunity,
+      },
+      private_message::{
+        create_or_update::CreateOrUpdatePrivateMessage,
+        delete::DeletePrivateMessage,
+        undo_delete::UndoDeletePrivateMessage,
+      },
+      voting::{undo_vote::UndoVote, vote::Vote},
     },
-    create_or_update::{comment::CreateOrUpdateComment, post::CreateOrUpdatePost},
-    deletion::{delete::Delete, undo_delete::UndoDelete},
-    following::{
-      accept::AcceptFollowCommunity,
-      follow::FollowCommunity,
-      undo_follow::UndoFollowCommunity,
-    },
-    private_message::{
-      create_or_update::CreateOrUpdatePrivateMessage,
-      delete::DeletePrivateMessage,
-      undo_delete::UndoDeletePrivateMessage,
-    },
-    voting::{undo_vote::UndoVote, vote::Vote},
+    objects::{note::Note, page::Page},
   },
 };
 use lemmy_apub_lib::traits::ActivityHandler;
@@ -79,6 +82,10 @@ pub enum AnnouncableActivities {
   UndoBlockUserFromCommunity(UndoBlockUserFromCommunity),
   AddMod(AddMod),
   RemoveMod(RemoveMod),
+  // For compatibility with Pleroma/Mastodon (send only)
+  Page(Page),
+  // For compatibility with Pleroma/Mastodon (send only)
+  Note(Note),
 }
 
 #[async_trait::async_trait(?Send)]
@@ -101,6 +108,8 @@ impl GetCommunity for AnnouncableActivities {
       UndoBlockUserFromCommunity(a) => a.get_community(context, request_counter).await?,
       AddMod(a) => a.get_community(context, request_counter).await?,
       RemoveMod(a) => a.get_community(context, request_counter).await?,
+      Page(a) => a.get_community(context, request_counter).await?,
+      Note(a) => a.get_community(context, request_counter).await?,
     };
     Ok(community)
   }

--- a/crates/apub/src/http/community.rs
+++ b/crates/apub/src/http/community.rs
@@ -79,7 +79,7 @@ pub(in crate::http) async fn receive_group_inbox(
   context: &LemmyContext,
 ) -> Result<HttpResponse, LemmyError> {
   let actor_id = ObjectId::new(activity_data.actor.clone());
-  let res = receive_activity(request, activity.clone(), activity_data, context).await;
+  let res = receive_activity(request, activity.clone(), activity_data, context).await?;
 
   if let GroupInboxActivities::AnnouncableActivities(announcable) = activity {
     let community = announcable.get_community(context, &mut 0).await?;
@@ -89,7 +89,7 @@ pub(in crate::http) async fn receive_group_inbox(
     }
   }
 
-  res
+  Ok(res)
 }
 
 /// Returns an empty followers collection, only populating the size (for privacy).

--- a/crates/apub/src/http/mod.rs
+++ b/crates/apub/src/http/mod.rs
@@ -109,14 +109,7 @@ where
 
   // Log the activity, so we avoid receiving and parsing it twice. Note that this could still happen
   // if we receive the same activity twice in very quick succession.
-  insert_activity(
-    &activity_data.id,
-    activity.clone(),
-    false,
-    true,
-    context.pool(),
-  )
-  .await?;
+  insert_activity(&activity_data.id, &activity, false, true, context.pool()).await?;
 
   info!("Receiving activity {}", activity_data.id.to_string());
   activity

--- a/crates/apub/src/lib.rs
+++ b/crates/apub/src/lib.rs
@@ -179,7 +179,7 @@ pub async fn get_actor_id_from_name(
 /// persistent.
 async fn insert_activity<T>(
   ap_id: &Url,
-  activity: T,
+  activity: &T,
   local: bool,
   sensitive: bool,
   pool: &DbPool,
@@ -187,9 +187,10 @@ async fn insert_activity<T>(
 where
   T: Serialize + std::fmt::Debug + Send + 'static,
 {
+  let data = serde_json::to_value(activity)?;
   let ap_id = ap_id.to_owned().into();
   blocking(pool, move |conn| {
-    Activity::insert(conn, ap_id, &activity, local, sensitive)
+    Activity::insert(conn, ap_id, data, local, sensitive)
   })
   .await??;
   Ok(())

--- a/crates/apub/src/protocol/objects/note.rs
+++ b/crates/apub/src/protocol/objects/note.rs
@@ -1,7 +1,6 @@
 use crate::{
-  activities::community::announce::GetCommunity,
   fetcher::post_or_comment::PostOrComment,
-  objects::{comment::ApubComment, community::ApubCommunity, person::ApubPerson, post::ApubPost},
+  objects::{comment::ApubComment, person::ApubPerson, post::ApubPost},
   protocol::Source,
 };
 use activitystreams::{object::kind::NoteType, unparsed::Unparsed};
@@ -14,11 +13,7 @@ use lemmy_apub_lib::{
   traits::ActivityHandler,
   values::MediaTypeHtml,
 };
-use lemmy_db_schema::{
-  newtypes::CommentId,
-  source::{community::Community, post::Post},
-  traits::Crud,
-};
+use lemmy_db_schema::{newtypes::CommentId, source::post::Post, traits::Crud};
 use lemmy_utils::LemmyError;
 use lemmy_websocket::LemmyContext;
 use serde::{Deserialize, Serialize};
@@ -101,24 +96,6 @@ impl ActivityHandler for Note {
     Err(anyhow!("Announce/Page can only be sent, not received").into())
   }
   async fn receive(self, _: &Data<Self::DataType>, _: &mut i32) -> Result<(), LemmyError> {
-    Ok(())
-  }
-}
-
-#[async_trait::async_trait(?Send)]
-impl GetCommunity for Note {
-  async fn get_community(
-    &self,
-    context: &LemmyContext,
-    request_counter: &mut i32,
-  ) -> Result<ApubCommunity, LemmyError> {
-    let post = self.get_parents(context, request_counter).await?.0;
-    Ok(
-      blocking(context.pool(), move |conn| {
-        Community::read(conn, post.community_id)
-      })
-      .await??
-      .into(),
-    )
+    unimplemented!()
   }
 }

--- a/crates/apub/src/protocol/objects/page.rs
+++ b/crates/apub/src/protocol/objects/page.rs
@@ -1,5 +1,4 @@
 use crate::{
-  activities::community::announce::GetCommunity,
   objects::{community::ApubCommunity, person::ApubPerson, post::ApubPost},
   protocol::{ImageObject, Source},
 };
@@ -88,17 +87,6 @@ impl ActivityHandler for Page {
     Err(anyhow!("Announce/Page can only be sent, not received").into())
   }
   async fn receive(self, _: &Data<Self::DataType>, _: &mut i32) -> Result<(), LemmyError> {
-    Ok(())
-  }
-}
-
-#[async_trait::async_trait(?Send)]
-impl GetCommunity for Page {
-  async fn get_community(
-    &self,
-    context: &LemmyContext,
-    request_counter: &mut i32,
-  ) -> Result<ApubCommunity, LemmyError> {
-    self.extract_community(context, request_counter).await
+    unimplemented!()
   }
 }

--- a/crates/apub_lib/src/activity_queue.rs
+++ b/crates/apub_lib/src/activity_queue.rs
@@ -1,4 +1,4 @@
-use crate::{signatures::sign_and_send, traits::ActorType, APUB_JSON_CONTENT_TYPE};
+use crate::{signatures::sign_and_send, traits::ActorType};
 use anyhow::{anyhow, Context, Error};
 use background_jobs::{
   create_server,
@@ -13,7 +13,7 @@ use lemmy_utils::{location_info, LemmyError};
 use log::warn;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, env, fmt::Debug, future::Future, pin::Pin};
+use std::{env, fmt::Debug, future::Future, pin::Pin};
 use url::Url;
 
 pub async fn send_activity(
@@ -64,11 +64,8 @@ impl ActixJob for SendActivityTask {
 }
 
 async fn do_send(task: SendActivityTask, client: &Client) -> Result<(), Error> {
-  let mut headers = BTreeMap::<String, String>::new();
-  headers.insert("Content-Type".into(), APUB_JSON_CONTENT_TYPE.to_string());
   let result = sign_and_send(
     client,
-    headers,
     &task.inbox,
     task.activity.clone(),
     &task.actor_id,

--- a/crates/db_schema/src/impls/activity.rs
+++ b/crates/db_schema/src/impls/activity.rs
@@ -1,10 +1,7 @@
 use crate::{newtypes::DbUrl, source::activity::*, traits::Crud};
 use diesel::{dsl::*, result::Error, *};
-use serde::Serialize;
-use std::{
-  fmt::Debug,
-  io::{Error as IoError, ErrorKind},
-};
+use serde_json::Value;
+use std::io::{Error as IoError, ErrorKind};
 
 impl Crud for Activity {
   type Form = ActivityForm;
@@ -38,19 +35,16 @@ impl Crud for Activity {
 }
 
 impl Activity {
-  pub fn insert<T>(
+  pub fn insert(
     conn: &PgConnection,
     ap_id: DbUrl,
-    data: &T,
+    data: Value,
     local: bool,
     sensitive: bool,
-  ) -> Result<Activity, IoError>
-  where
-    T: Serialize + Debug,
-  {
+  ) -> Result<Activity, IoError> {
     let activity_form = ActivityForm {
       ap_id,
-      data: serde_json::to_value(&data)?,
+      data,
       local: Some(local),
       sensitive,
       updated: None,


### PR DESCRIPTION
With these changes, new posts/comments from Lemmy get delivered successfully to Pleroma, which means we are ready to release 0.14!

@asonix The last commit is causing a weird error in background-jobs 0.9.1, crashes with `WARN  background_jobs_actix::server] Not restarting ticker, arbiter has died`. That doesnt make any sense to me, because its simply sending some different json. Any clue what that could be? I also tried background-jobs 0.10.0, same problem but it doesnt log anything.