### PR TITLE
Change NodeInfo `links` to an array

### DIFF
--- a/crates/routes/src/nodeinfo.rs
+++ b/crates/routes/src/nodeinfo.rs
@@ -17,13 +17,13 @@ async fn node_info_well_known(
   context: web::Data<LemmyContext>,
 ) -> Result<HttpResponse<Body>, LemmyError> {
   let node_info = NodeInfoWellKnown {
-    links: NodeInfoWellKnownLinks {
+    links: vec![NodeInfoWellKnownLinks {
       rel: Url::parse("http://nodeinfo.diaspora.software/ns/schema/2.0")?,
       href: Url::parse(&format!(
         "{}/nodeinfo/2.0.json",
         &context.settings().get_protocol_and_hostname(),
       ))?,
-    },
+    }],
   };
   Ok(HttpResponse::Ok().json(node_info))
 }
@@ -63,7 +63,7 @@ async fn node_info(context: web::Data<LemmyContext>) -> Result<HttpResponse, Err
 
 #[derive(Serialize, Deserialize, Debug)]
 struct NodeInfoWellKnown {
-  pub links: NodeInfoWellKnownLinks,
+  pub links: Vec<NodeInfoWellKnownLinks>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
NodeInfo spec[1] says that _.well-known/nodeinfo_ is a JSON Resource
Descriptor (JRD) document. That is specified in RFC 7033, where §4.4[2]
mandates that `links` is an array.

1. https://nodeinfo.diaspora.software/protocol.html
2. https://datatracker.ietf.org/doc/html/rfc7033#section-4.4