### PR TITLE
Remove HTTP signature compatibility mode (its not necessary)

### DIFF
--- a/crates/apub_lib/src/signatures.rs
+++ b/crates/apub_lib/src/signatures.rs
@@ -1,5 +1,4 @@
 use crate::APUB_JSON_CONTENT_TYPE;
-use activitystreams::chrono::Utc;
 use actix_web::HttpRequest;
 use anyhow::anyhow;
 use http::{header::HeaderName, HeaderMap, HeaderValue};
@@ -20,7 +19,7 @@ use url::Url;
 
 lazy_static! {
   static ref CONFIG2: ConfigActix = ConfigActix::new();
-  static ref HTTP_SIG_CONFIG: Config = Config::new().mastodon_compat();
+  static ref HTTP_SIG_CONFIG: Config = Config::new();
 }
 
 /// Creates an HTTP post request to `inbox_url`, with the given `client` and `headers`, and
@@ -44,9 +43,6 @@ pub async fn sign_and_send(
     HeaderValue::from_str(APUB_JSON_CONTENT_TYPE)?,
   );
   headers.insert(HeaderName::from_str("Host")?, HeaderValue::from_str(&host)?);
-  // Need to use legacy timezone because mastodon and doesnt understand any new standards
-  let date = Utc::now().to_rfc2822().replace("+0000", "GMT");
-  headers.insert(HeaderName::from_str("Date")?, HeaderValue::from_str(&date)?);
 
   let response = client
     .post(&inbox_url.to_string())


### PR DESCRIPTION
Deployed on ds9.lemmy.ml, and federates fine with both Pleroma and Mastodon in my tests.