### PR TITLE
Implement rate limits on comments

### DIFF
--- a/config/defaults.hjson
+++ b/config/defaults.hjson
@@ -32,6 +32,10 @@
     image: 6
     # Interval length for image uploads, in seconds
     image_per_second: 3600
+    # Maximum number of comments created in interval
+    comment: 6
+    # Interval length for comment limit, in seconds
+    comment_per_second: 600
   }
   # Settings related to activitypub federation
   federation: {

--- a/crates/utils/src/rate_limit/mod.rs
+++ b/crates/utils/src/rate_limit/mod.rs
@@ -49,6 +49,10 @@ impl RateLimit {
     self.kind(RateLimitType::Image)
   }
 
+  pub fn comment(&self) -> RateLimited {
+    self.kind(RateLimitType::Comment)
+  }
+
   fn kind(&self, type_: RateLimitType) -> RateLimited {
     RateLimited {
       rate_limiter: self.rate_limiter.clone(),
@@ -112,6 +116,15 @@ impl RateLimited {
             &ip_addr,
             rate_limit.image,
             rate_limit.image_per_second,
+            false,
+          )?;
+        }
+        RateLimitType::Comment => {
+          limiter.check_rate_limit_full(
+            self.type_,
+            &ip_addr,
+            rate_limit.comment,
+            rate_limit.comment_per_second,
             false,
           )?;
         }

--- a/crates/utils/src/rate_limit/rate_limiter.rs
+++ b/crates/utils/src/rate_limit/rate_limiter.rs
@@ -15,6 +15,7 @@ pub(crate) enum RateLimitType {
   Register,
   Post,
   Image,
+  Comment,
 }
 
 /// Rate limiting based on rate type and IP addr

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -149,6 +149,12 @@ pub struct RateLimitConfig {
   /// Interval length for image uploads, in seconds
   #[default(3600)]
   pub image_per_second: i32,
+  /// Maximum number of comments created in interval
+  #[default(6)]
+  pub comment: i32,
+  /// Interval length for comment limit, in seconds
+  #[default(600)]
+  pub comment_per_second: i32,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, SmartDefault, Document)]

--- a/crates/websocket/src/chat_server.rs
+++ b/crates/websocket/src/chat_server.rs
@@ -485,6 +485,7 @@ impl ChatServer {
           UserOperationCrud::Register => rate_limiter.register().wrap(ip, fut).await,
           UserOperationCrud::CreatePost => rate_limiter.post().wrap(ip, fut).await,
           UserOperationCrud::CreateCommunity => rate_limiter.register().wrap(ip, fut).await,
+          UserOperationCrud::CreateComment => rate_limiter.comment().wrap(ip, fut).await,
           _ => rate_limiter.message().wrap(ip, fut).await,
         }
       } else {

--- a/docker/federation/lemmy_alpha.hjson
+++ b/docker/federation/lemmy_alpha.hjson
@@ -33,5 +33,7 @@
     register_per_second: 3600
     image: 6
     image_per_second: 3600
+    comment: 99999
+    comment_per_second: 600
   }
 }

--- a/docker/federation/lemmy_beta.hjson
+++ b/docker/federation/lemmy_beta.hjson
@@ -32,5 +32,7 @@
     register_per_second: 3600
     image: 6
     image_per_second: 3600
+    comment: 99999
+    comment_per_second: 600
   }
 }

--- a/docker/federation/lemmy_delta.hjson
+++ b/docker/federation/lemmy_delta.hjson
@@ -32,5 +32,7 @@
     register_per_second: 3600
     image: 6
     image_per_second: 3600
+    comment: 99999
+    comment_per_second: 600
   }
 }

--- a/docker/federation/lemmy_epsilon.hjson
+++ b/docker/federation/lemmy_epsilon.hjson
@@ -32,5 +32,7 @@
     register_per_second: 3600
     image: 6
     image_per_second: 3600
+    comment: 99999
+    comment_per_second: 600
   }
 }

--- a/docker/federation/lemmy_gamma.hjson
+++ b/docker/federation/lemmy_gamma.hjson
@@ -32,5 +32,7 @@
     register_per_second: 3600
     image: 6
     image_per_second: 3600
+    comment: 99999
+    comment_per_second: 600
   }
 }

--- a/src/api_routes.rs
+++ b/src/api_routes.rs
@@ -102,9 +102,15 @@ pub fn config(cfg: &mut web::ServiceConfig, rate_limit: &RateLimit) {
       )
       // Comment
       .service(
+        // Handle POST to /comment separately to add the comment() rate limitter
+        web::resource("/comment")
+          .guard(guard::Post())
+          .wrap(rate_limit.comment())
+          .route(web::post().to(route_post_crud::<CreateComment>)),
+      )
+      .service(
         web::scope("/comment")
           .wrap(rate_limit.message())
-          .route("", web::post().to(route_post_crud::<CreateComment>))
           .route("", web::put().to(route_post_crud::<EditComment>))
           .route("/delete", web::post().to(route_post_crud::<DeleteComment>))
           .route("/remove", web::post().to(route_post_crud::<RemoveComment>))


### PR DESCRIPTION
Comments are often a target for spammers, particularly because they are not rate limited whereas posts etc are. Comment rate limits are already present on e.g. Reddit, and we have found them indispensable since we implemented them.
