### PR TITLE
Dont announce comments, edited posts to Pleroma/Mastodon followers

### DIFF
--- a/crates/apub/src/activity_lists.rs
+++ b/crates/apub/src/activity_lists.rs
@@ -26,7 +26,7 @@ use crate::{
       },
       voting::{undo_vote::UndoVote, vote::Vote},
     },
-    objects::{note::Note, page::Page},
+    objects::page::Page,
   },
 };
 use lemmy_apub_lib::traits::ActivityHandler;
@@ -84,8 +84,6 @@ pub enum AnnouncableActivities {
   RemoveMod(RemoveMod),
   // For compatibility with Pleroma/Mastodon (send only)
   Page(Page),
-  // For compatibility with Pleroma/Mastodon (send only)
-  Note(Note),
 }
 
 #[async_trait::async_trait(?Send)]
@@ -109,7 +107,6 @@ impl GetCommunity for AnnouncableActivities {
       AddMod(a) => a.get_community(context, request_counter).await?,
       RemoveMod(a) => a.get_community(context, request_counter).await?,
       Page(_) => unimplemented!(),
-      Note(_) => unimplemented!(),
     };
     Ok(community)
   }

--- a/crates/apub/src/protocol/activities/mod.rs
+++ b/crates/apub/src/protocol/activities/mod.rs
@@ -8,7 +8,7 @@ pub mod following;
 pub mod private_message;
 pub mod voting;
 
-#[derive(Clone, Debug, ToString, Deserialize, Serialize)]
+#[derive(Clone, Debug, ToString, Deserialize, Serialize, PartialEq)]
 pub enum CreateOrUpdateType {
   Create,
   Update,

--- a/crates/apub/src/protocol/objects/note.rs
+++ b/crates/apub/src/protocol/objects/note.rs
@@ -4,15 +4,9 @@ use crate::{
   protocol::Source,
 };
 use activitystreams::{link::Mention, object::kind::NoteType, unparsed::Unparsed};
-use anyhow::anyhow;
 use chrono::{DateTime, FixedOffset};
 use lemmy_api_common::blocking;
-use lemmy_apub_lib::{
-  data::Data,
-  object_id::ObjectId,
-  traits::ActivityHandler,
-  values::MediaTypeHtml,
-};
+use lemmy_apub_lib::{object_id::ObjectId, values::MediaTypeHtml};
 use lemmy_db_schema::{newtypes::CommentId, source::post::Post, traits::Crud};
 use lemmy_utils::LemmyError;
 use lemmy_websocket::LemmyContext;
@@ -87,17 +81,5 @@ impl Note {
         Ok((post.into(), Some(c.id)))
       }
     }
-  }
-}
-
-// For Pleroma/Mastodon compat. Unimplemented because its only used for sending.
-#[async_trait::async_trait(?Send)]
-impl ActivityHandler for Note {
-  type DataType = LemmyContext;
-  async fn verify(&self, _: &Data<Self::DataType>, _: &mut i32) -> Result<(), LemmyError> {
-    Err(anyhow!("Announce/Page can only be sent, not received").into())
-  }
-  async fn receive(self, _: &Data<Self::DataType>, _: &mut i32) -> Result<(), LemmyError> {
-    unimplemented!()
   }
 }


### PR DESCRIPTION
It was mentioned that the current Lemmy behaviour of announcing all new and edited posts/comments to Pleroma and Mastodon followers might be too noisy. So here is a PR which changes it so that only new posts are announced to them. For us this doesnt make a difference, as we are specifically sending these activities for compatibility with Mastodon/Pleroma. 

Note that these users wont receive any comments from Lemmy then, unless it is a mention. Lemmy also doesnt provide a `replies` collection on posts or comments for the time being. So let me know what you prefer @lanodan @gargron @ClearlyClaire.