### PR TITLE
Replace activitystreams crate with activitystreams-kinds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "activitystreams-kinds"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0784e99afd032199d3ed70cefb8eb3a8d1aef15f7f2c4e68d033c4e12bb6079e"
+dependencies = [
+ "serde",
+ "url",
+]
+
+[[package]]
 name = "actix"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1842,7 +1852,7 @@ dependencies = [
 name = "lemmy_apub"
 version = "0.14.1"
 dependencies = [
- "activitystreams",
+ "activitystreams-kinds",
  "actix",
  "actix-rt",
  "actix-web",

--- a/crates/apub/Cargo.toml
+++ b/crates/apub/Cargo.toml
@@ -21,7 +21,7 @@ lemmy_db_views_actor = { version = "=0.14.1", path = "../db_views_actor" }
 lemmy_api_common = { version = "=0.14.1", path = "../api_common" }
 lemmy_websocket = { version = "=0.14.1", path = "../websocket" }
 diesel = "1.4.8"
-activitystreams = "0.7.0-alpha.11"
+activitystreams-kinds = "0.1.2"
 bcrypt = "0.10.1"
 chrono = { version = "0.4.19", features = ["serde"] }
 serde_json = { version = "1.0.68", features = ["preserve_order"] }

--- a/crates/apub/src/activities/comment/create_or_update.rs
+++ b/crates/apub/src/activities/comment/create_or_update.rs
@@ -12,7 +12,7 @@ use crate::{
   objects::{comment::ApubComment, community::ApubCommunity, person::ApubPerson},
   protocol::activities::{create_or_update::comment::CreateOrUpdateComment, CreateOrUpdateType},
 };
-use activitystreams::{link::LinkExt, public};
+use activitystreams_kinds::public;
 use lemmy_api_common::{blocking, check_post_deleted_or_removed};
 use lemmy_apub_lib::{
   data::Data,
@@ -65,9 +65,8 @@ impl CreateOrUpdateComment {
     let tagged_users: Vec<ObjectId<ApubPerson>> = create_or_update
       .tag
       .iter()
-      .map(|t| t.href())
-      .flatten()
-      .map(|t| ObjectId::new(t.clone()))
+      .map(|t| t.href.clone())
+      .map(ObjectId::new)
       .collect();
     let mut inboxes = vec![];
     for t in tagged_users {

--- a/crates/apub/src/activities/community/add_mod.rs
+++ b/crates/apub/src/activities/community/add_mod.rs
@@ -17,7 +17,7 @@ use crate::{
   objects::{community::ApubCommunity, person::ApubPerson},
   protocol::activities::community::add_mod::AddMod,
 };
-use activitystreams::{activity::kind::AddType, public};
+use activitystreams_kinds::{activity::AddType, public};
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::{
   data::Data,

--- a/crates/apub/src/activities/community/announce.rs
+++ b/crates/apub/src/activities/community/announce.rs
@@ -6,7 +6,7 @@ use crate::{
   objects::community::ApubCommunity,
   protocol::activities::{community::announce::AnnounceActivity, CreateOrUpdateType},
 };
-use activitystreams::{activity::kind::AnnounceType, public};
+use activitystreams_kinds::{activity::AnnounceType, public};
 use lemmy_apub_lib::{
   data::Data,
   object_id::ObjectId,

--- a/crates/apub/src/activities/community/block_user.rs
+++ b/crates/apub/src/activities/community/block_user.rs
@@ -11,7 +11,7 @@ use crate::{
   objects::{community::ApubCommunity, person::ApubPerson},
   protocol::activities::community::block_user::BlockUserFromCommunity,
 };
-use activitystreams::{activity::kind::BlockType, public};
+use activitystreams_kinds::{activity::BlockType, public};
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::{
   data::Data,

--- a/crates/apub/src/activities/community/remove_mod.rs
+++ b/crates/apub/src/activities/community/remove_mod.rs
@@ -17,7 +17,7 @@ use crate::{
   objects::{community::ApubCommunity, person::ApubPerson},
   protocol::activities::community::remove_mod::RemoveMod,
 };
-use activitystreams::{activity::kind::RemoveType, public};
+use activitystreams_kinds::{activity::RemoveType, public};
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::{
   data::Data,

--- a/crates/apub/src/activities/community/report.rs
+++ b/crates/apub/src/activities/community/report.rs
@@ -9,7 +9,7 @@ use crate::{
   protocol::activities::community::report::Report,
   PostOrComment,
 };
-use activitystreams::activity::kind::FlagType;
+use activitystreams_kinds::activity::FlagType;
 use lemmy_api_common::{blocking, comment::CommentReportResponse, post::PostReportResponse};
 use lemmy_apub_lib::{
   data::Data,

--- a/crates/apub/src/activities/community/undo_block_user.rs
+++ b/crates/apub/src/activities/community/undo_block_user.rs
@@ -14,7 +14,7 @@ use crate::{
     undo_block_user::UndoBlockUserFromCommunity,
   },
 };
-use activitystreams::{activity::kind::UndoType, public};
+use activitystreams_kinds::{activity::UndoType, public};
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::{
   data::Data,

--- a/crates/apub/src/activities/community/update.rs
+++ b/crates/apub/src/activities/community/update.rs
@@ -11,7 +11,7 @@ use crate::{
   objects::{community::ApubCommunity, person::ApubPerson},
   protocol::activities::community::update::UpdateCommunity,
 };
-use activitystreams::{activity::kind::UpdateType, public};
+use activitystreams_kinds::{activity::UpdateType, public};
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::{
   data::Data,

--- a/crates/apub/src/activities/deletion/delete.rs
+++ b/crates/apub/src/activities/deletion/delete.rs
@@ -10,7 +10,7 @@ use crate::{
   objects::{community::ApubCommunity, person::ApubPerson},
   protocol::activities::deletion::delete::Delete,
 };
-use activitystreams::{activity::kind::DeleteType, public};
+use activitystreams_kinds::{activity::DeleteType, public};
 use anyhow::anyhow;
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::{

--- a/crates/apub/src/activities/deletion/undo_delete.rs
+++ b/crates/apub/src/activities/deletion/undo_delete.rs
@@ -10,7 +10,7 @@ use crate::{
   objects::{community::ApubCommunity, person::ApubPerson},
   protocol::activities::deletion::{delete::Delete, undo_delete::UndoDelete},
 };
-use activitystreams::{activity::kind::UndoType, public};
+use activitystreams_kinds::{activity::UndoType, public};
 use anyhow::anyhow;
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::{

--- a/crates/apub/src/activities/following/accept.rs
+++ b/crates/apub/src/activities/following/accept.rs
@@ -2,7 +2,7 @@ use crate::{
   activities::{generate_activity_id, send_lemmy_activity, verify_activity},
   protocol::activities::following::{accept::AcceptFollowCommunity, follow::FollowCommunity},
 };
-use activitystreams::activity::kind::AcceptType;
+use activitystreams_kinds::activity::AcceptType;
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::{
   data::Data,

--- a/crates/apub/src/activities/following/follow.rs
+++ b/crates/apub/src/activities/following/follow.rs
@@ -9,7 +9,7 @@ use crate::{
   objects::{community::ApubCommunity, person::ApubPerson},
   protocol::activities::following::{accept::AcceptFollowCommunity, follow::FollowCommunity},
 };
-use activitystreams::activity::kind::FollowType;
+use activitystreams_kinds::activity::FollowType;
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::{
   data::Data,

--- a/crates/apub/src/activities/following/undo_follow.rs
+++ b/crates/apub/src/activities/following/undo_follow.rs
@@ -3,7 +3,7 @@ use crate::{
   objects::{community::ApubCommunity, person::ApubPerson},
   protocol::activities::following::{follow::FollowCommunity, undo_follow::UndoFollowCommunity},
 };
-use activitystreams::activity::kind::UndoType;
+use activitystreams_kinds::activity::UndoType;
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::{
   data::Data,

--- a/crates/apub/src/activities/mod.rs
+++ b/crates/apub/src/activities/mod.rs
@@ -5,7 +5,7 @@ use crate::{
   insert_activity,
   objects::{community::ApubCommunity, person::ApubPerson},
 };
-use activitystreams::public;
+use activitystreams_kinds::public;
 use anyhow::anyhow;
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::{

--- a/crates/apub/src/activities/post/create_or_update.rs
+++ b/crates/apub/src/activities/post/create_or_update.rs
@@ -12,7 +12,7 @@ use crate::{
   objects::{community::ApubCommunity, person::ApubPerson, post::ApubPost},
   protocol::activities::{create_or_update::post::CreateOrUpdatePost, CreateOrUpdateType},
 };
-use activitystreams::public;
+use activitystreams_kinds::public;
 use anyhow::anyhow;
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::{

--- a/crates/apub/src/activities/private_message/delete.rs
+++ b/crates/apub/src/activities/private_message/delete.rs
@@ -3,7 +3,7 @@ use crate::{
   objects::{person::ApubPerson, private_message::ApubPrivateMessage},
   protocol::activities::private_message::delete::DeletePrivateMessage,
 };
-use activitystreams::activity::kind::DeleteType;
+use activitystreams_kinds::activity::DeleteType;
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::{
   data::Data,

--- a/crates/apub/src/activities/private_message/undo_delete.rs
+++ b/crates/apub/src/activities/private_message/undo_delete.rs
@@ -6,7 +6,7 @@ use crate::{
     undo_delete::UndoDeletePrivateMessage,
   },
 };
-use activitystreams::activity::kind::UndoType;
+use activitystreams_kinds::activity::UndoType;
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::{
   data::Data,

--- a/crates/apub/src/activities/voting/undo_vote.rs
+++ b/crates/apub/src/activities/voting/undo_vote.rs
@@ -15,7 +15,7 @@ use crate::{
   },
   PostOrComment,
 };
-use activitystreams::{activity::kind::UndoType, public};
+use activitystreams_kinds::{activity::UndoType, public};
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::{
   data::Data,

--- a/crates/apub/src/activities/voting/vote.rs
+++ b/crates/apub/src/activities/voting/vote.rs
@@ -12,7 +12,7 @@ use crate::{
   protocol::activities::voting::vote::{Vote, VoteType},
   PostOrComment,
 };
-use activitystreams::public;
+use activitystreams_kinds::public;
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::{
   data::Data,

--- a/crates/apub/src/collections/community_moderators.rs
+++ b/crates/apub/src/collections/community_moderators.rs
@@ -4,7 +4,8 @@ use crate::{
   objects::person::ApubPerson,
   protocol::collections::group_moderators::GroupModerators,
 };
-use activitystreams::{chrono::NaiveDateTime, collection::kind::OrderedCollectionType};
+use activitystreams_kinds::collection::OrderedCollectionType;
+use chrono::NaiveDateTime;
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::{object_id::ObjectId, traits::ApubObject, verify::verify_domains_match};
 use lemmy_db_schema::{

--- a/crates/apub/src/collections/community_outbox.rs
+++ b/crates/apub/src/collections/community_outbox.rs
@@ -8,7 +8,7 @@ use crate::{
     collections::group_outbox::GroupOutbox,
   },
 };
-use activitystreams::collection::kind::OrderedCollectionType;
+use activitystreams_kinds::collection::OrderedCollectionType;
 use chrono::NaiveDateTime;
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::{

--- a/crates/apub/src/context.rs
+++ b/crates/apub/src/context.rs
@@ -1,15 +1,14 @@
-use activitystreams::{base::AnyBase, primitives::OneOrMany};
 use serde::{Deserialize, Serialize};
 
 lazy_static! {
-  static ref CONTEXT: OneOrMany<AnyBase> =
+  static ref CONTEXT: Vec<serde_json::Value> =
     serde_json::from_str(include_str!("../assets/lemmy/context.json")).expect("parse context");
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct WithContext<T> {
   #[serde(rename = "@context")]
-  context: OneOrMany<AnyBase>,
+  context: Vec<serde_json::Value>,
   #[serde(flatten)]
   inner: T,
 }

--- a/crates/apub/src/fetcher/user_or_community.rs
+++ b/crates/apub/src/fetcher/user_or_community.rs
@@ -2,11 +2,12 @@ use crate::{
   objects::{community::ApubCommunity, person::ApubPerson},
   protocol::objects::{group::Group, person::Person},
 };
-use activitystreams::{chrono::NaiveDateTime, url::Url};
+use chrono::NaiveDateTime;
 use lemmy_apub_lib::traits::{ActorType, ApubObject};
 use lemmy_utils::LemmyError;
 use lemmy_websocket::LemmyContext;
 use serde::Deserialize;
+use url::Url;
 
 #[derive(Clone, Debug)]
 pub enum UserOrCommunity {

--- a/crates/apub/src/objects/comment.rs
+++ b/crates/apub/src/objects/comment.rs
@@ -11,7 +11,7 @@ use crate::{
   },
   PostOrComment,
 };
-use activitystreams::{object::kind::NoteType, public};
+use activitystreams_kinds::{object::NoteType, public};
 use anyhow::anyhow;
 use chrono::NaiveDateTime;
 use html2md::parse_html;

--- a/crates/apub/src/objects/community.rs
+++ b/crates/apub/src/objects/community.rs
@@ -9,7 +9,7 @@ use crate::{
     Source,
   },
 };
-use activitystreams::{actor::kind::GroupType, object::kind::ImageType};
+use activitystreams_kinds::actor::GroupType;
 use chrono::NaiveDateTime;
 use itertools::Itertools;
 use lemmy_api_common::blocking;
@@ -81,14 +81,8 @@ impl ApubObject for ApubCommunity {
       content: bio,
       media_type: MediaTypeMarkdown::Markdown,
     });
-    let icon = self.icon.clone().map(|url| ImageObject {
-      kind: ImageType::Image,
-      url: url.into(),
-    });
-    let image = self.banner.clone().map(|url| ImageObject {
-      kind: ImageType::Image,
-      url: url.into(),
-    });
+    let icon = self.icon.clone().map(ImageObject::new);
+    let image = self.banner.clone().map(ImageObject::new);
 
     let group = Group {
       kind: GroupType::Group,

--- a/crates/apub/src/objects/person.rs
+++ b/crates/apub/src/objects/person.rs
@@ -11,7 +11,6 @@ use crate::{
     Source,
   },
 };
-use activitystreams::object::kind::ImageType;
 use chrono::NaiveDateTime;
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::{
@@ -89,14 +88,8 @@ impl ApubObject for ApubPerson {
       content: bio,
       media_type: MediaTypeMarkdown::Markdown,
     });
-    let icon = self.avatar.clone().map(|url| ImageObject {
-      kind: ImageType::Image,
-      url: url.into(),
-    });
-    let image = self.banner.clone().map(|url| ImageObject {
-      kind: ImageType::Image,
-      url: url.into(),
-    });
+    let icon = self.avatar.clone().map(ImageObject::new);
+    let image = self.banner.clone().map(ImageObject::new);
 
     let person = Person {
       kind,

--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -7,10 +7,7 @@ use crate::{
     Source,
   },
 };
-use activitystreams::{
-  object::kind::{ImageType, PageType},
-  public,
-};
+use activitystreams_kinds::{object::PageType, public};
 use chrono::NaiveDateTime;
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::{
@@ -100,10 +97,7 @@ impl ApubObject for ApubPost {
       content: body,
       media_type: MediaTypeMarkdown::Markdown,
     });
-    let image = self.thumbnail_url.clone().map(|thumb| ImageObject {
-      kind: ImageType::Image,
-      url: thumb.into(),
-    });
+    let image = self.thumbnail_url.clone().map(ImageObject::new);
 
     let page = Page {
       r#type: PageType::Page,

--- a/crates/apub/src/protocol/activities/community/add_mod.rs
+++ b/crates/apub/src/protocol/activities/community/add_mod.rs
@@ -1,5 +1,5 @@
-use crate::objects::person::ApubPerson;
-use activitystreams::{activity::kind::AddType, unparsed::Unparsed};
+use crate::{objects::person::ApubPerson, protocol::Unparsed};
+use activitystreams_kinds::activity::AddType;
 use lemmy_apub_lib::object_id::ObjectId;
 use serde::{Deserialize, Serialize};
 use url::Url;

--- a/crates/apub/src/protocol/activities/community/announce.rs
+++ b/crates/apub/src/protocol/activities/community/announce.rs
@@ -1,5 +1,9 @@
-use crate::{activity_lists::AnnouncableActivities, objects::community::ApubCommunity};
-use activitystreams::{activity::kind::AnnounceType, unparsed::Unparsed};
+use crate::{
+  activity_lists::AnnouncableActivities,
+  objects::community::ApubCommunity,
+  protocol::Unparsed,
+};
+use activitystreams_kinds::activity::AnnounceType;
 use lemmy_apub_lib::object_id::ObjectId;
 use serde::{Deserialize, Serialize};
 use url::Url;

--- a/crates/apub/src/protocol/activities/community/block_user.rs
+++ b/crates/apub/src/protocol/activities/community/block_user.rs
@@ -1,5 +1,8 @@
-use crate::objects::{community::ApubCommunity, person::ApubPerson};
-use activitystreams::{activity::kind::BlockType, unparsed::Unparsed};
+use crate::{
+  objects::{community::ApubCommunity, person::ApubPerson},
+  protocol::Unparsed,
+};
+use activitystreams_kinds::activity::BlockType;
 use lemmy_apub_lib::object_id::ObjectId;
 use serde::{Deserialize, Serialize};
 use url::Url;

--- a/crates/apub/src/protocol/activities/community/mod.rs
+++ b/crates/apub/src/protocol/activities/community/mod.rs
@@ -11,6 +11,7 @@ mod tests {
   use crate::protocol::{
     activities::community::{
       add_mod::AddMod,
+      announce::AnnounceActivity,
       block_user::BlockUserFromCommunity,
       remove_mod::RemoveMod,
       report::Report,
@@ -19,13 +20,10 @@ mod tests {
     },
     tests::test_parse_lemmy_item,
   };
-  use activitystreams::activity::Announce;
-  use serial_test::serial;
 
   #[actix_rt::test]
-  #[serial]
   async fn test_parse_lemmy_community() {
-    test_parse_lemmy_item::<Announce>(
+    test_parse_lemmy_item::<AnnounceActivity>(
       "assets/lemmy/activities/community/announce_create_page.json",
     );
 

--- a/crates/apub/src/protocol/activities/community/remove_mod.rs
+++ b/crates/apub/src/protocol/activities/community/remove_mod.rs
@@ -1,5 +1,5 @@
-use crate::objects::person::ApubPerson;
-use activitystreams::{activity::kind::RemoveType, unparsed::Unparsed};
+use crate::{objects::person::ApubPerson, protocol::Unparsed};
+use activitystreams_kinds::activity::RemoveType;
 use lemmy_apub_lib::object_id::ObjectId;
 use serde::{Deserialize, Serialize};
 use url::Url;

--- a/crates/apub/src/protocol/activities/community/report.rs
+++ b/crates/apub/src/protocol/activities/community/report.rs
@@ -1,8 +1,9 @@
 use crate::{
   fetcher::post_or_comment::PostOrComment,
   objects::{community::ApubCommunity, person::ApubPerson},
+  protocol::Unparsed,
 };
-use activitystreams::{activity::kind::FlagType, unparsed::Unparsed};
+use activitystreams_kinds::activity::FlagType;
 use lemmy_apub_lib::object_id::ObjectId;
 use serde::{Deserialize, Serialize};
 use url::Url;

--- a/crates/apub/src/protocol/activities/community/undo_block_user.rs
+++ b/crates/apub/src/protocol/activities/community/undo_block_user.rs
@@ -1,8 +1,8 @@
 use crate::{
   objects::person::ApubPerson,
-  protocol::activities::community::block_user::BlockUserFromCommunity,
+  protocol::{activities::community::block_user::BlockUserFromCommunity, Unparsed},
 };
-use activitystreams::{activity::kind::UndoType, unparsed::Unparsed};
+use activitystreams_kinds::activity::UndoType;
 use lemmy_apub_lib::object_id::ObjectId;
 use serde::{Deserialize, Serialize};
 use url::Url;

--- a/crates/apub/src/protocol/activities/community/update.rs
+++ b/crates/apub/src/protocol/activities/community/update.rs
@@ -1,5 +1,8 @@
-use crate::{objects::person::ApubPerson, protocol::objects::group::Group};
-use activitystreams::{activity::kind::UpdateType, unparsed::Unparsed};
+use crate::{
+  objects::person::ApubPerson,
+  protocol::{objects::group::Group, Unparsed},
+};
+use activitystreams_kinds::activity::UpdateType;
 use lemmy_apub_lib::object_id::ObjectId;
 use serde::{Deserialize, Serialize};
 use url::Url;

--- a/crates/apub/src/protocol/activities/create_or_update/comment.rs
+++ b/crates/apub/src/protocol/activities/create_or_update/comment.rs
@@ -1,8 +1,8 @@
 use crate::{
+  mentions::Mention,
   objects::person::ApubPerson,
-  protocol::{activities::CreateOrUpdateType, objects::note::Note},
+  protocol::{activities::CreateOrUpdateType, objects::note::Note, Unparsed},
 };
-use activitystreams::{link::Mention, unparsed::Unparsed};
 use lemmy_apub_lib::object_id::ObjectId;
 use serde::{Deserialize, Serialize};
 use url::Url;

--- a/crates/apub/src/protocol/activities/create_or_update/mod.rs
+++ b/crates/apub/src/protocol/activities/create_or_update/mod.rs
@@ -10,10 +10,8 @@ mod tests {
       tests::test_parse_lemmy_item,
     },
   };
-  use serial_test::serial;
 
   #[actix_rt::test]
-  #[serial]
   async fn test_parse_create_or_update() {
     test_parse_lemmy_item::<CreateOrUpdatePost>(
       "assets/lemmy/activities/create_or_update/create_page.json",

--- a/crates/apub/src/protocol/activities/create_or_update/post.rs
+++ b/crates/apub/src/protocol/activities/create_or_update/post.rs
@@ -1,8 +1,7 @@
 use crate::{
   objects::person::ApubPerson,
-  protocol::{activities::CreateOrUpdateType, objects::page::Page},
+  protocol::{activities::CreateOrUpdateType, objects::page::Page, Unparsed},
 };
-use activitystreams::unparsed::Unparsed;
 use lemmy_apub_lib::object_id::ObjectId;
 use serde::{Deserialize, Serialize};
 use url::Url;

--- a/crates/apub/src/protocol/activities/deletion/delete.rs
+++ b/crates/apub/src/protocol/activities/deletion/delete.rs
@@ -1,5 +1,8 @@
-use crate::{objects::person::ApubPerson, protocol::objects::tombstone::Tombstone};
-use activitystreams::{activity::kind::DeleteType, unparsed::Unparsed};
+use crate::{
+  objects::person::ApubPerson,
+  protocol::{objects::tombstone::Tombstone, Unparsed},
+};
+use activitystreams_kinds::activity::DeleteType;
 use lemmy_apub_lib::object_id::ObjectId;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;

--- a/crates/apub/src/protocol/activities/deletion/mod.rs
+++ b/crates/apub/src/protocol/activities/deletion/mod.rs
@@ -7,10 +7,8 @@ mod tests {
     activities::deletion::{delete::Delete, undo_delete::UndoDelete},
     tests::test_parse_lemmy_item,
   };
-  use serial_test::serial;
 
   #[actix_rt::test]
-  #[serial]
   async fn test_parse_lemmy_deletion() {
     test_parse_lemmy_item::<Delete>("assets/lemmy/activities/deletion/remove_note.json");
     test_parse_lemmy_item::<Delete>("assets/lemmy/activities/deletion/delete_page.json");

--- a/crates/apub/src/protocol/activities/deletion/undo_delete.rs
+++ b/crates/apub/src/protocol/activities/deletion/undo_delete.rs
@@ -1,5 +1,8 @@
-use crate::{objects::person::ApubPerson, protocol::activities::deletion::delete::Delete};
-use activitystreams::{activity::kind::UndoType, unparsed::Unparsed};
+use crate::{
+  objects::person::ApubPerson,
+  protocol::{activities::deletion::delete::Delete, Unparsed},
+};
+use activitystreams_kinds::activity::UndoType;
 use lemmy_apub_lib::object_id::ObjectId;
 use serde::{Deserialize, Serialize};
 use url::Url;

--- a/crates/apub/src/protocol/activities/following/accept.rs
+++ b/crates/apub/src/protocol/activities/following/accept.rs
@@ -1,8 +1,8 @@
 use crate::{
   objects::community::ApubCommunity,
-  protocol::activities::following::follow::FollowCommunity,
+  protocol::{activities::following::follow::FollowCommunity, Unparsed},
 };
-use activitystreams::{activity::kind::AcceptType, unparsed::Unparsed};
+use activitystreams_kinds::activity::AcceptType;
 use lemmy_apub_lib::object_id::ObjectId;
 use serde::{Deserialize, Serialize};
 use url::Url;

--- a/crates/apub/src/protocol/activities/following/follow.rs
+++ b/crates/apub/src/protocol/activities/following/follow.rs
@@ -1,5 +1,8 @@
-use crate::objects::{community::ApubCommunity, person::ApubPerson};
-use activitystreams::{activity::kind::FollowType, unparsed::Unparsed};
+use crate::{
+  objects::{community::ApubCommunity, person::ApubPerson},
+  protocol::Unparsed,
+};
+use activitystreams_kinds::activity::FollowType;
 use lemmy_apub_lib::object_id::ObjectId;
 use serde::{Deserialize, Serialize};
 use url::Url;

--- a/crates/apub/src/protocol/activities/following/mod.rs
+++ b/crates/apub/src/protocol/activities/following/mod.rs
@@ -12,10 +12,8 @@ mod tests {
     },
     tests::test_parse_lemmy_item,
   };
-  use serial_test::serial;
 
   #[actix_rt::test]
-  #[serial]
   async fn test_parse_lemmy_accept_follow() {
     test_parse_lemmy_item::<FollowCommunity>("assets/lemmy/activities/following/follow.json");
     test_parse_lemmy_item::<AcceptFollowCommunity>("assets/lemmy/activities/following/accept.json");

--- a/crates/apub/src/protocol/activities/following/undo_follow.rs
+++ b/crates/apub/src/protocol/activities/following/undo_follow.rs
@@ -1,8 +1,8 @@
 use crate::{
   objects::person::ApubPerson,
-  protocol::activities::following::follow::FollowCommunity,
+  protocol::{activities::following::follow::FollowCommunity, Unparsed},
 };
-use activitystreams::{activity::kind::UndoType, unparsed::Unparsed};
+use activitystreams_kinds::activity::UndoType;
 use lemmy_apub_lib::object_id::ObjectId;
 use serde::{Deserialize, Serialize};
 use url::Url;

--- a/crates/apub/src/protocol/activities/private_message/create_or_update.rs
+++ b/crates/apub/src/protocol/activities/private_message/create_or_update.rs
@@ -1,8 +1,7 @@
 use crate::{
   objects::person::ApubPerson,
-  protocol::{activities::CreateOrUpdateType, objects::chat_message::ChatMessage},
+  protocol::{activities::CreateOrUpdateType, objects::chat_message::ChatMessage, Unparsed},
 };
-use activitystreams::unparsed::Unparsed;
 use lemmy_apub_lib::object_id::ObjectId;
 use serde::{Deserialize, Serialize};
 use url::Url;

--- a/crates/apub/src/protocol/activities/private_message/delete.rs
+++ b/crates/apub/src/protocol/activities/private_message/delete.rs
@@ -1,5 +1,8 @@
-use crate::objects::{person::ApubPerson, private_message::ApubPrivateMessage};
-use activitystreams::{activity::kind::DeleteType, unparsed::Unparsed};
+use crate::{
+  objects::{person::ApubPerson, private_message::ApubPrivateMessage},
+  protocol::Unparsed,
+};
+use activitystreams_kinds::activity::DeleteType;
 use lemmy_apub_lib::object_id::ObjectId;
 use serde::{Deserialize, Serialize};
 use url::Url;

--- a/crates/apub/src/protocol/activities/private_message/mod.rs
+++ b/crates/apub/src/protocol/activities/private_message/mod.rs
@@ -12,10 +12,8 @@ mod tests {
     },
     tests::test_parse_lemmy_item,
   };
-  use serial_test::serial;
 
   #[actix_rt::test]
-  #[serial]
   async fn test_parse_lemmy_private_message() {
     test_parse_lemmy_item::<CreateOrUpdatePrivateMessage>(
       "assets/lemmy/activities/private_message/create.json",

--- a/crates/apub/src/protocol/activities/private_message/undo_delete.rs
+++ b/crates/apub/src/protocol/activities/private_message/undo_delete.rs
@@ -1,8 +1,8 @@
 use crate::{
   objects::person::ApubPerson,
-  protocol::activities::private_message::delete::DeletePrivateMessage,
+  protocol::{activities::private_message::delete::DeletePrivateMessage, Unparsed},
 };
-use activitystreams::{activity::kind::UndoType, unparsed::Unparsed};
+use activitystreams_kinds::activity::UndoType;
 use lemmy_apub_lib::object_id::ObjectId;
 use serde::{Deserialize, Serialize};
 use url::Url;

--- a/crates/apub/src/protocol/activities/voting/mod.rs
+++ b/crates/apub/src/protocol/activities/voting/mod.rs
@@ -7,10 +7,8 @@ mod tests {
     activities::voting::{undo_vote::UndoVote, vote::Vote},
     tests::test_parse_lemmy_item,
   };
-  use serial_test::serial;
 
   #[actix_rt::test]
-  #[serial]
   async fn test_parse_lemmy_voting() {
     test_parse_lemmy_item::<Vote>("assets/lemmy/activities/voting/like_note.json");
     test_parse_lemmy_item::<Vote>("assets/lemmy/activities/voting/dislike_page.json");

--- a/crates/apub/src/protocol/activities/voting/undo_vote.rs
+++ b/crates/apub/src/protocol/activities/voting/undo_vote.rs
@@ -1,5 +1,8 @@
-use crate::{objects::person::ApubPerson, protocol::activities::voting::vote::Vote};
-use activitystreams::{activity::kind::UndoType, unparsed::Unparsed};
+use crate::{
+  objects::person::ApubPerson,
+  protocol::{activities::voting::vote::Vote, Unparsed},
+};
+use activitystreams_kinds::activity::UndoType;
 use lemmy_apub_lib::object_id::ObjectId;
 use serde::{Deserialize, Serialize};
 use url::Url;

--- a/crates/apub/src/protocol/activities/voting/vote.rs
+++ b/crates/apub/src/protocol/activities/voting/vote.rs
@@ -1,5 +1,8 @@
-use crate::{fetcher::post_or_comment::PostOrComment, objects::person::ApubPerson};
-use activitystreams::unparsed::Unparsed;
+use crate::{
+  fetcher::post_or_comment::PostOrComment,
+  objects::person::ApubPerson,
+  protocol::Unparsed,
+};
 use anyhow::anyhow;
 use lemmy_apub_lib::object_id::ObjectId;
 use lemmy_utils::LemmyError;

--- a/crates/apub/src/protocol/collections/group_followers.rs
+++ b/crates/apub/src/protocol/collections/group_followers.rs
@@ -1,5 +1,5 @@
 use crate::generate_followers_url;
-use activitystreams::collection::kind::CollectionType;
+use activitystreams_kinds::collection::CollectionType;
 use lemmy_api_common::blocking;
 use lemmy_db_schema::source::community::Community;
 use lemmy_db_views_actor::community_follower_view::CommunityFollowerView;

--- a/crates/apub/src/protocol/collections/group_moderators.rs
+++ b/crates/apub/src/protocol/collections/group_moderators.rs
@@ -1,5 +1,5 @@
 use crate::objects::person::ApubPerson;
-use activitystreams::collection::kind::OrderedCollectionType;
+use activitystreams_kinds::collection::OrderedCollectionType;
 use lemmy_apub_lib::object_id::ObjectId;
 use serde::{Deserialize, Serialize};
 use url::Url;

--- a/crates/apub/src/protocol/collections/group_outbox.rs
+++ b/crates/apub/src/protocol/collections/group_outbox.rs
@@ -1,5 +1,5 @@
 use crate::protocol::activities::community::announce::AnnounceActivity;
-use activitystreams::collection::kind::OrderedCollectionType;
+use activitystreams_kinds::collection::OrderedCollectionType;
 use serde::{Deserialize, Serialize};
 use url::Url;
 

--- a/crates/apub/src/protocol/collections/mod.rs
+++ b/crates/apub/src/protocol/collections/mod.rs
@@ -14,10 +14,8 @@ mod tests {
     },
     tests::test_parse_lemmy_item,
   };
-  use serial_test::serial;
 
   #[actix_rt::test]
-  #[serial]
   async fn test_parse_lemmy_collections() {
     test_parse_lemmy_item::<GroupFollowers>("assets/lemmy/collections/group_followers.json");
     let outbox = test_parse_lemmy_item::<GroupOutbox>("assets/lemmy/collections/group_outbox.json");

--- a/crates/apub/src/protocol/collections/person_outbox.rs
+++ b/crates/apub/src/protocol/collections/person_outbox.rs
@@ -1,5 +1,5 @@
 use crate::generate_outbox_url;
-use activitystreams::collection::kind::OrderedCollectionType;
+use activitystreams_kinds::collection::OrderedCollectionType;
 use lemmy_db_schema::source::person::Person;
 use lemmy_utils::LemmyError;
 use serde::{Deserialize, Serialize};

--- a/crates/apub/src/protocol/mod.rs
+++ b/crates/apub/src/protocol/mod.rs
@@ -1,8 +1,10 @@
-use activitystreams::object::kind::ImageType;
+use activitystreams_kinds::object::ImageType;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
 use lemmy_apub_lib::values::MediaTypeMarkdown;
+use lemmy_db_schema::newtypes::DbUrl;
+use std::collections::HashMap;
 
 pub mod activities;
 pub(crate) mod collections;
@@ -19,9 +21,22 @@ pub struct Source {
 #[serde(rename_all = "camelCase")]
 pub struct ImageObject {
   #[serde(rename = "type")]
-  pub(crate) kind: ImageType,
+  kind: ImageType,
   pub(crate) url: Url,
 }
+
+impl ImageObject {
+  pub(crate) fn new(url: DbUrl) -> Self {
+    ImageObject {
+      kind: ImageType::Image,
+      url: url.into(),
+    }
+  }
+}
+
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
+#[serde(transparent)]
+pub struct Unparsed(HashMap<String, serde_json::Value>);
 
 #[cfg(test)]
 pub(crate) mod tests {

--- a/crates/apub/src/protocol/objects/chat_message.rs
+++ b/crates/apub/src/protocol/objects/chat_message.rs
@@ -1,11 +1,8 @@
 use crate::{
   objects::{person::ApubPerson, private_message::ApubPrivateMessage},
-  protocol::Source,
+  protocol::{Source, Unparsed},
 };
-use activitystreams::{
-  chrono::{DateTime, FixedOffset},
-  unparsed::Unparsed,
-};
+use chrono::{DateTime, FixedOffset};
 use lemmy_apub_lib::{object_id::ObjectId, values::MediaTypeHtml};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;

--- a/crates/apub/src/protocol/objects/group.rs
+++ b/crates/apub/src/protocol/objects/group.rs
@@ -5,9 +5,9 @@ use crate::{
     community_outbox::ApubCommunityOutbox,
   },
   objects::{community::ApubCommunity, get_summary_from_string_or_source},
-  protocol::{objects::Endpoints, ImageObject, Source},
+  protocol::{objects::Endpoints, ImageObject, Source, Unparsed},
 };
-use activitystreams::{actor::kind::GroupType, unparsed::Unparsed};
+use activitystreams_kinds::actor::GroupType;
 use chrono::{DateTime, FixedOffset};
 use lemmy_apub_lib::{object_id::ObjectId, signatures::PublicKey, verify::verify_domains_match};
 use lemmy_db_schema::{naive_now, source::community::CommunityForm};

--- a/crates/apub/src/protocol/objects/mod.rs
+++ b/crates/apub/src/protocol/objects/mod.rs
@@ -24,10 +24,8 @@ mod tests {
       tests::test_parse_lemmy_item,
     },
   };
-  use serial_test::serial;
 
   #[actix_rt::test]
-  #[serial]
   async fn test_parse_object() {
     test_parse_lemmy_item::<Person>("assets/lemmy/objects/person.json");
     test_parse_lemmy_item::<Group>("assets/lemmy/objects/group.json");

--- a/crates/apub/src/protocol/objects/note.rs
+++ b/crates/apub/src/protocol/objects/note.rs
@@ -1,9 +1,10 @@
 use crate::{
   fetcher::post_or_comment::PostOrComment,
+  mentions::Mention,
   objects::{comment::ApubComment, person::ApubPerson, post::ApubPost},
-  protocol::Source,
+  protocol::{Source, Unparsed},
 };
-use activitystreams::{link::Mention, object::kind::NoteType, unparsed::Unparsed};
+use activitystreams_kinds::object::NoteType;
 use chrono::{DateTime, FixedOffset};
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::{object_id::ObjectId, values::MediaTypeHtml};

--- a/crates/apub/src/protocol/objects/page.rs
+++ b/crates/apub/src/protocol/objects/page.rs
@@ -1,8 +1,8 @@
 use crate::{
   objects::{community::ApubCommunity, person::ApubPerson, post::ApubPost},
-  protocol::{ImageObject, Source},
+  protocol::{ImageObject, Source, Unparsed},
 };
-use activitystreams::{object::kind::PageType, unparsed::Unparsed};
+use activitystreams_kinds::object::PageType;
 use anyhow::anyhow;
 use chrono::{DateTime, FixedOffset};
 use lemmy_apub_lib::{

--- a/crates/apub/src/protocol/objects/person.rs
+++ b/crates/apub/src/protocol/objects/person.rs
@@ -1,12 +1,12 @@
 use crate::{
   objects::person::ApubPerson,
-  protocol::{objects::Endpoints, ImageObject, Source},
+  protocol::{objects::Endpoints, ImageObject, Source, Unparsed},
 };
-use activitystreams::{unparsed::Unparsed, url::Url};
 use chrono::{DateTime, FixedOffset};
 use lemmy_apub_lib::{object_id::ObjectId, signatures::PublicKey};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
+use url::Url;
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq)]
 pub enum UserTypes {

--- a/crates/apub/src/protocol/objects/tombstone.rs
+++ b/crates/apub/src/protocol/objects/tombstone.rs
@@ -1,4 +1,4 @@
-use activitystreams::object::kind::TombstoneType;
+use activitystreams_kinds::object::TombstoneType;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use url::Url;


### PR DESCRIPTION
This will speed up the build a little. But note that activitystreams is still used in crates/apub_lib, mainly for some error types.