### PR TITLE
Dont send email notifications for edited comments (fixes #1925)

### DIFF
--- a/crates/apub/src/activities/comment/create_or_update.rs
+++ b/crates/apub/src/activities/comment/create_or_update.rs
@@ -108,7 +108,15 @@ impl ActivityHandler for CreateOrUpdateComment {
     request_counter: &mut i32,
   ) -> Result<(), LemmyError> {
     let comment = ApubComment::from_apub(self.object, context, request_counter).await?;
-    let recipients = get_notif_recipients(&self.actor, &comment, context, request_counter).await?;
+    let do_send_email = self.kind == CreateOrUpdateType::Create;
+    let recipients = get_notif_recipients(
+      &self.actor,
+      &comment,
+      do_send_email,
+      context,
+      request_counter,
+    )
+    .await?;
     let notif_type = match self.kind {
       CreateOrUpdateType::Create => UserOperationCrud::CreateComment,
       CreateOrUpdateType::Update => UserOperationCrud::EditComment,

--- a/crates/apub/src/activities/comment/mod.rs
+++ b/crates/apub/src/activities/comment/mod.rs
@@ -14,6 +14,7 @@ pub mod create_or_update;
 async fn get_notif_recipients(
   actor: &ObjectId<ApubPerson>,
   comment: &Comment,
+  do_send_email: bool,
   context: &LemmyContext,
   request_counter: &mut i32,
 ) -> Result<Vec<LocalUserId>, LemmyError> {
@@ -27,5 +28,5 @@ async fn get_notif_recipients(
   // anyway.
   // TODO: for compatibility with other projects, it would be much better to read this from cc or tags
   let mentions = scrape_text_for_mentions(&comment.content);
-  send_local_notifs(mentions, comment, &*actor, &post, true, context).await
+  send_local_notifs(mentions, comment, &*actor, &post, do_send_email, context).await
 }


### PR DESCRIPTION
This is quite the spaghetti code and could really use a rewrite. Untested.