### PR TITLE
Adding a GetComment endpoint. Fixes #1919

### DIFF
--- a/crates/api_common/src/comment.rs
+++ b/crates/api_common/src/comment.rs
@@ -12,6 +12,12 @@ pub struct CreateComment {
 }
 
 #[derive(Serialize, Deserialize)]
+pub struct GetComment {
+  pub id: CommentId,
+  pub auth: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
 pub struct EditComment {
   pub content: String,
   pub comment_id: CommentId,

--- a/crates/api_crud/src/comment/read.rs
+++ b/crates/api_crud/src/comment/read.rs
@@ -12,9 +12,38 @@ use lemmy_db_schema::{
   ListingType,
   SortType,
 };
-use lemmy_db_views::comment_view::CommentQueryBuilder;
+use lemmy_db_views::comment_view::{CommentQueryBuilder, CommentView};
 use lemmy_utils::{ApiError, ConnectionId, LemmyError};
 use lemmy_websocket::LemmyContext;
+
+#[async_trait::async_trait(?Send)]
+impl PerformCrud for GetComment {
+  type Response = CommentResponse;
+
+  async fn perform(
+    &self,
+    context: &Data<LemmyContext>,
+    _websocket_id: Option<ConnectionId>,
+  ) -> Result<Self::Response, LemmyError> {
+    let data = self;
+    let local_user_view =
+      get_local_user_view_from_jwt_opt(&data.auth, context.pool(), context.secret()).await?;
+
+    let person_id = local_user_view.map(|u| u.person.id);
+    let id = data.id;
+    let comment_view = blocking(context.pool(), move |conn| {
+      CommentView::read(conn, id, person_id)
+    })
+    .await?
+    .map_err(|e| ApiError::err("couldnt_find_comment", e))?;
+
+    Ok(Self::Response {
+      comment_view,
+      form_id: None,
+      recipient_ids: Vec::new(),
+    })
+  }
+}
 
 #[async_trait::async_trait(?Send)]
 impl PerformCrud for GetComments {

--- a/crates/api_crud/src/lib.rs
+++ b/crates/api_crud/src/lib.rs
@@ -108,6 +108,9 @@ pub async fn match_websocket_operation_crud(
     UserOperationCrud::RemoveComment => {
       do_websocket_operation::<RemoveComment>(context, id, op, data).await
     }
+    UserOperationCrud::GetComment => {
+      do_websocket_operation::<GetComment>(context, id, op, data).await
+    }
     UserOperationCrud::GetComments => {
       do_websocket_operation::<GetComments>(context, id, op, data).await
     }

--- a/crates/websocket/src/lib.rs
+++ b/crates/websocket/src/lib.rs
@@ -168,6 +168,7 @@ pub enum UserOperationCrud {
   RemovePost,
   // Comment
   CreateComment,
+  GetComment,
   GetComments,
   EditComment,
   DeleteComment,

--- a/src/api_routes.rs
+++ b/src/api_routes.rs
@@ -111,6 +111,7 @@ pub fn config(cfg: &mut web::ServiceConfig, rate_limit: &RateLimit) {
       .service(
         web::scope("/comment")
           .wrap(rate_limit.message())
+          .route("", web::get().to(route_get_crud::<GetComment>))
           .route("", web::put().to(route_post_crud::<EditComment>))
           .route("/delete", web::post().to(route_post_crud::<DeleteComment>))
           .route("/remove", web::post().to(route_post_crud::<RemoveComment>))


### PR DESCRIPTION
One thing, is that this doesn't serve them under `/comment/123`, but as `/comment?id=123`, just like post: 

https://lemmy.ml/api/v3/post?id=93553

@Nutomic I'd rather that change on the apub side if possible, let me know.