### PR TITLE
Don't drop error context when adding a message to errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,6 +1779,7 @@ dependencies = [
  "lemmy_utils",
  "serde",
  "serde_json",
+ "tracing",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.0.0-beta.12"
+version = "3.0.0-beta.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afaeb3d3fcb06b775ac62f05d580aae4afe5a149513333a73f688fdf26c06639"
+checksum = "1bc3f9d97e32d75fae3ad7d955ac005eea3fd3ea60a89132768700911a60fd94"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "actix-tls"
-version = "3.0.0-beta.8"
+version = "3.0.0-beta.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a563b0245222230c860c1b077ca7309179fff0f575b1914967c1ee385aa5da64"
+checksum = "53d4739910b49c77ea88308a9fbfae544524b34884161527f9978c0102052da0"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -182,6 +182,7 @@ dependencies = [
  "futures-core",
  "http",
  "log",
+ "pin-project-lite",
  "tokio-rustls",
  "tokio-util",
  "webpki-roots",
@@ -199,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.0.0-beta.11"
+version = "4.0.0-beta.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e85aa9bb018d83a0db70f557ba0cde9c6170a5d1de4fede02e377f68c1ac5aa9"
+checksum = "e87cfc4efaad42f8a054e269d1b85046397ff4e8707e49128dea3f99a512a9d6"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -388,9 +389,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "awc"
-version = "3.0.0-beta.10"
+version = "3.0.0-beta.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f122bed94dc044b13a991b292ff6a3cde4c3fba890a4e3dbbec0f2eedc607f0a"
+checksum = "f9f7d0c472987e454f41c3f4c7fa336ca139707ab255644b0480144c2060c800"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -3999,9 +4000,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-actix-web"
-version = "0.5.0-beta.2"
+version = "0.5.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cac34827e06f78b69523b2fbe5b2dd4dfc75940b2ea5ba37e4fa2a25d4a0edf"
+checksum = "994e4a59135823bdca121a8d086e3fcc71741c8677b47fa95a6afdd15e8f646f"
 dependencies = [
  "actix-web",
  "pin-project",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1985,6 +1985,7 @@ dependencies = [
  "serde",
  "sha2",
  "strum",
+ "tracing",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "actix-rt"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0c218d0a17c120f10ee0c69c9f0c45d87319e8f66b1f065e8412b612fc3e24"
+checksum = "05c2f80ce8d0c990941c7a7a931f69fd0701b76d521f8d36298edf59cd3fbf1f"
 dependencies = [
  "actix-macros",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1759,6 +1759,7 @@ dependencies = [
  "strum_macros",
  "thiserror",
  "tokio",
+ "tracing",
  "url",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde = { version = "1.0.130", features = ["derive"] }
 actix = "0.12.0"
 actix-web = { version = "4.0.0-beta.9", default-features = false, features = ["rustls"] }
 tracing = "0.1.29"
-tracing-actix-web = "0.5.0-beta.2"
+tracing-actix-web = "0.5.0-beta.3"
 tracing-error = "0.2.0"
 tracing-log = "0.1.2"
 tracing-subscriber = { version = "0.3.2", features = ["env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde = { version = "1.0.130", features = ["derive"] }
 actix = "0.12.0"
 actix-web = { version = "4.0.0-beta.9", default-features = false, features = ["rustls"] }
 tracing = "0.1.29"
-tracing-actix-web = "0.5.0-beta.3"
+tracing-actix-web = { version = "0.5.0-beta.3", default-features = false }
 tracing-error = "0.2.0"
 tracing-log = "0.1.2"
 tracing-subscriber = { version = "0.3.2", features = ["env-filter"] }

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -48,5 +48,6 @@ async-trait = "0.1.51"
 captcha = "0.0.8"
 anyhow = "1.0.44"
 thiserror = "1.0.29"
+tracing = "0.1.29"
 background-jobs = "0.11.0"
 reqwest = { version = "0.11.4", features = ["json"] }

--- a/crates/api/src/comment.rs
+++ b/crates/api/src/comment.rs
@@ -32,7 +32,7 @@ use crate::Perform;
 impl Perform for MarkCommentAsRead {
   type Response = CommentResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -91,7 +91,7 @@ impl Perform for MarkCommentAsRead {
 impl Perform for SaveComment {
   type Response = CommentResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -139,7 +139,7 @@ impl Perform for SaveComment {
 impl Perform for CreateCommentLike {
   type Response = CommentResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api/src/comment.rs
+++ b/crates/api/src/comment.rs
@@ -23,7 +23,7 @@ use lemmy_db_schema::{
   traits::{Likeable, Saveable},
 };
 use lemmy_db_views::{comment_view::CommentView, local_user_view::LocalUserView};
-use lemmy_utils::{ApiError, ConnectionId, LemmyError};
+use lemmy_utils::{ConnectionId, LemmyError};
 use lemmy_websocket::{send::send_comment_ws_message, LemmyContext, UserOperation};
 
 use crate::Perform;
@@ -32,6 +32,7 @@ use crate::Perform;
 impl Perform for MarkCommentAsRead {
   type Response = CommentResponse;
 
+  #[tracing::instrument(skip(self, context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -56,7 +57,7 @@ impl Perform for MarkCommentAsRead {
 
     // Verify that only the recipient can mark as read
     if local_user_view.person.id != orig_comment.get_recipient_id() {
-      return Err(ApiError::err_plain("no_comment_edit_allowed").into());
+      return Err(LemmyError::from_message("no_comment_edit_allowed".into()));
     }
 
     // Do the mark as read
@@ -65,7 +66,8 @@ impl Perform for MarkCommentAsRead {
       Comment::update_read(conn, comment_id, read)
     })
     .await?
-    .map_err(|_| ApiError::err_plain("couldnt_update_comment"))?;
+    .map_err(LemmyError::from)
+    .map_err(|e| e.with_message("couldnt_update_comment".into()))?;
 
     // Refetch it
     let comment_id = data.comment_id;
@@ -89,6 +91,7 @@ impl Perform for MarkCommentAsRead {
 impl Perform for SaveComment {
   type Response = CommentResponse;
 
+  #[tracing::instrument(skip(self, context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -107,12 +110,14 @@ impl Perform for SaveComment {
       let save_comment = move |conn: &'_ _| CommentSaved::save(conn, &comment_saved_form);
       blocking(context.pool(), save_comment)
         .await?
-        .map_err(|e| ApiError::err("couldnt_save_comment", e))?;
+        .map_err(LemmyError::from)
+        .map_err(|e| e.with_message("couldnt_save_comment".into()))?;
     } else {
       let unsave_comment = move |conn: &'_ _| CommentSaved::unsave(conn, &comment_saved_form);
       blocking(context.pool(), unsave_comment)
         .await?
-        .map_err(|e| ApiError::err("couldnt_save_comment", e))?;
+        .map_err(LemmyError::from)
+        .map_err(|e| e.with_message("couldnt_save_comment".into()))?;
     }
 
     let comment_id = data.comment_id;
@@ -134,6 +139,7 @@ impl Perform for SaveComment {
 impl Perform for CreateCommentLike {
   type Response = CommentResponse;
 
+  #[tracing::instrument(skip(self, context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -201,7 +207,8 @@ impl Perform for CreateCommentLike {
       let like = move |conn: &'_ _| CommentLike::like(conn, &like_form2);
       blocking(context.pool(), like)
         .await?
-        .map_err(|e| ApiError::err("couldnt_like_comment", e))?;
+        .map_err(LemmyError::from)
+        .map_err(|e| e.with_message("couldnt_like_comment".into()))?;
 
       Vote::send(
         &object,

--- a/crates/api/src/comment.rs
+++ b/crates/api/src/comment.rs
@@ -57,7 +57,7 @@ impl Perform for MarkCommentAsRead {
 
     // Verify that only the recipient can mark as read
     if local_user_view.person.id != orig_comment.get_recipient_id() {
-      return Err(LemmyError::from_message("no_comment_edit_allowed".into()));
+      return Err(LemmyError::from_message("no_comment_edit_allowed"));
     }
 
     // Do the mark as read
@@ -67,7 +67,7 @@ impl Perform for MarkCommentAsRead {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_update_comment".into()))?;
+    .map_err(|e| e.with_message("couldnt_update_comment"))?;
 
     // Refetch it
     let comment_id = data.comment_id;
@@ -111,13 +111,13 @@ impl Perform for SaveComment {
       blocking(context.pool(), save_comment)
         .await?
         .map_err(LemmyError::from)
-        .map_err(|e| e.with_message("couldnt_save_comment".into()))?;
+        .map_err(|e| e.with_message("couldnt_save_comment"))?;
     } else {
       let unsave_comment = move |conn: &'_ _| CommentSaved::unsave(conn, &comment_saved_form);
       blocking(context.pool(), unsave_comment)
         .await?
         .map_err(LemmyError::from)
-        .map_err(|e| e.with_message("couldnt_save_comment".into()))?;
+        .map_err(|e| e.with_message("couldnt_save_comment"))?;
     }
 
     let comment_id = data.comment_id;
@@ -208,7 +208,7 @@ impl Perform for CreateCommentLike {
       blocking(context.pool(), like)
         .await?
         .map_err(LemmyError::from)
-        .map_err(|e| e.with_message("couldnt_like_comment".into()))?;
+        .map_err(|e| e.with_message("couldnt_like_comment"))?;
 
       Vote::send(
         &object,

--- a/crates/api/src/comment_report.rs
+++ b/crates/api/src/comment_report.rs
@@ -35,10 +35,10 @@ impl Perform for CreateCommentReport {
     // check size of report and check for whitespace
     let reason = data.reason.trim();
     if reason.is_empty() {
-      return Err(LemmyError::from_message("report_reason_required".into()));
+      return Err(LemmyError::from_message("report_reason_required"));
     }
     if reason.chars().count() > 1000 {
-      return Err(LemmyError::from_message("report_too_long".into()));
+      return Err(LemmyError::from_message("report_too_long"));
     }
 
     let person_id = local_user_view.person.id;
@@ -62,7 +62,7 @@ impl Perform for CreateCommentReport {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_create_report".into()))?;
+    .map_err(|e| e.with_message("couldnt_create_report"))?;
 
     let comment_report_view = blocking(context.pool(), move |conn| {
       CommentReportView::read(conn, report.id, person_id)
@@ -130,7 +130,7 @@ impl Perform for ResolveCommentReport {
     blocking(context.pool(), resolve_fun)
       .await?
       .map_err(LemmyError::from)
-      .map_err(|e| e.with_message("couldnt_resolve_report".into()))?;
+      .map_err(|e| e.with_message("couldnt_resolve_report"))?;
 
     let report_id = data.report_id;
     let comment_report_view = blocking(context.pool(), move |conn| {

--- a/crates/api/src/comment_report.rs
+++ b/crates/api/src/comment_report.rs
@@ -22,7 +22,7 @@ use lemmy_websocket::{messages::SendModRoomMessage, LemmyContext, UserOperation}
 impl Perform for CreateCommentReport {
   type Response = CommentReportResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -98,7 +98,7 @@ impl Perform for CreateCommentReport {
 impl Perform for ResolveCommentReport {
   type Response = CommentReportResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -159,7 +159,7 @@ impl Perform for ResolveCommentReport {
 impl Perform for ListCommentReports {
   type Response = ListCommentReportsResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api/src/community.rs
+++ b/crates/api/src/community.rs
@@ -61,7 +61,7 @@ use lemmy_websocket::{messages::SendCommunityRoomMessage, LemmyContext, UserOper
 impl Perform for FollowCommunity {
   type Response = CommunityResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -138,7 +138,7 @@ impl Perform for FollowCommunity {
 impl Perform for BlockCommunity {
   type Response = BlockCommunityResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -202,7 +202,7 @@ impl Perform for BlockCommunity {
 impl Perform for BanFromCommunity {
   type Response = BanFromCommunityResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -346,7 +346,7 @@ impl Perform for BanFromCommunity {
 impl Perform for AddModToCommunity {
   type Response = AddModToCommunityResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -447,7 +447,7 @@ impl Perform for AddModToCommunity {
 impl Perform for TransferCommunity {
   type Response = GetCommunityResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api/src/community.rs
+++ b/crates/api/src/community.rs
@@ -54,13 +54,14 @@ use lemmy_db_views_actor::{
   community_view::CommunityView,
   person_view::PersonViewSafe,
 };
-use lemmy_utils::{location_info, utils::naive_from_unix, ApiError, ConnectionId, LemmyError};
+use lemmy_utils::{location_info, utils::naive_from_unix, ConnectionId, LemmyError};
 use lemmy_websocket::{messages::SendCommunityRoomMessage, LemmyContext, UserOperation};
 
 #[async_trait::async_trait(?Send)]
 impl Perform for FollowCommunity {
   type Response = CommunityResponse;
 
+  #[tracing::instrument(skip(self, context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -90,13 +91,15 @@ impl Perform for FollowCommunity {
         let follow = move |conn: &'_ _| CommunityFollower::follow(conn, &community_follower_form);
         blocking(context.pool(), follow)
           .await?
-          .map_err(|e| ApiError::err("community_follower_already_exists", e))?;
+          .map_err(LemmyError::from)
+          .map_err(|e| e.with_message("community_follower_already_exists".into()))?;
       } else {
         let unfollow =
           move |conn: &'_ _| CommunityFollower::unfollow(conn, &community_follower_form);
         blocking(context.pool(), unfollow)
           .await?
-          .map_err(|e| ApiError::err("community_follower_already_exists", e))?;
+          .map_err(LemmyError::from)
+          .map_err(|e| e.with_message("community_follower_already_exists".into()))?;
       }
     } else if data.follow {
       // Dont actually add to the community followers here, because you need
@@ -109,7 +112,8 @@ impl Perform for FollowCommunity {
       let unfollow = move |conn: &'_ _| CommunityFollower::unfollow(conn, &community_follower_form);
       blocking(context.pool(), unfollow)
         .await?
-        .map_err(|e| ApiError::err("community_follower_already_exists", e))?;
+        .map_err(LemmyError::from)
+        .map_err(|e| e.with_message("community_follower_already_exists".into()))?;
     }
 
     let community_id = data.community_id;
@@ -134,6 +138,7 @@ impl Perform for FollowCommunity {
 impl Perform for BlockCommunity {
   type Response = BlockCommunityResponse;
 
+  #[tracing::instrument(skip(self, context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -154,7 +159,8 @@ impl Perform for BlockCommunity {
       let block = move |conn: &'_ _| CommunityBlock::block(conn, &community_block_form);
       blocking(context.pool(), block)
         .await?
-        .map_err(|e| ApiError::err("community_block_already_exists", e))?;
+        .map_err(LemmyError::from)
+        .map_err(|e| e.with_message("community_block_already_exists".into()))?;
 
       // Also, unfollow the community, and send a federated unfollow
       let community_follower_form = CommunityFollowerForm {
@@ -176,7 +182,8 @@ impl Perform for BlockCommunity {
       let unblock = move |conn: &'_ _| CommunityBlock::unblock(conn, &community_block_form);
       blocking(context.pool(), unblock)
         .await?
-        .map_err(|e| ApiError::err("community_block_already_exists", e))?;
+        .map_err(LemmyError::from)
+        .map_err(|e| e.with_message("community_block_already_exists".into()))?;
     }
 
     let community_view = blocking(context.pool(), move |conn| {
@@ -195,6 +202,7 @@ impl Perform for BlockCommunity {
 impl Perform for BanFromCommunity {
   type Response = BanFromCommunityResponse;
 
+  #[tracing::instrument(skip(self, context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -230,7 +238,8 @@ impl Perform for BanFromCommunity {
       let ban = move |conn: &'_ _| CommunityPersonBan::ban(conn, &community_user_ban_form);
       blocking(context.pool(), ban)
         .await?
-        .map_err(|e| ApiError::err("community_user_already_banned", e))?;
+        .map_err(LemmyError::from)
+        .map_err(|e| e.with_message("community_user_already_banned".into()))?;
 
       // Also unsubscribe them from the community, if they are subscribed
       let community_follower_form = CommunityFollowerForm {
@@ -255,7 +264,8 @@ impl Perform for BanFromCommunity {
       let unban = move |conn: &'_ _| CommunityPersonBan::unban(conn, &community_user_ban_form);
       blocking(context.pool(), unban)
         .await?
-        .map_err(|e| ApiError::err("community_user_already_banned", e))?;
+        .map_err(LemmyError::from)
+        .map_err(|e| e.with_message("community_user_already_banned".into()))?;
       UndoBlockUserFromCommunity::send(
         &community,
         &banned_person,
@@ -336,6 +346,7 @@ impl Perform for BanFromCommunity {
 impl Perform for AddModToCommunity {
   type Response = AddModToCommunityResponse;
 
+  #[tracing::instrument(skip(self, context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -359,12 +370,14 @@ impl Perform for AddModToCommunity {
       let join = move |conn: &'_ _| CommunityModerator::join(conn, &community_moderator_form);
       blocking(context.pool(), join)
         .await?
-        .map_err(|e| ApiError::err("community_moderator_already_exists", e))?;
+        .map_err(LemmyError::from)
+        .map_err(|e| e.with_message("community_moderator_already_exists".into()))?;
     } else {
       let leave = move |conn: &'_ _| CommunityModerator::leave(conn, &community_moderator_form);
       blocking(context.pool(), leave)
         .await?
-        .map_err(|e| ApiError::err("community_moderator_already_exists", e))?;
+        .map_err(LemmyError::from)
+        .map_err(|e| e.with_message("community_moderator_already_exists".into()))?;
     }
 
     // Mod tables
@@ -434,6 +447,7 @@ impl Perform for AddModToCommunity {
 impl Perform for TransferCommunity {
   type Response = GetCommunityResponse;
 
+  #[tracing::instrument(skip(self, context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -472,7 +486,7 @@ impl Perform for TransferCommunity {
         .map(|a| a.person.id)
         .any(|x| x == local_user_view.person.id)
     {
-      return Err(ApiError::err_plain("not_an_admin").into());
+      return Err(LemmyError::from_message("not_an_admin".into()));
     }
 
     // You have to re-do the community_moderator table, reordering it.
@@ -502,7 +516,8 @@ impl Perform for TransferCommunity {
       let join = move |conn: &'_ _| CommunityModerator::join(conn, &community_moderator_form);
       blocking(context.pool(), join)
         .await?
-        .map_err(|e| ApiError::err("community_moderator_already_exists", e))?;
+        .map_err(LemmyError::from)
+        .map_err(|e| e.with_message("community_moderator_already_exists".into()))?;
     }
 
     // Mod tables
@@ -523,14 +538,16 @@ impl Perform for TransferCommunity {
       CommunityView::read(conn, community_id, Some(person_id))
     })
     .await?
-    .map_err(|e| ApiError::err("couldnt_find_community", e))?;
+    .map_err(LemmyError::from)
+    .map_err(|e| e.with_message("couldnt_find_community".into()))?;
 
     let community_id = data.community_id;
     let moderators = blocking(context.pool(), move |conn| {
       CommunityModeratorView::for_community(conn, community_id)
     })
     .await?
-    .map_err(|e| ApiError::err("couldnt_find_community", e))?;
+    .map_err(LemmyError::from)
+    .map_err(|e| e.with_message("couldnt_find_community".into()))?;
 
     // Return the jwt
     Ok(GetCommunityResponse {

--- a/crates/api/src/community.rs
+++ b/crates/api/src/community.rs
@@ -92,14 +92,14 @@ impl Perform for FollowCommunity {
         blocking(context.pool(), follow)
           .await?
           .map_err(LemmyError::from)
-          .map_err(|e| e.with_message("community_follower_already_exists".into()))?;
+          .map_err(|e| e.with_message("community_follower_already_exists"))?;
       } else {
         let unfollow =
           move |conn: &'_ _| CommunityFollower::unfollow(conn, &community_follower_form);
         blocking(context.pool(), unfollow)
           .await?
           .map_err(LemmyError::from)
-          .map_err(|e| e.with_message("community_follower_already_exists".into()))?;
+          .map_err(|e| e.with_message("community_follower_already_exists"))?;
       }
     } else if data.follow {
       // Dont actually add to the community followers here, because you need
@@ -113,7 +113,7 @@ impl Perform for FollowCommunity {
       blocking(context.pool(), unfollow)
         .await?
         .map_err(LemmyError::from)
-        .map_err(|e| e.with_message("community_follower_already_exists".into()))?;
+        .map_err(|e| e.with_message("community_follower_already_exists"))?;
     }
 
     let community_id = data.community_id;
@@ -160,7 +160,7 @@ impl Perform for BlockCommunity {
       blocking(context.pool(), block)
         .await?
         .map_err(LemmyError::from)
-        .map_err(|e| e.with_message("community_block_already_exists".into()))?;
+        .map_err(|e| e.with_message("community_block_already_exists"))?;
 
       // Also, unfollow the community, and send a federated unfollow
       let community_follower_form = CommunityFollowerForm {
@@ -183,7 +183,7 @@ impl Perform for BlockCommunity {
       blocking(context.pool(), unblock)
         .await?
         .map_err(LemmyError::from)
-        .map_err(|e| e.with_message("community_block_already_exists".into()))?;
+        .map_err(|e| e.with_message("community_block_already_exists"))?;
     }
 
     let community_view = blocking(context.pool(), move |conn| {
@@ -239,7 +239,7 @@ impl Perform for BanFromCommunity {
       blocking(context.pool(), ban)
         .await?
         .map_err(LemmyError::from)
-        .map_err(|e| e.with_message("community_user_already_banned".into()))?;
+        .map_err(|e| e.with_message("community_user_already_banned"))?;
 
       // Also unsubscribe them from the community, if they are subscribed
       let community_follower_form = CommunityFollowerForm {
@@ -265,7 +265,7 @@ impl Perform for BanFromCommunity {
       blocking(context.pool(), unban)
         .await?
         .map_err(LemmyError::from)
-        .map_err(|e| e.with_message("community_user_already_banned".into()))?;
+        .map_err(|e| e.with_message("community_user_already_banned"))?;
       UndoBlockUserFromCommunity::send(
         &community,
         &banned_person,
@@ -371,13 +371,13 @@ impl Perform for AddModToCommunity {
       blocking(context.pool(), join)
         .await?
         .map_err(LemmyError::from)
-        .map_err(|e| e.with_message("community_moderator_already_exists".into()))?;
+        .map_err(|e| e.with_message("community_moderator_already_exists"))?;
     } else {
       let leave = move |conn: &'_ _| CommunityModerator::leave(conn, &community_moderator_form);
       blocking(context.pool(), leave)
         .await?
         .map_err(LemmyError::from)
-        .map_err(|e| e.with_message("community_moderator_already_exists".into()))?;
+        .map_err(|e| e.with_message("community_moderator_already_exists"))?;
     }
 
     // Mod tables
@@ -486,7 +486,7 @@ impl Perform for TransferCommunity {
         .map(|a| a.person.id)
         .any(|x| x == local_user_view.person.id)
     {
-      return Err(LemmyError::from_message("not_an_admin".into()));
+      return Err(LemmyError::from_message("not_an_admin"));
     }
 
     // You have to re-do the community_moderator table, reordering it.
@@ -517,7 +517,7 @@ impl Perform for TransferCommunity {
       blocking(context.pool(), join)
         .await?
         .map_err(LemmyError::from)
-        .map_err(|e| e.with_message("community_moderator_already_exists".into()))?;
+        .map_err(|e| e.with_message("community_moderator_already_exists"))?;
     }
 
     // Mod tables
@@ -539,7 +539,7 @@ impl Perform for TransferCommunity {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_find_community".into()))?;
+    .map_err(|e| e.with_message("couldnt_find_community"))?;
 
     let community_id = data.community_id;
     let moderators = blocking(context.pool(), move |conn| {
@@ -547,7 +547,7 @@ impl Perform for TransferCommunity {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_find_community".into()))?;
+    .map_err(|e| e.with_message("couldnt_find_community"))?;
 
     // Return the jwt
     Ok(GetCommunityResponse {

--- a/crates/api/src/local_user.rs
+++ b/crates/api/src/local_user.rs
@@ -62,7 +62,7 @@ use lemmy_websocket::{
 impl Perform for Login {
   type Response = LoginResponse;
 
-  #[tracing::instrument(skip(context, _websocket_id))]
+  #[tracing::instrument(skip_all)]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api/src/local_user.rs
+++ b/crates/api/src/local_user.rs
@@ -62,7 +62,7 @@ use lemmy_websocket::{
 impl Perform for Login {
   type Response = LoginResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -104,7 +104,7 @@ impl Perform for Login {
 impl Perform for GetCaptcha {
   type Response = GetCaptchaResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -150,7 +150,7 @@ impl Perform for GetCaptcha {
 impl Perform for SaveUserSettings {
   type Response = LoginResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -325,7 +325,7 @@ impl Perform for ChangePassword {
 impl Perform for AddAdmin {
   type Response = AddAdminResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -385,7 +385,7 @@ impl Perform for AddAdmin {
 impl Perform for BanPerson {
   type Response = BanPersonResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -480,7 +480,7 @@ impl Perform for BanPerson {
 impl Perform for BlockPerson {
   type Response = BlockPersonResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -537,7 +537,7 @@ impl Perform for BlockPerson {
 impl Perform for GetReplies {
   type Response = GetRepliesResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -576,7 +576,7 @@ impl Perform for GetReplies {
 impl Perform for GetPersonMentions {
   type Response = GetPersonMentionsResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -612,7 +612,7 @@ impl Perform for GetPersonMentions {
 impl Perform for MarkPersonMentionAsRead {
   type Response = PersonMentionResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -658,7 +658,7 @@ impl Perform for MarkPersonMentionAsRead {
 impl Perform for MarkAllAsRead {
   type Response = GetRepliesResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -813,7 +813,7 @@ impl Perform for PasswordChange {
 impl Perform for GetReportCount {
   type Response = GetReportCountResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -851,7 +851,7 @@ impl Perform for GetReportCount {
 impl Perform for GetUnreadCount {
   type Response = GetUnreadCountResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api/src/local_user.rs
+++ b/crates/api/src/local_user.rs
@@ -63,7 +63,7 @@ use lemmy_websocket::{
 impl Perform for Login {
   type Response = LoginResponse;
 
-  #[tracing::instrument(skip_all)]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api/src/local_user.rs
+++ b/crates/api/src/local_user.rs
@@ -77,7 +77,7 @@ impl Perform for Login {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_find_that_username_or_email".into()))?;
+    .map_err(|e| e.with_message("couldnt_find_that_username_or_email"))?;
 
     // Verify the password
     let valid: bool = verify(
@@ -86,7 +86,7 @@ impl Perform for Login {
     )
     .unwrap_or(false);
     if !valid {
-      return Err(LemmyError::from_message("password_incorrect".into()));
+      return Err(LemmyError::from_message("password_incorrect"));
     }
 
     // Return the jwt
@@ -170,7 +170,7 @@ impl Perform for SaveUserSettings {
 
     if let Some(Some(bio)) = &bio {
       if bio.chars().count() > 300 {
-        return Err(LemmyError::from_message("bio_length_overflow".into()));
+        return Err(LemmyError::from_message("bio_length_overflow"));
       }
     }
 
@@ -179,13 +179,13 @@ impl Perform for SaveUserSettings {
         display_name.trim(),
         context.settings().actor_name_max_length,
       ) {
-        return Err(LemmyError::from_message("invalid_username".into()));
+        return Err(LemmyError::from_message("invalid_username"));
       }
     }
 
     if let Some(Some(matrix_user_id)) = &matrix_user_id {
       if !is_valid_matrix_id(matrix_user_id) {
-        return Err(LemmyError::from_message("invalid_matrix_id".into()));
+        return Err(LemmyError::from_message("invalid_matrix_id"));
       }
     }
 
@@ -223,7 +223,7 @@ impl Perform for SaveUserSettings {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("user_already_exists".into()))?;
+    .map_err(|e| e.with_message("user_already_exists"))?;
 
     let local_user_form = LocalUserForm {
       person_id,
@@ -257,7 +257,7 @@ impl Perform for SaveUserSettings {
           "user_already_exists"
         };
 
-        return Err(LemmyError::from(e).with_message(err_type.into()));
+        return Err(LemmyError::from(e).with_message(err_type));
       }
     };
 
@@ -290,7 +290,7 @@ impl Perform for ChangePassword {
 
     // Make sure passwords match
     if data.new_password != data.new_password_verify {
-      return Err(LemmyError::from_message("passwords_dont_match".into()));
+      return Err(LemmyError::from_message("passwords_dont_match"));
     }
 
     // Check the old password
@@ -300,7 +300,7 @@ impl Perform for ChangePassword {
     )
     .unwrap_or(false);
     if !valid {
-      return Err(LemmyError::from_message("password_incorrect".into()));
+      return Err(LemmyError::from_message("password_incorrect"));
     }
 
     let local_user_id = local_user_view.local_user.id;
@@ -345,7 +345,7 @@ impl Perform for AddAdmin {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_update_user".into()))?;
+    .map_err(|e| e.with_message("couldnt_update_user"))?;
 
     // Mod tables
     let form = ModAddForm {
@@ -404,7 +404,7 @@ impl Perform for BanPerson {
     blocking(context.pool(), ban_person)
       .await?
       .map_err(LemmyError::from)
-      .map_err(|e| e.with_message("couldnt_update_user".into()))?;
+      .map_err(|e| e.with_message("couldnt_update_user"))?;
 
     // Remove their data if that's desired
     if data.remove_data.unwrap_or(false) {
@@ -495,7 +495,7 @@ impl Perform for BlockPerson {
 
     // Don't let a person block themselves
     if target_id == person_id {
-      return Err(LemmyError::from_message("cant_block_yourself".into()));
+      return Err(LemmyError::from_message("cant_block_yourself"));
     }
 
     let person_block_form = PersonBlockForm {
@@ -508,13 +508,13 @@ impl Perform for BlockPerson {
       blocking(context.pool(), block)
         .await?
         .map_err(LemmyError::from)
-        .map_err(|e| e.with_message("person_block_already_exists".into()))?;
+        .map_err(|e| e.with_message("person_block_already_exists"))?;
     } else {
       let unblock = move |conn: &'_ _| PersonBlock::unblock(conn, &person_block_form);
       blocking(context.pool(), unblock)
         .await?
         .map_err(LemmyError::from)
-        .map_err(|e| e.with_message("person_block_already_exists".into()))?;
+        .map_err(|e| e.with_message("person_block_already_exists"))?;
     }
 
     // TODO does any federated stuff need to be done here?
@@ -629,7 +629,7 @@ impl Perform for MarkPersonMentionAsRead {
     .await??;
 
     if local_user_view.person.id != read_person_mention.recipient_id {
-      return Err(LemmyError::from_message("couldnt_update_comment".into()));
+      return Err(LemmyError::from_message("couldnt_update_comment"));
     }
 
     let person_mention_id = read_person_mention.id;
@@ -639,7 +639,7 @@ impl Perform for MarkPersonMentionAsRead {
     blocking(context.pool(), update_mention)
       .await?
       .map_err(LemmyError::from)
-      .map_err(|e| e.with_message("couldnt_update_comment".into()))?;
+      .map_err(|e| e.with_message("couldnt_update_comment"))?;
 
     let person_mention_id = read_person_mention.id;
     let person_id = local_user_view.person.id;
@@ -689,7 +689,7 @@ impl Perform for MarkAllAsRead {
       blocking(context.pool(), mark_as_read)
         .await?
         .map_err(LemmyError::from)
-        .map_err(|e| e.with_message("couldnt_update_comment".into()))?;
+        .map_err(|e| e.with_message("couldnt_update_comment"))?;
     }
 
     // Mark all user mentions as read
@@ -698,14 +698,14 @@ impl Perform for MarkAllAsRead {
     blocking(context.pool(), update_person_mentions)
       .await?
       .map_err(LemmyError::from)
-      .map_err(|e| e.with_message("couldnt_update_comment".into()))?;
+      .map_err(|e| e.with_message("couldnt_update_comment"))?;
 
     // Mark all private_messages as read
     let update_pm = move |conn: &'_ _| PrivateMessage::mark_all_as_read(conn, person_id);
     blocking(context.pool(), update_pm)
       .await?
       .map_err(LemmyError::from)
-      .map_err(|e| e.with_message("couldnt_update_private_message".into()))?;
+      .map_err(|e| e.with_message("couldnt_update_private_message"))?;
 
     Ok(GetRepliesResponse { replies: vec![] })
   }
@@ -730,7 +730,7 @@ impl Perform for PasswordReset {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_find_that_username_or_email".into()))?;
+    .map_err(|e| e.with_message("couldnt_find_that_username_or_email"))?;
 
     // Generate a random token
     let token = generate_random_string();
@@ -756,8 +756,9 @@ impl Perform for PasswordReset {
       html,
       &context.settings(),
     )
-    .map_err(LemmyError::from_message)
-    .map_err(|e| e.with_message("email_send_failed".into()))?;
+    .map_err(|e| anyhow::anyhow!("{}", e))
+    .map_err(LemmyError::from)
+    .map_err(|e| e.with_message("email_send_failed"))?;
 
     Ok(PasswordResetResponse {})
   }
@@ -786,7 +787,7 @@ impl Perform for PasswordChange {
 
     // Make sure passwords match
     if data.password != data.password_verify {
-      return Err(LemmyError::from_message("passwords_dont_match".into()));
+      return Err(LemmyError::from_message("passwords_dont_match"));
     }
 
     // Update the user with the new password
@@ -796,7 +797,7 @@ impl Perform for PasswordChange {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_update_user".into()))?;
+    .map_err(|e| e.with_message("couldnt_update_user"))?;
 
     // Return the jwt
     Ok(LoginResponse {

--- a/crates/api/src/local_user.rs
+++ b/crates/api/src/local_user.rs
@@ -51,6 +51,7 @@ use lemmy_utils::{
   utils::{generate_random_string, is_valid_display_name, is_valid_matrix_id, naive_from_unix},
   ConnectionId,
   LemmyError,
+  Sensitive,
 };
 use lemmy_websocket::{
   messages::{CaptchaItem, SendAllMessage},
@@ -95,7 +96,8 @@ impl Perform for Login {
         local_user_view.local_user.id.0,
         &context.secret().jwt_secret,
         &context.settings().hostname,
-      )?,
+      )?
+      .into(),
     })
   }
 }
@@ -162,7 +164,7 @@ impl Perform for SaveUserSettings {
 
     let avatar = diesel_option_overwrite_to_url(&data.avatar)?;
     let banner = diesel_option_overwrite_to_url(&data.banner)?;
-    let email = diesel_option_overwrite(&data.email);
+    let email = diesel_option_overwrite(&data.email.clone().map(Sensitive::into_inner));
     let bio = diesel_option_overwrite(&data.bio);
     let display_name = diesel_option_overwrite(&data.display_name);
     let matrix_user_id = diesel_option_overwrite(&data.matrix_user_id);
@@ -267,7 +269,8 @@ impl Perform for SaveUserSettings {
         updated_local_user.id.0,
         &context.secret().jwt_secret,
         &context.settings().hostname,
-      )?,
+      )?
+      .into(),
     })
   }
 }
@@ -284,7 +287,7 @@ impl Perform for ChangePassword {
   ) -> Result<LoginResponse, LemmyError> {
     let data: &ChangePassword = self;
     let local_user_view =
-      get_local_user_view_from_jwt(&data.auth, context.pool(), context.secret()).await?;
+      get_local_user_view_from_jwt(data.auth.as_ref(), context.pool(), context.secret()).await?;
 
     password_length_check(&data.new_password)?;
 
@@ -316,7 +319,8 @@ impl Perform for ChangePassword {
         updated_local_user.id.0,
         &context.secret().jwt_secret,
         &context.settings().hostname,
-      )?,
+      )?
+      .into(),
     })
   }
 }
@@ -805,7 +809,8 @@ impl Perform for PasswordChange {
         updated_local_user.id.0,
         &context.secret().jwt_secret,
         &context.settings().hostname,
-      )?,
+      )?
+      .into(),
     })
   }
 }

--- a/crates/api/src/post.rs
+++ b/crates/api/src/post.rs
@@ -37,7 +37,7 @@ use std::convert::TryInto;
 impl Perform for CreatePostLike {
   type Response = PostResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -125,7 +125,7 @@ impl Perform for CreatePostLike {
 impl Perform for MarkPostAsRead {
   type Response = PostResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -161,7 +161,7 @@ impl Perform for MarkPostAsRead {
 impl Perform for LockPost {
   type Response = PostResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -231,7 +231,7 @@ impl Perform for LockPost {
 impl Perform for StickyPost {
   type Response = PostResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -305,7 +305,7 @@ impl Perform for StickyPost {
 impl Perform for SavePost {
   type Response = PostResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -352,7 +352,7 @@ impl Perform for SavePost {
 impl Perform for GetSiteMetadata {
   type Response = GetSiteMetadataResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api/src/post.rs
+++ b/crates/api/src/post.rs
@@ -85,7 +85,7 @@ impl Perform for CreatePostLike {
       blocking(context.pool(), like)
         .await?
         .map_err(LemmyError::from)
-        .map_err(|e| e.with_message("couldnt_like_post".into()))?;
+        .map_err(|e| e.with_message("couldnt_like_post"))?;
 
       Vote::send(
         &object,
@@ -325,13 +325,13 @@ impl Perform for SavePost {
       blocking(context.pool(), save)
         .await?
         .map_err(LemmyError::from)
-        .map_err(|e| e.with_message("couldnt_save_post".into()))?;
+        .map_err(|e| e.with_message("couldnt_save_post"))?;
     } else {
       let unsave = move |conn: &'_ _| PostSaved::unsave(conn, &post_saved_form);
       blocking(context.pool(), unsave)
         .await?
         .map_err(LemmyError::from)
-        .map_err(|e| e.with_message("couldnt_save_post".into()))?;
+        .map_err(|e| e.with_message("couldnt_save_post"))?;
     }
 
     let post_id = data.post_id;

--- a/crates/api/src/post_report.rs
+++ b/crates/api/src/post_report.rs
@@ -44,10 +44,10 @@ impl Perform for CreatePostReport {
     // check size of report and check for whitespace
     let reason = data.reason.trim();
     if reason.is_empty() {
-      return Err(LemmyError::from_message("report_reason_required".into()));
+      return Err(LemmyError::from_message("report_reason_required"));
     }
     if reason.chars().count() > 1000 {
-      return Err(LemmyError::from_message("report_too_long".into()));
+      return Err(LemmyError::from_message("report_too_long"));
     }
 
     let person_id = local_user_view.person.id;
@@ -73,7 +73,7 @@ impl Perform for CreatePostReport {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_create_report".into()))?;
+    .map_err(|e| e.with_message("couldnt_create_report"))?;
 
     let post_report_view = blocking(context.pool(), move |conn| {
       PostReportView::read(conn, report.id, person_id)
@@ -139,7 +139,7 @@ impl Perform for ResolvePostReport {
     blocking(context.pool(), resolve_fun)
       .await?
       .map_err(LemmyError::from)
-      .map_err(|e| e.with_message("couldnt_resolve_report".into()))?;
+      .map_err(|e| e.with_message("couldnt_resolve_report"))?;
 
     let post_report_view = blocking(context.pool(), move |conn| {
       PostReportView::read(conn, report_id, person_id)

--- a/crates/api/src/post_report.rs
+++ b/crates/api/src/post_report.rs
@@ -23,7 +23,7 @@ use lemmy_db_views::{
   post_report_view::{PostReportQueryBuilder, PostReportView},
   post_view::PostView,
 };
-use lemmy_utils::{ApiError, ConnectionId, LemmyError};
+use lemmy_utils::{ConnectionId, LemmyError};
 use lemmy_websocket::{messages::SendModRoomMessage, LemmyContext, UserOperation};
 
 /// Creates a post report and notifies the moderators of the community
@@ -31,6 +31,7 @@ use lemmy_websocket::{messages::SendModRoomMessage, LemmyContext, UserOperation}
 impl Perform for CreatePostReport {
   type Response = PostReportResponse;
 
+  #[tracing::instrument(skip(self, context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -43,10 +44,10 @@ impl Perform for CreatePostReport {
     // check size of report and check for whitespace
     let reason = data.reason.trim();
     if reason.is_empty() {
-      return Err(ApiError::err_plain("report_reason_required").into());
+      return Err(LemmyError::from_message("report_reason_required".into()));
     }
     if reason.chars().count() > 1000 {
-      return Err(ApiError::err_plain("report_too_long").into());
+      return Err(LemmyError::from_message("report_too_long".into()));
     }
 
     let person_id = local_user_view.person.id;
@@ -71,7 +72,8 @@ impl Perform for CreatePostReport {
       PostReport::report(conn, &report_form)
     })
     .await?
-    .map_err(|e| ApiError::err("couldnt_create_report", e))?;
+    .map_err(LemmyError::from)
+    .map_err(|e| e.with_message("couldnt_create_report".into()))?;
 
     let post_report_view = blocking(context.pool(), move |conn| {
       PostReportView::read(conn, report.id, person_id)
@@ -105,6 +107,7 @@ impl Perform for CreatePostReport {
 impl Perform for ResolvePostReport {
   type Response = PostReportResponse;
 
+  #[tracing::instrument(skip(self, context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -135,7 +138,8 @@ impl Perform for ResolvePostReport {
 
     blocking(context.pool(), resolve_fun)
       .await?
-      .map_err(|e| ApiError::err("couldnt_resolve_report", e))?;
+      .map_err(LemmyError::from)
+      .map_err(|e| e.with_message("couldnt_resolve_report".into()))?;
 
     let post_report_view = blocking(context.pool(), move |conn| {
       PostReportView::read(conn, report_id, person_id)
@@ -161,6 +165,7 @@ impl Perform for ResolvePostReport {
 impl Perform for ListPostReports {
   type Response = ListPostReportsResponse;
 
+  #[tracing::instrument(skip(self, context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api/src/post_report.rs
+++ b/crates/api/src/post_report.rs
@@ -31,7 +31,7 @@ use lemmy_websocket::{messages::SendModRoomMessage, LemmyContext, UserOperation}
 impl Perform for CreatePostReport {
   type Response = PostReportResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -107,7 +107,7 @@ impl Perform for CreatePostReport {
 impl Perform for ResolvePostReport {
   type Response = PostReportResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -165,7 +165,7 @@ impl Perform for ResolvePostReport {
 impl Perform for ListPostReports {
   type Response = ListPostReportsResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api/src/private_message.rs
+++ b/crates/api/src/private_message.rs
@@ -13,7 +13,7 @@ use lemmy_websocket::{send::send_pm_ws_message, LemmyContext, UserOperation};
 impl Perform for MarkPrivateMessageAsRead {
   type Response = PrivateMessageResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api/src/private_message.rs
+++ b/crates/api/src/private_message.rs
@@ -6,13 +6,14 @@ use lemmy_api_common::{
   person::{MarkPrivateMessageAsRead, PrivateMessageResponse},
 };
 use lemmy_db_schema::{source::private_message::PrivateMessage, traits::Crud};
-use lemmy_utils::{ApiError, ConnectionId, LemmyError};
+use lemmy_utils::{ConnectionId, LemmyError};
 use lemmy_websocket::{send::send_pm_ws_message, LemmyContext, UserOperation};
 
 #[async_trait::async_trait(?Send)]
 impl Perform for MarkPrivateMessageAsRead {
   type Response = PrivateMessageResponse;
 
+  #[tracing::instrument(skip(self, context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -29,7 +30,9 @@ impl Perform for MarkPrivateMessageAsRead {
     })
     .await??;
     if local_user_view.person.id != orig_private_message.recipient_id {
-      return Err(ApiError::err_plain("couldnt_update_private_message").into());
+      return Err(LemmyError::from_message(
+        "couldnt_update_private_message".into(),
+      ));
     }
 
     // Doing the update
@@ -39,7 +42,8 @@ impl Perform for MarkPrivateMessageAsRead {
       PrivateMessage::update_read(conn, private_message_id, read)
     })
     .await?
-    .map_err(|e| ApiError::err("couldnt_update_private_message", e))?;
+    .map_err(LemmyError::from)
+    .map_err(|e| e.with_message("couldnt_update_private_message".into()))?;
 
     // No need to send an apub update
     let op = UserOperation::MarkPrivateMessageAsRead;

--- a/crates/api/src/private_message.rs
+++ b/crates/api/src/private_message.rs
@@ -30,9 +30,7 @@ impl Perform for MarkPrivateMessageAsRead {
     })
     .await??;
     if local_user_view.person.id != orig_private_message.recipient_id {
-      return Err(LemmyError::from_message(
-        "couldnt_update_private_message".into(),
-      ));
+      return Err(LemmyError::from_message("couldnt_update_private_message"));
     }
 
     // Doing the update
@@ -43,7 +41,7 @@ impl Perform for MarkPrivateMessageAsRead {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_update_private_message".into()))?;
+    .map_err(|e| e.with_message("couldnt_update_private_message"))?;
 
     // No need to send an apub update
     let op = UserOperation::MarkPrivateMessageAsRead;

--- a/crates/api/src/site.rs
+++ b/crates/api/src/site.rs
@@ -146,7 +146,8 @@ impl Perform for Search {
     let data: &Search = self;
 
     let local_user_view =
-      get_local_user_view_from_jwt_opt(&data.auth, context.pool(), context.secret()).await?;
+      get_local_user_view_from_jwt_opt(data.auth.as_ref(), context.pool(), context.secret())
+        .await?;
 
     let show_nsfw = local_user_view.as_ref().map(|t| t.local_user.show_nsfw);
     let show_bot_accounts = local_user_view
@@ -385,7 +386,8 @@ impl Perform for ResolveObject {
     _websocket_id: Option<ConnectionId>,
   ) -> Result<ResolveObjectResponse, LemmyError> {
     let local_user_view =
-      get_local_user_view_from_jwt_opt(&self.auth, context.pool(), context.secret()).await?;
+      get_local_user_view_from_jwt_opt(self.auth.as_ref(), context.pool(), context.secret())
+        .await?;
     let res = search_by_apub_id(&self.q, context)
       .await
       .map_err(LemmyError::from)

--- a/crates/api/src/site.rs
+++ b/crates/api/src/site.rs
@@ -56,7 +56,7 @@ use lemmy_websocket::LemmyContext;
 impl Perform for GetModlog {
   type Response = GetModlogResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -137,7 +137,7 @@ impl Perform for GetModlog {
 impl Perform for Search {
   type Response = SearchResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -378,7 +378,7 @@ impl Perform for Search {
 impl Perform for ResolveObject {
   type Response = ResolveObjectResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -440,7 +440,7 @@ async fn convert_response(
 impl Perform for TransferSite {
   type Response = GetSiteResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -509,7 +509,7 @@ impl Perform for TransferSite {
 impl Perform for GetSiteConfig {
   type Response = GetSiteConfigResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -532,7 +532,7 @@ impl Perform for GetSiteConfig {
 impl Perform for SaveSiteConfig {
   type Response = GetSiteConfigResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api/src/site.rs
+++ b/crates/api/src/site.rs
@@ -389,11 +389,11 @@ impl Perform for ResolveObject {
     let res = search_by_apub_id(&self.q, context)
       .await
       .map_err(LemmyError::from)
-      .map_err(|e| e.with_message("couldnt_find_object".into()))?;
+      .map_err(|e| e.with_message("couldnt_find_object"))?;
     convert_response(res, local_user_view.map(|l| l.person.id), context.pool())
       .await
       .map_err(LemmyError::from)
-      .map_err(|e| e.with_message("couldnt_find_object".into()))
+      .map_err(|e| e.with_message("couldnt_find_object"))
   }
 }
 
@@ -456,7 +456,7 @@ impl Perform for TransferSite {
 
     // Make sure user is the creator
     if read_site.creator_id != local_user_view.person.id {
-      return Err(LemmyError::from_message("not_an_admin".into()));
+      return Err(LemmyError::from_message("not_an_admin"));
     }
 
     let new_creator_id = data.person_id;
@@ -464,7 +464,7 @@ impl Perform for TransferSite {
     blocking(context.pool(), transfer_site)
       .await?
       .map_err(LemmyError::from)
-      .map_err(|e| e.with_message("couldnt_update_site".into()))?;
+      .map_err(|e| e.with_message("couldnt_update_site"))?;
 
     // Mod tables
     let form = ModAddForm {
@@ -548,7 +548,7 @@ impl Perform for SaveSiteConfig {
     // Make sure docker doesn't have :ro at the end of the volume, so its not a read-only filesystem
     let config_hjson = Settings::save_config_file(&data.config_hjson)
       .map_err(LemmyError::from)
-      .map_err(|e| e.with_message("couldnt_update_site".into()))?;
+      .map_err(|e| e.with_message("couldnt_update_site"))?;
 
     Ok(GetSiteConfigResponse { config_hjson })
   }

--- a/crates/api/src/websocket.rs
+++ b/crates/api/src/websocket.rs
@@ -11,7 +11,7 @@ use lemmy_websocket::{
 impl Perform for UserJoin {
   type Response = UserJoinResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -36,7 +36,7 @@ impl Perform for UserJoin {
 impl Perform for CommunityJoin {
   type Response = CommunityJoinResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -59,7 +59,7 @@ impl Perform for CommunityJoin {
 impl Perform for ModJoin {
   type Response = ModJoinResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -82,7 +82,7 @@ impl Perform for ModJoin {
 impl Perform for PostJoin {
   type Response = PostJoinResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api/src/websocket.rs
+++ b/crates/api/src/websocket.rs
@@ -11,6 +11,7 @@ use lemmy_websocket::{
 impl Perform for UserJoin {
   type Response = UserJoinResponse;
 
+  #[tracing::instrument(skip(self, context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -35,6 +36,7 @@ impl Perform for UserJoin {
 impl Perform for CommunityJoin {
   type Response = CommunityJoinResponse;
 
+  #[tracing::instrument(skip(self, context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -57,6 +59,7 @@ impl Perform for CommunityJoin {
 impl Perform for ModJoin {
   type Response = ModJoinResponse;
 
+  #[tracing::instrument(skip(self, context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -79,6 +82,7 @@ impl Perform for ModJoin {
 impl Perform for PostJoin {
   type Response = PostJoinResponse;
 
+  #[tracing::instrument(skip(self, context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api_common/Cargo.toml
+++ b/crates/api_common/Cargo.toml
@@ -23,4 +23,5 @@ diesel = "1.4.8"
 actix-web = { version = "4.0.0-beta.9", default-features = false, features = ["cookies"] }
 chrono = { version = "0.4.19", features = ["serde"] }
 serde_json = { version = "1.0.68", features = ["preserve_order"] }
+tracing = "0.1.29"
 url = "2.2.2"

--- a/crates/api_common/src/comment.rs
+++ b/crates/api_common/src/comment.rs
@@ -1,5 +1,6 @@
 use lemmy_db_schema::newtypes::{CommentId, CommentReportId, CommunityId, LocalUserId, PostId};
 use lemmy_db_views::{comment_report_view::CommentReportView, comment_view::CommentView};
+use lemmy_utils::Sensitive;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -8,13 +9,13 @@ pub struct CreateComment {
   pub post_id: PostId,
   pub parent_id: Option<CommentId>,
   pub form_id: Option<String>,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetComment {
   pub id: CommentId,
-  pub auth: Option<String>,
+  pub auth: Option<Sensitive>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -22,14 +23,14 @@ pub struct EditComment {
   pub content: String,
   pub comment_id: CommentId,
   pub form_id: Option<String>,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DeleteComment {
   pub comment_id: CommentId,
   pub deleted: bool,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -37,21 +38,21 @@ pub struct RemoveComment {
   pub comment_id: CommentId,
   pub removed: bool,
   pub reason: Option<String>,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MarkCommentAsRead {
   pub comment_id: CommentId,
   pub read: bool,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SaveComment {
   pub comment_id: CommentId,
   pub save: bool,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -65,7 +66,7 @@ pub struct CommentResponse {
 pub struct CreateCommentLike {
   pub comment_id: CommentId,
   pub score: i16,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -77,7 +78,7 @@ pub struct GetComments {
   pub community_id: Option<CommunityId>,
   pub community_name: Option<String>,
   pub saved_only: Option<bool>,
-  pub auth: Option<String>,
+  pub auth: Option<Sensitive>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -89,7 +90,7 @@ pub struct GetCommentsResponse {
 pub struct CreateCommentReport {
   pub comment_id: CommentId,
   pub reason: String,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -101,7 +102,7 @@ pub struct CommentReportResponse {
 pub struct ResolveCommentReport {
   pub report_id: CommentReportId,
   pub resolved: bool,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -112,7 +113,7 @@ pub struct ListCommentReports {
   pub unresolved_only: Option<bool>,
   /// if no community is given, it returns reports for all communities moderated by the auth user
   pub community_id: Option<CommunityId>,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/api_common/src/comment.rs
+++ b/crates/api_common/src/comment.rs
@@ -2,7 +2,7 @@ use lemmy_db_schema::newtypes::{CommentId, CommentReportId, CommunityId, LocalUs
 use lemmy_db_views::{comment_report_view::CommentReportView, comment_view::CommentView};
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct CreateComment {
   pub content: String,
   pub post_id: PostId,
@@ -11,13 +11,13 @@ pub struct CreateComment {
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetComment {
   pub id: CommentId,
   pub auth: Option<String>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct EditComment {
   pub content: String,
   pub comment_id: CommentId,
@@ -25,14 +25,14 @@ pub struct EditComment {
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct DeleteComment {
   pub comment_id: CommentId,
   pub deleted: bool,
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct RemoveComment {
   pub comment_id: CommentId,
   pub removed: bool,
@@ -40,35 +40,35 @@ pub struct RemoveComment {
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct MarkCommentAsRead {
   pub comment_id: CommentId,
   pub read: bool,
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct SaveComment {
   pub comment_id: CommentId,
   pub save: bool,
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CommentResponse {
   pub comment_view: CommentView,
   pub recipient_ids: Vec<LocalUserId>,
   pub form_id: Option<String>, // An optional front end ID, to tell which is coming back
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct CreateCommentLike {
   pub comment_id: CommentId,
   pub score: i16,
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetComments {
   pub type_: Option<String>,
   pub sort: Option<String>,
@@ -80,31 +80,31 @@ pub struct GetComments {
   pub auth: Option<String>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetCommentsResponse {
   pub comments: Vec<CommentView>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct CreateCommentReport {
   pub comment_id: CommentId,
   pub reason: String,
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CommentReportResponse {
   pub comment_report_view: CommentReportView,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ResolveCommentReport {
   pub report_id: CommentReportId,
   pub resolved: bool,
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ListCommentReports {
   pub page: Option<i64>,
   pub limit: Option<i64>,
@@ -115,7 +115,7 @@ pub struct ListCommentReports {
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ListCommentReportsResponse {
   pub comment_reports: Vec<CommentReportView>,
 }

--- a/crates/api_common/src/comment.rs
+++ b/crates/api_common/src/comment.rs
@@ -9,13 +9,13 @@ pub struct CreateComment {
   pub post_id: PostId,
   pub parent_id: Option<CommentId>,
   pub form_id: Option<String>,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetComment {
   pub id: CommentId,
-  pub auth: Option<Sensitive>,
+  pub auth: Option<Sensitive<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -23,14 +23,14 @@ pub struct EditComment {
   pub content: String,
   pub comment_id: CommentId,
   pub form_id: Option<String>,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DeleteComment {
   pub comment_id: CommentId,
   pub deleted: bool,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -38,21 +38,21 @@ pub struct RemoveComment {
   pub comment_id: CommentId,
   pub removed: bool,
   pub reason: Option<String>,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MarkCommentAsRead {
   pub comment_id: CommentId,
   pub read: bool,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SaveComment {
   pub comment_id: CommentId,
   pub save: bool,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -66,7 +66,7 @@ pub struct CommentResponse {
 pub struct CreateCommentLike {
   pub comment_id: CommentId,
   pub score: i16,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -78,7 +78,7 @@ pub struct GetComments {
   pub community_id: Option<CommunityId>,
   pub community_name: Option<String>,
   pub saved_only: Option<bool>,
-  pub auth: Option<Sensitive>,
+  pub auth: Option<Sensitive<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -90,7 +90,7 @@ pub struct GetCommentsResponse {
 pub struct CreateCommentReport {
   pub comment_id: CommentId,
   pub reason: String,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -102,7 +102,7 @@ pub struct CommentReportResponse {
 pub struct ResolveCommentReport {
   pub report_id: CommentReportId,
   pub resolved: bool,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -113,7 +113,7 @@ pub struct ListCommentReports {
   pub unresolved_only: Option<bool>,
   /// if no community is given, it returns reports for all communities moderated by the auth user
   pub community_id: Option<CommunityId>,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/api_common/src/community.rs
+++ b/crates/api_common/src/community.rs
@@ -6,7 +6,7 @@ use lemmy_db_views_actor::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetCommunity {
   pub id: Option<CommunityId>,
   /// Example: star_trek , or star_trek@xyz.tld
@@ -14,14 +14,14 @@ pub struct GetCommunity {
   pub auth: Option<String>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetCommunityResponse {
   pub community_view: CommunityView,
   pub moderators: Vec<CommunityModeratorView>,
   pub online: usize,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct CreateCommunity {
   pub name: String,
   pub title: String,
@@ -32,7 +32,7 @@ pub struct CreateCommunity {
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CommunityResponse {
   pub community_view: CommunityView,
 }
@@ -51,7 +51,7 @@ pub struct ListCommunitiesResponse {
   pub communities: Vec<CommunityView>,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct BanFromCommunity {
   pub community_id: CommunityId,
   pub person_id: PersonId,
@@ -62,13 +62,13 @@ pub struct BanFromCommunity {
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct BanFromCommunityResponse {
   pub person_view: PersonViewSafe,
   pub banned: bool,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct AddModToCommunity {
   pub community_id: CommunityId,
   pub person_id: PersonId,
@@ -76,12 +76,12 @@ pub struct AddModToCommunity {
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct AddModToCommunityResponse {
   pub moderators: Vec<CommunityModeratorView>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct EditCommunity {
   pub community_id: CommunityId,
   pub title: Option<String>,
@@ -92,14 +92,14 @@ pub struct EditCommunity {
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct DeleteCommunity {
   pub community_id: CommunityId,
   pub deleted: bool,
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct RemoveCommunity {
   pub community_id: CommunityId,
   pub removed: bool,
@@ -108,27 +108,27 @@ pub struct RemoveCommunity {
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct FollowCommunity {
   pub community_id: CommunityId,
   pub follow: bool,
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct BlockCommunity {
   pub community_id: CommunityId,
   pub block: bool,
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct BlockCommunityResponse {
   pub community_view: CommunityView,
   pub blocked: bool,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct TransferCommunity {
   pub community_id: CommunityId,
   pub person_id: PersonId,

--- a/crates/api_common/src/community.rs
+++ b/crates/api_common/src/community.rs
@@ -4,6 +4,7 @@ use lemmy_db_views_actor::{
   community_view::CommunityView,
   person_view::PersonViewSafe,
 };
+use lemmy_utils::Sensitive;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -11,7 +12,7 @@ pub struct GetCommunity {
   pub id: Option<CommunityId>,
   /// Example: star_trek , or star_trek@xyz.tld
   pub name: Option<String>,
-  pub auth: Option<String>,
+  pub auth: Option<Sensitive>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -29,7 +30,7 @@ pub struct CreateCommunity {
   pub icon: Option<String>,
   pub banner: Option<String>,
   pub nsfw: Option<bool>,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -43,7 +44,7 @@ pub struct ListCommunities {
   pub sort: Option<String>,
   pub page: Option<i64>,
   pub limit: Option<i64>,
-  pub auth: Option<String>,
+  pub auth: Option<Sensitive>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -59,7 +60,7 @@ pub struct BanFromCommunity {
   pub remove_data: Option<bool>,
   pub reason: Option<String>,
   pub expires: Option<i64>,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -73,7 +74,7 @@ pub struct AddModToCommunity {
   pub community_id: CommunityId,
   pub person_id: PersonId,
   pub added: bool,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -89,14 +90,14 @@ pub struct EditCommunity {
   pub icon: Option<String>,
   pub banner: Option<String>,
   pub nsfw: Option<bool>,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DeleteCommunity {
   pub community_id: CommunityId,
   pub deleted: bool,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -105,21 +106,21 @@ pub struct RemoveCommunity {
   pub removed: bool,
   pub reason: Option<String>,
   pub expires: Option<i64>,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FollowCommunity {
   pub community_id: CommunityId,
   pub follow: bool,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BlockCommunity {
   pub community_id: CommunityId,
   pub block: bool,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -132,5 +133,5 @@ pub struct BlockCommunityResponse {
 pub struct TransferCommunity {
   pub community_id: CommunityId,
   pub person_id: PersonId,
-  pub auth: String,
+  pub auth: Sensitive,
 }

--- a/crates/api_common/src/community.rs
+++ b/crates/api_common/src/community.rs
@@ -12,7 +12,7 @@ pub struct GetCommunity {
   pub id: Option<CommunityId>,
   /// Example: star_trek , or star_trek@xyz.tld
   pub name: Option<String>,
-  pub auth: Option<Sensitive>,
+  pub auth: Option<Sensitive<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -30,7 +30,7 @@ pub struct CreateCommunity {
   pub icon: Option<String>,
   pub banner: Option<String>,
   pub nsfw: Option<bool>,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -44,7 +44,7 @@ pub struct ListCommunities {
   pub sort: Option<String>,
   pub page: Option<i64>,
   pub limit: Option<i64>,
-  pub auth: Option<Sensitive>,
+  pub auth: Option<Sensitive<String>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -60,7 +60,7 @@ pub struct BanFromCommunity {
   pub remove_data: Option<bool>,
   pub reason: Option<String>,
   pub expires: Option<i64>,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -74,7 +74,7 @@ pub struct AddModToCommunity {
   pub community_id: CommunityId,
   pub person_id: PersonId,
   pub added: bool,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -90,14 +90,14 @@ pub struct EditCommunity {
   pub icon: Option<String>,
   pub banner: Option<String>,
   pub nsfw: Option<bool>,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DeleteCommunity {
   pub community_id: CommunityId,
   pub deleted: bool,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -106,21 +106,21 @@ pub struct RemoveCommunity {
   pub removed: bool,
   pub reason: Option<String>,
   pub expires: Option<i64>,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FollowCommunity {
   pub community_id: CommunityId,
   pub follow: bool,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BlockCommunity {
   pub community_id: CommunityId,
   pub block: bool,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -133,5 +133,5 @@ pub struct BlockCommunityResponse {
 pub struct TransferCommunity {
   pub community_id: CommunityId,
   pub person_id: PersonId,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }

--- a/crates/api_common/src/lib.rs
+++ b/crates/api_common/src/lib.rs
@@ -55,14 +55,14 @@ pub async fn is_mod_or_admin(
   })
   .await?;
   if !is_mod_or_admin {
-    return Err(LemmyError::from_message("not_a_mod_or_admin".into()));
+    return Err(LemmyError::from_message("not_a_mod_or_admin"));
   }
   Ok(())
 }
 
 pub fn is_admin(local_user_view: &LocalUserView) -> Result<(), LemmyError> {
   if !local_user_view.person.admin {
-    return Err(LemmyError::from_message("not_an_admin".into()));
+    return Err(LemmyError::from_message("not_an_admin"));
   }
   Ok(())
 }
@@ -71,7 +71,7 @@ pub async fn get_post(post_id: PostId, pool: &DbPool) -> Result<Post, LemmyError
   blocking(pool, move |conn| Post::read(conn, post_id))
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_find_post".into()))
+    .map_err(|e| e.with_message("couldnt_find_post"))
 }
 
 pub async fn mark_post_as_read(
@@ -86,7 +86,7 @@ pub async fn mark_post_as_read(
   })
   .await?
   .map_err(LemmyError::from)
-  .map_err(|e| e.with_message("couldnt_mark_post_as_read".into()))
+  .map_err(|e| e.with_message("couldnt_mark_post_as_read"))
 }
 
 pub async fn mark_post_as_unread(
@@ -101,7 +101,7 @@ pub async fn mark_post_as_unread(
   })
   .await?
   .map_err(LemmyError::from)
-  .map_err(|e| e.with_message("couldnt_mark_post_as_read".into()))
+  .map_err(|e| e.with_message("couldnt_mark_post_as_read"))
 }
 
 pub async fn get_local_user_view_from_jwt(
@@ -111,19 +111,19 @@ pub async fn get_local_user_view_from_jwt(
 ) -> Result<LocalUserView, LemmyError> {
   let claims = Claims::decode(jwt, &secret.jwt_secret)
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("not_logged_in".into()))?
+    .map_err(|e| e.with_message("not_logged_in"))?
     .claims;
   let local_user_id = LocalUserId(claims.sub);
   let local_user_view =
     blocking(pool, move |conn| LocalUserView::read(conn, local_user_id)).await??;
   // Check for a site ban
   if local_user_view.person.banned {
-    return Err(LemmyError::from_message("site_ban".into()));
+    return Err(LemmyError::from_message("site_ban"));
   }
 
   // Check for user deletion
   if local_user_view.person.deleted {
-    return Err(LemmyError::from_message("deleted".into()));
+    return Err(LemmyError::from_message("deleted"));
   }
 
   check_validator_time(&local_user_view.local_user.validator_time, &claims)?;
@@ -138,7 +138,7 @@ pub fn check_validator_time(
 ) -> Result<(), LemmyError> {
   let user_validation_time = validator_time.timestamp();
   if user_validation_time > claims.iat {
-    Err(LemmyError::from_message("not_logged_in".into()))
+    Err(LemmyError::from_message("not_logged_in"))
   } else {
     Ok(())
   }
@@ -162,7 +162,7 @@ pub async fn get_local_user_settings_view_from_jwt(
 ) -> Result<LocalUserSettingsView, LemmyError> {
   let claims = Claims::decode(jwt, &secret.jwt_secret)
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("not_logged_in".into()))?
+    .map_err(|e| e.with_message("not_logged_in"))?
     .claims;
   let local_user_id = LocalUserId(claims.sub);
   let local_user_view = blocking(pool, move |conn| {
@@ -171,7 +171,7 @@ pub async fn get_local_user_settings_view_from_jwt(
   .await??;
   // Check for a site ban
   if local_user_view.person.banned {
-    return Err(LemmyError::from_message("site_ban".into()));
+    return Err(LemmyError::from_message("site_ban"));
   }
 
   check_validator_time(&local_user_view.local_user.validator_time, &claims)?;
@@ -200,7 +200,7 @@ pub async fn check_community_ban(
   let is_banned =
     move |conn: &'_ _| CommunityPersonBanView::get(conn, person_id, community_id).is_ok();
   if blocking(pool, is_banned).await? {
-    Err(LemmyError::from_message("community_ban".into()))
+    Err(LemmyError::from_message("community_ban"))
   } else {
     Ok(())
   }
@@ -213,9 +213,9 @@ pub async fn check_community_deleted_or_removed(
   let community = blocking(pool, move |conn| Community::read(conn, community_id))
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_find_community".into()))?;
+    .map_err(|e| e.with_message("couldnt_find_community"))?;
   if community.deleted || community.removed {
-    Err(LemmyError::from_message("deleted".into()))
+    Err(LemmyError::from_message("deleted"))
   } else {
     Ok(())
   }
@@ -223,7 +223,7 @@ pub async fn check_community_deleted_or_removed(
 
 pub fn check_post_deleted_or_removed(post: &Post) -> Result<(), LemmyError> {
   if post.deleted || post.removed {
-    Err(LemmyError::from_message("deleted".into()))
+    Err(LemmyError::from_message("deleted"))
   } else {
     Ok(())
   }
@@ -236,7 +236,7 @@ pub async fn check_person_block(
 ) -> Result<(), LemmyError> {
   let is_blocked = move |conn: &'_ _| PersonBlock::read(conn, potential_blocker_id, my_id).is_ok();
   if blocking(pool, is_blocked).await? {
-    Err(LemmyError::from_message("person_block".into()))
+    Err(LemmyError::from_message("person_block"))
   } else {
     Ok(())
   }
@@ -246,7 +246,7 @@ pub async fn check_downvotes_enabled(score: i16, pool: &DbPool) -> Result<(), Le
   if score == -1 {
     let site = blocking(pool, Site::read_simple).await??;
     if !site.enable_downvotes {
-      return Err(LemmyError::from_message("downvotes_disabled".into()));
+      return Err(LemmyError::from_message("downvotes_disabled"));
     }
   }
   Ok(())
@@ -297,7 +297,7 @@ pub async fn build_federated_instances(
 /// Checks the password length
 pub fn password_length_check(pass: &str) -> Result<(), LemmyError> {
   if !(10..=60).contains(&pass.len()) {
-    Err(LemmyError::from_message("invalid_password".into()))
+    Err(LemmyError::from_message("invalid_password"))
   } else {
     Ok(())
   }
@@ -306,9 +306,7 @@ pub fn password_length_check(pass: &str) -> Result<(), LemmyError> {
 /// Checks the site description length
 pub fn site_description_length_check(description: &str) -> Result<(), LemmyError> {
   if description.len() > 150 {
-    Err(LemmyError::from_message(
-      "site_description_length_overflow".into(),
-    ))
+    Err(LemmyError::from_message("site_description_length_overflow"))
   } else {
     Ok(())
   }
@@ -317,7 +315,7 @@ pub fn site_description_length_check(description: &str) -> Result<(), LemmyError
 /// Checks for a honeypot. If this field is filled, fail the rest of the function
 pub fn honeypot_check(honeypot: &Option<String>) -> Result<(), LemmyError> {
   if honeypot.is_some() {
-    Err(LemmyError::from_message("honeypot_fail".into()))
+    Err(LemmyError::from_message("honeypot_fail"))
   } else {
     Ok(())
   }

--- a/crates/api_common/src/lib.rs
+++ b/crates/api_common/src/lib.rs
@@ -145,7 +145,7 @@ pub fn check_validator_time(
 }
 
 pub async fn get_local_user_view_from_jwt_opt(
-  jwt: Option<&Sensitive>,
+  jwt: Option<&Sensitive<String>>,
   pool: &DbPool,
   secret: &Secret,
 ) -> Result<Option<LocalUserView>, LemmyError> {
@@ -156,7 +156,7 @@ pub async fn get_local_user_view_from_jwt_opt(
 }
 
 pub async fn get_local_user_settings_view_from_jwt(
-  jwt: &Sensitive,
+  jwt: &Sensitive<String>,
   pool: &DbPool,
   secret: &Secret,
 ) -> Result<LocalUserSettingsView, LemmyError> {
@@ -180,7 +180,7 @@ pub async fn get_local_user_settings_view_from_jwt(
 }
 
 pub async fn get_local_user_settings_view_from_jwt_opt(
-  jwt: Option<&Sensitive>,
+  jwt: Option<&Sensitive<String>>,
   pool: &DbPool,
   secret: &Secret,
 ) -> Result<Option<LocalUserSettingsView>, LemmyError> {

--- a/crates/api_common/src/lib.rs
+++ b/crates/api_common/src/lib.rs
@@ -32,9 +32,12 @@ where
   T: Send + 'static,
 {
   let pool = pool.clone();
+  let blocking_span = tracing::info_span!("blocking operation");
   let res = actix_web::web::block(move || {
+    let entered = blocking_span.enter();
     let conn = pool.get()?;
     let res = (f)(&conn);
+    drop(entered);
     Ok(res) as Result<T, LemmyError>
   })
   .await?;

--- a/crates/api_common/src/lib.rs
+++ b/crates/api_common/src/lib.rs
@@ -23,7 +23,7 @@ use lemmy_db_views_actor::{
   community_person_ban_view::CommunityPersonBanView,
   community_view::CommunityView,
 };
-use lemmy_utils::{claims::Claims, settings::structs::FederationConfig, LemmyError};
+use lemmy_utils::{claims::Claims, settings::structs::FederationConfig, LemmyError, Sensitive};
 use url::Url;
 
 pub async fn blocking<F, T>(pool: &DbPool, f: F) -> Result<T, LemmyError>
@@ -145,7 +145,7 @@ pub fn check_validator_time(
 }
 
 pub async fn get_local_user_view_from_jwt_opt(
-  jwt: &Option<String>,
+  jwt: Option<&Sensitive>,
   pool: &DbPool,
   secret: &Secret,
 ) -> Result<Option<LocalUserView>, LemmyError> {
@@ -156,11 +156,11 @@ pub async fn get_local_user_view_from_jwt_opt(
 }
 
 pub async fn get_local_user_settings_view_from_jwt(
-  jwt: &str,
+  jwt: &Sensitive,
   pool: &DbPool,
   secret: &Secret,
 ) -> Result<LocalUserSettingsView, LemmyError> {
-  let claims = Claims::decode(jwt, &secret.jwt_secret)
+  let claims = Claims::decode(jwt.as_ref(), &secret.jwt_secret)
     .map_err(LemmyError::from)
     .map_err(|e| e.with_message("not_logged_in"))?
     .claims;
@@ -180,7 +180,7 @@ pub async fn get_local_user_settings_view_from_jwt(
 }
 
 pub async fn get_local_user_settings_view_from_jwt_opt(
-  jwt: &Option<String>,
+  jwt: Option<&Sensitive>,
   pool: &DbPool,
   secret: &Secret,
 ) -> Result<Option<LocalUserSettingsView>, LemmyError> {

--- a/crates/api_common/src/person.rs
+++ b/crates/api_common/src/person.rs
@@ -10,7 +10,7 @@ use lemmy_db_views_actor::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize)]
 pub struct Login {
   pub username_or_email: String,
   pub password: String,

--- a/crates/api_common/src/person.rs
+++ b/crates/api_common/src/person.rs
@@ -29,22 +29,22 @@ pub struct Register {
   pub honeypot: Option<String>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetCaptcha {}
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetCaptchaResponse {
   pub ok: Option<CaptchaResponse>, // Will be None if captchas are disabled
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct CaptchaResponse {
   pub png: String, // A Base64 encoded png
   pub wav: String, // A Base64 encoded wav audio
   pub uuid: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct SaveUserSettings {
   pub show_nsfw: Option<bool>,
   pub show_scores: Option<bool>,
@@ -75,12 +75,12 @@ pub struct ChangePassword {
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct LoginResponse {
   pub jwt: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetPersonDetails {
   pub person_id: Option<PersonId>, // One of these two are required
   /// Example: dessalines , or dessalines@xyz.tld
@@ -93,7 +93,7 @@ pub struct GetPersonDetails {
   pub auth: Option<String>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetPersonDetailsResponse {
   pub person_view: PersonViewSafe,
   pub comments: Vec<CommentView>,
@@ -101,34 +101,34 @@ pub struct GetPersonDetailsResponse {
   pub moderates: Vec<CommunityModeratorView>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetRepliesResponse {
   pub replies: Vec<CommentView>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetPersonMentionsResponse {
   pub mentions: Vec<PersonMentionView>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct MarkAllAsRead {
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct AddAdmin {
   pub person_id: PersonId,
   pub added: bool,
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct AddAdminResponse {
   pub admins: Vec<PersonViewSafe>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct BanPerson {
   pub person_id: PersonId,
   pub ban: bool,
@@ -138,26 +138,26 @@ pub struct BanPerson {
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct BanPersonResponse {
   pub person_view: PersonViewSafe,
   pub banned: bool,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct BlockPerson {
   pub person_id: PersonId,
   pub block: bool,
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct BlockPersonResponse {
   pub person_view: PersonViewSafe,
   pub blocked: bool,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetReplies {
   pub sort: Option<String>,
   pub page: Option<i64>,
@@ -166,7 +166,7 @@ pub struct GetReplies {
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetPersonMentions {
   pub sort: Option<String>,
   pub page: Option<i64>,
@@ -175,14 +175,14 @@ pub struct GetPersonMentions {
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct MarkPersonMentionAsRead {
   pub person_mention_id: PersonMentionId,
   pub read: bool,
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PersonMentionResponse {
   pub person_mention_view: PersonMentionView,
 }
@@ -198,7 +198,7 @@ pub struct PasswordReset {
   pub email: String,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PasswordResetResponse {}
 
 #[derive(Serialize, Deserialize)]
@@ -208,35 +208,35 @@ pub struct PasswordChange {
   pub password_verify: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct CreatePrivateMessage {
   pub content: String,
   pub recipient_id: PersonId,
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct EditPrivateMessage {
   pub private_message_id: PrivateMessageId,
   pub content: String,
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct DeletePrivateMessage {
   pub private_message_id: PrivateMessageId,
   pub deleted: bool,
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct MarkPrivateMessageAsRead {
   pub private_message_id: PrivateMessageId,
   pub read: bool,
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetPrivateMessages {
   pub unread_only: Option<bool>,
   pub page: Option<i64>,
@@ -244,35 +244,35 @@ pub struct GetPrivateMessages {
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PrivateMessagesResponse {
   pub private_messages: Vec<PrivateMessageView>,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PrivateMessageResponse {
   pub private_message_view: PrivateMessageView,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetReportCount {
   pub community_id: Option<CommunityId>,
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct GetReportCountResponse {
   pub community_id: Option<CommunityId>,
   pub comment_reports: i64,
   pub post_reports: i64,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetUnreadCount {
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct GetUnreadCountResponse {
   pub replies: i64,
   pub mentions: i64,

--- a/crates/api_common/src/person.rs
+++ b/crates/api_common/src/person.rs
@@ -11,7 +11,7 @@ use lemmy_db_views_actor::{
 use lemmy_utils::Sensitive;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Login {
   pub username_or_email: Sensitive,
   pub password: Sensitive,

--- a/crates/api_common/src/person.rs
+++ b/crates/api_common/src/person.rs
@@ -13,18 +13,18 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Login {
-  pub username_or_email: Sensitive,
-  pub password: Sensitive,
+  pub username_or_email: Sensitive<String>,
+  pub password: Sensitive<String>,
 }
 use lemmy_db_schema::newtypes::{CommunityId, PersonId, PersonMentionId, PrivateMessageId};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Register {
   pub username: String,
-  pub password: Sensitive,
-  pub password_verify: Sensitive,
+  pub password: Sensitive<String>,
+  pub password_verify: Sensitive<String>,
   pub show_nsfw: bool,
-  pub email: Option<Sensitive>,
+  pub email: Option<Sensitive<String>>,
   pub captcha_uuid: Option<String>,
   pub captcha_answer: Option<String>,
   pub honeypot: Option<String>,
@@ -56,7 +56,7 @@ pub struct SaveUserSettings {
   pub avatar: Option<String>,
   pub banner: Option<String>,
   pub display_name: Option<String>,
-  pub email: Option<Sensitive>,
+  pub email: Option<Sensitive<String>>,
   pub bio: Option<String>,
   pub matrix_user_id: Option<String>,
   pub show_avatars: Option<bool>,
@@ -65,20 +65,20 @@ pub struct SaveUserSettings {
   pub show_bot_accounts: Option<bool>,
   pub show_read_posts: Option<bool>,
   pub show_new_post_notifs: Option<bool>,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ChangePassword {
-  pub new_password: Sensitive,
-  pub new_password_verify: Sensitive,
-  pub old_password: Sensitive,
-  pub auth: Sensitive,
+  pub new_password: Sensitive<String>,
+  pub new_password_verify: Sensitive<String>,
+  pub old_password: Sensitive<String>,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LoginResponse {
-  pub jwt: Sensitive,
+  pub jwt: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -91,7 +91,7 @@ pub struct GetPersonDetails {
   pub limit: Option<i64>,
   pub community_id: Option<CommunityId>,
   pub saved_only: Option<bool>,
-  pub auth: Option<Sensitive>,
+  pub auth: Option<Sensitive<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -114,14 +114,14 @@ pub struct GetPersonMentionsResponse {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MarkAllAsRead {
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AddAdmin {
   pub person_id: PersonId,
   pub added: bool,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -136,7 +136,7 @@ pub struct BanPerson {
   pub remove_data: Option<bool>,
   pub reason: Option<String>,
   pub expires: Option<i64>,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -149,7 +149,7 @@ pub struct BanPersonResponse {
 pub struct BlockPerson {
   pub person_id: PersonId,
   pub block: bool,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -164,7 +164,7 @@ pub struct GetReplies {
   pub page: Option<i64>,
   pub limit: Option<i64>,
   pub unread_only: Option<bool>,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -173,14 +173,14 @@ pub struct GetPersonMentions {
   pub page: Option<i64>,
   pub limit: Option<i64>,
   pub unread_only: Option<bool>,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MarkPersonMentionAsRead {
   pub person_mention_id: PersonMentionId,
   pub read: bool,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -190,13 +190,13 @@ pub struct PersonMentionResponse {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DeleteAccount {
-  pub password: Sensitive,
-  pub auth: Sensitive,
+  pub password: Sensitive<String>,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PasswordReset {
-  pub email: Sensitive,
+  pub email: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -204,37 +204,37 @@ pub struct PasswordResetResponse {}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PasswordChange {
-  pub token: Sensitive,
-  pub password: Sensitive,
-  pub password_verify: Sensitive,
+  pub token: Sensitive<String>,
+  pub password: Sensitive<String>,
+  pub password_verify: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CreatePrivateMessage {
   pub content: String,
   pub recipient_id: PersonId,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EditPrivateMessage {
   pub private_message_id: PrivateMessageId,
   pub content: String,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DeletePrivateMessage {
   pub private_message_id: PrivateMessageId,
   pub deleted: bool,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MarkPrivateMessageAsRead {
   pub private_message_id: PrivateMessageId,
   pub read: bool,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -242,7 +242,7 @@ pub struct GetPrivateMessages {
   pub unread_only: Option<bool>,
   pub page: Option<i64>,
   pub limit: Option<i64>,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -258,7 +258,7 @@ pub struct PrivateMessageResponse {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetReportCount {
   pub community_id: Option<CommunityId>,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -270,7 +270,7 @@ pub struct GetReportCountResponse {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetUnreadCount {
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/crates/api_common/src/person.rs
+++ b/crates/api_common/src/person.rs
@@ -8,22 +8,23 @@ use lemmy_db_views_actor::{
   person_mention_view::PersonMentionView,
   person_view::PersonViewSafe,
 };
+use lemmy_utils::Sensitive;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
 pub struct Login {
-  pub username_or_email: String,
-  pub password: String,
+  pub username_or_email: Sensitive,
+  pub password: Sensitive,
 }
 use lemmy_db_schema::newtypes::{CommunityId, PersonId, PersonMentionId, PrivateMessageId};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Register {
   pub username: String,
-  pub password: String,
-  pub password_verify: String,
+  pub password: Sensitive,
+  pub password_verify: Sensitive,
   pub show_nsfw: bool,
-  pub email: Option<String>,
+  pub email: Option<Sensitive>,
   pub captcha_uuid: Option<String>,
   pub captcha_answer: Option<String>,
   pub honeypot: Option<String>,
@@ -55,7 +56,7 @@ pub struct SaveUserSettings {
   pub avatar: Option<String>,
   pub banner: Option<String>,
   pub display_name: Option<String>,
-  pub email: Option<String>,
+  pub email: Option<Sensitive>,
   pub bio: Option<String>,
   pub matrix_user_id: Option<String>,
   pub show_avatars: Option<bool>,
@@ -64,20 +65,20 @@ pub struct SaveUserSettings {
   pub show_bot_accounts: Option<bool>,
   pub show_read_posts: Option<bool>,
   pub show_new_post_notifs: Option<bool>,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ChangePassword {
-  pub new_password: String,
-  pub new_password_verify: String,
-  pub old_password: String,
-  pub auth: String,
+  pub new_password: Sensitive,
+  pub new_password_verify: Sensitive,
+  pub old_password: Sensitive,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LoginResponse {
-  pub jwt: String,
+  pub jwt: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -90,7 +91,7 @@ pub struct GetPersonDetails {
   pub limit: Option<i64>,
   pub community_id: Option<CommunityId>,
   pub saved_only: Option<bool>,
-  pub auth: Option<String>,
+  pub auth: Option<Sensitive>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -113,14 +114,14 @@ pub struct GetPersonMentionsResponse {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MarkAllAsRead {
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AddAdmin {
   pub person_id: PersonId,
   pub added: bool,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -135,7 +136,7 @@ pub struct BanPerson {
   pub remove_data: Option<bool>,
   pub reason: Option<String>,
   pub expires: Option<i64>,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -148,7 +149,7 @@ pub struct BanPersonResponse {
 pub struct BlockPerson {
   pub person_id: PersonId,
   pub block: bool,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -163,7 +164,7 @@ pub struct GetReplies {
   pub page: Option<i64>,
   pub limit: Option<i64>,
   pub unread_only: Option<bool>,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -172,14 +173,14 @@ pub struct GetPersonMentions {
   pub page: Option<i64>,
   pub limit: Option<i64>,
   pub unread_only: Option<bool>,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MarkPersonMentionAsRead {
   pub person_mention_id: PersonMentionId,
   pub read: bool,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -187,53 +188,53 @@ pub struct PersonMentionResponse {
   pub person_mention_view: PersonMentionView,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct DeleteAccount {
-  pub password: String,
-  pub auth: String,
+  pub password: Sensitive,
+  pub auth: Sensitive,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct PasswordReset {
-  pub email: String,
+  pub email: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PasswordResetResponse {}
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct PasswordChange {
-  pub token: String,
-  pub password: String,
-  pub password_verify: String,
+  pub token: Sensitive,
+  pub password: Sensitive,
+  pub password_verify: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CreatePrivateMessage {
   pub content: String,
   pub recipient_id: PersonId,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EditPrivateMessage {
   pub private_message_id: PrivateMessageId,
   pub content: String,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DeletePrivateMessage {
   pub private_message_id: PrivateMessageId,
   pub deleted: bool,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MarkPrivateMessageAsRead {
   pub private_message_id: PrivateMessageId,
   pub read: bool,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -241,7 +242,7 @@ pub struct GetPrivateMessages {
   pub unread_only: Option<bool>,
   pub page: Option<i64>,
   pub limit: Option<i64>,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -257,7 +258,7 @@ pub struct PrivateMessageResponse {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetReportCount {
   pub community_id: Option<CommunityId>,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -269,7 +270,7 @@ pub struct GetReportCountResponse {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetUnreadCount {
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/crates/api_common/src/post.rs
+++ b/crates/api_common/src/post.rs
@@ -8,7 +8,7 @@ use lemmy_db_views_actor::{
   community_moderator_view::CommunityModeratorView,
   community_view::CommunityView,
 };
-use lemmy_utils::request::SiteMetadata;
+use lemmy_utils::{request::SiteMetadata, Sensitive};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -20,7 +20,7 @@ pub struct CreatePost {
   pub body: Option<String>,
   pub honeypot: Option<String>,
   pub nsfw: Option<bool>,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -31,7 +31,7 @@ pub struct PostResponse {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetPost {
   pub id: PostId,
-  pub auth: Option<String>,
+  pub auth: Option<Sensitive>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -52,7 +52,7 @@ pub struct GetPosts {
   pub community_id: Option<CommunityId>,
   pub community_name: Option<String>,
   pub saved_only: Option<bool>,
-  pub auth: Option<String>,
+  pub auth: Option<Sensitive>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -64,7 +64,7 @@ pub struct GetPostsResponse {
 pub struct CreatePostLike {
   pub post_id: PostId,
   pub score: i16,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -74,14 +74,14 @@ pub struct EditPost {
   pub url: Option<Url>,
   pub body: Option<String>,
   pub nsfw: Option<bool>,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DeletePost {
   pub post_id: PostId,
   pub deleted: bool,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -89,42 +89,42 @@ pub struct RemovePost {
   pub post_id: PostId,
   pub removed: bool,
   pub reason: Option<String>,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MarkPostAsRead {
   pub post_id: PostId,
   pub read: bool,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LockPost {
   pub post_id: PostId,
   pub locked: bool,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct StickyPost {
   pub post_id: PostId,
   pub stickied: bool,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SavePost {
   pub post_id: PostId,
   pub save: bool,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CreatePostReport {
   pub post_id: PostId,
   pub reason: String,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -136,7 +136,7 @@ pub struct PostReportResponse {
 pub struct ResolvePostReport {
   pub report_id: PostReportId,
   pub resolved: bool,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -147,7 +147,7 @@ pub struct ListPostReports {
   pub unresolved_only: Option<bool>,
   /// if no community is given, it returns reports for all communities moderated by the auth user
   pub community_id: Option<CommunityId>,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/api_common/src/post.rs
+++ b/crates/api_common/src/post.rs
@@ -20,7 +20,7 @@ pub struct CreatePost {
   pub body: Option<String>,
   pub honeypot: Option<String>,
   pub nsfw: Option<bool>,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -31,7 +31,7 @@ pub struct PostResponse {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetPost {
   pub id: PostId,
-  pub auth: Option<Sensitive>,
+  pub auth: Option<Sensitive<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -52,7 +52,7 @@ pub struct GetPosts {
   pub community_id: Option<CommunityId>,
   pub community_name: Option<String>,
   pub saved_only: Option<bool>,
-  pub auth: Option<Sensitive>,
+  pub auth: Option<Sensitive<String>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -64,7 +64,7 @@ pub struct GetPostsResponse {
 pub struct CreatePostLike {
   pub post_id: PostId,
   pub score: i16,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -74,14 +74,14 @@ pub struct EditPost {
   pub url: Option<Url>,
   pub body: Option<String>,
   pub nsfw: Option<bool>,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DeletePost {
   pub post_id: PostId,
   pub deleted: bool,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -89,42 +89,42 @@ pub struct RemovePost {
   pub post_id: PostId,
   pub removed: bool,
   pub reason: Option<String>,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MarkPostAsRead {
   pub post_id: PostId,
   pub read: bool,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LockPost {
   pub post_id: PostId,
   pub locked: bool,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct StickyPost {
   pub post_id: PostId,
   pub stickied: bool,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SavePost {
   pub post_id: PostId,
   pub save: bool,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CreatePostReport {
   pub post_id: PostId,
   pub reason: String,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -136,7 +136,7 @@ pub struct PostReportResponse {
 pub struct ResolvePostReport {
   pub report_id: PostReportId,
   pub resolved: bool,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -147,7 +147,7 @@ pub struct ListPostReports {
   pub unresolved_only: Option<bool>,
   /// if no community is given, it returns reports for all communities moderated by the auth user
   pub community_id: Option<CommunityId>,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/api_common/src/post.rs
+++ b/crates/api_common/src/post.rs
@@ -23,18 +23,18 @@ pub struct CreatePost {
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PostResponse {
   pub post_view: PostView,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetPost {
   pub id: PostId,
   pub auth: Option<String>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetPostResponse {
   pub post_view: PostView,
   pub community_view: CommunityView,
@@ -60,14 +60,14 @@ pub struct GetPostsResponse {
   pub posts: Vec<PostView>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct CreatePostLike {
   pub post_id: PostId,
   pub score: i16,
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct EditPost {
   pub post_id: PostId,
   pub name: Option<String>,
@@ -77,14 +77,14 @@ pub struct EditPost {
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct DeletePost {
   pub post_id: PostId,
   pub deleted: bool,
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct RemovePost {
   pub post_id: PostId,
   pub removed: bool,
@@ -92,54 +92,54 @@ pub struct RemovePost {
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct MarkPostAsRead {
   pub post_id: PostId,
   pub read: bool,
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct LockPost {
   pub post_id: PostId,
   pub locked: bool,
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct StickyPost {
   pub post_id: PostId,
   pub stickied: bool,
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct SavePost {
   pub post_id: PostId,
   pub save: bool,
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct CreatePostReport {
   pub post_id: PostId,
   pub reason: String,
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PostReportResponse {
   pub post_report_view: PostReportView,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ResolvePostReport {
   pub report_id: PostReportId,
   pub resolved: bool,
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ListPostReports {
   pub page: Option<i64>,
   pub limit: Option<i64>,
@@ -150,7 +150,7 @@ pub struct ListPostReports {
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ListPostReportsResponse {
   pub post_reports: Vec<PostReportView>,
 }

--- a/crates/api_common/src/site.rs
+++ b/crates/api_common/src/site.rs
@@ -56,7 +56,7 @@ pub struct ResolveObject {
   pub auth: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 pub struct ResolveObjectResponse {
   pub comment: Option<CommentView>,
   pub post: Option<PostView>,
@@ -64,7 +64,7 @@ pub struct ResolveObjectResponse {
   pub person: Option<PersonViewSafe>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetModlog {
   pub mod_person_id: Option<PersonId>,
   pub community_id: Option<CommunityId>,
@@ -72,7 +72,7 @@ pub struct GetModlog {
   pub limit: Option<i64>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetModlogResponse {
   pub removed_posts: Vec<ModRemovePostView>,
   pub locked_posts: Vec<ModLockPostView>,
@@ -86,7 +86,7 @@ pub struct GetModlogResponse {
   pub added: Vec<ModAddView>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct CreateSite {
   pub name: String,
   pub sidebar: Option<String>,
@@ -100,7 +100,7 @@ pub struct CreateSite {
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct EditSite {
   pub name: Option<String>,
   pub sidebar: Option<String>,
@@ -114,17 +114,17 @@ pub struct EditSite {
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetSite {
   pub auth: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SiteResponse {
   pub site_view: SiteView,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetSiteResponse {
   pub site_view: Option<SiteView>, // Because the site might not be set up yet
   pub admins: Vec<PersonViewSafe>,
@@ -135,7 +135,7 @@ pub struct GetSiteResponse {
   pub federated_instances: Option<FederatedInstances>, // Federation may be disabled
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct MyUserInfo {
   pub local_user_view: LocalUserSettingsView,
   pub follows: Vec<CommunityFollowerView>,
@@ -144,29 +144,29 @@ pub struct MyUserInfo {
   pub person_blocks: Vec<PersonBlockView>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct TransferSite {
   pub person_id: PersonId,
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetSiteConfig {
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetSiteConfigResponse {
   pub config_hjson: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct SaveSiteConfig {
   pub config_hjson: String,
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct FederatedInstances {
   pub linked: Vec<String>,
   pub allowed: Option<Vec<String>>,

--- a/crates/api_common/src/site.rs
+++ b/crates/api_common/src/site.rs
@@ -39,7 +39,7 @@ pub struct Search {
   pub listing_type: Option<String>,
   pub page: Option<i64>,
   pub limit: Option<i64>,
-  pub auth: Option<Sensitive>,
+  pub auth: Option<Sensitive<String>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -54,7 +54,7 @@ pub struct SearchResponse {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ResolveObject {
   pub q: String,
-  pub auth: Option<Sensitive>,
+  pub auth: Option<Sensitive<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -98,7 +98,7 @@ pub struct CreateSite {
   pub open_registration: Option<bool>,
   pub enable_nsfw: Option<bool>,
   pub community_creation_admin_only: Option<bool>,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -112,12 +112,12 @@ pub struct EditSite {
   pub open_registration: Option<bool>,
   pub enable_nsfw: Option<bool>,
   pub community_creation_admin_only: Option<bool>,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetSite {
-  pub auth: Option<Sensitive>,
+  pub auth: Option<Sensitive<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -148,12 +148,12 @@ pub struct MyUserInfo {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TransferSite {
   pub person_id: PersonId,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetSiteConfig {
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -164,7 +164,7 @@ pub struct GetSiteConfigResponse {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SaveSiteConfig {
   pub config_hjson: String,
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/api_common/src/site.rs
+++ b/crates/api_common/src/site.rs
@@ -25,6 +25,7 @@ use lemmy_db_views_moderator::{
   mod_sticky_post_view::ModStickyPostView,
   mod_transfer_community_view::ModTransferCommunityView,
 };
+use lemmy_utils::Sensitive;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -38,7 +39,7 @@ pub struct Search {
   pub listing_type: Option<String>,
   pub page: Option<i64>,
   pub limit: Option<i64>,
-  pub auth: Option<String>,
+  pub auth: Option<Sensitive>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -53,7 +54,7 @@ pub struct SearchResponse {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ResolveObject {
   pub q: String,
-  pub auth: Option<String>,
+  pub auth: Option<Sensitive>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -97,7 +98,7 @@ pub struct CreateSite {
   pub open_registration: Option<bool>,
   pub enable_nsfw: Option<bool>,
   pub community_creation_admin_only: Option<bool>,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -111,12 +112,12 @@ pub struct EditSite {
   pub open_registration: Option<bool>,
   pub enable_nsfw: Option<bool>,
   pub community_creation_admin_only: Option<bool>,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetSite {
-  pub auth: Option<String>,
+  pub auth: Option<Sensitive>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -147,12 +148,12 @@ pub struct MyUserInfo {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TransferSite {
   pub person_id: PersonId,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetSiteConfig {
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -163,7 +164,7 @@ pub struct GetSiteConfigResponse {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SaveSiteConfig {
   pub config_hjson: String,
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/api_common/src/websocket.rs
+++ b/crates/api_common/src/websocket.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct UserJoin {
-  pub auth: Sensitive,
+  pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/crates/api_common/src/websocket.rs
+++ b/crates/api_common/src/websocket.rs
@@ -1,9 +1,10 @@
 use lemmy_db_schema::newtypes::{CommunityId, PostId};
+use lemmy_utils::Sensitive;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct UserJoin {
-  pub auth: String,
+  pub auth: Sensitive,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/crates/api_common/src/websocket.rs
+++ b/crates/api_common/src/websocket.rs
@@ -6,7 +6,7 @@ pub struct UserJoin {
   pub auth: String,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct UserJoinResponse {
   pub joined: bool,
 }
@@ -16,7 +16,7 @@ pub struct CommunityJoin {
   pub community_id: CommunityId,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CommunityJoinResponse {
   pub joined: bool,
 }
@@ -26,7 +26,7 @@ pub struct ModJoin {
   pub community_id: CommunityId,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ModJoinResponse {
   pub joined: bool,
 }
@@ -36,7 +36,7 @@ pub struct PostJoin {
   pub post_id: PostId,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PostJoinResponse {
   pub joined: bool,
 }

--- a/crates/api_crud/src/comment/create.rs
+++ b/crates/api_crud/src/comment/create.rs
@@ -44,7 +44,7 @@ use lemmy_websocket::{
 impl PerformCrud for CreateComment {
   type Response = CommentResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api_crud/src/comment/create.rs
+++ b/crates/api_crud/src/comment/create.rs
@@ -31,7 +31,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::comment_view::CommentView;
 use lemmy_utils::{
   utils::{remove_slurs, scrape_text_for_mentions},
-  ApiError,
   ConnectionId,
   LemmyError,
 };
@@ -45,6 +44,7 @@ use lemmy_websocket::{
 impl PerformCrud for CreateComment {
   type Response = CommentResponse;
 
+  #[tracing::instrument(skip(self, context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -70,7 +70,7 @@ impl PerformCrud for CreateComment {
 
     // Check if post is locked, no new comments
     if post.locked {
-      return Err(ApiError::err_plain("locked").into());
+      return Err(LemmyError::from_message("locked".into()));
     }
 
     // If there's a parent_id, check to make sure that comment is in that post
@@ -78,13 +78,14 @@ impl PerformCrud for CreateComment {
       // Make sure the parent comment exists
       let parent = blocking(context.pool(), move |conn| Comment::read(conn, parent_id))
         .await?
-        .map_err(|e| ApiError::err("couldnt_create_comment", e))?;
+        .map_err(LemmyError::from)
+        .map_err(|e| e.with_message("couldnt_create_comment".into()))?;
 
       check_person_block(local_user_view.person.id, parent.creator_id, context.pool()).await?;
 
       // Strange issue where sometimes the post ID is incorrect
       if parent.post_id != post_id {
-        return Err(ApiError::err_plain("couldnt_create_comment").into());
+        return Err(LemmyError::from_message("couldnt_create_comment".into()));
       }
     }
 
@@ -102,7 +103,8 @@ impl PerformCrud for CreateComment {
       Comment::create(conn, &comment_form2)
     })
     .await?
-    .map_err(|e| ApiError::err("couldnt_create_comment", e))?;
+    .map_err(LemmyError::from)
+    .map_err(|e| e.with_message("couldnt_create_comment".into()))?;
 
     // Necessary to update the ap_id
     let inserted_comment_id = inserted_comment.id;
@@ -118,7 +120,8 @@ impl PerformCrud for CreateComment {
         Ok(Comment::update_ap_id(conn, inserted_comment_id, apub_id)?)
       })
       .await?
-      .map_err(|e| ApiError::err("couldnt_create_comment", e))?;
+      .map_err(LemmyError::from)
+      .map_err(|e| e.with_message("couldnt_create_comment".into()))?;
 
     // Scan the comment for user mentions, add those rows
     let post_id = post.id;
@@ -144,7 +147,8 @@ impl PerformCrud for CreateComment {
     let like = move |conn: &'_ _| CommentLike::like(conn, &like_form);
     blocking(context.pool(), like)
       .await?
-      .map_err(|e| ApiError::err("couldnt_like_comment", e))?;
+      .map_err(LemmyError::from)
+      .map_err(|e| e.with_message("couldnt_like_comment".into()))?;
 
     let apub_comment: ApubComment = updated_comment.into();
     CreateOrUpdateComment::send(
@@ -179,7 +183,8 @@ impl PerformCrud for CreateComment {
         Comment::update_read(conn, comment_id, true)
       })
       .await?
-      .map_err(|e| ApiError::err("couldnt_update_comment", e))?;
+      .map_err(LemmyError::from)
+      .map_err(|e| e.with_message("couldnt_update_comment".into()))?;
     }
     // If its a reply, mark the parent as read
     if let Some(parent_id) = data.parent_id {
@@ -192,7 +197,8 @@ impl PerformCrud for CreateComment {
           Comment::update_read(conn, parent_id, true)
         })
         .await?
-        .map_err(|e| ApiError::err("couldnt_update_parent_comment", e))?;
+        .map_err(LemmyError::from)
+        .map_err(|e| e.with_message("couldnt_update_parent_comment".into()))?;
       }
       // If the parent has PersonMentions mark them as read too
       let person_id = local_user_view.person.id;
@@ -205,7 +211,8 @@ impl PerformCrud for CreateComment {
           PersonMention::update_read(conn, mention.id, true)
         })
         .await?
-        .map_err(|e| ApiError::err("couldnt_update_person_mentions", e))?;
+        .map_err(LemmyError::from)
+        .map_err(|e| e.with_message("couldnt_update_person_mentions".into()))?;
       }
     }
 

--- a/crates/api_crud/src/comment/create.rs
+++ b/crates/api_crud/src/comment/create.rs
@@ -70,7 +70,7 @@ impl PerformCrud for CreateComment {
 
     // Check if post is locked, no new comments
     if post.locked {
-      return Err(LemmyError::from_message("locked".into()));
+      return Err(LemmyError::from_message("locked"));
     }
 
     // If there's a parent_id, check to make sure that comment is in that post
@@ -79,13 +79,13 @@ impl PerformCrud for CreateComment {
       let parent = blocking(context.pool(), move |conn| Comment::read(conn, parent_id))
         .await?
         .map_err(LemmyError::from)
-        .map_err(|e| e.with_message("couldnt_create_comment".into()))?;
+        .map_err(|e| e.with_message("couldnt_create_comment"))?;
 
       check_person_block(local_user_view.person.id, parent.creator_id, context.pool()).await?;
 
       // Strange issue where sometimes the post ID is incorrect
       if parent.post_id != post_id {
-        return Err(LemmyError::from_message("couldnt_create_comment".into()));
+        return Err(LemmyError::from_message("couldnt_create_comment"));
       }
     }
 
@@ -104,7 +104,7 @@ impl PerformCrud for CreateComment {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_create_comment".into()))?;
+    .map_err(|e| e.with_message("couldnt_create_comment"))?;
 
     // Necessary to update the ap_id
     let inserted_comment_id = inserted_comment.id;
@@ -121,7 +121,7 @@ impl PerformCrud for CreateComment {
       })
       .await?
       .map_err(LemmyError::from)
-      .map_err(|e| e.with_message("couldnt_create_comment".into()))?;
+      .map_err(|e| e.with_message("couldnt_create_comment"))?;
 
     // Scan the comment for user mentions, add those rows
     let post_id = post.id;
@@ -148,7 +148,7 @@ impl PerformCrud for CreateComment {
     blocking(context.pool(), like)
       .await?
       .map_err(LemmyError::from)
-      .map_err(|e| e.with_message("couldnt_like_comment".into()))?;
+      .map_err(|e| e.with_message("couldnt_like_comment"))?;
 
     let apub_comment: ApubComment = updated_comment.into();
     CreateOrUpdateComment::send(
@@ -184,7 +184,7 @@ impl PerformCrud for CreateComment {
       })
       .await?
       .map_err(LemmyError::from)
-      .map_err(|e| e.with_message("couldnt_update_comment".into()))?;
+      .map_err(|e| e.with_message("couldnt_update_comment"))?;
     }
     // If its a reply, mark the parent as read
     if let Some(parent_id) = data.parent_id {
@@ -198,7 +198,7 @@ impl PerformCrud for CreateComment {
         })
         .await?
         .map_err(LemmyError::from)
-        .map_err(|e| e.with_message("couldnt_update_parent_comment".into()))?;
+        .map_err(|e| e.with_message("couldnt_update_parent_comment"))?;
       }
       // If the parent has PersonMentions mark them as read too
       let person_id = local_user_view.person.id;
@@ -212,7 +212,7 @@ impl PerformCrud for CreateComment {
         })
         .await?
         .map_err(LemmyError::from)
-        .map_err(|e| e.with_message("couldnt_update_person_mentions".into()))?;
+        .map_err(|e| e.with_message("couldnt_update_person_mentions"))?;
       }
     }
 

--- a/crates/api_crud/src/comment/delete.rs
+++ b/crates/api_crud/src/comment/delete.rs
@@ -29,7 +29,7 @@ use lemmy_websocket::{
 impl PerformCrud for DeleteComment {
   type Response = CommentResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -114,7 +114,7 @@ impl PerformCrud for DeleteComment {
 impl PerformCrud for RemoveComment {
   type Response = CommentResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api_crud/src/comment/delete.rs
+++ b/crates/api_crud/src/comment/delete.rs
@@ -18,7 +18,7 @@ use lemmy_db_schema::{
   traits::Crud,
 };
 use lemmy_db_views::comment_view::CommentView;
-use lemmy_utils::{ApiError, ConnectionId, LemmyError};
+use lemmy_utils::{ConnectionId, LemmyError};
 use lemmy_websocket::{
   send::{send_comment_ws_message, send_local_notifs},
   LemmyContext,
@@ -29,6 +29,7 @@ use lemmy_websocket::{
 impl PerformCrud for DeleteComment {
   type Response = CommentResponse;
 
+  #[tracing::instrument(skip(self, context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -46,7 +47,7 @@ impl PerformCrud for DeleteComment {
 
     // Dont delete it if its already been deleted.
     if orig_comment.comment.deleted == data.deleted {
-      return Err(ApiError::err_plain("couldnt_update_comment").into());
+      return Err(LemmyError::from_message("couldnt_update_comment".into()));
     }
 
     check_community_ban(
@@ -58,7 +59,7 @@ impl PerformCrud for DeleteComment {
 
     // Verify that only the creator can delete
     if local_user_view.person.id != orig_comment.creator.id {
-      return Err(ApiError::err_plain("no_comment_edit_allowed").into());
+      return Err(LemmyError::from_message("no_comment_edit_allowed".into()));
     }
 
     // Do the delete
@@ -67,7 +68,8 @@ impl PerformCrud for DeleteComment {
       Comment::update_deleted(conn, comment_id, deleted)
     })
     .await?
-    .map_err(|e| ApiError::err("couldnt_update_comment", e))?;
+    .map_err(LemmyError::from)
+    .map_err(|e| e.with_message("couldnt_update_comment".into()))?;
 
     let post_id = updated_comment.post_id;
     let post = blocking(context.pool(), move |conn| Post::read(conn, post_id)).await??;
@@ -112,6 +114,7 @@ impl PerformCrud for DeleteComment {
 impl PerformCrud for RemoveComment {
   type Response = CommentResponse;
 
+  #[tracing::instrument(skip(self, context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -148,7 +151,8 @@ impl PerformCrud for RemoveComment {
       Comment::update_removed(conn, comment_id, removed)
     })
     .await?
-    .map_err(|e| ApiError::err("couldnt_update_comment", e))?;
+    .map_err(LemmyError::from)
+    .map_err(|e| e.with_message("couldnt_update_comment".into()))?;
 
     // Mod tables
     let form = ModRemoveCommentForm {

--- a/crates/api_crud/src/comment/delete.rs
+++ b/crates/api_crud/src/comment/delete.rs
@@ -47,7 +47,7 @@ impl PerformCrud for DeleteComment {
 
     // Dont delete it if its already been deleted.
     if orig_comment.comment.deleted == data.deleted {
-      return Err(LemmyError::from_message("couldnt_update_comment".into()));
+      return Err(LemmyError::from_message("couldnt_update_comment"));
     }
 
     check_community_ban(
@@ -59,7 +59,7 @@ impl PerformCrud for DeleteComment {
 
     // Verify that only the creator can delete
     if local_user_view.person.id != orig_comment.creator.id {
-      return Err(LemmyError::from_message("no_comment_edit_allowed".into()));
+      return Err(LemmyError::from_message("no_comment_edit_allowed"));
     }
 
     // Do the delete
@@ -69,7 +69,7 @@ impl PerformCrud for DeleteComment {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_update_comment".into()))?;
+    .map_err(|e| e.with_message("couldnt_update_comment"))?;
 
     let post_id = updated_comment.post_id;
     let post = blocking(context.pool(), move |conn| Post::read(conn, post_id)).await??;
@@ -152,7 +152,7 @@ impl PerformCrud for RemoveComment {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_update_comment".into()))?;
+    .map_err(|e| e.with_message("couldnt_update_comment"))?;
 
     // Mod tables
     let form = ModRemoveCommentForm {

--- a/crates/api_crud/src/comment/read.rs
+++ b/crates/api_crud/src/comment/read.rs
@@ -28,7 +28,8 @@ impl PerformCrud for GetComment {
   ) -> Result<Self::Response, LemmyError> {
     let data = self;
     let local_user_view =
-      get_local_user_view_from_jwt_opt(&data.auth, context.pool(), context.secret()).await?;
+      get_local_user_view_from_jwt_opt(data.auth.as_ref(), context.pool(), context.secret())
+        .await?;
 
     let person_id = local_user_view.map(|u| u.person.id);
     let id = data.id;
@@ -59,7 +60,8 @@ impl PerformCrud for GetComments {
   ) -> Result<GetCommentsResponse, LemmyError> {
     let data: &GetComments = self;
     let local_user_view =
-      get_local_user_view_from_jwt_opt(&data.auth, context.pool(), context.secret()).await?;
+      get_local_user_view_from_jwt_opt(data.auth.as_ref(), context.pool(), context.secret())
+        .await?;
 
     let show_bot_accounts = local_user_view
       .as_ref()

--- a/crates/api_crud/src/comment/read.rs
+++ b/crates/api_crud/src/comment/read.rs
@@ -20,7 +20,7 @@ use lemmy_websocket::LemmyContext;
 impl PerformCrud for GetComment {
   type Response = CommentResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -51,7 +51,7 @@ impl PerformCrud for GetComment {
 impl PerformCrud for GetComments {
   type Response = GetCommentsResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api_crud/src/comment/read.rs
+++ b/crates/api_crud/src/comment/read.rs
@@ -37,7 +37,7 @@ impl PerformCrud for GetComment {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_find_comment".into()))?;
+    .map_err(|e| e.with_message("couldnt_find_comment"))?;
 
     Ok(Self::Response {
       comment_view,
@@ -95,7 +95,7 @@ impl PerformCrud for GetComments {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_get_comments".into()))?;
+    .map_err(|e| e.with_message("couldnt_get_comments"))?;
 
     // Blank out deleted or removed info
     for cv in comments

--- a/crates/api_crud/src/comment/update.rs
+++ b/crates/api_crud/src/comment/update.rs
@@ -59,7 +59,7 @@ impl PerformCrud for EditComment {
 
     // Verify that only the creator can edit
     if local_user_view.person.id != orig_comment.creator.id {
-      return Err(LemmyError::from_message("no_comment_edit_allowed".into()));
+      return Err(LemmyError::from_message("no_comment_edit_allowed"));
     }
 
     // Do the update
@@ -71,7 +71,7 @@ impl PerformCrud for EditComment {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_update_comment".into()))?;
+    .map_err(|e| e.with_message("couldnt_update_comment"))?;
 
     // Do the mentions / recipients
     let updated_comment_content = updated_comment.content.to_owned();

--- a/crates/api_crud/src/comment/update.rs
+++ b/crates/api_crud/src/comment/update.rs
@@ -31,7 +31,7 @@ use crate::PerformCrud;
 impl PerformCrud for EditComment {
   type Response = CommentResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api_crud/src/comment/update.rs
+++ b/crates/api_crud/src/comment/update.rs
@@ -16,7 +16,6 @@ use lemmy_db_schema::source::comment::Comment;
 use lemmy_db_views::comment_view::CommentView;
 use lemmy_utils::{
   utils::{remove_slurs, scrape_text_for_mentions},
-  ApiError,
   ConnectionId,
   LemmyError,
 };
@@ -32,6 +31,7 @@ use crate::PerformCrud;
 impl PerformCrud for EditComment {
   type Response = CommentResponse;
 
+  #[tracing::instrument(skip(self, context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -59,7 +59,7 @@ impl PerformCrud for EditComment {
 
     // Verify that only the creator can edit
     if local_user_view.person.id != orig_comment.creator.id {
-      return Err(ApiError::err_plain("no_comment_edit_allowed").into());
+      return Err(LemmyError::from_message("no_comment_edit_allowed".into()));
     }
 
     // Do the update
@@ -70,7 +70,8 @@ impl PerformCrud for EditComment {
       Comment::update_content(conn, comment_id, &content_slurs_removed)
     })
     .await?
-    .map_err(|e| ApiError::err("couldnt_update_comment", e))?;
+    .map_err(LemmyError::from)
+    .map_err(|e| e.with_message("couldnt_update_comment".into()))?;
 
     // Do the mentions / recipients
     let updated_comment_content = updated_comment.content.to_owned();

--- a/crates/api_crud/src/community/create.rs
+++ b/crates/api_crud/src/community/create.rs
@@ -34,7 +34,6 @@ use lemmy_db_views_actor::community_view::CommunityView;
 use lemmy_utils::{
   apub::generate_actor_keypair,
   utils::{check_slurs, check_slurs_opt, is_valid_actor_name},
-  ApiError,
   ConnectionId,
   LemmyError,
 };
@@ -44,6 +43,7 @@ use lemmy_websocket::LemmyContext;
 impl PerformCrud for CreateCommunity {
   type Response = CommunityResponse;
 
+  #[tracing::instrument(skip(self, context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -55,7 +55,9 @@ impl PerformCrud for CreateCommunity {
 
     let site = blocking(context.pool(), move |conn| Site::read(conn, 0)).await??;
     if site.community_creation_admin_only && is_admin(&local_user_view).is_err() {
-      return Err(ApiError::err_plain("only_admins_can_create_communities").into());
+      return Err(LemmyError::from_message(
+        "only_admins_can_create_communities".into(),
+      ));
     }
 
     check_slurs(&data.name, &context.settings().slur_regex())?;
@@ -63,7 +65,7 @@ impl PerformCrud for CreateCommunity {
     check_slurs_opt(&data.description, &context.settings().slur_regex())?;
 
     if !is_valid_actor_name(&data.name, context.settings().actor_name_max_length) {
-      return Err(ApiError::err_plain("invalid_community_name").into());
+      return Err(LemmyError::from_message("invalid_community_name".into()));
     }
 
     // Double check for duplicate community actor_ids
@@ -75,7 +77,7 @@ impl PerformCrud for CreateCommunity {
     let community_actor_id_wrapped = ObjectId::<ApubCommunity>::new(community_actor_id.clone());
     let community_dupe = community_actor_id_wrapped.dereference_local(context).await;
     if community_dupe.is_ok() {
-      return Err(ApiError::err_plain("community_already_exists").into());
+      return Err(LemmyError::from_message("community_already_exists".into()));
     }
 
     // Check to make sure the icon and banners are urls
@@ -105,7 +107,8 @@ impl PerformCrud for CreateCommunity {
       Community::create(conn, &community_form)
     })
     .await?
-    .map_err(|e| ApiError::err("community_already_exists", e))?;
+    .map_err(LemmyError::from)
+    .map_err(|e| e.with_message("community_already_exists".into()))?;
 
     // The community creator becomes a moderator
     let community_moderator_form = CommunityModeratorForm {
@@ -115,7 +118,9 @@ impl PerformCrud for CreateCommunity {
 
     let join = move |conn: &'_ _| CommunityModerator::join(conn, &community_moderator_form);
     if blocking(context.pool(), join).await?.is_err() {
-      return Err(ApiError::err_plain("community_moderator_already_exists").into());
+      return Err(LemmyError::from_message(
+        "community_moderator_already_exists".into(),
+      ));
     }
 
     // Follow your own community
@@ -127,7 +132,9 @@ impl PerformCrud for CreateCommunity {
 
     let follow = move |conn: &'_ _| CommunityFollower::follow(conn, &community_follower_form);
     if blocking(context.pool(), follow).await?.is_err() {
-      return Err(ApiError::err_plain("community_follower_already_exists").into());
+      return Err(LemmyError::from_message(
+        "community_follower_already_exists".into(),
+      ));
     }
 
     let person_id = local_user_view.person.id;

--- a/crates/api_crud/src/community/create.rs
+++ b/crates/api_crud/src/community/create.rs
@@ -56,7 +56,7 @@ impl PerformCrud for CreateCommunity {
     let site = blocking(context.pool(), move |conn| Site::read(conn, 0)).await??;
     if site.community_creation_admin_only && is_admin(&local_user_view).is_err() {
       return Err(LemmyError::from_message(
-        "only_admins_can_create_communities".into(),
+        "only_admins_can_create_communities",
       ));
     }
 
@@ -65,7 +65,7 @@ impl PerformCrud for CreateCommunity {
     check_slurs_opt(&data.description, &context.settings().slur_regex())?;
 
     if !is_valid_actor_name(&data.name, context.settings().actor_name_max_length) {
-      return Err(LemmyError::from_message("invalid_community_name".into()));
+      return Err(LemmyError::from_message("invalid_community_name"));
     }
 
     // Double check for duplicate community actor_ids
@@ -77,7 +77,7 @@ impl PerformCrud for CreateCommunity {
     let community_actor_id_wrapped = ObjectId::<ApubCommunity>::new(community_actor_id.clone());
     let community_dupe = community_actor_id_wrapped.dereference_local(context).await;
     if community_dupe.is_ok() {
-      return Err(LemmyError::from_message("community_already_exists".into()));
+      return Err(LemmyError::from_message("community_already_exists"));
     }
 
     // Check to make sure the icon and banners are urls
@@ -108,7 +108,7 @@ impl PerformCrud for CreateCommunity {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("community_already_exists".into()))?;
+    .map_err(|e| e.with_message("community_already_exists"))?;
 
     // The community creator becomes a moderator
     let community_moderator_form = CommunityModeratorForm {
@@ -119,7 +119,7 @@ impl PerformCrud for CreateCommunity {
     let join = move |conn: &'_ _| CommunityModerator::join(conn, &community_moderator_form);
     if blocking(context.pool(), join).await?.is_err() {
       return Err(LemmyError::from_message(
-        "community_moderator_already_exists".into(),
+        "community_moderator_already_exists",
       ));
     }
 
@@ -133,7 +133,7 @@ impl PerformCrud for CreateCommunity {
     let follow = move |conn: &'_ _| CommunityFollower::follow(conn, &community_follower_form);
     if blocking(context.pool(), follow).await?.is_err() {
       return Err(LemmyError::from_message(
-        "community_follower_already_exists".into(),
+        "community_follower_already_exists",
       ));
     }
 

--- a/crates/api_crud/src/community/create.rs
+++ b/crates/api_crud/src/community/create.rs
@@ -43,7 +43,7 @@ use lemmy_websocket::LemmyContext;
 impl PerformCrud for CreateCommunity {
   type Response = CommunityResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api_crud/src/community/delete.rs
+++ b/crates/api_crud/src/community/delete.rs
@@ -10,13 +10,14 @@ use lemmy_db_schema::{
   traits::Crud,
 };
 use lemmy_db_views_actor::community_moderator_view::CommunityModeratorView;
-use lemmy_utils::{utils::naive_from_unix, ApiError, ConnectionId, LemmyError};
+use lemmy_utils::{utils::naive_from_unix, ConnectionId, LemmyError};
 use lemmy_websocket::{send::send_community_ws_message, LemmyContext, UserOperationCrud};
 
 #[async_trait::async_trait(?Send)]
 impl PerformCrud for DeleteCommunity {
   type Response = CommunityResponse;
 
+  #[tracing::instrument(skip(self, context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -35,7 +36,7 @@ impl PerformCrud for DeleteCommunity {
 
     // Make sure deleter is the top mod
     if local_user_view.person.id != community_mods[0].moderator.id {
-      return Err(ApiError::err_plain("no_community_edit_allowed").into());
+      return Err(LemmyError::from_message("no_community_edit_allowed".into()));
     }
 
     // Do the delete
@@ -45,7 +46,8 @@ impl PerformCrud for DeleteCommunity {
       Community::update_deleted(conn, community_id, deleted)
     })
     .await?
-    .map_err(|e| ApiError::err("couldnt_update_community", e))?;
+    .map_err(LemmyError::from)
+    .map_err(|e| e.with_message("couldnt_update_community".into()))?;
 
     // Send apub messages
     send_apub_delete(
@@ -72,6 +74,7 @@ impl PerformCrud for DeleteCommunity {
 impl PerformCrud for RemoveCommunity {
   type Response = CommunityResponse;
 
+  #[tracing::instrument(skip(self, context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -91,7 +94,8 @@ impl PerformCrud for RemoveCommunity {
       Community::update_removed(conn, community_id, removed)
     })
     .await?
-    .map_err(|e| ApiError::err("couldnt_update_community", e))?;
+    .map_err(LemmyError::from)
+    .map_err(|e| e.with_message("couldnt_update_community".into()))?;
 
     // Mod tables
     let expires = data.expires.map(naive_from_unix);

--- a/crates/api_crud/src/community/delete.rs
+++ b/crates/api_crud/src/community/delete.rs
@@ -17,7 +17,7 @@ use lemmy_websocket::{send::send_community_ws_message, LemmyContext, UserOperati
 impl PerformCrud for DeleteCommunity {
   type Response = CommunityResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -74,7 +74,7 @@ impl PerformCrud for DeleteCommunity {
 impl PerformCrud for RemoveCommunity {
   type Response = CommunityResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api_crud/src/community/delete.rs
+++ b/crates/api_crud/src/community/delete.rs
@@ -36,7 +36,7 @@ impl PerformCrud for DeleteCommunity {
 
     // Make sure deleter is the top mod
     if local_user_view.person.id != community_mods[0].moderator.id {
-      return Err(LemmyError::from_message("no_community_edit_allowed".into()));
+      return Err(LemmyError::from_message("no_community_edit_allowed"));
     }
 
     // Do the delete
@@ -47,7 +47,7 @@ impl PerformCrud for DeleteCommunity {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_update_community".into()))?;
+    .map_err(|e| e.with_message("couldnt_update_community"))?;
 
     // Send apub messages
     send_apub_delete(
@@ -95,7 +95,7 @@ impl PerformCrud for RemoveCommunity {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_update_community".into()))?;
+    .map_err(|e| e.with_message("couldnt_update_community"))?;
 
     // Mod tables
     let expires = data.expires.map(naive_from_unix);

--- a/crates/api_crud/src/community/read.rs
+++ b/crates/api_crud/src/community/read.rs
@@ -24,7 +24,7 @@ use lemmy_websocket::{messages::GetCommunityUsersOnline, LemmyContext};
 impl PerformCrud for GetCommunity {
   type Response = GetCommunityResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -93,7 +93,7 @@ impl PerformCrud for GetCommunity {
 impl PerformCrud for ListCommunities {
   type Response = ListCommunitiesResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api_crud/src/community/read.rs
+++ b/crates/api_crud/src/community/read.rs
@@ -47,7 +47,7 @@ impl PerformCrud for GetCommunity {
           .dereference(context, &mut 0)
           .await
           .map_err(LemmyError::from)
-          .map_err(|e| e.with_message("couldnt_find_community".into()))?
+          .map_err(|e| e.with_message("couldnt_find_community"))?
           .id
       }
     };
@@ -57,7 +57,7 @@ impl PerformCrud for GetCommunity {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_find_community".into()))?;
+    .map_err(|e| e.with_message("couldnt_find_community"))?;
 
     // Blank out deleted or removed info for non-logged in users
     if person_id.is_none() && (community_view.community.deleted || community_view.community.removed)
@@ -70,7 +70,7 @@ impl PerformCrud for GetCommunity {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_find_community".into()))?;
+    .map_err(|e| e.with_message("couldnt_find_community"))?;
 
     let online = context
       .chat_server()

--- a/crates/api_crud/src/community/read.rs
+++ b/crates/api_crud/src/community/read.rs
@@ -32,7 +32,8 @@ impl PerformCrud for GetCommunity {
   ) -> Result<GetCommunityResponse, LemmyError> {
     let data: &GetCommunity = self;
     let local_user_view =
-      get_local_user_view_from_jwt_opt(&data.auth, context.pool(), context.secret()).await?;
+      get_local_user_view_from_jwt_opt(data.auth.as_ref(), context.pool(), context.secret())
+        .await?;
     let person_id = local_user_view.map(|u| u.person.id);
 
     let community_id = match data.id {
@@ -101,7 +102,8 @@ impl PerformCrud for ListCommunities {
   ) -> Result<ListCommunitiesResponse, LemmyError> {
     let data: &ListCommunities = self;
     let local_user_view =
-      get_local_user_view_from_jwt_opt(&data.auth, context.pool(), context.secret()).await?;
+      get_local_user_view_from_jwt_opt(data.auth.as_ref(), context.pool(), context.secret())
+        .await?;
 
     let person_id = local_user_view.to_owned().map(|l| l.person.id);
 

--- a/crates/api_crud/src/community/update.rs
+++ b/crates/api_crud/src/community/update.rs
@@ -21,7 +21,7 @@ use lemmy_websocket::{send::send_community_ws_message, LemmyContext, UserOperati
 impl PerformCrud for EditCommunity {
   type Response = CommunityResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api_crud/src/community/update.rs
+++ b/crates/api_crud/src/community/update.rs
@@ -42,7 +42,7 @@ impl PerformCrud for EditCommunity {
     })
     .await??;
     if !mods.contains(&local_user_view.person.id) {
-      return Err(LemmyError::from_message("not_a_moderator".into()));
+      return Err(LemmyError::from_message("not_a_moderator"));
     }
 
     let community_id = data.community_id;
@@ -72,7 +72,7 @@ impl PerformCrud for EditCommunity {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_update_community".into()))?;
+    .map_err(|e| e.with_message("couldnt_update_community"))?;
 
     UpdateCommunity::send(
       updated_community.into(),

--- a/crates/api_crud/src/post/create.rs
+++ b/crates/api_crud/src/post/create.rs
@@ -39,7 +39,7 @@ use webmention::{Webmention, WebmentionError};
 impl PerformCrud for CreatePost {
   type Response = PostResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api_crud/src/post/create.rs
+++ b/crates/api_crud/src/post/create.rs
@@ -55,7 +55,7 @@ impl PerformCrud for CreatePost {
     honeypot_check(&data.honeypot)?;
 
     if !is_valid_post_title(&data.name) {
-      return Err(LemmyError::from_message("invalid_post_title".into()));
+      return Err(LemmyError::from_message("invalid_post_title"));
     }
 
     check_community_ban(local_user_view.person.id, data.community_id, context.pool()).await?;
@@ -93,7 +93,7 @@ impl PerformCrud for CreatePost {
             "couldnt_create_post"
           };
 
-          return Err(LemmyError::from(e).with_message(err_type.into()));
+          return Err(LemmyError::from(e).with_message(err_type));
         }
       };
 
@@ -109,7 +109,7 @@ impl PerformCrud for CreatePost {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_create_post".into()))?;
+    .map_err(|e| e.with_message("couldnt_create_post"))?;
 
     // They like their own post by default
     let person_id = local_user_view.person.id;
@@ -122,7 +122,7 @@ impl PerformCrud for CreatePost {
 
     let like = move |conn: &'_ _| PostLike::like(conn, &like_form);
     if blocking(context.pool(), like).await?.is_err() {
-      return Err(LemmyError::from_message("couldnt_like_post".into()));
+      return Err(LemmyError::from_message("couldnt_like_post"));
     }
 
     // Mark the post as read

--- a/crates/api_crud/src/post/delete.rs
+++ b/crates/api_crud/src/post/delete.rs
@@ -24,7 +24,7 @@ use lemmy_websocket::{send::send_post_ws_message, LemmyContext, UserOperationCru
 impl PerformCrud for DeletePost {
   type Response = PostResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -92,7 +92,7 @@ impl PerformCrud for DeletePost {
 impl PerformCrud for RemovePost {
   type Response = PostResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api_crud/src/post/delete.rs
+++ b/crates/api_crud/src/post/delete.rs
@@ -39,7 +39,7 @@ impl PerformCrud for DeletePost {
 
     // Dont delete it if its already been deleted.
     if orig_post.deleted == data.deleted {
-      return Err(LemmyError::from_message("couldnt_update_post".into()));
+      return Err(LemmyError::from_message("couldnt_update_post"));
     }
 
     check_community_ban(
@@ -52,7 +52,7 @@ impl PerformCrud for DeletePost {
 
     // Verify that only the creator can delete
     if !Post::is_post_creator(local_user_view.person.id, orig_post.creator_id) {
-      return Err(LemmyError::from_message("no_post_edit_allowed".into()));
+      return Err(LemmyError::from_message("no_post_edit_allowed"));
     }
 
     // Update the post

--- a/crates/api_crud/src/post/read.rs
+++ b/crates/api_crud/src/post/read.rs
@@ -48,7 +48,7 @@ impl PerformCrud for GetPost {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_find_post".into()))?;
+    .map_err(|e| e.with_message("couldnt_find_post"))?;
 
     // Mark the post as read
     if let Some(person_id) = person_id {
@@ -73,7 +73,7 @@ impl PerformCrud for GetPost {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_find_community".into()))?;
+    .map_err(|e| e.with_message("couldnt_find_community"))?;
 
     // Blank out deleted or removed info for non-logged in users
     if person_id.is_none() {
@@ -170,7 +170,7 @@ impl PerformCrud for GetPosts {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_get_posts".into()))?;
+    .map_err(|e| e.with_message("couldnt_get_posts"))?;
 
     // Blank out deleted or removed info for non-logged in users
     if person_id.is_none() {

--- a/crates/api_crud/src/post/read.rs
+++ b/crates/api_crud/src/post/read.rs
@@ -35,7 +35,8 @@ impl PerformCrud for GetPost {
   ) -> Result<GetPostResponse, LemmyError> {
     let data: &GetPost = self;
     let local_user_view =
-      get_local_user_view_from_jwt_opt(&data.auth, context.pool(), context.secret()).await?;
+      get_local_user_view_from_jwt_opt(data.auth.as_ref(), context.pool(), context.secret())
+        .await?;
 
     let show_bot_accounts = local_user_view
       .as_ref()
@@ -126,7 +127,8 @@ impl PerformCrud for GetPosts {
   ) -> Result<GetPostsResponse, LemmyError> {
     let data: &GetPosts = self;
     let local_user_view =
-      get_local_user_view_from_jwt_opt(&data.auth, context.pool(), context.secret()).await?;
+      get_local_user_view_from_jwt_opt(data.auth.as_ref(), context.pool(), context.secret())
+        .await?;
 
     let person_id = local_user_view.to_owned().map(|l| l.person.id);
 

--- a/crates/api_crud/src/post/read.rs
+++ b/crates/api_crud/src/post/read.rs
@@ -27,7 +27,7 @@ use lemmy_websocket::{messages::GetPostUsersOnline, LemmyContext};
 impl PerformCrud for GetPost {
   type Response = GetPostResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -118,7 +118,7 @@ impl PerformCrud for GetPost {
 impl PerformCrud for GetPosts {
   type Response = GetPostsResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api_crud/src/post/update.rs
+++ b/crates/api_crud/src/post/update.rs
@@ -46,7 +46,7 @@ impl PerformCrud for EditPost {
 
     if let Some(name) = &data.name {
       if !is_valid_post_title(name) {
-        return Err(LemmyError::from_message("invalid_post_title".into()));
+        return Err(LemmyError::from_message("invalid_post_title"));
       }
     }
 
@@ -63,7 +63,7 @@ impl PerformCrud for EditPost {
 
     // Verify that only the creator can edit
     if !Post::is_post_creator(local_user_view.person.id, orig_post.creator_id) {
-      return Err(LemmyError::from_message("no_post_edit_allowed".into()));
+      return Err(LemmyError::from_message("no_post_edit_allowed"));
     }
 
     // Fetch post links and Pictrs cached image
@@ -103,7 +103,7 @@ impl PerformCrud for EditPost {
           "couldnt_update_post"
         };
 
-        return Err(LemmyError::from(e).with_message(err_type.into()));
+        return Err(LemmyError::from(e).with_message(err_type));
       }
     };
 

--- a/crates/api_crud/src/post/update.rs
+++ b/crates/api_crud/src/post/update.rs
@@ -19,7 +19,6 @@ use lemmy_db_schema::{
 use lemmy_utils::{
   request::fetch_site_data,
   utils::{check_slurs_opt, clean_url_params, is_valid_post_title},
-  ApiError,
   ConnectionId,
   LemmyError,
 };
@@ -31,6 +30,7 @@ use crate::PerformCrud;
 impl PerformCrud for EditPost {
   type Response = PostResponse;
 
+  #[tracing::instrument(skip(self, context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -46,7 +46,7 @@ impl PerformCrud for EditPost {
 
     if let Some(name) = &data.name {
       if !is_valid_post_title(name) {
-        return Err(ApiError::err_plain("invalid_post_title").into());
+        return Err(LemmyError::from_message("invalid_post_title".into()));
       }
     }
 
@@ -63,7 +63,7 @@ impl PerformCrud for EditPost {
 
     // Verify that only the creator can edit
     if !Post::is_post_creator(local_user_view.person.id, orig_post.creator_id) {
-      return Err(ApiError::err_plain("no_post_edit_allowed").into());
+      return Err(LemmyError::from_message("no_post_edit_allowed".into()));
     }
 
     // Fetch post links and Pictrs cached image
@@ -103,7 +103,7 @@ impl PerformCrud for EditPost {
           "couldnt_update_post"
         };
 
-        return Err(ApiError::err(err_type, e).into());
+        return Err(LemmyError::from(e).with_message(err_type.into()));
       }
     };
 

--- a/crates/api_crud/src/post/update.rs
+++ b/crates/api_crud/src/post/update.rs
@@ -30,7 +30,7 @@ use crate::PerformCrud;
 impl PerformCrud for EditPost {
   type Response = PostResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api_crud/src/private_message/create.rs
+++ b/crates/api_crud/src/private_message/create.rs
@@ -59,7 +59,7 @@ impl PerformCrud for CreatePrivateMessage {
     {
       Ok(private_message) => private_message,
       Err(e) => {
-        return Err(LemmyError::from(e).with_message("couldnt_create_private_message".into()));
+        return Err(LemmyError::from(e).with_message("couldnt_create_private_message"));
       }
     };
 
@@ -82,7 +82,7 @@ impl PerformCrud for CreatePrivateMessage {
     )
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_create_private_message".into()))?;
+    .map_err(|e| e.with_message("couldnt_create_private_message"))?;
 
     CreateOrUpdatePrivateMessage::send(
       updated_private_message.into(),

--- a/crates/api_crud/src/private_message/delete.rs
+++ b/crates/api_crud/src/private_message/delete.rs
@@ -37,9 +37,7 @@ impl PerformCrud for DeletePrivateMessage {
     })
     .await??;
     if local_user_view.person.id != orig_private_message.creator_id {
-      return Err(LemmyError::from_message(
-        "no_private_message_edit_allowed".into(),
-      ));
+      return Err(LemmyError::from_message("no_private_message_edit_allowed"));
     }
 
     // Doing the update
@@ -50,7 +48,7 @@ impl PerformCrud for DeletePrivateMessage {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_update_private_message".into()))?;
+    .map_err(|e| e.with_message("couldnt_update_private_message"))?;
 
     // Send the apub update
     if data.deleted {

--- a/crates/api_crud/src/private_message/read.rs
+++ b/crates/api_crud/src/private_message/read.rs
@@ -22,7 +22,7 @@ impl PerformCrud for GetPrivateMessages {
   ) -> Result<PrivateMessagesResponse, LemmyError> {
     let data: &GetPrivateMessages = self;
     let local_user_view =
-      get_local_user_view_from_jwt(&data.auth, context.pool(), context.secret()).await?;
+      get_local_user_view_from_jwt(data.auth.as_ref(), context.pool(), context.secret()).await?;
     let person_id = local_user_view.person.id;
 
     let page = data.page;

--- a/crates/api_crud/src/private_message/read.rs
+++ b/crates/api_crud/src/private_message/read.rs
@@ -14,6 +14,7 @@ use lemmy_websocket::LemmyContext;
 impl PerformCrud for GetPrivateMessages {
   type Response = PrivateMessagesResponse;
 
+  #[tracing::instrument(skip(self, context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api_crud/src/private_message/update.rs
+++ b/crates/api_crud/src/private_message/update.rs
@@ -34,9 +34,7 @@ impl PerformCrud for EditPrivateMessage {
     })
     .await??;
     if local_user_view.person.id != orig_private_message.creator_id {
-      return Err(LemmyError::from_message(
-        "no_private_message_edit_allowed".into(),
-      ));
+      return Err(LemmyError::from_message("no_private_message_edit_allowed"));
     }
 
     // Doing the update
@@ -47,7 +45,7 @@ impl PerformCrud for EditPrivateMessage {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("couldnt_update_private_message".into()))?;
+    .map_err(|e| e.with_message("couldnt_update_private_message"))?;
 
     // Send the apub update
     CreateOrUpdatePrivateMessage::send(

--- a/crates/api_crud/src/private_message/update.rs
+++ b/crates/api_crud/src/private_message/update.rs
@@ -10,13 +10,14 @@ use lemmy_apub::protocol::activities::{
   CreateOrUpdateType,
 };
 use lemmy_db_schema::{source::private_message::PrivateMessage, traits::Crud};
-use lemmy_utils::{utils::remove_slurs, ApiError, ConnectionId, LemmyError};
+use lemmy_utils::{utils::remove_slurs, ConnectionId, LemmyError};
 use lemmy_websocket::{send::send_pm_ws_message, LemmyContext, UserOperationCrud};
 
 #[async_trait::async_trait(?Send)]
 impl PerformCrud for EditPrivateMessage {
   type Response = PrivateMessageResponse;
 
+  #[tracing::instrument(skip(self, context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -33,7 +34,9 @@ impl PerformCrud for EditPrivateMessage {
     })
     .await??;
     if local_user_view.person.id != orig_private_message.creator_id {
-      return Err(ApiError::err_plain("no_private_message_edit_allowed").into());
+      return Err(LemmyError::from_message(
+        "no_private_message_edit_allowed".into(),
+      ));
     }
 
     // Doing the update
@@ -43,7 +46,8 @@ impl PerformCrud for EditPrivateMessage {
       PrivateMessage::update_content(conn, private_message_id, &content_slurs_removed)
     })
     .await?
-    .map_err(|e| ApiError::err("couldnt_update_private_message", e))?;
+    .map_err(LemmyError::from)
+    .map_err(|e| e.with_message("couldnt_update_private_message".into()))?;
 
     // Send the apub update
     CreateOrUpdatePrivateMessage::send(

--- a/crates/api_crud/src/site/create.rs
+++ b/crates/api_crud/src/site/create.rs
@@ -25,7 +25,7 @@ use lemmy_websocket::LemmyContext;
 impl PerformCrud for CreateSite {
   type Response = SiteResponse;
 
-  #[tracing::instrument(skip(self, context, _websocket_id))]
+  #[tracing::instrument(skip(context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api_crud/src/site/create.rs
+++ b/crates/api_crud/src/site/create.rs
@@ -35,7 +35,7 @@ impl PerformCrud for CreateSite {
 
     let read_site = Site::read_simple;
     if blocking(context.pool(), read_site).await?.is_ok() {
-      return Err(LemmyError::from_message("site_already_exists".into()));
+      return Err(LemmyError::from_message("site_already_exists"));
     };
 
     let local_user_view =
@@ -72,7 +72,7 @@ impl PerformCrud for CreateSite {
 
     let create_site = move |conn: &'_ _| Site::create(conn, &site_form);
     if blocking(context.pool(), create_site).await?.is_err() {
-      return Err(LemmyError::from_message("site_already_exists".into()));
+      return Err(LemmyError::from_message("site_already_exists"));
     }
 
     let site_view = blocking(context.pool(), SiteView::read).await??;

--- a/crates/api_crud/src/site/create.rs
+++ b/crates/api_crud/src/site/create.rs
@@ -16,7 +16,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::site_view::SiteView;
 use lemmy_utils::{
   utils::{check_slurs, check_slurs_opt},
-  ApiError,
   ConnectionId,
   LemmyError,
 };
@@ -26,6 +25,7 @@ use lemmy_websocket::LemmyContext;
 impl PerformCrud for CreateSite {
   type Response = SiteResponse;
 
+  #[tracing::instrument(skip(self, context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -35,7 +35,7 @@ impl PerformCrud for CreateSite {
 
     let read_site = Site::read_simple;
     if blocking(context.pool(), read_site).await?.is_ok() {
-      return Err(ApiError::err_plain("site_already_exists").into());
+      return Err(LemmyError::from_message("site_already_exists".into()));
     };
 
     let local_user_view =
@@ -72,7 +72,7 @@ impl PerformCrud for CreateSite {
 
     let create_site = move |conn: &'_ _| Site::create(conn, &site_form);
     if blocking(context.pool(), create_site).await?.is_err() {
-      return Err(ApiError::err_plain("site_already_exists").into());
+      return Err(LemmyError::from_message("site_already_exists".into()));
     }
 
     let site_view = blocking(context.pool(), SiteView::read).await??;

--- a/crates/api_crud/src/site/read.rs
+++ b/crates/api_crud/src/site/read.rs
@@ -102,7 +102,7 @@ impl PerformCrud for GetSite {
       })
       .await?
       .map_err(LemmyError::from)
-      .map_err(|e| e.with_message("system_err_login".into()))?;
+      .map_err(|e| e.with_message("system_err_login"))?;
 
       let person_id = local_user_view.person.id;
       let community_blocks = blocking(context.pool(), move |conn| {
@@ -110,7 +110,7 @@ impl PerformCrud for GetSite {
       })
       .await?
       .map_err(LemmyError::from)
-      .map_err(|e| e.with_message("system_err_login".into()))?;
+      .map_err(|e| e.with_message("system_err_login"))?;
 
       let person_id = local_user_view.person.id;
       let person_blocks = blocking(context.pool(), move |conn| {
@@ -118,14 +118,14 @@ impl PerformCrud for GetSite {
       })
       .await?
       .map_err(LemmyError::from)
-      .map_err(|e| e.with_message("system_err_login".into()))?;
+      .map_err(|e| e.with_message("system_err_login"))?;
 
       let moderates = blocking(context.pool(), move |conn| {
         CommunityModeratorView::for_person(conn, person_id)
       })
       .await?
       .map_err(LemmyError::from)
-      .map_err(|e| e.with_message("system_err_login".into()))?;
+      .map_err(|e| e.with_message("system_err_login"))?;
 
       Some(MyUserInfo {
         local_user_view,

--- a/crates/api_crud/src/site/read.rs
+++ b/crates/api_crud/src/site/read.rs
@@ -38,9 +38,9 @@ impl PerformCrud for GetSite {
         if let Some(setup) = context.settings().setup.as_ref() {
           let register = Register {
             username: setup.admin_username.to_owned(),
-            email: setup.admin_email.to_owned(),
-            password: setup.admin_password.to_owned(),
-            password_verify: setup.admin_password.to_owned(),
+            email: setup.admin_email.clone().map(|s| s.into()),
+            password: setup.admin_password.clone().into(),
+            password_verify: setup.admin_password.clone().into(),
             show_nsfw: true,
             captcha_uuid: None,
             captcha_answer: None,
@@ -92,9 +92,12 @@ impl PerformCrud for GetSite {
       .unwrap_or(1);
 
     // Build the local user
-    let my_user = if let Some(local_user_view) =
-      get_local_user_settings_view_from_jwt_opt(&data.auth, context.pool(), context.secret())
-        .await?
+    let my_user = if let Some(local_user_view) = get_local_user_settings_view_from_jwt_opt(
+      data.auth.as_ref(),
+      context.pool(),
+      context.secret(),
+    )
+    .await?
     {
       let person_id = local_user_view.person.id;
       let follows = blocking(context.pool(), move |conn| {

--- a/crates/api_crud/src/site/read.rs
+++ b/crates/api_crud/src/site/read.rs
@@ -23,7 +23,7 @@ use tracing::info;
 impl PerformCrud for GetSite {
   type Response = GetSiteResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api_crud/src/site/update.rs
+++ b/crates/api_crud/src/site/update.rs
@@ -67,7 +67,7 @@ impl PerformCrud for EditSite {
     blocking(context.pool(), update_site)
       .await?
       .map_err(LemmyError::from)
-      .map_err(|e| e.with_message("couldnt_update_site".into()))?;
+      .map_err(|e| e.with_message("couldnt_update_site"))?;
 
     let site_view = blocking(context.pool(), SiteView::read).await??;
 

--- a/crates/api_crud/src/site/update.rs
+++ b/crates/api_crud/src/site/update.rs
@@ -22,7 +22,7 @@ use lemmy_websocket::{messages::SendAllMessage, LemmyContext, UserOperationCrud}
 impl PerformCrud for EditSite {
   type Response = SiteResponse;
 
-  #[tracing::instrument(skip(self, context, websocket_id))]
+  #[tracing::instrument(skip(context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,

--- a/crates/api_crud/src/site/update.rs
+++ b/crates/api_crud/src/site/update.rs
@@ -15,12 +15,14 @@ use lemmy_db_schema::{
   traits::Crud,
 };
 use lemmy_db_views::site_view::SiteView;
-use lemmy_utils::{utils::check_slurs_opt, ApiError, ConnectionId, LemmyError};
+use lemmy_utils::{utils::check_slurs_opt, ConnectionId, LemmyError};
 use lemmy_websocket::{messages::SendAllMessage, LemmyContext, UserOperationCrud};
 
 #[async_trait::async_trait(?Send)]
 impl PerformCrud for EditSite {
   type Response = SiteResponse;
+
+  #[tracing::instrument(skip(self, context, websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -64,7 +66,8 @@ impl PerformCrud for EditSite {
     let update_site = move |conn: &'_ _| Site::update(conn, 1, &site_form);
     blocking(context.pool(), update_site)
       .await?
-      .map_err(|e| ApiError::err("couldnt_update_site", e))?;
+      .map_err(LemmyError::from)
+      .map_err(|e| e.with_message("couldnt_update_site".into()))?;
 
     let site_view = blocking(context.pool(), SiteView::read).await??;
 

--- a/crates/api_crud/src/user/create.rs
+++ b/crates/api_crud/src/user/create.rs
@@ -52,7 +52,7 @@ impl PerformCrud for Register {
     // Make sure site has open registration
     if let Ok(site) = blocking(context.pool(), Site::read_simple).await? {
       if !site.open_registration {
-        return Err(LemmyError::from_message("registration_closed".into()));
+        return Err(LemmyError::from_message("registration_closed"));
       }
     }
 
@@ -61,7 +61,7 @@ impl PerformCrud for Register {
 
     // Make sure passwords match
     if data.password != data.password_verify {
-      return Err(LemmyError::from_message("passwords_dont_match".into()));
+      return Err(LemmyError::from_message("passwords_dont_match"));
     }
 
     // Check if there are admins. False if admins exist
@@ -86,7 +86,7 @@ impl PerformCrud for Register {
         })
         .await?;
       if !check {
-        return Err(LemmyError::from_message("captcha_incorrect".into()));
+        return Err(LemmyError::from_message("captcha_incorrect"));
       }
     }
 
@@ -94,7 +94,7 @@ impl PerformCrud for Register {
 
     let actor_keypair = generate_actor_keypair()?;
     if !is_valid_actor_name(&data.username, context.settings().actor_name_max_length) {
-      return Err(LemmyError::from_message("invalid_username".into()));
+      return Err(LemmyError::from_message("invalid_username"));
     }
     let actor_id = generate_local_apub_endpoint(
       EndpointType::Person,
@@ -122,7 +122,7 @@ impl PerformCrud for Register {
     })
     .await?
     .map_err(LemmyError::from)
-    .map_err(|e| e.with_message("user_already_exists".into()))?;
+    .map_err(|e| e.with_message("user_already_exists"))?;
 
     // Create the local user
     // TODO some of these could probably use the DB defaults
@@ -164,7 +164,7 @@ impl PerformCrud for Register {
         })
         .await??;
 
-        return Err(LemmyError::from(e).with_message(err_type.into()));
+        return Err(LemmyError::from(e).with_message(err_type));
       }
     };
 
@@ -215,7 +215,7 @@ impl PerformCrud for Register {
     blocking(context.pool(), follow)
       .await?
       .map_err(LemmyError::from)
-      .map_err(|e| e.with_message("community_follower_already_exists".into()))?;
+      .map_err(|e| e.with_message("community_follower_already_exists"))?;
 
     // If its an admin, add them as a mod and follower to main
     if no_admins {
@@ -228,7 +228,7 @@ impl PerformCrud for Register {
       blocking(context.pool(), join)
         .await?
         .map_err(LemmyError::from)
-        .map_err(|e| e.with_message("community_moderator_already_exists".into()))?;
+        .map_err(|e| e.with_message("community_moderator_already_exists"))?;
     }
 
     // Return the jwt

--- a/crates/api_crud/src/user/create.rs
+++ b/crates/api_crud/src/user/create.rs
@@ -128,8 +128,8 @@ impl PerformCrud for Register {
     // TODO some of these could probably use the DB defaults
     let local_user_form = LocalUserForm {
       person_id: inserted_person.id,
-      email: Some(data.email.to_owned()),
-      password_encrypted: data.password.to_owned(),
+      email: Some(data.email.as_deref().map(|s| s.to_owned())),
+      password_encrypted: data.password.to_string(),
       show_nsfw: Some(data.show_nsfw),
       show_bot_accounts: Some(true),
       theme: Some("browser".into()),
@@ -237,7 +237,8 @@ impl PerformCrud for Register {
         inserted_local_user.id.0,
         &context.secret().jwt_secret,
         &context.settings().hostname,
-      )?,
+      )?
+      .into(),
     })
   }
 }

--- a/crates/api_crud/src/user/delete.rs
+++ b/crates/api_crud/src/user/delete.rs
@@ -18,7 +18,7 @@ impl PerformCrud for DeleteAccount {
   ) -> Result<LoginResponse, LemmyError> {
     let data: &DeleteAccount = self;
     let local_user_view =
-      get_local_user_view_from_jwt(&data.auth, context.pool(), context.secret()).await?;
+      get_local_user_view_from_jwt(data.auth.as_ref(), context.pool(), context.secret()).await?;
 
     // Verify the password
     let valid: bool = verify(
@@ -51,7 +51,7 @@ impl PerformCrud for DeleteAccount {
     .await??;
 
     Ok(LoginResponse {
-      jwt: data.auth.to_owned(),
+      jwt: data.auth.clone(),
     })
   }
 }

--- a/crates/api_crud/src/user/delete.rs
+++ b/crates/api_crud/src/user/delete.rs
@@ -27,7 +27,7 @@ impl PerformCrud for DeleteAccount {
     )
     .unwrap_or(false);
     if !valid {
-      return Err(LemmyError::from_message("password_incorrect".into()));
+      return Err(LemmyError::from_message("password_incorrect"));
     }
 
     // Comments
@@ -36,14 +36,14 @@ impl PerformCrud for DeleteAccount {
     blocking(context.pool(), permadelete)
       .await?
       .map_err(LemmyError::from)
-      .map_err(|e| e.with_message("couldnt_update_comment".into()))?;
+      .map_err(|e| e.with_message("couldnt_update_comment"))?;
 
     // Posts
     let permadelete = move |conn: &'_ _| Post::permadelete_for_creator(conn, person_id);
     blocking(context.pool(), permadelete)
       .await?
       .map_err(LemmyError::from)
-      .map_err(|e| e.with_message("couldnt_update_post".into()))?;
+      .map_err(|e| e.with_message("couldnt_update_post"))?;
 
     blocking(context.pool(), move |conn| {
       Person::delete_account(conn, person_id)

--- a/crates/api_crud/src/user/read.rs
+++ b/crates/api_crud/src/user/read.rs
@@ -13,13 +13,14 @@ use lemmy_db_views_actor::{
   community_moderator_view::CommunityModeratorView,
   person_view::PersonViewSafe,
 };
-use lemmy_utils::{ApiError, ConnectionId, LemmyError};
+use lemmy_utils::{ConnectionId, LemmyError};
 use lemmy_websocket::LemmyContext;
 
 #[async_trait::async_trait(?Send)]
 impl PerformCrud for GetPersonDetails {
   type Response = GetPersonDetailsResponse;
 
+  #[tracing::instrument(skip(self, context, _websocket_id))]
   async fn perform(
     &self,
     context: &Data<LemmyContext>,
@@ -53,7 +54,8 @@ impl PerformCrud for GetPersonDetails {
           .dereference(context, &mut 0)
           .await;
         person
-          .map_err(|e| ApiError::err("couldnt_find_that_username_or_email", e))?
+          .map_err(LemmyError::from)
+          .map_err(|e| e.with_message("couldnt_find_that_username_or_email".into()))?
           .id
       }
     };

--- a/crates/api_crud/src/user/read.rs
+++ b/crates/api_crud/src/user/read.rs
@@ -28,7 +28,8 @@ impl PerformCrud for GetPersonDetails {
   ) -> Result<GetPersonDetailsResponse, LemmyError> {
     let data: &GetPersonDetails = self;
     let local_user_view =
-      get_local_user_view_from_jwt_opt(&data.auth, context.pool(), context.secret()).await?;
+      get_local_user_view_from_jwt_opt(data.auth.as_ref(), context.pool(), context.secret())
+        .await?;
 
     let show_nsfw = local_user_view.as_ref().map(|t| t.local_user.show_nsfw);
     let show_bot_accounts = local_user_view

--- a/crates/api_crud/src/user/read.rs
+++ b/crates/api_crud/src/user/read.rs
@@ -55,7 +55,7 @@ impl PerformCrud for GetPersonDetails {
           .await;
         person
           .map_err(LemmyError::from)
-          .map_err(|e| e.with_message("couldnt_find_that_username_or_email".into()))?
+          .map_err(|e| e.with_message("couldnt_find_that_username_or_email"))?
           .id
       }
     };

--- a/crates/apub/src/activities/comment/create_or_update.rs
+++ b/crates/apub/src/activities/comment/create_or_update.rs
@@ -28,6 +28,7 @@ use lemmy_utils::LemmyError;
 use lemmy_websocket::{send::send_comment_ws_message, LemmyContext, UserOperationCrud};
 
 impl CreateOrUpdateComment {
+  #[tracing::instrument(skip(comment, actor, kind, context))]
   pub async fn send(
     comment: ApubComment,
     actor: &ApubPerson,
@@ -83,6 +84,7 @@ impl CreateOrUpdateComment {
 impl ActivityHandler for CreateOrUpdateComment {
   type DataType = LemmyContext;
 
+  #[tracing::instrument(skip(self, context))]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -102,6 +104,7 @@ impl ActivityHandler for CreateOrUpdateComment {
     Ok(())
   }
 
+  #[tracing::instrument(skip(self, context))]
   async fn receive(
     self,
     context: &Data<LemmyContext>,
@@ -131,6 +134,7 @@ impl ActivityHandler for CreateOrUpdateComment {
 
 #[async_trait::async_trait(?Send)]
 impl GetCommunity for CreateOrUpdateComment {
+  #[tracing::instrument(skip(self, context))]
   async fn get_community(
     &self,
     context: &LemmyContext,

--- a/crates/apub/src/activities/comment/create_or_update.rs
+++ b/crates/apub/src/activities/comment/create_or_update.rs
@@ -84,7 +84,7 @@ impl CreateOrUpdateComment {
 impl ActivityHandler for CreateOrUpdateComment {
   type DataType = LemmyContext;
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -104,7 +104,7 @@ impl ActivityHandler for CreateOrUpdateComment {
     Ok(())
   }
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn receive(
     self,
     context: &Data<LemmyContext>,
@@ -134,7 +134,7 @@ impl ActivityHandler for CreateOrUpdateComment {
 
 #[async_trait::async_trait(?Send)]
 impl GetCommunity for CreateOrUpdateComment {
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn get_community(
     &self,
     context: &LemmyContext,

--- a/crates/apub/src/activities/comment/mod.rs
+++ b/crates/apub/src/activities/comment/mod.rs
@@ -11,6 +11,7 @@ use lemmy_websocket::{send::send_local_notifs, LemmyContext};
 
 pub mod create_or_update;
 
+#[tracing::instrument(skip(actor, comment, context))]
 async fn get_notif_recipients(
   actor: &ObjectId<ApubPerson>,
   comment: &Comment,

--- a/crates/apub/src/activities/comment/mod.rs
+++ b/crates/apub/src/activities/comment/mod.rs
@@ -11,7 +11,7 @@ use lemmy_websocket::{send::send_local_notifs, LemmyContext};
 
 pub mod create_or_update;
 
-#[tracing::instrument(skip(actor, comment, context))]
+#[tracing::instrument(skip_all)]
 async fn get_notif_recipients(
   actor: &ObjectId<ApubPerson>,
   comment: &Comment,

--- a/crates/apub/src/activities/community/add_mod.rs
+++ b/crates/apub/src/activities/community/add_mod.rs
@@ -32,7 +32,7 @@ use lemmy_utils::LemmyError;
 use lemmy_websocket::LemmyContext;
 
 impl AddMod {
-  #[tracing::instrument(skip(community, added_mod, actor, context))]
+  #[tracing::instrument(skip_all)]
   pub async fn send(
     community: &ApubCommunity,
     added_mod: &ApubPerson,
@@ -64,7 +64,7 @@ impl AddMod {
 impl ActivityHandler for AddMod {
   type DataType = LemmyContext;
 
-  #[tracing::instrument(skip(context))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -79,7 +79,7 @@ impl ActivityHandler for AddMod {
     Ok(())
   }
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn receive(
     self,
     context: &Data<LemmyContext>,
@@ -112,7 +112,7 @@ impl ActivityHandler for AddMod {
 
 #[async_trait::async_trait(?Send)]
 impl GetCommunity for AddMod {
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn get_community(
     &self,
     context: &LemmyContext,

--- a/crates/apub/src/activities/community/add_mod.rs
+++ b/crates/apub/src/activities/community/add_mod.rs
@@ -32,6 +32,7 @@ use lemmy_utils::LemmyError;
 use lemmy_websocket::LemmyContext;
 
 impl AddMod {
+  #[tracing::instrument(skip(community, added_mod, actor, context))]
   pub async fn send(
     community: &ApubCommunity,
     added_mod: &ApubPerson,
@@ -63,6 +64,7 @@ impl AddMod {
 impl ActivityHandler for AddMod {
   type DataType = LemmyContext;
 
+  #[tracing::instrument(skip(context))]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -77,6 +79,7 @@ impl ActivityHandler for AddMod {
     Ok(())
   }
 
+  #[tracing::instrument(skip(self, context))]
   async fn receive(
     self,
     context: &Data<LemmyContext>,
@@ -109,6 +112,7 @@ impl ActivityHandler for AddMod {
 
 #[async_trait::async_trait(?Send)]
 impl GetCommunity for AddMod {
+  #[tracing::instrument(skip(self, context))]
   async fn get_community(
     &self,
     context: &LemmyContext,

--- a/crates/apub/src/activities/community/announce.rs
+++ b/crates/apub/src/activities/community/announce.rs
@@ -44,6 +44,7 @@ impl AnnounceActivity {
     })
   }
 
+  #[tracing::instrument(skip(object, community, context))]
   pub async fn send(
     object: AnnouncableActivities,
     community: &ApubCommunity,
@@ -85,6 +86,8 @@ impl AnnounceActivity {
 #[async_trait::async_trait(?Send)]
 impl ActivityHandler for AnnounceActivity {
   type DataType = LemmyContext;
+
+  #[tracing::instrument(skip(self, context))]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -96,6 +99,7 @@ impl ActivityHandler for AnnounceActivity {
     Ok(())
   }
 
+  #[tracing::instrument(skip(self, context))]
   async fn receive(
     self,
     context: &Data<LemmyContext>,

--- a/crates/apub/src/activities/community/announce.rs
+++ b/crates/apub/src/activities/community/announce.rs
@@ -44,7 +44,7 @@ impl AnnounceActivity {
     })
   }
 
-  #[tracing::instrument(skip(object, community, context))]
+  #[tracing::instrument(skip_all)]
   pub async fn send(
     object: AnnouncableActivities,
     community: &ApubCommunity,
@@ -87,7 +87,7 @@ impl AnnounceActivity {
 impl ActivityHandler for AnnounceActivity {
   type DataType = LemmyContext;
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -99,7 +99,7 @@ impl ActivityHandler for AnnounceActivity {
     Ok(())
   }
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn receive(
     self,
     context: &Data<LemmyContext>,

--- a/crates/apub/src/activities/community/block_user.rs
+++ b/crates/apub/src/activities/community/block_user.rs
@@ -52,7 +52,7 @@ impl BlockUserFromCommunity {
     })
   }
 
-  #[tracing::instrument(skip(community, target, actor, context))]
+  #[tracing::instrument(skip_all)]
   pub async fn send(
     community: &ApubCommunity,
     target: &ApubPerson,
@@ -72,7 +72,7 @@ impl BlockUserFromCommunity {
 impl ActivityHandler for BlockUserFromCommunity {
   type DataType = LemmyContext;
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -86,7 +86,7 @@ impl ActivityHandler for BlockUserFromCommunity {
     Ok(())
   }
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn receive(
     self,
     context: &Data<LemmyContext>,
@@ -123,7 +123,7 @@ impl ActivityHandler for BlockUserFromCommunity {
 
 #[async_trait::async_trait(?Send)]
 impl GetCommunity for BlockUserFromCommunity {
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn get_community(
     &self,
     context: &LemmyContext,

--- a/crates/apub/src/activities/community/block_user.rs
+++ b/crates/apub/src/activities/community/block_user.rs
@@ -52,6 +52,7 @@ impl BlockUserFromCommunity {
     })
   }
 
+  #[tracing::instrument(skip(community, target, actor, context))]
   pub async fn send(
     community: &ApubCommunity,
     target: &ApubPerson,
@@ -70,6 +71,8 @@ impl BlockUserFromCommunity {
 #[async_trait::async_trait(?Send)]
 impl ActivityHandler for BlockUserFromCommunity {
   type DataType = LemmyContext;
+
+  #[tracing::instrument(skip(self, context))]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -83,6 +86,7 @@ impl ActivityHandler for BlockUserFromCommunity {
     Ok(())
   }
 
+  #[tracing::instrument(skip(self, context))]
   async fn receive(
     self,
     context: &Data<LemmyContext>,
@@ -119,6 +123,7 @@ impl ActivityHandler for BlockUserFromCommunity {
 
 #[async_trait::async_trait(?Send)]
 impl GetCommunity for BlockUserFromCommunity {
+  #[tracing::instrument(skip(self, context))]
   async fn get_community(
     &self,
     context: &LemmyContext,

--- a/crates/apub/src/activities/community/mod.rs
+++ b/crates/apub/src/activities/community/mod.rs
@@ -17,7 +17,7 @@ pub mod report;
 pub mod undo_block_user;
 pub mod update;
 
-#[tracing::instrument(skip(activity, actor, community, context))]
+#[tracing::instrument(skip_all)]
 pub(crate) async fn send_activity_in_community<T: ActorType>(
   activity: AnnouncableActivities,
   activity_id: &Url,
@@ -36,7 +36,7 @@ pub(crate) async fn send_activity_in_community<T: ActorType>(
   Ok(())
 }
 
-#[tracing::instrument(skip(moderators, context))]
+#[tracing::instrument(skip_all)]
 async fn get_community_from_moderators_url(
   moderators: &Url,
   context: &LemmyContext,

--- a/crates/apub/src/activities/community/mod.rs
+++ b/crates/apub/src/activities/community/mod.rs
@@ -17,6 +17,7 @@ pub mod report;
 pub mod undo_block_user;
 pub mod update;
 
+#[tracing::instrument(skip(activity, actor, community, context))]
 pub(crate) async fn send_activity_in_community<T: ActorType>(
   activity: AnnouncableActivities,
   activity_id: &Url,
@@ -35,6 +36,7 @@ pub(crate) async fn send_activity_in_community<T: ActorType>(
   Ok(())
 }
 
+#[tracing::instrument(skip(moderators, context))]
 async fn get_community_from_moderators_url(
   moderators: &Url,
   context: &LemmyContext,

--- a/crates/apub/src/activities/community/remove_mod.rs
+++ b/crates/apub/src/activities/community/remove_mod.rs
@@ -32,6 +32,7 @@ use lemmy_utils::LemmyError;
 use lemmy_websocket::LemmyContext;
 
 impl RemoveMod {
+  #[tracing::instrument(skip(community, removed_mod, actor, context))]
   pub async fn send(
     community: &ApubCommunity,
     removed_mod: &ApubPerson,
@@ -62,6 +63,8 @@ impl RemoveMod {
 #[async_trait::async_trait(?Send)]
 impl ActivityHandler for RemoveMod {
   type DataType = LemmyContext;
+
+  #[tracing::instrument(skip(self, context))]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -76,6 +79,7 @@ impl ActivityHandler for RemoveMod {
     Ok(())
   }
 
+  #[tracing::instrument(skip(self, context))]
   async fn receive(
     self,
     context: &Data<LemmyContext>,
@@ -99,6 +103,7 @@ impl ActivityHandler for RemoveMod {
 
 #[async_trait::async_trait(?Send)]
 impl GetCommunity for RemoveMod {
+  #[tracing::instrument(skip(self, context))]
   async fn get_community(
     &self,
     context: &LemmyContext,

--- a/crates/apub/src/activities/community/remove_mod.rs
+++ b/crates/apub/src/activities/community/remove_mod.rs
@@ -32,7 +32,7 @@ use lemmy_utils::LemmyError;
 use lemmy_websocket::LemmyContext;
 
 impl RemoveMod {
-  #[tracing::instrument(skip(community, removed_mod, actor, context))]
+  #[tracing::instrument(skip_all)]
   pub async fn send(
     community: &ApubCommunity,
     removed_mod: &ApubPerson,
@@ -64,7 +64,7 @@ impl RemoveMod {
 impl ActivityHandler for RemoveMod {
   type DataType = LemmyContext;
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -79,7 +79,7 @@ impl ActivityHandler for RemoveMod {
     Ok(())
   }
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn receive(
     self,
     context: &Data<LemmyContext>,
@@ -103,7 +103,7 @@ impl ActivityHandler for RemoveMod {
 
 #[async_trait::async_trait(?Send)]
 impl GetCommunity for RemoveMod {
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn get_community(
     &self,
     context: &LemmyContext,

--- a/crates/apub/src/activities/community/report.rs
+++ b/crates/apub/src/activities/community/report.rs
@@ -28,6 +28,7 @@ use lemmy_utils::LemmyError;
 use lemmy_websocket::{messages::SendModRoomMessage, LemmyContext, UserOperation};
 
 impl Report {
+  #[tracing::instrument(skip(object_id, actor, community_id, reason, context))]
   pub async fn send(
     object_id: ObjectId<PostOrComment>,
     actor: &ApubPerson,
@@ -65,6 +66,8 @@ impl Report {
 #[async_trait::async_trait(?Send)]
 impl ActivityHandler for Report {
   type DataType = LemmyContext;
+
+  #[tracing::instrument(skip(self, context))]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -76,6 +79,7 @@ impl ActivityHandler for Report {
     Ok(())
   }
 
+  #[tracing::instrument(skip(self, context))]
   async fn receive(
     self,
     context: &Data<LemmyContext>,

--- a/crates/apub/src/activities/community/report.rs
+++ b/crates/apub/src/activities/community/report.rs
@@ -28,7 +28,7 @@ use lemmy_utils::LemmyError;
 use lemmy_websocket::{messages::SendModRoomMessage, LemmyContext, UserOperation};
 
 impl Report {
-  #[tracing::instrument(skip(object_id, actor, community_id, reason, context))]
+  #[tracing::instrument(skip_all)]
   pub async fn send(
     object_id: ObjectId<PostOrComment>,
     actor: &ApubPerson,
@@ -67,7 +67,7 @@ impl Report {
 impl ActivityHandler for Report {
   type DataType = LemmyContext;
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -79,7 +79,7 @@ impl ActivityHandler for Report {
     Ok(())
   }
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn receive(
     self,
     context: &Data<LemmyContext>,

--- a/crates/apub/src/activities/community/undo_block_user.rs
+++ b/crates/apub/src/activities/community/undo_block_user.rs
@@ -29,6 +29,7 @@ use lemmy_utils::LemmyError;
 use lemmy_websocket::LemmyContext;
 
 impl UndoBlockUserFromCommunity {
+  #[tracing::instrument(skip(community, target, actor, context))]
   pub async fn send(
     community: &ApubCommunity,
     target: &ApubPerson,
@@ -60,6 +61,8 @@ impl UndoBlockUserFromCommunity {
 #[async_trait::async_trait(?Send)]
 impl ActivityHandler for UndoBlockUserFromCommunity {
   type DataType = LemmyContext;
+
+  #[tracing::instrument(skip(self, context))]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -74,6 +77,7 @@ impl ActivityHandler for UndoBlockUserFromCommunity {
     Ok(())
   }
 
+  #[tracing::instrument(skip(self, context))]
   async fn receive(
     self,
     context: &Data<LemmyContext>,
@@ -102,6 +106,7 @@ impl ActivityHandler for UndoBlockUserFromCommunity {
 
 #[async_trait::async_trait(?Send)]
 impl GetCommunity for UndoBlockUserFromCommunity {
+  #[tracing::instrument(skip(self, context))]
   async fn get_community(
     &self,
     context: &LemmyContext,

--- a/crates/apub/src/activities/community/undo_block_user.rs
+++ b/crates/apub/src/activities/community/undo_block_user.rs
@@ -29,7 +29,7 @@ use lemmy_utils::LemmyError;
 use lemmy_websocket::LemmyContext;
 
 impl UndoBlockUserFromCommunity {
-  #[tracing::instrument(skip(community, target, actor, context))]
+  #[tracing::instrument(skip_all)]
   pub async fn send(
     community: &ApubCommunity,
     target: &ApubPerson,
@@ -62,7 +62,7 @@ impl UndoBlockUserFromCommunity {
 impl ActivityHandler for UndoBlockUserFromCommunity {
   type DataType = LemmyContext;
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -77,7 +77,7 @@ impl ActivityHandler for UndoBlockUserFromCommunity {
     Ok(())
   }
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn receive(
     self,
     context: &Data<LemmyContext>,
@@ -106,7 +106,7 @@ impl ActivityHandler for UndoBlockUserFromCommunity {
 
 #[async_trait::async_trait(?Send)]
 impl GetCommunity for UndoBlockUserFromCommunity {
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn get_community(
     &self,
     context: &LemmyContext,

--- a/crates/apub/src/activities/community/update.rs
+++ b/crates/apub/src/activities/community/update.rs
@@ -26,7 +26,7 @@ use lemmy_utils::LemmyError;
 use lemmy_websocket::{send::send_community_ws_message, LemmyContext, UserOperationCrud};
 
 impl UpdateCommunity {
-  #[tracing::instrument(skip(community, actor, context))]
+  #[tracing::instrument(skip_all)]
   pub async fn send(
     community: ApubCommunity,
     actor: &ApubPerson,
@@ -55,7 +55,7 @@ impl UpdateCommunity {
 impl ActivityHandler for UpdateCommunity {
   type DataType = LemmyContext;
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -76,7 +76,7 @@ impl ActivityHandler for UpdateCommunity {
     Ok(())
   }
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn receive(
     self,
     context: &Data<LemmyContext>,
@@ -114,7 +114,7 @@ impl ActivityHandler for UpdateCommunity {
 
 #[async_trait::async_trait(?Send)]
 impl GetCommunity for UpdateCommunity {
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn get_community(
     &self,
     context: &LemmyContext,

--- a/crates/apub/src/activities/community/update.rs
+++ b/crates/apub/src/activities/community/update.rs
@@ -26,6 +26,7 @@ use lemmy_utils::LemmyError;
 use lemmy_websocket::{send::send_community_ws_message, LemmyContext, UserOperationCrud};
 
 impl UpdateCommunity {
+  #[tracing::instrument(skip(community, actor, context))]
   pub async fn send(
     community: ApubCommunity,
     actor: &ApubPerson,
@@ -53,6 +54,8 @@ impl UpdateCommunity {
 #[async_trait::async_trait(?Send)]
 impl ActivityHandler for UpdateCommunity {
   type DataType = LemmyContext;
+
+  #[tracing::instrument(skip(self, context))]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -73,6 +76,7 @@ impl ActivityHandler for UpdateCommunity {
     Ok(())
   }
 
+  #[tracing::instrument(skip(self, context))]
   async fn receive(
     self,
     context: &Data<LemmyContext>,
@@ -110,6 +114,7 @@ impl ActivityHandler for UpdateCommunity {
 
 #[async_trait::async_trait(?Send)]
 impl GetCommunity for UpdateCommunity {
+  #[tracing::instrument(skip(self, context))]
   async fn get_community(
     &self,
     context: &LemmyContext,

--- a/crates/apub/src/activities/deletion/delete.rs
+++ b/crates/apub/src/activities/deletion/delete.rs
@@ -145,7 +145,7 @@ pub(in crate::activities) async fn receive_remove_action(
     DeletableObjects::Community(community) => {
       if community.local {
         return Err(LemmyError::from_message(
-          "Only local admin can remove community".into(),
+          "Only local admin can remove community",
         ));
       }
       let form = ModRemoveCommunityForm {

--- a/crates/apub/src/activities/deletion/delete.rs
+++ b/crates/apub/src/activities/deletion/delete.rs
@@ -11,7 +11,6 @@ use crate::{
   protocol::activities::deletion::delete::Delete,
 };
 use activitystreams_kinds::{activity::DeleteType, public};
-use anyhow::anyhow;
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::{
   data::Data,
@@ -45,6 +44,8 @@ use url::Url;
 #[async_trait::async_trait(?Send)]
 impl ActivityHandler for Delete {
   type DataType = LemmyContext;
+
+  #[tracing::instrument(skip(self, context))]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -65,6 +66,7 @@ impl ActivityHandler for Delete {
     Ok(())
   }
 
+  #[tracing::instrument(skip(self, context))]
   async fn receive(
     self,
     context: &Data<LemmyContext>,
@@ -112,6 +114,8 @@ impl Delete {
       unparsed: Default::default(),
     })
   }
+
+  #[tracing::instrument(skip(actor, community, object, summary, context))]
   pub(in crate::activities::deletion) async fn send(
     actor: &ApubPerson,
     community: &ApubCommunity,
@@ -127,6 +131,7 @@ impl Delete {
   }
 }
 
+#[tracing::instrument(skip(actor, object, reason, context))]
 pub(in crate::activities) async fn receive_remove_action(
   actor: &ObjectId<ApubPerson>,
   object: &Url,
@@ -139,7 +144,9 @@ pub(in crate::activities) async fn receive_remove_action(
   match DeletableObjects::read_from_db(object, context).await? {
     DeletableObjects::Community(community) => {
       if community.local {
-        return Err(anyhow!("Only local admin can remove community").into());
+        return Err(LemmyError::from_message(
+          "Only local admin can remove community".into(),
+        ));
       }
       let form = ModRemoveCommunityForm {
         mod_person_id: actor.id,
@@ -201,6 +208,7 @@ pub(in crate::activities) async fn receive_remove_action(
 
 #[async_trait::async_trait(?Send)]
 impl GetCommunity for Delete {
+  #[tracing::instrument(skip(self, context))]
   async fn get_community(
     &self,
     context: &LemmyContext,

--- a/crates/apub/src/activities/deletion/delete.rs
+++ b/crates/apub/src/activities/deletion/delete.rs
@@ -45,7 +45,7 @@ use url::Url;
 impl ActivityHandler for Delete {
   type DataType = LemmyContext;
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -66,7 +66,7 @@ impl ActivityHandler for Delete {
     Ok(())
   }
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn receive(
     self,
     context: &Data<LemmyContext>,
@@ -115,7 +115,7 @@ impl Delete {
     })
   }
 
-  #[tracing::instrument(skip(actor, community, object, summary, context))]
+  #[tracing::instrument(skip_all)]
   pub(in crate::activities::deletion) async fn send(
     actor: &ApubPerson,
     community: &ApubCommunity,
@@ -131,7 +131,7 @@ impl Delete {
   }
 }
 
-#[tracing::instrument(skip(actor, object, reason, context))]
+#[tracing::instrument(skip_all)]
 pub(in crate::activities) async fn receive_remove_action(
   actor: &ObjectId<ApubPerson>,
   object: &Url,
@@ -208,7 +208,7 @@ pub(in crate::activities) async fn receive_remove_action(
 
 #[async_trait::async_trait(?Send)]
 impl GetCommunity for Delete {
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn get_community(
     &self,
     context: &LemmyContext,

--- a/crates/apub/src/activities/deletion/mod.rs
+++ b/crates/apub/src/activities/deletion/mod.rs
@@ -20,6 +20,7 @@ use url::Url;
 pub mod delete;
 pub mod undo_delete;
 
+#[tracing::instrument(skip(actor, community, object, deleted, context))]
 pub async fn send_apub_delete(
   actor: &ApubPerson,
   community: &ApubCommunity,
@@ -36,6 +37,7 @@ pub async fn send_apub_delete(
 
 // TODO: remove reason is actually optional in lemmy. we set an empty string in that case, but its
 //       ugly
+#[tracing::instrument(skip(actor, community, object, reason, removed, context))]
 pub async fn send_apub_remove(
   actor: &ApubPerson,
   community: &ApubCommunity,
@@ -58,6 +60,7 @@ pub enum DeletableObjects {
 }
 
 impl DeletableObjects {
+  #[tracing::instrument(skip(ap_id, context))]
   pub(crate) async fn read_from_db(
     ap_id: &Url,
     context: &LemmyContext,
@@ -83,6 +86,7 @@ impl DeletableObjects {
   }
 }
 
+#[tracing::instrument(skip(object, actor, community, is_mod_action, context))]
 pub(in crate::activities) async fn verify_delete_activity(
   object: &Url,
   actor: &ObjectId<ApubPerson>,
@@ -128,6 +132,7 @@ pub(in crate::activities) async fn verify_delete_activity(
   Ok(())
 }
 
+#[tracing::instrument(skip(actor, object_id, community, is_mod_action, context))]
 async fn verify_delete_activity_post_or_comment(
   actor: &ObjectId<ApubPerson>,
   object_id: &Url,
@@ -149,6 +154,7 @@ async fn verify_delete_activity_post_or_comment(
 /// Write deletion or restoring of an object to the database, and send websocket message.
 /// TODO: we should do something similar for receive_remove_action(), but its much more complicated
 ///       because of the mod log
+#[tracing::instrument(skip(object, actor, deleted, context))]
 async fn receive_delete_action(
   object: &Url,
   actor: &ObjectId<ApubPerson>,

--- a/crates/apub/src/activities/deletion/mod.rs
+++ b/crates/apub/src/activities/deletion/mod.rs
@@ -20,7 +20,7 @@ use url::Url;
 pub mod delete;
 pub mod undo_delete;
 
-#[tracing::instrument(skip(actor, community, object, deleted, context))]
+#[tracing::instrument(skip_all)]
 pub async fn send_apub_delete(
   actor: &ApubPerson,
   community: &ApubCommunity,
@@ -37,7 +37,7 @@ pub async fn send_apub_delete(
 
 // TODO: remove reason is actually optional in lemmy. we set an empty string in that case, but its
 //       ugly
-#[tracing::instrument(skip(actor, community, object, reason, removed, context))]
+#[tracing::instrument(skip_all)]
 pub async fn send_apub_remove(
   actor: &ApubPerson,
   community: &ApubCommunity,
@@ -60,7 +60,7 @@ pub enum DeletableObjects {
 }
 
 impl DeletableObjects {
-  #[tracing::instrument(skip(ap_id, context))]
+  #[tracing::instrument(skip_all)]
   pub(crate) async fn read_from_db(
     ap_id: &Url,
     context: &LemmyContext,
@@ -86,7 +86,7 @@ impl DeletableObjects {
   }
 }
 
-#[tracing::instrument(skip(object, actor, community, is_mod_action, context))]
+#[tracing::instrument(skip_all)]
 pub(in crate::activities) async fn verify_delete_activity(
   object: &Url,
   actor: &ObjectId<ApubPerson>,
@@ -132,7 +132,7 @@ pub(in crate::activities) async fn verify_delete_activity(
   Ok(())
 }
 
-#[tracing::instrument(skip(actor, object_id, community, is_mod_action, context))]
+#[tracing::instrument(skip_all)]
 async fn verify_delete_activity_post_or_comment(
   actor: &ObjectId<ApubPerson>,
   object_id: &Url,
@@ -154,7 +154,7 @@ async fn verify_delete_activity_post_or_comment(
 /// Write deletion or restoring of an object to the database, and send websocket message.
 /// TODO: we should do something similar for receive_remove_action(), but its much more complicated
 ///       because of the mod log
-#[tracing::instrument(skip(object, actor, deleted, context))]
+#[tracing::instrument(skip_all)]
 async fn receive_delete_action(
   object: &Url,
   actor: &ObjectId<ApubPerson>,

--- a/crates/apub/src/activities/deletion/undo_delete.rs
+++ b/crates/apub/src/activities/deletion/undo_delete.rs
@@ -112,7 +112,7 @@ impl UndoDelete {
       DeletableObjects::Community(community) => {
         if community.local {
           return Err(LemmyError::from_message(
-            "Only local admin can restore community".into(),
+            "Only local admin can restore community",
           ));
         }
         let deleted_community = blocking(context.pool(), move |conn| {

--- a/crates/apub/src/activities/deletion/undo_delete.rs
+++ b/crates/apub/src/activities/deletion/undo_delete.rs
@@ -30,7 +30,7 @@ use url::Url;
 impl ActivityHandler for UndoDelete {
   type DataType = LemmyContext;
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -52,7 +52,7 @@ impl ActivityHandler for UndoDelete {
     Ok(())
   }
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn receive(
     self,
     context: &Data<LemmyContext>,
@@ -74,7 +74,7 @@ impl ActivityHandler for UndoDelete {
 }
 
 impl UndoDelete {
-  #[tracing::instrument(skip(actor, community, object, summary, context))]
+  #[tracing::instrument(skip_all)]
   pub(in crate::activities::deletion) async fn send(
     actor: &ApubPerson,
     community: &ApubCommunity,
@@ -102,7 +102,7 @@ impl UndoDelete {
     send_activity_in_community(activity, &id, actor, community, vec![], context).await
   }
 
-  #[tracing::instrument(skip(object, context))]
+  #[tracing::instrument(skip_all)]
   pub(in crate::activities) async fn receive_undo_remove_action(
     object: &Url,
     context: &LemmyContext,
@@ -142,7 +142,7 @@ impl UndoDelete {
 
 #[async_trait::async_trait(?Send)]
 impl GetCommunity for UndoDelete {
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn get_community(
     &self,
     context: &LemmyContext,

--- a/crates/apub/src/activities/following/accept.rs
+++ b/crates/apub/src/activities/following/accept.rs
@@ -15,6 +15,7 @@ use lemmy_utils::LemmyError;
 use lemmy_websocket::LemmyContext;
 
 impl AcceptFollowCommunity {
+  #[tracing::instrument(skip(follow, context))]
   pub async fn send(
     follow: FollowCommunity,
     context: &LemmyContext,
@@ -45,6 +46,8 @@ impl AcceptFollowCommunity {
 #[async_trait::async_trait(?Send)]
 impl ActivityHandler for AcceptFollowCommunity {
   type DataType = LemmyContext;
+
+  #[tracing::instrument(skip(self, context))]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -56,6 +59,7 @@ impl ActivityHandler for AcceptFollowCommunity {
     Ok(())
   }
 
+  #[tracing::instrument(skip(self, context))]
   async fn receive(
     self,
     context: &Data<LemmyContext>,

--- a/crates/apub/src/activities/following/accept.rs
+++ b/crates/apub/src/activities/following/accept.rs
@@ -15,7 +15,7 @@ use lemmy_utils::LemmyError;
 use lemmy_websocket::LemmyContext;
 
 impl AcceptFollowCommunity {
-  #[tracing::instrument(skip(follow, context))]
+  #[tracing::instrument(skip_all)]
   pub async fn send(
     follow: FollowCommunity,
     context: &LemmyContext,
@@ -47,7 +47,7 @@ impl AcceptFollowCommunity {
 impl ActivityHandler for AcceptFollowCommunity {
   type DataType = LemmyContext;
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -59,7 +59,7 @@ impl ActivityHandler for AcceptFollowCommunity {
     Ok(())
   }
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn receive(
     self,
     context: &Data<LemmyContext>,

--- a/crates/apub/src/activities/following/follow.rs
+++ b/crates/apub/src/activities/following/follow.rs
@@ -40,6 +40,8 @@ impl FollowCommunity {
       unparsed: Default::default(),
     })
   }
+
+  #[tracing::instrument(skip(actor, community, context))]
   pub async fn send(
     actor: &ApubPerson,
     community: &ApubCommunity,
@@ -64,6 +66,8 @@ impl FollowCommunity {
 #[async_trait::async_trait(?Send)]
 impl ActivityHandler for FollowCommunity {
   type DataType = LemmyContext;
+
+  #[tracing::instrument(skip(self, context))]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -76,6 +80,7 @@ impl ActivityHandler for FollowCommunity {
     Ok(())
   }
 
+  #[tracing::instrument(skip(self, context))]
   async fn receive(
     self,
     context: &Data<LemmyContext>,

--- a/crates/apub/src/activities/following/follow.rs
+++ b/crates/apub/src/activities/following/follow.rs
@@ -41,7 +41,7 @@ impl FollowCommunity {
     })
   }
 
-  #[tracing::instrument(skip(actor, community, context))]
+  #[tracing::instrument(skip_all)]
   pub async fn send(
     actor: &ApubPerson,
     community: &ApubCommunity,
@@ -67,7 +67,7 @@ impl FollowCommunity {
 impl ActivityHandler for FollowCommunity {
   type DataType = LemmyContext;
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -80,7 +80,7 @@ impl ActivityHandler for FollowCommunity {
     Ok(())
   }
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn receive(
     self,
     context: &Data<LemmyContext>,

--- a/crates/apub/src/activities/following/undo_follow.rs
+++ b/crates/apub/src/activities/following/undo_follow.rs
@@ -19,6 +19,7 @@ use lemmy_utils::LemmyError;
 use lemmy_websocket::LemmyContext;
 
 impl UndoFollowCommunity {
+  #[tracing::instrument(skip(actor, community, context))]
   pub async fn send(
     actor: &ApubPerson,
     community: &ApubCommunity,
@@ -43,6 +44,8 @@ impl UndoFollowCommunity {
 #[async_trait::async_trait(?Send)]
 impl ActivityHandler for UndoFollowCommunity {
   type DataType = LemmyContext;
+
+  #[tracing::instrument(skip(self, context))]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -55,6 +58,7 @@ impl ActivityHandler for UndoFollowCommunity {
     Ok(())
   }
 
+  #[tracing::instrument(skip(self, context))]
   async fn receive(
     self,
     context: &Data<LemmyContext>,

--- a/crates/apub/src/activities/following/undo_follow.rs
+++ b/crates/apub/src/activities/following/undo_follow.rs
@@ -19,7 +19,7 @@ use lemmy_utils::LemmyError;
 use lemmy_websocket::LemmyContext;
 
 impl UndoFollowCommunity {
-  #[tracing::instrument(skip(actor, community, context))]
+  #[tracing::instrument(skip_all)]
   pub async fn send(
     actor: &ApubPerson,
     community: &ApubCommunity,
@@ -45,7 +45,7 @@ impl UndoFollowCommunity {
 impl ActivityHandler for UndoFollowCommunity {
   type DataType = LemmyContext;
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -58,7 +58,7 @@ impl ActivityHandler for UndoFollowCommunity {
     Ok(())
   }
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn receive(
     self,
     context: &Data<LemmyContext>,

--- a/crates/apub/src/activities/mod.rs
+++ b/crates/apub/src/activities/mod.rs
@@ -6,7 +6,6 @@ use crate::{
   objects::{community::ApubCommunity, person::ApubPerson},
 };
 use activitystreams_kinds::public;
-use anyhow::anyhow;
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::{
   activity_queue::send_activity,
@@ -36,6 +35,7 @@ pub mod voting;
 
 /// Checks that the specified Url actually identifies a Person (by fetching it), and that the person
 /// doesn't have a site ban.
+#[tracing::instrument(skip(person_id, context))]
 async fn verify_person(
   person_id: &ObjectId<ApubPerson>,
   context: &LemmyContext,
@@ -43,13 +43,17 @@ async fn verify_person(
 ) -> Result<(), LemmyError> {
   let person = person_id.dereference(context, request_counter).await?;
   if person.banned {
-    return Err(anyhow!("Person {} is banned", person_id).into());
+    return Err(LemmyError::from_message(format!(
+      "Person {} is banned",
+      person_id
+    )));
   }
   Ok(())
 }
 
 /// Fetches the person and community to verify their type, then checks if person is banned from site
 /// or community.
+#[tracing::instrument(skip(person_id, community, context))]
 pub(crate) async fn verify_person_in_community(
   person_id: &ObjectId<ApubPerson>,
   community: &ApubCommunity,
@@ -58,14 +62,18 @@ pub(crate) async fn verify_person_in_community(
 ) -> Result<(), LemmyError> {
   let person = person_id.dereference(context, request_counter).await?;
   if person.banned {
-    return Err(anyhow!("Person is banned from site").into());
+    return Err(LemmyError::from_message(
+      "Person is banned from site".to_string(),
+    ));
   }
   let person_id = person.id;
   let community_id = community.id;
   let is_banned =
     move |conn: &'_ _| CommunityPersonBanView::get(conn, person_id, community_id).is_ok();
   if blocking(context.pool(), is_banned).await? {
-    return Err(anyhow!("Person is banned from community").into());
+    return Err(LemmyError::from_message(
+      "Person is banned from community".to_string(),
+    ));
   }
 
   Ok(())
@@ -80,6 +88,7 @@ fn verify_activity(id: &Url, actor: &Url, settings: &Settings) -> Result<(), Lem
 /// Verify that the actor is a community mod. This check is only run if the community is local,
 /// because in case of remote communities, admins can also perform mod actions. As admin status
 /// is not federated, we cant verify their actions remotely.
+#[tracing::instrument(skip(actor_id, community, context))]
 pub(crate) async fn verify_mod_action(
   actor_id: &ObjectId<ApubPerson>,
   community: &ApubCommunity,
@@ -98,7 +107,7 @@ pub(crate) async fn verify_mod_action(
     })
     .await?;
     if !is_mod_or_admin {
-      return Err(anyhow!("Not a mod").into());
+      return Err(LemmyError::from_message("Not a mod".into()));
     }
   }
   Ok(())
@@ -111,21 +120,23 @@ fn verify_add_remove_moderator_target(
   community: &ApubCommunity,
 ) -> Result<(), LemmyError> {
   if target != &generate_moderators_url(&community.actor_id)?.into() {
-    return Err(anyhow!("Unkown target url").into());
+    return Err(LemmyError::from_message("Unkown target url".into()));
   }
   Ok(())
 }
 
 pub(crate) fn verify_is_public(to: &[Url], cc: &[Url]) -> Result<(), LemmyError> {
   if ![to, cc].iter().any(|set| set.contains(&public())) {
-    return Err(anyhow!("Object is not public").into());
+    return Err(LemmyError::from_message("Object is not public".into()));
   }
   Ok(())
 }
 
 pub(crate) fn check_community_deleted_or_removed(community: &Community) -> Result<(), LemmyError> {
   if community.deleted || community.removed {
-    Err(anyhow!("New post or comment cannot be created in deleted or removed community").into())
+    Err(LemmyError::from_message(
+      "New post or comment cannot be created in deleted or removed community".into(),
+    ))
   } else {
     Ok(())
   }
@@ -146,6 +157,7 @@ where
   Url::parse(&id)
 }
 
+#[tracing::instrument(skip(context, activity, activity_id, actor, inboxes, sensitive))]
 async fn send_lemmy_activity<T: Serialize>(
   context: &LemmyContext,
   activity: &T,

--- a/crates/apub/src/activities/mod.rs
+++ b/crates/apub/src/activities/mod.rs
@@ -35,7 +35,7 @@ pub mod voting;
 
 /// Checks that the specified Url actually identifies a Person (by fetching it), and that the person
 /// doesn't have a site ban.
-#[tracing::instrument(skip(person_id, context))]
+#[tracing::instrument(skip_all)]
 async fn verify_person(
   person_id: &ObjectId<ApubPerson>,
   context: &LemmyContext,
@@ -53,7 +53,7 @@ async fn verify_person(
 
 /// Fetches the person and community to verify their type, then checks if person is banned from site
 /// or community.
-#[tracing::instrument(skip(person_id, community, context))]
+#[tracing::instrument(skip_all)]
 pub(crate) async fn verify_person_in_community(
   person_id: &ObjectId<ApubPerson>,
   community: &ApubCommunity,
@@ -88,7 +88,7 @@ fn verify_activity(id: &Url, actor: &Url, settings: &Settings) -> Result<(), Lem
 /// Verify that the actor is a community mod. This check is only run if the community is local,
 /// because in case of remote communities, admins can also perform mod actions. As admin status
 /// is not federated, we cant verify their actions remotely.
-#[tracing::instrument(skip(actor_id, community, context))]
+#[tracing::instrument(skip_all)]
 pub(crate) async fn verify_mod_action(
   actor_id: &ObjectId<ApubPerson>,
   community: &ApubCommunity,
@@ -157,7 +157,7 @@ where
   Url::parse(&id)
 }
 
-#[tracing::instrument(skip(context, activity, activity_id, actor, inboxes, sensitive))]
+#[tracing::instrument(skip_all)]
 async fn send_lemmy_activity<T: Serialize>(
   context: &LemmyContext,
   activity: &T,

--- a/crates/apub/src/activities/post/create_or_update.rs
+++ b/crates/apub/src/activities/post/create_or_update.rs
@@ -47,7 +47,7 @@ impl CreateOrUpdatePost {
     })
   }
 
-  #[tracing::instrument(skip(post, actor, kind, context))]
+  #[tracing::instrument(skip_all)]
   pub async fn send(
     post: ApubPost,
     actor: &ApubPerson,
@@ -72,7 +72,7 @@ impl CreateOrUpdatePost {
 impl ActivityHandler for CreateOrUpdatePost {
   type DataType = LemmyContext;
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -114,7 +114,7 @@ impl ActivityHandler for CreateOrUpdatePost {
     Ok(())
   }
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn receive(
     self,
     context: &Data<LemmyContext>,
@@ -133,7 +133,7 @@ impl ActivityHandler for CreateOrUpdatePost {
 
 #[async_trait::async_trait(?Send)]
 impl GetCommunity for CreateOrUpdatePost {
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn get_community(
     &self,
     context: &LemmyContext,

--- a/crates/apub/src/activities/post/create_or_update.rs
+++ b/crates/apub/src/activities/post/create_or_update.rs
@@ -96,7 +96,7 @@ impl ActivityHandler for CreateOrUpdatePost {
           self.object.stickied == Some(true) || self.object.comments_enabled == Some(false);
         if community.local && is_stickied_or_locked {
           return Err(LemmyError::from_message(
-            "New post cannot be stickied or locked".into(),
+            "New post cannot be stickied or locked",
           ));
         }
       }

--- a/crates/apub/src/activities/private_message/create_or_update.rs
+++ b/crates/apub/src/activities/private_message/create_or_update.rs
@@ -18,7 +18,7 @@ use lemmy_utils::LemmyError;
 use lemmy_websocket::{send::send_pm_ws_message, LemmyContext, UserOperationCrud};
 
 impl CreateOrUpdatePrivateMessage {
-  #[tracing::instrument(skip(private_message, actor, kind, context))]
+  #[tracing::instrument(skip_all)]
   pub async fn send(
     private_message: ApubPrivateMessage,
     actor: &ApubPerson,
@@ -52,7 +52,7 @@ impl CreateOrUpdatePrivateMessage {
 impl ActivityHandler for CreateOrUpdatePrivateMessage {
   type DataType = LemmyContext;
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -65,7 +65,7 @@ impl ActivityHandler for CreateOrUpdatePrivateMessage {
     Ok(())
   }
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn receive(
     self,
     context: &Data<LemmyContext>,

--- a/crates/apub/src/activities/private_message/create_or_update.rs
+++ b/crates/apub/src/activities/private_message/create_or_update.rs
@@ -18,6 +18,7 @@ use lemmy_utils::LemmyError;
 use lemmy_websocket::{send::send_pm_ws_message, LemmyContext, UserOperationCrud};
 
 impl CreateOrUpdatePrivateMessage {
+  #[tracing::instrument(skip(private_message, actor, kind, context))]
   pub async fn send(
     private_message: ApubPrivateMessage,
     actor: &ApubPerson,
@@ -46,9 +47,12 @@ impl CreateOrUpdatePrivateMessage {
     send_lemmy_activity(context, &create_or_update, &id, actor, inbox, true).await
   }
 }
+
 #[async_trait::async_trait(?Send)]
 impl ActivityHandler for CreateOrUpdatePrivateMessage {
   type DataType = LemmyContext;
+
+  #[tracing::instrument(skip(self, context))]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -61,6 +65,7 @@ impl ActivityHandler for CreateOrUpdatePrivateMessage {
     Ok(())
   }
 
+  #[tracing::instrument(skip(self, context))]
   async fn receive(
     self,
     context: &Data<LemmyContext>,

--- a/crates/apub/src/activities/private_message/delete.rs
+++ b/crates/apub/src/activities/private_message/delete.rs
@@ -37,7 +37,7 @@ impl DeletePrivateMessage {
     })
   }
 
-  #[tracing::instrument(skip(actor, pm, context))]
+  #[tracing::instrument(skip_all)]
   pub async fn send(
     actor: &ApubPerson,
     pm: &ApubPrivateMessage,
@@ -60,7 +60,7 @@ impl DeletePrivateMessage {
 impl ActivityHandler for DeletePrivateMessage {
   type DataType = LemmyContext;
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -72,7 +72,7 @@ impl ActivityHandler for DeletePrivateMessage {
     Ok(())
   }
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn receive(
     self,
     context: &Data<LemmyContext>,

--- a/crates/apub/src/activities/private_message/delete.rs
+++ b/crates/apub/src/activities/private_message/delete.rs
@@ -36,6 +36,8 @@ impl DeletePrivateMessage {
       unparsed: Default::default(),
     })
   }
+
+  #[tracing::instrument(skip(actor, pm, context))]
   pub async fn send(
     actor: &ApubPerson,
     pm: &ApubPrivateMessage,
@@ -57,6 +59,8 @@ impl DeletePrivateMessage {
 #[async_trait::async_trait(?Send)]
 impl ActivityHandler for DeletePrivateMessage {
   type DataType = LemmyContext;
+
+  #[tracing::instrument(skip(self, context))]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -68,6 +72,7 @@ impl ActivityHandler for DeletePrivateMessage {
     Ok(())
   }
 
+  #[tracing::instrument(skip(self, context))]
   async fn receive(
     self,
     context: &Data<LemmyContext>,

--- a/crates/apub/src/activities/private_message/undo_delete.rs
+++ b/crates/apub/src/activities/private_message/undo_delete.rs
@@ -22,6 +22,7 @@ use lemmy_utils::LemmyError;
 use lemmy_websocket::{send::send_pm_ws_message, LemmyContext, UserOperationCrud};
 
 impl UndoDeletePrivateMessage {
+  #[tracing::instrument(skip(actor, pm, context))]
   pub async fn send(
     actor: &ApubPerson,
     pm: &ApubPrivateMessage,
@@ -54,6 +55,8 @@ impl UndoDeletePrivateMessage {
 #[async_trait::async_trait(?Send)]
 impl ActivityHandler for UndoDeletePrivateMessage {
   type DataType = LemmyContext;
+
+  #[tracing::instrument(skip(self, context))]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -67,6 +70,7 @@ impl ActivityHandler for UndoDeletePrivateMessage {
     Ok(())
   }
 
+  #[tracing::instrument(skip(self, context))]
   async fn receive(
     self,
     context: &Data<LemmyContext>,

--- a/crates/apub/src/activities/private_message/undo_delete.rs
+++ b/crates/apub/src/activities/private_message/undo_delete.rs
@@ -22,7 +22,7 @@ use lemmy_utils::LemmyError;
 use lemmy_websocket::{send::send_pm_ws_message, LemmyContext, UserOperationCrud};
 
 impl UndoDeletePrivateMessage {
-  #[tracing::instrument(skip(actor, pm, context))]
+  #[tracing::instrument(skip_all)]
   pub async fn send(
     actor: &ApubPerson,
     pm: &ApubPrivateMessage,
@@ -56,7 +56,7 @@ impl UndoDeletePrivateMessage {
 impl ActivityHandler for UndoDeletePrivateMessage {
   type DataType = LemmyContext;
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -70,7 +70,7 @@ impl ActivityHandler for UndoDeletePrivateMessage {
     Ok(())
   }
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn receive(
     self,
     context: &Data<LemmyContext>,

--- a/crates/apub/src/activities/voting/mod.rs
+++ b/crates/apub/src/activities/voting/mod.rs
@@ -21,6 +21,7 @@ use crate::{
 pub mod undo_vote;
 pub mod vote;
 
+#[tracing::instrument(skip(vote_type, actor, comment, context))]
 async fn vote_comment(
   vote_type: &VoteType,
   actor: ApubPerson,
@@ -45,6 +46,7 @@ async fn vote_comment(
   Ok(())
 }
 
+#[tracing::instrument(skip(vote_type, actor, post, context))]
 async fn vote_post(
   vote_type: &VoteType,
   actor: ApubPerson,
@@ -68,6 +70,7 @@ async fn vote_post(
   Ok(())
 }
 
+#[tracing::instrument(skip(actor, comment, context))]
 async fn undo_vote_comment(
   actor: ApubPerson,
   comment: &ApubComment,
@@ -84,6 +87,7 @@ async fn undo_vote_comment(
   Ok(())
 }
 
+#[tracing::instrument(skip(actor, post, context))]
 async fn undo_vote_post(
   actor: ApubPerson,
   post: &ApubPost,

--- a/crates/apub/src/activities/voting/mod.rs
+++ b/crates/apub/src/activities/voting/mod.rs
@@ -21,7 +21,7 @@ use crate::{
 pub mod undo_vote;
 pub mod vote;
 
-#[tracing::instrument(skip(vote_type, actor, comment, context))]
+#[tracing::instrument(skip_all)]
 async fn vote_comment(
   vote_type: &VoteType,
   actor: ApubPerson,
@@ -46,7 +46,7 @@ async fn vote_comment(
   Ok(())
 }
 
-#[tracing::instrument(skip(vote_type, actor, post, context))]
+#[tracing::instrument(skip_all)]
 async fn vote_post(
   vote_type: &VoteType,
   actor: ApubPerson,
@@ -70,7 +70,7 @@ async fn vote_post(
   Ok(())
 }
 
-#[tracing::instrument(skip(actor, comment, context))]
+#[tracing::instrument(skip_all)]
 async fn undo_vote_comment(
   actor: ApubPerson,
   comment: &ApubComment,
@@ -87,7 +87,7 @@ async fn undo_vote_comment(
   Ok(())
 }
 
-#[tracing::instrument(skip(actor, post, context))]
+#[tracing::instrument(skip_all)]
 async fn undo_vote_post(
   actor: ApubPerson,
   post: &ApubPost,

--- a/crates/apub/src/activities/voting/undo_vote.rs
+++ b/crates/apub/src/activities/voting/undo_vote.rs
@@ -28,7 +28,7 @@ use lemmy_utils::LemmyError;
 use lemmy_websocket::LemmyContext;
 
 impl UndoVote {
-  #[tracing::instrument(skip(object, actor, community_id, kind, context))]
+  #[tracing::instrument(skip_all)]
   pub async fn send(
     object: &PostOrComment,
     actor: &ApubPerson,
@@ -65,7 +65,7 @@ impl UndoVote {
 impl ActivityHandler for UndoVote {
   type DataType = LemmyContext;
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -80,7 +80,7 @@ impl ActivityHandler for UndoVote {
     Ok(())
   }
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn receive(
     self,
     context: &Data<LemmyContext>,
@@ -101,7 +101,7 @@ impl ActivityHandler for UndoVote {
 
 #[async_trait::async_trait(?Send)]
 impl GetCommunity for UndoVote {
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn get_community(
     &self,
     context: &LemmyContext,

--- a/crates/apub/src/activities/voting/undo_vote.rs
+++ b/crates/apub/src/activities/voting/undo_vote.rs
@@ -28,6 +28,7 @@ use lemmy_utils::LemmyError;
 use lemmy_websocket::LemmyContext;
 
 impl UndoVote {
+  #[tracing::instrument(skip(object, actor, community_id, kind, context))]
   pub async fn send(
     object: &PostOrComment,
     actor: &ApubPerson,
@@ -63,6 +64,8 @@ impl UndoVote {
 #[async_trait::async_trait(?Send)]
 impl ActivityHandler for UndoVote {
   type DataType = LemmyContext;
+
+  #[tracing::instrument(skip(self, context))]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -77,6 +80,7 @@ impl ActivityHandler for UndoVote {
     Ok(())
   }
 
+  #[tracing::instrument(skip(self, context))]
   async fn receive(
     self,
     context: &Data<LemmyContext>,
@@ -97,6 +101,7 @@ impl ActivityHandler for UndoVote {
 
 #[async_trait::async_trait(?Send)]
 impl GetCommunity for UndoVote {
+  #[tracing::instrument(skip(self, context))]
   async fn get_community(
     &self,
     context: &LemmyContext,

--- a/crates/apub/src/activities/voting/vote.rs
+++ b/crates/apub/src/activities/voting/vote.rs
@@ -46,6 +46,7 @@ impl Vote {
     })
   }
 
+  #[tracing::instrument(skip(object, actor, community_id, kind, context))]
   pub async fn send(
     object: &PostOrComment,
     actor: &ApubPerson,
@@ -69,6 +70,8 @@ impl Vote {
 #[async_trait::async_trait(?Send)]
 impl ActivityHandler for Vote {
   type DataType = LemmyContext;
+
+  #[tracing::instrument(skip(self, context))]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -81,6 +84,7 @@ impl ActivityHandler for Vote {
     Ok(())
   }
 
+  #[tracing::instrument(skip(self, context))]
   async fn receive(
     self,
     context: &Data<LemmyContext>,
@@ -97,6 +101,7 @@ impl ActivityHandler for Vote {
 
 #[async_trait::async_trait(?Send)]
 impl GetCommunity for Vote {
+  #[tracing::instrument(skip(self, context))]
   async fn get_community(
     &self,
     context: &LemmyContext,

--- a/crates/apub/src/activities/voting/vote.rs
+++ b/crates/apub/src/activities/voting/vote.rs
@@ -46,7 +46,7 @@ impl Vote {
     })
   }
 
-  #[tracing::instrument(skip(object, actor, community_id, kind, context))]
+  #[tracing::instrument(skip_all)]
   pub async fn send(
     object: &PostOrComment,
     actor: &ApubPerson,
@@ -71,7 +71,7 @@ impl Vote {
 impl ActivityHandler for Vote {
   type DataType = LemmyContext;
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     &self,
     context: &Data<LemmyContext>,
@@ -84,7 +84,7 @@ impl ActivityHandler for Vote {
     Ok(())
   }
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn receive(
     self,
     context: &Data<LemmyContext>,
@@ -101,7 +101,7 @@ impl ActivityHandler for Vote {
 
 #[async_trait::async_trait(?Send)]
 impl GetCommunity for Vote {
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn get_community(
     &self,
     context: &LemmyContext,

--- a/crates/apub/src/activity_lists.rs
+++ b/crates/apub/src/activity_lists.rs
@@ -88,6 +88,7 @@ pub enum AnnouncableActivities {
 
 #[async_trait::async_trait(?Send)]
 impl GetCommunity for AnnouncableActivities {
+  #[tracing::instrument(skip(self, context))]
   async fn get_community(
     &self,
     context: &LemmyContext,

--- a/crates/apub/src/collections/community_moderators.rs
+++ b/crates/apub/src/collections/community_moderators.rs
@@ -29,7 +29,7 @@ impl ApubObject for ApubCommunityModerators {
     None
   }
 
-  #[tracing::instrument(skip(_object_id, data))]
+  #[tracing::instrument(skip_all)]
   async fn read_from_apub_id(
     _object_id: Url,
     data: &Self::DataType,
@@ -47,12 +47,12 @@ impl ApubObject for ApubCommunityModerators {
     }
   }
 
-  #[tracing::instrument(skip(self, _data))]
+  #[tracing::instrument(skip_all)]
   async fn delete(self, _data: &Self::DataType) -> Result<(), LemmyError> {
     unimplemented!()
   }
 
-  #[tracing::instrument(skip(self, data))]
+  #[tracing::instrument(skip_all)]
   async fn into_apub(self, data: &Self::DataType) -> Result<Self::ApubType, LemmyError> {
     let ordered_items = self
       .0
@@ -70,7 +70,7 @@ impl ApubObject for ApubCommunityModerators {
     unimplemented!()
   }
 
-  #[tracing::instrument(skip(group_moderators, expected_domain, _context))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     group_moderators: &GroupModerators,
     expected_domain: &Url,
@@ -81,7 +81,7 @@ impl ApubObject for ApubCommunityModerators {
     Ok(())
   }
 
-  #[tracing::instrument(skip(apub, data))]
+  #[tracing::instrument(skip_all)]
   async fn from_apub(
     apub: Self::ApubType,
     data: &Self::DataType,

--- a/crates/apub/src/collections/community_moderators.rs
+++ b/crates/apub/src/collections/community_moderators.rs
@@ -29,6 +29,7 @@ impl ApubObject for ApubCommunityModerators {
     None
   }
 
+  #[tracing::instrument(skip(_object_id, data))]
   async fn read_from_apub_id(
     _object_id: Url,
     data: &Self::DataType,
@@ -46,10 +47,12 @@ impl ApubObject for ApubCommunityModerators {
     }
   }
 
+  #[tracing::instrument(skip(self, _data))]
   async fn delete(self, _data: &Self::DataType) -> Result<(), LemmyError> {
     unimplemented!()
   }
 
+  #[tracing::instrument(skip(self, data))]
   async fn into_apub(self, data: &Self::DataType) -> Result<Self::ApubType, LemmyError> {
     let ordered_items = self
       .0
@@ -67,6 +70,7 @@ impl ApubObject for ApubCommunityModerators {
     unimplemented!()
   }
 
+  #[tracing::instrument(skip(group_moderators, expected_domain, _context))]
   async fn verify(
     group_moderators: &GroupModerators,
     expected_domain: &Url,
@@ -77,6 +81,7 @@ impl ApubObject for ApubCommunityModerators {
     Ok(())
   }
 
+  #[tracing::instrument(skip(apub, data))]
   async fn from_apub(
     apub: Self::ApubType,
     data: &Self::DataType,

--- a/crates/apub/src/collections/community_outbox.rs
+++ b/crates/apub/src/collections/community_outbox.rs
@@ -33,7 +33,7 @@ impl ApubObject for ApubCommunityOutbox {
     None
   }
 
-  #[tracing::instrument(skip(_object_id, data))]
+  #[tracing::instrument(skip_all)]
   async fn read_from_apub_id(
     _object_id: Url,
     data: &Self::DataType,
@@ -59,7 +59,7 @@ impl ApubObject for ApubCommunityOutbox {
     Ok(())
   }
 
-  #[tracing::instrument(skip(self, data))]
+  #[tracing::instrument(skip_all)]
   async fn into_apub(self, data: &Self::DataType) -> Result<Self::ApubType, LemmyError> {
     let mut ordered_items = vec![];
     for post in self.0 {
@@ -82,7 +82,7 @@ impl ApubObject for ApubCommunityOutbox {
     unimplemented!()
   }
 
-  #[tracing::instrument(skip(group_outbox, expected_domain, _context))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     group_outbox: &GroupOutbox,
     expected_domain: &Url,
@@ -93,7 +93,7 @@ impl ApubObject for ApubCommunityOutbox {
     Ok(())
   }
 
-  #[tracing::instrument(skip(apub, data))]
+  #[tracing::instrument(skip_all)]
   async fn from_apub(
     apub: Self::ApubType,
     data: &Self::DataType,

--- a/crates/apub/src/collections/community_outbox.rs
+++ b/crates/apub/src/collections/community_outbox.rs
@@ -33,6 +33,7 @@ impl ApubObject for ApubCommunityOutbox {
     None
   }
 
+  #[tracing::instrument(skip(_object_id, data))]
   async fn read_from_apub_id(
     _object_id: Url,
     data: &Self::DataType,
@@ -58,6 +59,7 @@ impl ApubObject for ApubCommunityOutbox {
     Ok(())
   }
 
+  #[tracing::instrument(skip(self, data))]
   async fn into_apub(self, data: &Self::DataType) -> Result<Self::ApubType, LemmyError> {
     let mut ordered_items = vec![];
     for post in self.0 {
@@ -80,6 +82,7 @@ impl ApubObject for ApubCommunityOutbox {
     unimplemented!()
   }
 
+  #[tracing::instrument(skip(group_outbox, expected_domain, _context))]
   async fn verify(
     group_outbox: &GroupOutbox,
     expected_domain: &Url,
@@ -90,6 +93,7 @@ impl ApubObject for ApubCommunityOutbox {
     Ok(())
   }
 
+  #[tracing::instrument(skip(apub, data))]
   async fn from_apub(
     apub: Self::ApubType,
     data: &Self::DataType,

--- a/crates/apub/src/fetcher/post_or_comment.rs
+++ b/crates/apub/src/fetcher/post_or_comment.rs
@@ -33,6 +33,7 @@ impl ApubObject for PostOrComment {
   }
 
   // TODO: this can probably be implemented using a single sql query
+  #[tracing::instrument(skip(object_id, data))]
   async fn read_from_apub_id(
     object_id: Url,
     data: &Self::DataType,
@@ -46,6 +47,7 @@ impl ApubObject for PostOrComment {
     })
   }
 
+  #[tracing::instrument(skip(self, data))]
   async fn delete(self, data: &Self::DataType) -> Result<(), LemmyError> {
     match self {
       PostOrComment::Post(p) => p.delete(data).await,
@@ -61,6 +63,7 @@ impl ApubObject for PostOrComment {
     unimplemented!()
   }
 
+  #[tracing::instrument(skip(apub, expected_domain, data))]
   async fn verify(
     apub: &Self::ApubType,
     expected_domain: &Url,
@@ -73,6 +76,7 @@ impl ApubObject for PostOrComment {
     }
   }
 
+  #[tracing::instrument(skip(apub, context))]
   async fn from_apub(
     apub: PageOrNote,
     context: &LemmyContext,

--- a/crates/apub/src/fetcher/post_or_comment.rs
+++ b/crates/apub/src/fetcher/post_or_comment.rs
@@ -33,7 +33,7 @@ impl ApubObject for PostOrComment {
   }
 
   // TODO: this can probably be implemented using a single sql query
-  #[tracing::instrument(skip(object_id, data))]
+  #[tracing::instrument(skip_all)]
   async fn read_from_apub_id(
     object_id: Url,
     data: &Self::DataType,
@@ -47,7 +47,7 @@ impl ApubObject for PostOrComment {
     })
   }
 
-  #[tracing::instrument(skip(self, data))]
+  #[tracing::instrument(skip_all)]
   async fn delete(self, data: &Self::DataType) -> Result<(), LemmyError> {
     match self {
       PostOrComment::Post(p) => p.delete(data).await,
@@ -63,7 +63,7 @@ impl ApubObject for PostOrComment {
     unimplemented!()
   }
 
-  #[tracing::instrument(skip(apub, expected_domain, data))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     apub: &Self::ApubType,
     expected_domain: &Url,
@@ -76,7 +76,7 @@ impl ApubObject for PostOrComment {
     }
   }
 
-  #[tracing::instrument(skip(apub, context))]
+  #[tracing::instrument(skip_all)]
   async fn from_apub(
     apub: PageOrNote,
     context: &LemmyContext,

--- a/crates/apub/src/fetcher/search.rs
+++ b/crates/apub/src/fetcher/search.rs
@@ -18,7 +18,7 @@ use url::Url;
 /// http://lemmy_beta:8551/u/lemmy_alpha, or @lemmy_beta@lemmy_beta:8551
 /// http://lemmy_gamma:8561/post/3
 /// http://lemmy_delta:8571/comment/2
-#[tracing::instrument(skip(query, context))]
+#[tracing::instrument(skip_all)]
 pub async fn search_by_apub_id(
   query: &str,
   context: &LemmyContext,
@@ -105,7 +105,7 @@ impl ApubObject for SearchableObjects {
   //       a single query.
   //       we could skip this and always return an error, but then it would always fetch objects
   //       over http, and not be able to mark objects as deleted that were deleted by remote server.
-  #[tracing::instrument(skip(object_id, context))]
+  #[tracing::instrument(skip_all)]
   async fn read_from_apub_id(
     object_id: Url,
     context: &LemmyContext,
@@ -129,7 +129,7 @@ impl ApubObject for SearchableObjects {
     Ok(None)
   }
 
-  #[tracing::instrument(skip(self, data))]
+  #[tracing::instrument(skip_all)]
   async fn delete(self, data: &Self::DataType) -> Result<(), LemmyError> {
     match self {
       SearchableObjects::Person(p) => p.delete(data).await,
@@ -147,7 +147,7 @@ impl ApubObject for SearchableObjects {
     unimplemented!()
   }
 
-  #[tracing::instrument(skip(apub, expected_domain, data))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     apub: &Self::ApubType,
     expected_domain: &Url,
@@ -170,7 +170,7 @@ impl ApubObject for SearchableObjects {
     }
   }
 
-  #[tracing::instrument(skip(apub, context))]
+  #[tracing::instrument(skip_all)]
   async fn from_apub(
     apub: Self::ApubType,
     context: &LemmyContext,

--- a/crates/apub/src/fetcher/search.rs
+++ b/crates/apub/src/fetcher/search.rs
@@ -4,7 +4,6 @@ use crate::{
   protocol::objects::{group::Group, note::Note, page::Page, person::Person},
   EndpointType,
 };
-use anyhow::anyhow;
 use chrono::NaiveDateTime;
 use lemmy_apub_lib::{object_id::ObjectId, traits::ApubObject};
 use lemmy_utils::LemmyError;
@@ -19,6 +18,7 @@ use url::Url;
 /// http://lemmy_beta:8551/u/lemmy_alpha, or @lemmy_beta@lemmy_beta:8551
 /// http://lemmy_gamma:8561/post/3
 /// http://lemmy_delta:8571/comment/2
+#[tracing::instrument(skip(query, context))]
 pub async fn search_by_apub_id(
   query: &str,
   context: &LemmyContext,
@@ -61,7 +61,7 @@ pub async fn search_by_apub_id(
               .await?,
           ))
         }
-        _ => Err(anyhow!("invalid query").into()),
+        _ => Err(LemmyError::from_message("invalid query".into())),
       }
     }
   }
@@ -105,6 +105,7 @@ impl ApubObject for SearchableObjects {
   //       a single query.
   //       we could skip this and always return an error, but then it would always fetch objects
   //       over http, and not be able to mark objects as deleted that were deleted by remote server.
+  #[tracing::instrument(skip(object_id, context))]
   async fn read_from_apub_id(
     object_id: Url,
     context: &LemmyContext,
@@ -128,6 +129,7 @@ impl ApubObject for SearchableObjects {
     Ok(None)
   }
 
+  #[tracing::instrument(skip(self, data))]
   async fn delete(self, data: &Self::DataType) -> Result<(), LemmyError> {
     match self {
       SearchableObjects::Person(p) => p.delete(data).await,
@@ -145,6 +147,7 @@ impl ApubObject for SearchableObjects {
     unimplemented!()
   }
 
+  #[tracing::instrument(skip(apub, expected_domain, data))]
   async fn verify(
     apub: &Self::ApubType,
     expected_domain: &Url,
@@ -167,6 +170,7 @@ impl ApubObject for SearchableObjects {
     }
   }
 
+  #[tracing::instrument(skip(apub, context))]
   async fn from_apub(
     apub: Self::ApubType,
     context: &LemmyContext,

--- a/crates/apub/src/fetcher/search.rs
+++ b/crates/apub/src/fetcher/search.rs
@@ -61,7 +61,7 @@ pub async fn search_by_apub_id(
               .await?,
           ))
         }
-        _ => Err(LemmyError::from_message("invalid query".into())),
+        _ => Err(LemmyError::from_message("invalid query")),
       }
     }
   }

--- a/crates/apub/src/fetcher/user_or_community.rs
+++ b/crates/apub/src/fetcher/user_or_community.rs
@@ -35,6 +35,7 @@ impl ApubObject for UserOrCommunity {
     })
   }
 
+  #[tracing::instrument(skip(object_id, data))]
   async fn read_from_apub_id(
     object_id: Url,
     data: &Self::DataType,
@@ -48,6 +49,7 @@ impl ApubObject for UserOrCommunity {
     })
   }
 
+  #[tracing::instrument(skip(self, data))]
   async fn delete(self, data: &Self::DataType) -> Result<(), LemmyError> {
     match self {
       UserOrCommunity::User(p) => p.delete(data).await,
@@ -63,6 +65,7 @@ impl ApubObject for UserOrCommunity {
     unimplemented!()
   }
 
+  #[tracing::instrument(skip(apub, expected_domain, data))]
   async fn verify(
     apub: &Self::ApubType,
     expected_domain: &Url,
@@ -79,6 +82,7 @@ impl ApubObject for UserOrCommunity {
     }
   }
 
+  #[tracing::instrument(skip(apub, data))]
   async fn from_apub(
     apub: Self::ApubType,
     data: &Self::DataType,

--- a/crates/apub/src/fetcher/user_or_community.rs
+++ b/crates/apub/src/fetcher/user_or_community.rs
@@ -35,7 +35,7 @@ impl ApubObject for UserOrCommunity {
     })
   }
 
-  #[tracing::instrument(skip(object_id, data))]
+  #[tracing::instrument(skip_all)]
   async fn read_from_apub_id(
     object_id: Url,
     data: &Self::DataType,
@@ -49,7 +49,7 @@ impl ApubObject for UserOrCommunity {
     })
   }
 
-  #[tracing::instrument(skip(self, data))]
+  #[tracing::instrument(skip_all)]
   async fn delete(self, data: &Self::DataType) -> Result<(), LemmyError> {
     match self {
       UserOrCommunity::User(p) => p.delete(data).await,
@@ -65,7 +65,7 @@ impl ApubObject for UserOrCommunity {
     unimplemented!()
   }
 
-  #[tracing::instrument(skip(apub, expected_domain, data))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     apub: &Self::ApubType,
     expected_domain: &Url,
@@ -82,7 +82,7 @@ impl ApubObject for UserOrCommunity {
     }
   }
 
-  #[tracing::instrument(skip(apub, data))]
+  #[tracing::instrument(skip_all)]
   async fn from_apub(
     apub: Self::ApubType,
     data: &Self::DataType,

--- a/crates/apub/src/fetcher/webfinger.rs
+++ b/crates/apub/src/fetcher/webfinger.rs
@@ -33,7 +33,7 @@ pub struct WebfingerResponse {
 ///
 /// TODO: later provide a method in ApubObject to generate the endpoint, so that we dont have to
 ///       pass in EndpointType
-#[tracing::instrument(skip(identifier, endpoint_type, context))]
+#[tracing::instrument(skip_all)]
 pub async fn webfinger_resolve<Kind>(
   identifier: &str,
   endpoint_type: EndpointType,
@@ -61,7 +61,7 @@ where
 
 /// Turns a person id like `@name@example.com` into an apub ID, like `https://example.com/user/name`,
 /// using webfinger.
-#[tracing::instrument(skip(identifier, context))]
+#[tracing::instrument(skip_all)]
 pub(crate) async fn webfinger_resolve_actor<Kind>(
   identifier: &str,
   context: &LemmyContext,

--- a/crates/apub/src/fetcher/webfinger.rs
+++ b/crates/apub/src/fetcher/webfinger.rs
@@ -110,8 +110,9 @@ where
       return object.map(|o| o.actor_id().into());
     }
   }
-  Err(LemmyError::from_message(format!(
+  let error = LemmyError::from(anyhow::anyhow!(
     "Failed to resolve actor for {}",
     identifier
-  )))
+  ));
+  Err(error.with_message("failed_to_resolve"))
 }

--- a/crates/apub/src/fetcher/webfinger.rs
+++ b/crates/apub/src/fetcher/webfinger.rs
@@ -1,5 +1,4 @@
 use crate::{generate_local_apub_endpoint, EndpointType};
-use anyhow::anyhow;
 use itertools::Itertools;
 use lemmy_apub_lib::{
   object_id::ObjectId,
@@ -34,6 +33,7 @@ pub struct WebfingerResponse {
 ///
 /// TODO: later provide a method in ApubObject to generate the endpoint, so that we dont have to
 ///       pass in EndpointType
+#[tracing::instrument(skip(identifier, endpoint_type, context))]
 pub async fn webfinger_resolve<Kind>(
   identifier: &str,
   endpoint_type: EndpointType,
@@ -61,6 +61,7 @@ where
 
 /// Turns a person id like `@name@example.com` into an apub ID, like `https://example.com/user/name`,
 /// using webfinger.
+#[tracing::instrument(skip(identifier, context))]
 pub(crate) async fn webfinger_resolve_actor<Kind>(
   identifier: &str,
   context: &LemmyContext,
@@ -109,5 +110,8 @@ where
       return object.map(|o| o.actor_id().into());
     }
   }
-  Err(anyhow!("Failed to resolve actor for {}", identifier).into())
+  Err(LemmyError::from_message(format!(
+    "Failed to resolve actor for {}",
+    identifier
+  )))
 }

--- a/crates/apub/src/http/comment.rs
+++ b/crates/apub/src/http/comment.rs
@@ -2,7 +2,7 @@ use crate::{
   http::{create_apub_response, create_apub_tombstone_response},
   objects::comment::ApubComment,
 };
-use actix_web::{body::Body, web, web::Path, HttpResponse};
+use actix_web::{body::AnyBody, web, web::Path, HttpResponse};
 use diesel::result::Error::NotFound;
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::traits::ApubObject;
@@ -20,7 +20,7 @@ pub(crate) struct CommentQuery {
 pub(crate) async fn get_apub_comment(
   info: Path<CommentQuery>,
   context: web::Data<LemmyContext>,
-) -> Result<HttpResponse<Body>, LemmyError> {
+) -> Result<HttpResponse<AnyBody>, LemmyError> {
   let id = CommentId(info.comment_id.parse::<i32>()?);
   let comment: ApubComment = blocking(context.pool(), move |conn| Comment::read(conn, id))
     .await??

--- a/crates/apub/src/http/comment.rs
+++ b/crates/apub/src/http/comment.rs
@@ -17,7 +17,7 @@ pub(crate) struct CommentQuery {
 }
 
 /// Return the ActivityPub json representation of a local comment over HTTP.
-#[tracing::instrument(skip(info, context))]
+#[tracing::instrument(skip_all)]
 pub(crate) async fn get_apub_comment(
   info: Path<CommentQuery>,
   context: web::Data<LemmyContext>,

--- a/crates/apub/src/http/comment.rs
+++ b/crates/apub/src/http/comment.rs
@@ -17,6 +17,7 @@ pub(crate) struct CommentQuery {
 }
 
 /// Return the ActivityPub json representation of a local comment over HTTP.
+#[tracing::instrument(skip(info, context))]
 pub(crate) async fn get_apub_comment(
   info: Path<CommentQuery>,
   context: web::Data<LemmyContext>,

--- a/crates/apub/src/http/community.rs
+++ b/crates/apub/src/http/community.rs
@@ -36,7 +36,7 @@ pub(crate) struct CommunityQuery {
 }
 
 /// Return the ActivityPub json representation of a local community over HTTP.
-#[tracing::instrument(skip(info, context))]
+#[tracing::instrument(skip_all)]
 pub(crate) async fn get_apub_community_http(
   info: web::Path<CommunityQuery>,
   context: web::Data<LemmyContext>,
@@ -57,7 +57,7 @@ pub(crate) async fn get_apub_community_http(
 }
 
 /// Handler for all incoming receive to community inboxes.
-#[tracing::instrument(skip(request, payload, _path, context))]
+#[tracing::instrument(skip_all)]
 pub async fn community_inbox(
   request: HttpRequest,
   payload: Payload,
@@ -123,7 +123,7 @@ pub(crate) async fn get_apub_community_outbox(
   Ok(create_apub_response(&outbox.into_apub(&outbox_data).await?))
 }
 
-#[tracing::instrument(skip(info, context))]
+#[tracing::instrument(skip_all)]
 pub(crate) async fn get_apub_community_moderators(
   info: web::Path<CommunityQuery>,
   context: web::Data<LemmyContext>,

--- a/crates/apub/src/http/community.rs
+++ b/crates/apub/src/http/community.rs
@@ -36,6 +36,7 @@ pub(crate) struct CommunityQuery {
 }
 
 /// Return the ActivityPub json representation of a local community over HTTP.
+#[tracing::instrument(skip(info, context))]
 pub(crate) async fn get_apub_community_http(
   info: web::Path<CommunityQuery>,
   context: web::Data<LemmyContext>,
@@ -56,6 +57,7 @@ pub(crate) async fn get_apub_community_http(
 }
 
 /// Handler for all incoming receive to community inboxes.
+#[tracing::instrument(skip(request, payload, _path, context))]
 pub async fn community_inbox(
   request: HttpRequest,
   payload: Payload,
@@ -121,6 +123,7 @@ pub(crate) async fn get_apub_community_outbox(
   Ok(create_apub_response(&outbox.into_apub(&outbox_data).await?))
 }
 
+#[tracing::instrument(skip(info, context))]
 pub(crate) async fn get_apub_community_moderators(
   info: web::Path<CommunityQuery>,
   context: web::Data<LemmyContext>,

--- a/crates/apub/src/http/community.rs
+++ b/crates/apub/src/http/community.rs
@@ -21,7 +21,7 @@ use crate::{
     collections::group_followers::GroupFollowers,
   },
 };
-use actix_web::{body::Body, web, web::Payload, HttpRequest, HttpResponse};
+use actix_web::{body::AnyBody, web, web::Payload, HttpRequest, HttpResponse};
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::{object_id::ObjectId, traits::ApubObject};
 use lemmy_db_schema::source::community::Community;
@@ -39,7 +39,7 @@ pub(crate) struct CommunityQuery {
 pub(crate) async fn get_apub_community_http(
   info: web::Path<CommunityQuery>,
   context: web::Data<LemmyContext>,
-) -> Result<HttpResponse<Body>, LemmyError> {
+) -> Result<HttpResponse<AnyBody>, LemmyError> {
   let community: ApubCommunity = blocking(context.pool(), move |conn| {
     Community::read_from_name(conn, &info.community_name)
   })
@@ -96,7 +96,7 @@ pub(in crate::http) async fn receive_group_inbox(
 pub(crate) async fn get_apub_community_followers(
   info: web::Path<CommunityQuery>,
   context: web::Data<LemmyContext>,
-) -> Result<HttpResponse<Body>, LemmyError> {
+) -> Result<HttpResponse<AnyBody>, LemmyError> {
   let community = blocking(context.pool(), move |conn| {
     Community::read_from_name(conn, &info.community_name)
   })
@@ -110,7 +110,7 @@ pub(crate) async fn get_apub_community_followers(
 pub(crate) async fn get_apub_community_outbox(
   info: web::Path<CommunityQuery>,
   context: web::Data<LemmyContext>,
-) -> Result<HttpResponse<Body>, LemmyError> {
+) -> Result<HttpResponse<AnyBody>, LemmyError> {
   let community = blocking(context.pool(), move |conn| {
     Community::read_from_name(conn, &info.community_name)
   })
@@ -124,7 +124,7 @@ pub(crate) async fn get_apub_community_outbox(
 pub(crate) async fn get_apub_community_moderators(
   info: web::Path<CommunityQuery>,
   context: web::Data<LemmyContext>,
-) -> Result<HttpResponse<Body>, LemmyError> {
+) -> Result<HttpResponse<AnyBody>, LemmyError> {
   let community: ApubCommunity = blocking(context.pool(), move |conn| {
     Community::read_from_name(conn, &info.community_name)
   })

--- a/crates/apub/src/http/mod.rs
+++ b/crates/apub/src/http/mod.rs
@@ -38,7 +38,7 @@ mod person;
 mod post;
 pub mod routes;
 
-#[tracing::instrument(skip(request, payload, context))]
+#[tracing::instrument(skip_all)]
 pub async fn shared_inbox(
   request: HttpRequest,
   payload: Payload,
@@ -76,7 +76,7 @@ pub(crate) struct ActivityCommonFields {
 }
 
 // TODO: move most of this code to library
-#[tracing::instrument(skip(request, activity, activity_data, context))]
+#[tracing::instrument(skip_all)]
 async fn receive_activity<'a, T>(
   request: HttpRequest,
   activity: T,
@@ -151,7 +151,7 @@ pub struct ActivityQuery {
 }
 
 /// Return the ActivityPub json representation of a local activity over HTTP.
-#[tracing::instrument(skip(info, context))]
+#[tracing::instrument(skip_all)]
 pub(crate) async fn get_activity(
   info: web::Path<ActivityQuery>,
   context: web::Data<LemmyContext>,

--- a/crates/apub/src/http/mod.rs
+++ b/crates/apub/src/http/mod.rs
@@ -181,10 +181,11 @@ fn assert_activity_not_local(id: &Url, hostname: &str) -> Result<(), LemmyError>
   let activity_domain = id.domain().context(location_info!())?;
 
   if activity_domain == hostname {
-    return Err(LemmyError::from_message(format!(
+    let error = LemmyError::from(anyhow::anyhow!(
       "Error: received activity which was sent by local instance: {:?}",
       id
-    )));
+    ));
+    return Err(error.with_message("received_local_activity"));
   }
   Ok(())
 }

--- a/crates/apub/src/http/mod.rs
+++ b/crates/apub/src/http/mod.rs
@@ -7,7 +7,7 @@ use crate::{
   insert_activity,
 };
 use actix_web::{
-  body::Body,
+  body::AnyBody,
   web,
   web::{Bytes, BytesMut, Payload},
   HttpRequest,
@@ -117,7 +117,7 @@ where
 
 /// Convert the data to json and turn it into an HTTP Response with the correct ActivityPub
 /// headers.
-fn create_apub_response<T>(data: &T) -> HttpResponse<Body>
+fn create_apub_response<T>(data: &T) -> HttpResponse<AnyBody>
 where
   T: Serialize,
 {
@@ -126,13 +126,13 @@ where
     .json(WithContext::new(data))
 }
 
-fn create_json_apub_response(data: serde_json::Value) -> HttpResponse<Body> {
+fn create_json_apub_response(data: serde_json::Value) -> HttpResponse<AnyBody> {
   HttpResponse::Ok()
     .content_type(APUB_JSON_CONTENT_TYPE)
     .json(data)
 }
 
-fn create_apub_tombstone_response<T>(data: &T) -> HttpResponse<Body>
+fn create_apub_tombstone_response<T>(data: &T) -> HttpResponse<AnyBody>
 where
   T: Serialize,
 {
@@ -152,7 +152,7 @@ pub struct ActivityQuery {
 pub(crate) async fn get_activity(
   info: web::Path<ActivityQuery>,
   context: web::Data<LemmyContext>,
-) -> Result<HttpResponse<Body>, LemmyError> {
+) -> Result<HttpResponse<AnyBody>, LemmyError> {
   let settings = context.settings();
   let activity_id = Url::parse(&format!(
     "{}/activities/{}/{}",

--- a/crates/apub/src/http/person.rs
+++ b/crates/apub/src/http/person.rs
@@ -26,7 +26,7 @@ pub struct PersonQuery {
 }
 
 /// Return the ActivityPub json representation of a local person over HTTP.
-#[tracing::instrument(skip(info, context))]
+#[tracing::instrument(skip_all)]
 pub(crate) async fn get_apub_person_http(
   info: web::Path<PersonQuery>,
   context: web::Data<LemmyContext>,
@@ -48,7 +48,7 @@ pub(crate) async fn get_apub_person_http(
   }
 }
 
-#[tracing::instrument(skip(request, payload, _path, context))]
+#[tracing::instrument(skip_all)]
 pub async fn person_inbox(
   request: HttpRequest,
   payload: Payload,
@@ -71,7 +71,7 @@ pub(in crate::http) async fn receive_person_inbox(
   receive_activity(request, activity, activity_data, context).await
 }
 
-#[tracing::instrument(skip(info, context))]
+#[tracing::instrument(skip_all)]
 pub(crate) async fn get_apub_person_outbox(
   info: web::Path<PersonQuery>,
   context: web::Data<LemmyContext>,

--- a/crates/apub/src/http/person.rs
+++ b/crates/apub/src/http/person.rs
@@ -26,6 +26,7 @@ pub struct PersonQuery {
 }
 
 /// Return the ActivityPub json representation of a local person over HTTP.
+#[tracing::instrument(skip(info, context))]
 pub(crate) async fn get_apub_person_http(
   info: web::Path<PersonQuery>,
   context: web::Data<LemmyContext>,
@@ -47,6 +48,7 @@ pub(crate) async fn get_apub_person_http(
   }
 }
 
+#[tracing::instrument(skip(request, payload, _path, context))]
 pub async fn person_inbox(
   request: HttpRequest,
   payload: Payload,
@@ -69,6 +71,7 @@ pub(in crate::http) async fn receive_person_inbox(
   receive_activity(request, activity, activity_data, context).await
 }
 
+#[tracing::instrument(skip(info, context))]
 pub(crate) async fn get_apub_person_outbox(
   info: web::Path<PersonQuery>,
   context: web::Data<LemmyContext>,

--- a/crates/apub/src/http/person.rs
+++ b/crates/apub/src/http/person.rs
@@ -11,7 +11,7 @@ use crate::{
   objects::person::ApubPerson,
   protocol::collections::person_outbox::PersonOutbox,
 };
-use actix_web::{body::Body, web, web::Payload, HttpRequest, HttpResponse};
+use actix_web::{body::AnyBody, web, web::Payload, HttpRequest, HttpResponse};
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::traits::ApubObject;
 use lemmy_db_schema::source::person::Person;
@@ -29,7 +29,7 @@ pub struct PersonQuery {
 pub(crate) async fn get_apub_person_http(
   info: web::Path<PersonQuery>,
   context: web::Data<LemmyContext>,
-) -> Result<HttpResponse<Body>, LemmyError> {
+) -> Result<HttpResponse<AnyBody>, LemmyError> {
   let user_name = info.into_inner().user_name;
   // TODO: this needs to be able to read deleted persons, so that it can send tombstones
   let person: ApubPerson = blocking(context.pool(), move |conn| {
@@ -72,7 +72,7 @@ pub(in crate::http) async fn receive_person_inbox(
 pub(crate) async fn get_apub_person_outbox(
   info: web::Path<PersonQuery>,
   context: web::Data<LemmyContext>,
-) -> Result<HttpResponse<Body>, LemmyError> {
+) -> Result<HttpResponse<AnyBody>, LemmyError> {
   let person = blocking(context.pool(), move |conn| {
     Person::find_by_name(conn, &info.user_name)
   })

--- a/crates/apub/src/http/post.rs
+++ b/crates/apub/src/http/post.rs
@@ -2,7 +2,7 @@ use crate::{
   http::{create_apub_response, create_apub_tombstone_response},
   objects::post::ApubPost,
 };
-use actix_web::{body::Body, web, HttpResponse};
+use actix_web::{body::AnyBody, web, HttpResponse};
 use diesel::result::Error::NotFound;
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::traits::ApubObject;
@@ -20,7 +20,7 @@ pub(crate) struct PostQuery {
 pub(crate) async fn get_apub_post(
   info: web::Path<PostQuery>,
   context: web::Data<LemmyContext>,
-) -> Result<HttpResponse<Body>, LemmyError> {
+) -> Result<HttpResponse<AnyBody>, LemmyError> {
   let id = PostId(info.post_id.parse::<i32>()?);
   let post: ApubPost = blocking(context.pool(), move |conn| Post::read(conn, id))
     .await??

--- a/crates/apub/src/http/post.rs
+++ b/crates/apub/src/http/post.rs
@@ -17,6 +17,7 @@ pub(crate) struct PostQuery {
 }
 
 /// Return the ActivityPub json representation of a local post over HTTP.
+#[tracing::instrument(skip(info, context))]
 pub(crate) async fn get_apub_post(
   info: web::Path<PostQuery>,
   context: web::Data<LemmyContext>,

--- a/crates/apub/src/http/post.rs
+++ b/crates/apub/src/http/post.rs
@@ -17,7 +17,7 @@ pub(crate) struct PostQuery {
 }
 
 /// Return the ActivityPub json representation of a local post over HTTP.
-#[tracing::instrument(skip(info, context))]
+#[tracing::instrument(skip_all)]
 pub(crate) async fn get_apub_post(
   info: web::Path<PostQuery>,
   context: web::Data<LemmyContext>,

--- a/crates/apub/src/mentions.rs
+++ b/crates/apub/src/mentions.rs
@@ -34,6 +34,7 @@ pub struct MentionsAndAddresses {
 /// This takes a comment, and builds a list of to_addresses, inboxes,
 /// and mention tags, so they know where to be sent to.
 /// Addresses are the persons / addresses that go in the cc field.
+#[tracing::instrument(skip(comment, community_id, context))]
 pub async fn collect_non_local_mentions(
   comment: &ApubComment,
   community_id: ObjectId<ApubCommunity>,
@@ -88,6 +89,7 @@ pub async fn collect_non_local_mentions(
 
 /// Returns the apub ID of the person this comment is responding to. Meaning, in case this is a
 /// top-level comment, the creator of the post, otherwise the creator of the parent comment.
+#[tracing::instrument(skip(pool, comment))]
 async fn get_comment_parent_creator(
   pool: &DbPool,
   comment: &Comment,

--- a/crates/apub/src/objects/comment.rs
+++ b/crates/apub/src/objects/comment.rs
@@ -64,7 +64,7 @@ impl ApubObject for ApubComment {
     None
   }
 
-  #[tracing::instrument(skip(object_id, context))]
+  #[tracing::instrument(skip_all)]
   async fn read_from_apub_id(
     object_id: Url,
     context: &LemmyContext,
@@ -78,7 +78,7 @@ impl ApubObject for ApubComment {
     )
   }
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn delete(self, context: &LemmyContext) -> Result<(), LemmyError> {
     if !self.deleted {
       blocking(context.pool(), move |conn| {
@@ -89,7 +89,7 @@ impl ApubObject for ApubComment {
     Ok(())
   }
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn into_apub(self, context: &LemmyContext) -> Result<Note, LemmyError> {
     let creator_id = self.creator_id;
     let creator = blocking(context.pool(), move |conn| Person::read(conn, creator_id)).await??;
@@ -138,7 +138,7 @@ impl ApubObject for ApubComment {
     Ok(Tombstone::new(self.ap_id.clone().into()))
   }
 
-  #[tracing::instrument(skip(note, expected_domain, context))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     note: &Note,
     expected_domain: &Url,
@@ -171,7 +171,7 @@ impl ApubObject for ApubComment {
   /// Converts a `Note` to `Comment`.
   ///
   /// If the parent community, post and comment(s) are not known locally, these are also fetched.
-  #[tracing::instrument(skip(note, context))]
+  #[tracing::instrument(skip_all)]
   async fn from_apub(
     note: Note,
     context: &LemmyContext,

--- a/crates/apub/src/objects/comment.rs
+++ b/crates/apub/src/objects/comment.rs
@@ -12,7 +12,6 @@ use crate::{
   PostOrComment,
 };
 use activitystreams_kinds::{object::NoteType, public};
-use anyhow::anyhow;
 use chrono::NaiveDateTime;
 use html2md::parse_html;
 use lemmy_api_common::blocking;
@@ -65,6 +64,7 @@ impl ApubObject for ApubComment {
     None
   }
 
+  #[tracing::instrument(skip(object_id, context))]
   async fn read_from_apub_id(
     object_id: Url,
     context: &LemmyContext,
@@ -78,6 +78,7 @@ impl ApubObject for ApubComment {
     )
   }
 
+  #[tracing::instrument(skip(self, context))]
   async fn delete(self, context: &LemmyContext) -> Result<(), LemmyError> {
     if !self.deleted {
       blocking(context.pool(), move |conn| {
@@ -88,6 +89,7 @@ impl ApubObject for ApubComment {
     Ok(())
   }
 
+  #[tracing::instrument(skip(self, context))]
   async fn into_apub(self, context: &LemmyContext) -> Result<Note, LemmyError> {
     let creator_id = self.creator_id;
     let creator = blocking(context.pool(), move |conn| Person::read(conn, creator_id)).await??;
@@ -136,6 +138,7 @@ impl ApubObject for ApubComment {
     Ok(Tombstone::new(self.ap_id.clone().into()))
   }
 
+  #[tracing::instrument(skip(note, expected_domain, context))]
   async fn verify(
     note: &Note,
     expected_domain: &Url,
@@ -160,7 +163,7 @@ impl ApubObject for ApubComment {
     )
     .await?;
     if post.locked {
-      return Err(anyhow!("Post is locked").into());
+      return Err(LemmyError::from_message("Post is locked".into()));
     }
     Ok(())
   }
@@ -168,6 +171,7 @@ impl ApubObject for ApubComment {
   /// Converts a `Note` to `Comment`.
   ///
   /// If the parent community, post and comment(s) are not known locally, these are also fetched.
+  #[tracing::instrument(skip(note, context))]
   async fn from_apub(
     note: Note,
     context: &LemmyContext,

--- a/crates/apub/src/objects/comment.rs
+++ b/crates/apub/src/objects/comment.rs
@@ -163,7 +163,7 @@ impl ApubObject for ApubComment {
     )
     .await?;
     if post.locked {
-      return Err(LemmyError::from_message("Post is locked".into()));
+      return Err(LemmyError::from_message("Post is locked"));
     }
     Ok(())
   }

--- a/crates/apub/src/objects/community.rs
+++ b/crates/apub/src/objects/community.rs
@@ -55,7 +55,7 @@ impl ApubObject for ApubCommunity {
     Some(self.last_refreshed_at)
   }
 
-  #[tracing::instrument(skip(object_id, context))]
+  #[tracing::instrument(skip_all)]
   async fn read_from_apub_id(
     object_id: Url,
     context: &LemmyContext,
@@ -69,7 +69,7 @@ impl ApubObject for ApubCommunity {
     )
   }
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn delete(self, context: &LemmyContext) -> Result<(), LemmyError> {
     blocking(context.pool(), move |conn| {
       Community::update_deleted(conn, self.id, true)
@@ -78,7 +78,7 @@ impl ApubObject for ApubCommunity {
     Ok(())
   }
 
-  #[tracing::instrument(skip(self, _context))]
+  #[tracing::instrument(skip_all)]
   async fn into_apub(self, _context: &LemmyContext) -> Result<Group, LemmyError> {
     let source = self.description.clone().map(|bio| Source {
       content: bio,
@@ -118,7 +118,7 @@ impl ApubObject for ApubCommunity {
     Ok(Tombstone::new(self.actor_id()))
   }
 
-  #[tracing::instrument(skip(group, expected_domain, context))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     group: &Group,
     expected_domain: &Url,
@@ -129,7 +129,7 @@ impl ApubObject for ApubCommunity {
   }
 
   /// Converts a `Group` to `Community`, inserts it into the database and updates moderators.
-  #[tracing::instrument(skip(group, context))]
+  #[tracing::instrument(skip_all)]
   async fn from_apub(
     group: Group,
     context: &LemmyContext,
@@ -186,7 +186,7 @@ impl ActorType for ApubCommunity {
 
 impl ApubCommunity {
   /// For a given community, returns the inboxes of all followers.
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   pub(crate) async fn get_follower_inboxes(
     &self,
     context: &LemmyContext,

--- a/crates/apub/src/objects/community.rs
+++ b/crates/apub/src/objects/community.rs
@@ -55,6 +55,7 @@ impl ApubObject for ApubCommunity {
     Some(self.last_refreshed_at)
   }
 
+  #[tracing::instrument(skip(object_id, context))]
   async fn read_from_apub_id(
     object_id: Url,
     context: &LemmyContext,
@@ -68,6 +69,7 @@ impl ApubObject for ApubCommunity {
     )
   }
 
+  #[tracing::instrument(skip(self, context))]
   async fn delete(self, context: &LemmyContext) -> Result<(), LemmyError> {
     blocking(context.pool(), move |conn| {
       Community::update_deleted(conn, self.id, true)
@@ -76,6 +78,7 @@ impl ApubObject for ApubCommunity {
     Ok(())
   }
 
+  #[tracing::instrument(skip(self, _context))]
   async fn into_apub(self, _context: &LemmyContext) -> Result<Group, LemmyError> {
     let source = self.description.clone().map(|bio| Source {
       content: bio,
@@ -115,6 +118,7 @@ impl ApubObject for ApubCommunity {
     Ok(Tombstone::new(self.actor_id()))
   }
 
+  #[tracing::instrument(skip(group, expected_domain, context))]
   async fn verify(
     group: &Group,
     expected_domain: &Url,
@@ -125,6 +129,7 @@ impl ApubObject for ApubCommunity {
   }
 
   /// Converts a `Group` to `Community`, inserts it into the database and updates moderators.
+  #[tracing::instrument(skip(group, context))]
   async fn from_apub(
     group: Group,
     context: &LemmyContext,
@@ -181,6 +186,7 @@ impl ActorType for ApubCommunity {
 
 impl ApubCommunity {
   /// For a given community, returns the inboxes of all followers.
+  #[tracing::instrument(skip(self, context))]
   pub(crate) async fn get_follower_inboxes(
     &self,
     context: &LemmyContext,

--- a/crates/apub/src/objects/person.rs
+++ b/crates/apub/src/objects/person.rs
@@ -57,6 +57,7 @@ impl ApubObject for ApubPerson {
     Some(self.last_refreshed_at)
   }
 
+  #[tracing::instrument(skip(object_id, context))]
   async fn read_from_apub_id(
     object_id: Url,
     context: &LemmyContext,
@@ -70,6 +71,7 @@ impl ApubObject for ApubPerson {
     )
   }
 
+  #[tracing::instrument(skip(self, context))]
   async fn delete(self, context: &LemmyContext) -> Result<(), LemmyError> {
     blocking(context.pool(), move |conn| {
       DbPerson::update_deleted(conn, self.id, true)
@@ -78,6 +80,7 @@ impl ApubObject for ApubPerson {
     Ok(())
   }
 
+  #[tracing::instrument(skip(self, _pool))]
   async fn into_apub(self, _pool: &LemmyContext) -> Result<Person, LemmyError> {
     let kind = if self.bot_account {
       UserTypes::Service
@@ -118,6 +121,7 @@ impl ApubObject for ApubPerson {
     unimplemented!()
   }
 
+  #[tracing::instrument(skip(person, expected_domain, context))]
   async fn verify(
     person: &Person,
     expected_domain: &Url,
@@ -135,6 +139,7 @@ impl ApubObject for ApubPerson {
     Ok(())
   }
 
+  #[tracing::instrument(skip(person, context))]
   async fn from_apub(
     person: Person,
     context: &LemmyContext,

--- a/crates/apub/src/objects/person.rs
+++ b/crates/apub/src/objects/person.rs
@@ -57,7 +57,7 @@ impl ApubObject for ApubPerson {
     Some(self.last_refreshed_at)
   }
 
-  #[tracing::instrument(skip(object_id, context))]
+  #[tracing::instrument(skip_all)]
   async fn read_from_apub_id(
     object_id: Url,
     context: &LemmyContext,
@@ -71,7 +71,7 @@ impl ApubObject for ApubPerson {
     )
   }
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn delete(self, context: &LemmyContext) -> Result<(), LemmyError> {
     blocking(context.pool(), move |conn| {
       DbPerson::update_deleted(conn, self.id, true)
@@ -80,7 +80,7 @@ impl ApubObject for ApubPerson {
     Ok(())
   }
 
-  #[tracing::instrument(skip(self, _pool))]
+  #[tracing::instrument(skip_all)]
   async fn into_apub(self, _pool: &LemmyContext) -> Result<Person, LemmyError> {
     let kind = if self.bot_account {
       UserTypes::Service
@@ -121,7 +121,7 @@ impl ApubObject for ApubPerson {
     unimplemented!()
   }
 
-  #[tracing::instrument(skip(person, expected_domain, context))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     person: &Person,
     expected_domain: &Url,
@@ -139,7 +139,7 @@ impl ApubObject for ApubPerson {
     Ok(())
   }
 
-  #[tracing::instrument(skip(person, context))]
+  #[tracing::instrument(skip_all)]
   async fn from_apub(
     person: Person,
     context: &LemmyContext,

--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -60,6 +60,7 @@ impl ApubObject for ApubPost {
     None
   }
 
+  #[tracing::instrument(skip(object_id, context))]
   async fn read_from_apub_id(
     object_id: Url,
     context: &LemmyContext,
@@ -73,6 +74,7 @@ impl ApubObject for ApubPost {
     )
   }
 
+  #[tracing::instrument(skip(self, context))]
   async fn delete(self, context: &LemmyContext) -> Result<(), LemmyError> {
     if !self.deleted {
       blocking(context.pool(), move |conn| {
@@ -84,6 +86,7 @@ impl ApubObject for ApubPost {
   }
 
   // Turn a Lemmy post into an ActivityPub page that can be sent out over the network.
+  #[tracing::instrument(skip(self, context))]
   async fn into_apub(self, context: &LemmyContext) -> Result<Page, LemmyError> {
     let creator_id = self.creator_id;
     let creator = blocking(context.pool(), move |conn| Person::read(conn, creator_id)).await??;
@@ -125,6 +128,7 @@ impl ApubObject for ApubPost {
     Ok(Tombstone::new(self.ap_id.clone().into()))
   }
 
+  #[tracing::instrument(skip(page, expected_domain, context))]
   async fn verify(
     page: &Page,
     expected_domain: &Url,
@@ -146,6 +150,7 @@ impl ApubObject for ApubPost {
     Ok(())
   }
 
+  #[tracing::instrument(skip(page, context))]
   async fn from_apub(
     page: Page,
     context: &LemmyContext,

--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -60,7 +60,7 @@ impl ApubObject for ApubPost {
     None
   }
 
-  #[tracing::instrument(skip(object_id, context))]
+  #[tracing::instrument(skip_all)]
   async fn read_from_apub_id(
     object_id: Url,
     context: &LemmyContext,
@@ -74,7 +74,7 @@ impl ApubObject for ApubPost {
     )
   }
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn delete(self, context: &LemmyContext) -> Result<(), LemmyError> {
     if !self.deleted {
       blocking(context.pool(), move |conn| {
@@ -86,7 +86,7 @@ impl ApubObject for ApubPost {
   }
 
   // Turn a Lemmy post into an ActivityPub page that can be sent out over the network.
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn into_apub(self, context: &LemmyContext) -> Result<Page, LemmyError> {
     let creator_id = self.creator_id;
     let creator = blocking(context.pool(), move |conn| Person::read(conn, creator_id)).await??;
@@ -128,7 +128,7 @@ impl ApubObject for ApubPost {
     Ok(Tombstone::new(self.ap_id.clone().into()))
   }
 
-  #[tracing::instrument(skip(page, expected_domain, context))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     page: &Page,
     expected_domain: &Url,
@@ -150,7 +150,7 @@ impl ApubObject for ApubPost {
     Ok(())
   }
 
-  #[tracing::instrument(skip(page, context))]
+  #[tracing::instrument(skip_all)]
   async fn from_apub(
     page: Page,
     context: &LemmyContext,

--- a/crates/apub/src/objects/private_message.rs
+++ b/crates/apub/src/objects/private_message.rs
@@ -52,7 +52,7 @@ impl ApubObject for ApubPrivateMessage {
     None
   }
 
-  #[tracing::instrument(skip(object_id, context))]
+  #[tracing::instrument(skip_all)]
   async fn read_from_apub_id(
     object_id: Url,
     context: &LemmyContext,
@@ -71,7 +71,7 @@ impl ApubObject for ApubPrivateMessage {
     unimplemented!()
   }
 
-  #[tracing::instrument(skip(self, context))]
+  #[tracing::instrument(skip_all)]
   async fn into_apub(self, context: &LemmyContext) -> Result<ChatMessage, LemmyError> {
     let creator_id = self.creator_id;
     let creator = blocking(context.pool(), move |conn| Person::read(conn, creator_id)).await??;
@@ -102,7 +102,7 @@ impl ApubObject for ApubPrivateMessage {
     unimplemented!()
   }
 
-  #[tracing::instrument(skip(note, expected_domain, context))]
+  #[tracing::instrument(skip_all)]
   async fn verify(
     note: &ChatMessage,
     expected_domain: &Url,
@@ -123,7 +123,7 @@ impl ApubObject for ApubPrivateMessage {
     Ok(())
   }
 
-  #[tracing::instrument(skip(note, context))]
+  #[tracing::instrument(skip_all)]
   async fn from_apub(
     note: ChatMessage,
     context: &LemmyContext,

--- a/crates/apub/src/objects/private_message.rs
+++ b/crates/apub/src/objects/private_message.rs
@@ -116,9 +116,7 @@ impl ApubObject for ApubPrivateMessage {
       .dereference(context, request_counter)
       .await?;
     if person.banned {
-      return Err(LemmyError::from_message(
-        "Person is banned from site".into(),
-      ));
+      return Err(LemmyError::from_message("Person is banned from site"));
     }
     Ok(())
   }

--- a/crates/apub/src/protocol/activities/voting/vote.rs
+++ b/crates/apub/src/protocol/activities/voting/vote.rs
@@ -37,7 +37,7 @@ impl TryFrom<i16> for VoteType {
     match value {
       1 => Ok(VoteType::Like),
       -1 => Ok(VoteType::Dislike),
-      _ => Err(LemmyError::from_message("invalid vote value".into())),
+      _ => Err(LemmyError::from_message("invalid vote value")),
     }
   }
 }

--- a/crates/apub/src/protocol/activities/voting/vote.rs
+++ b/crates/apub/src/protocol/activities/voting/vote.rs
@@ -3,7 +3,6 @@ use crate::{
   objects::person::ApubPerson,
   protocol::Unparsed,
 };
-use anyhow::anyhow;
 use lemmy_apub_lib::object_id::ObjectId;
 use lemmy_utils::LemmyError;
 use serde::{Deserialize, Serialize};
@@ -38,7 +37,7 @@ impl TryFrom<i16> for VoteType {
     match value {
       1 => Ok(VoteType::Like),
       -1 => Ok(VoteType::Dislike),
-      _ => Err(anyhow!("invalid vote value").into()),
+      _ => Err(LemmyError::from_message("invalid vote value".into())),
     }
   }
 }

--- a/crates/apub/src/protocol/objects/page.rs
+++ b/crates/apub/src/protocol/objects/page.rs
@@ -3,7 +3,6 @@ use crate::{
   protocol::{ImageObject, Source, Unparsed},
 };
 use activitystreams_kinds::object::PageType;
-use anyhow::anyhow;
 use chrono::{DateTime, FixedOffset};
 use lemmy_apub_lib::{
   data::Data,
@@ -73,7 +72,7 @@ impl Page {
           break Ok(c);
         }
       } else {
-        return Err(anyhow!("No community found in cc").into());
+        return Err(LemmyError::from_message("No community found in cc".into()));
       }
     }
   }

--- a/crates/apub/src/protocol/objects/page.rs
+++ b/crates/apub/src/protocol/objects/page.rs
@@ -72,7 +72,7 @@ impl Page {
           break Ok(c);
         }
       } else {
-        return Err(LemmyError::from_message("No community found in cc".into()));
+        return Err(LemmyError::from_message("No community found in cc"));
       }
     }
   }

--- a/crates/db_schema/src/lib.rs
+++ b/crates/db_schema/src/lib.rs
@@ -106,7 +106,7 @@ pub fn diesel_option_overwrite_to_url(
     Some("") => Ok(Some(None)),
     Some(str_url) => match Url::parse(str_url) {
       Ok(url) => Ok(Some(Some(url.into()))),
-      Err(e) => Err(LemmyError::from(e).with_message("invalid_url".into())),
+      Err(e) => Err(LemmyError::from(e).with_message("invalid_url")),
     },
     None => Ok(None),
   }

--- a/crates/db_schema/src/lib.rs
+++ b/crates/db_schema/src/lib.rs
@@ -21,7 +21,7 @@ pub type DbPool = diesel::r2d2::Pool<diesel::r2d2::ConnectionManager<diesel::PgC
 use crate::newtypes::DbUrl;
 use chrono::NaiveDateTime;
 use diesel::{Connection, PgConnection};
-use lemmy_utils::ApiError;
+use lemmy_utils::LemmyError;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -100,13 +100,13 @@ pub fn diesel_option_overwrite(opt: &Option<String>) -> Option<Option<String>> {
 
 pub fn diesel_option_overwrite_to_url(
   opt: &Option<String>,
-) -> Result<Option<Option<DbUrl>>, ApiError> {
+) -> Result<Option<Option<DbUrl>>, LemmyError> {
   match opt.as_ref().map(|s| s.as_str()) {
     // An empty string is an erase
     Some("") => Ok(Some(None)),
     Some(str_url) => match Url::parse(str_url) {
       Ok(url) => Ok(Some(Some(url.into()))),
-      Err(e) => Err(ApiError::err("invalid_url", e)),
+      Err(e) => Err(LemmyError::from(e).with_message("invalid_url".into())),
     },
     None => Ok(None),
   }

--- a/crates/routes/Cargo.toml
+++ b/crates/routes/Cargo.toml
@@ -32,3 +32,4 @@ awc = { version = "3.0.0-beta.8", default-features = false }
 url = { version = "2.2.2", features = ["serde"] }
 strum = "0.21.0"
 once_cell = "1.8.0"
+tracing = "0.1.29"

--- a/crates/routes/src/feeds.rs
+++ b/crates/routes/src/feeds.rs
@@ -58,6 +58,7 @@ static RSS_NAMESPACE: Lazy<HashMap<String, String>> = Lazy::new(|| {
   h
 });
 
+#[tracing::instrument(skip_all)]
 async fn get_all_feed(
   info: web::Query<Params>,
   context: web::Data<LemmyContext>,
@@ -66,6 +67,7 @@ async fn get_all_feed(
   Ok(get_feed_data(&context, ListingType::All, sort_type).await?)
 }
 
+#[tracing::instrument(skip_all)]
 async fn get_local_feed(
   info: web::Query<Params>,
   context: web::Data<LemmyContext>,
@@ -74,6 +76,7 @@ async fn get_local_feed(
   Ok(get_feed_data(&context, ListingType::Local, sort_type).await?)
 }
 
+#[tracing::instrument(skip_all)]
 async fn get_feed_data(
   context: &LemmyContext,
   listing_type: ListingType,
@@ -114,6 +117,7 @@ async fn get_feed_data(
   )
 }
 
+#[tracing::instrument(skip_all)]
 async fn get_feed(
   req: HttpRequest,
   info: web::Query<Params>,
@@ -167,6 +171,7 @@ fn get_sort_type(info: web::Query<Params>) -> Result<SortType, ParseError> {
   SortType::from_str(&sort_query)
 }
 
+#[tracing::instrument(skip_all)]
 fn get_feed_user(
   conn: &PgConnection,
   sort_type: &SortType,
@@ -194,6 +199,7 @@ fn get_feed_user(
   Ok(channel_builder)
 }
 
+#[tracing::instrument(skip_all)]
 fn get_feed_community(
   conn: &PgConnection,
   sort_type: &SortType,
@@ -225,6 +231,7 @@ fn get_feed_community(
   Ok(channel_builder)
 }
 
+#[tracing::instrument(skip_all)]
 fn get_feed_front(
   conn: &PgConnection,
   jwt_secret: &str,
@@ -260,6 +267,7 @@ fn get_feed_front(
   Ok(channel_builder)
 }
 
+#[tracing::instrument(skip_all)]
 fn get_feed_inbox(
   conn: &PgConnection,
   jwt_secret: &str,
@@ -303,6 +311,7 @@ fn get_feed_inbox(
   Ok(channel_builder)
 }
 
+#[tracing::instrument(skip_all)]
 fn create_reply_and_mention_items(
   replies: Vec<CommentView>,
   mentions: Vec<PersonMentionView>,
@@ -346,6 +355,7 @@ fn create_reply_and_mention_items(
   Ok(reply_items)
 }
 
+#[tracing::instrument(skip_all)]
 fn build_item(
   creator_name: &str,
   published: &NaiveDateTime,
@@ -376,6 +386,7 @@ fn build_item(
   Ok(i.build().map_err(|e| anyhow!(e))?)
 }
 
+#[tracing::instrument(skip_all)]
 fn create_post_items(
   posts: Vec<PostView>,
   protocol_and_hostname: &str,

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -48,7 +48,6 @@ struct ApiError {
   error: String,
 }
 
-#[derive(Debug)]
 pub struct LemmyError {
   pub message: Option<String>,
   pub inner: anyhow::Error,
@@ -82,6 +81,16 @@ where
       inner: t.into(),
       context: SpanTrace::capture(),
     }
+  }
+}
+
+impl std::fmt::Debug for LemmyError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.debug_struct("LemmyError")
+      .field("message", &self.message)
+      .field("inner", &self.inner)
+      .field("context", &"SpanTrace")
+      .finish()
   }
 }
 

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -45,17 +45,17 @@ macro_rules! location_info {
 
 #[derive(serde::Serialize)]
 struct ApiError {
-  error: String,
+  error: &'static str,
 }
 
 pub struct LemmyError {
-  pub message: Option<String>,
+  pub message: Option<&'static str>,
   pub inner: anyhow::Error,
   pub context: SpanTrace,
 }
 
 impl LemmyError {
-  pub fn from_message(message: String) -> Self {
+  pub fn from_message(message: &'static str) -> Self {
     let inner = anyhow::anyhow!("{}", message);
     LemmyError {
       message: Some(message),
@@ -63,7 +63,7 @@ impl LemmyError {
       context: SpanTrace::capture(),
     }
   }
-  pub fn with_message(self, message: String) -> Self {
+  pub fn with_message(self, message: &'static str) -> Self {
     LemmyError {
       message: Some(message),
       ..self
@@ -111,9 +111,7 @@ impl actix_web::error::ResponseError for LemmyError {
 
   fn error_response(&self) -> HttpResponse {
     if let Some(message) = &self.message {
-      HttpResponse::build(self.status_code()).json(ApiError {
-        error: message.clone(),
-      })
+      HttpResponse::build(self.status_code()).json(ApiError { error: message })
     } else {
       HttpResponse::build(self.status_code())
         .content_type("text/plain")

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -69,6 +69,14 @@ impl LemmyError {
       ..self
     }
   }
+  pub fn to_json(&self) -> Result<String, Self> {
+    let api_error = match self.message {
+      Some(error) => ApiError { error },
+      None => ApiError { error: "Unknown" },
+    };
+
+    Ok(serde_json::to_string(&api_error)?)
+  }
 }
 
 impl<T> From<T> for LemmyError

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -104,6 +104,9 @@ impl std::fmt::Debug for LemmyError {
 
 impl Display for LemmyError {
   fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    if let Some(message) = self.message {
+      write!(f, "{}: ", message)?;
+    }
     writeln!(f, "{}", self.inner)?;
     self.context.fmt(f)
   }

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -15,6 +15,10 @@ mod test;
 pub mod utils;
 pub mod version;
 
+mod sensitive;
+
+pub use sensitive::Sensitive;
+
 use actix_web::HttpResponse;
 use http::StatusCode;
 use std::{fmt, fmt::Display};

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -96,7 +96,7 @@ impl std::fmt::Debug for LemmyError {
 
 impl Display for LemmyError {
   fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-    self.inner.fmt(f)?;
+    writeln!(f, "{}", self.inner)?;
     self.context.fmt(f)
   }
 }

--- a/crates/utils/src/rate_limit/rate_limiter.rs
+++ b/crates/utils/src/rate_limit/rate_limiter.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, IpAddr, LemmyError};
+use crate::{IpAddr, LemmyError};
 use std::{collections::HashMap, time::SystemTime};
 use strum::IntoEnumIterator;
 use tracing::debug;
@@ -79,18 +79,13 @@ impl RateLimiter {
             time_passed,
             rate_limit.allowance
           );
-          Err(
-            ApiError {
-              message: format!(
-                "Too many requests. type: {}, IP: {}, {} per {} seconds",
-                type_.as_ref(),
-                ip,
-                rate,
-                per
-              ),
-            }
-            .into(),
-          )
+          Err(LemmyError::from_message(format!(
+            "Too many requests. type: {}, IP: {}, {} per {} seconds",
+            type_.as_ref(),
+            ip,
+            rate,
+            per
+          )))
         } else {
           if !check_only {
             rate_limit.allowance -= 1.0;

--- a/crates/utils/src/rate_limit/rate_limiter.rs
+++ b/crates/utils/src/rate_limit/rate_limiter.rs
@@ -79,13 +79,14 @@ impl RateLimiter {
             time_passed,
             rate_limit.allowance
           );
-          Err(LemmyError::from_message(format!(
+          let error = LemmyError::from(anyhow::anyhow!(
             "Too many requests. type: {}, IP: {}, {} per {} seconds",
             type_.as_ref(),
             ip,
             rate,
             per
-          )))
+          ));
+          Err(error.with_message("too_many_requests"))
         } else {
           if !check_only {
             rate_limit.allowance -= 1.0;

--- a/crates/utils/src/sensitive.rs
+++ b/crates/utils/src/sensitive.rs
@@ -5,55 +5,61 @@ use std::{
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Deserialize, serde::Serialize)]
 #[serde(transparent)]
-pub struct Sensitive(String);
+pub struct Sensitive<T>(T);
 
-impl Sensitive {
-  pub fn new(string: String) -> Self {
-    Sensitive(string)
+impl<T> Sensitive<T> {
+  pub fn new(item: T) -> Self {
+    Sensitive(item)
   }
 
-  pub fn into_inner(this: Self) -> String {
+  pub fn into_inner(this: Self) -> T {
     this.0
   }
 }
 
-impl std::fmt::Debug for Sensitive {
+impl<T> std::fmt::Debug for Sensitive<T> {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     f.debug_struct("Sensitive").finish()
   }
 }
 
-impl AsRef<String> for Sensitive {
-  fn as_ref(&self) -> &String {
+impl<T> AsRef<T> for Sensitive<T> {
+  fn as_ref(&self) -> &T {
     &self.0
   }
 }
 
-impl AsRef<str> for Sensitive {
+impl AsRef<str> for Sensitive<String> {
   fn as_ref(&self) -> &str {
     &self.0
   }
 }
 
-impl AsRef<[u8]> for Sensitive {
+impl AsRef<[u8]> for Sensitive<String> {
   fn as_ref(&self) -> &[u8] {
     self.0.as_ref()
   }
 }
 
-impl AsMut<String> for Sensitive {
-  fn as_mut(&mut self) -> &mut String {
+impl AsRef<[u8]> for Sensitive<Vec<u8>> {
+  fn as_ref(&self) -> &[u8] {
+    self.0.as_ref()
+  }
+}
+
+impl<T> AsMut<T> for Sensitive<T> {
+  fn as_mut(&mut self) -> &mut T {
     &mut self.0
   }
 }
 
-impl AsMut<str> for Sensitive {
+impl AsMut<str> for Sensitive<String> {
   fn as_mut(&mut self) -> &mut str {
     &mut self.0
   }
 }
 
-impl Deref for Sensitive {
+impl Deref for Sensitive<String> {
   type Target = str;
 
   fn deref(&self) -> &Self::Target {
@@ -61,31 +67,31 @@ impl Deref for Sensitive {
   }
 }
 
-impl DerefMut for Sensitive {
+impl DerefMut for Sensitive<String> {
   fn deref_mut(&mut self) -> &mut Self::Target {
     &mut self.0
   }
 }
 
-impl From<String> for Sensitive {
-  fn from(s: String) -> Self {
-    Sensitive(s)
+impl<T> From<T> for Sensitive<T> {
+  fn from(t: T) -> Self {
+    Sensitive(t)
   }
 }
 
-impl From<&str> for Sensitive {
+impl From<&str> for Sensitive<String> {
   fn from(s: &str) -> Self {
     Sensitive(s.into())
   }
 }
 
-impl Borrow<String> for Sensitive {
-  fn borrow(&self) -> &String {
+impl<T> Borrow<T> for Sensitive<T> {
+  fn borrow(&self) -> &T {
     &self.0
   }
 }
 
-impl Borrow<str> for Sensitive {
+impl Borrow<str> for Sensitive<String> {
   fn borrow(&self) -> &str {
     &self.0
   }

--- a/crates/utils/src/sensitive.rs
+++ b/crates/utils/src/sensitive.rs
@@ -1,0 +1,92 @@
+use std::{
+  borrow::Borrow,
+  ops::{Deref, DerefMut},
+};
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Deserialize, serde::Serialize)]
+#[serde(transparent)]
+pub struct Sensitive(String);
+
+impl Sensitive {
+  pub fn new(string: String) -> Self {
+    Sensitive(string)
+  }
+
+  pub fn into_inner(this: Self) -> String {
+    this.0
+  }
+}
+
+impl std::fmt::Debug for Sensitive {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("Sensitive").finish()
+  }
+}
+
+impl AsRef<String> for Sensitive {
+  fn as_ref(&self) -> &String {
+    &self.0
+  }
+}
+
+impl AsRef<str> for Sensitive {
+  fn as_ref(&self) -> &str {
+    &self.0
+  }
+}
+
+impl AsRef<[u8]> for Sensitive {
+  fn as_ref(&self) -> &[u8] {
+    self.0.as_ref()
+  }
+}
+
+impl AsMut<String> for Sensitive {
+  fn as_mut(&mut self) -> &mut String {
+    &mut self.0
+  }
+}
+
+impl AsMut<str> for Sensitive {
+  fn as_mut(&mut self) -> &mut str {
+    &mut self.0
+  }
+}
+
+impl Deref for Sensitive {
+  type Target = str;
+
+  fn deref(&self) -> &Self::Target {
+    &self.0
+  }
+}
+
+impl DerefMut for Sensitive {
+  fn deref_mut(&mut self) -> &mut Self::Target {
+    &mut self.0
+  }
+}
+
+impl From<String> for Sensitive {
+  fn from(s: String) -> Self {
+    Sensitive(s)
+  }
+}
+
+impl From<&str> for Sensitive {
+  fn from(s: &str) -> Self {
+    Sensitive(s.into())
+  }
+}
+
+impl Borrow<String> for Sensitive {
+  fn borrow(&self) -> &String {
+    &self.0
+  }
+}
+
+impl Borrow<str> for Sensitive {
+  fn borrow(&self) -> &str {
+    &self.0
+  }
+}

--- a/crates/utils/src/utils.rs
+++ b/crates/utils/src/utils.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, IpAddr};
+use crate::{IpAddr, LemmyError};
 use actix_web::dev::ConnectionInfo;
 use chrono::{DateTime, FixedOffset, NaiveDateTime};
 use itertools::Itertools;
@@ -60,15 +60,18 @@ pub(crate) fn slur_check<'a>(
   }
 }
 
-pub fn check_slurs(text: &str, slur_regex: &Option<Regex>) -> Result<(), ApiError> {
+pub fn check_slurs(text: &str, slur_regex: &Option<Regex>) -> Result<(), LemmyError> {
   if let Err(slurs) = slur_check(text, slur_regex) {
-    Err(ApiError::err_plain(&slurs_vec_to_str(slurs)))
+    Err(LemmyError::from_message(slurs_vec_to_str(slurs)))
   } else {
     Ok(())
   }
 }
 
-pub fn check_slurs_opt(text: &Option<String>, slur_regex: &Option<Regex>) -> Result<(), ApiError> {
+pub fn check_slurs_opt(
+  text: &Option<String>,
+  slur_regex: &Option<Regex>,
+) -> Result<(), LemmyError> {
   match text {
     Some(t) => check_slurs(t, slur_regex),
     None => Ok(()),

--- a/crates/utils/src/utils.rs
+++ b/crates/utils/src/utils.rs
@@ -62,7 +62,8 @@ pub(crate) fn slur_check<'a>(
 
 pub fn check_slurs(text: &str, slur_regex: &Option<Regex>) -> Result<(), LemmyError> {
   if let Err(slurs) = slur_check(text, slur_regex) {
-    Err(LemmyError::from_message(slurs_vec_to_str(slurs)))
+    let error = LemmyError::from(anyhow::anyhow!("{}", slurs_vec_to_str(slurs)));
+    Err(error.with_message("slurs"))
   } else {
     Ok(())
   }

--- a/crates/websocket/src/chat_server.rs
+++ b/crates/websocket/src/chat_server.rs
@@ -22,7 +22,6 @@ use lemmy_utils::{
   location_info,
   rate_limit::RateLimit,
   settings::structs::Settings,
-  ApiError,
   ConnectionId,
   IpAddr,
   LemmyError,
@@ -477,7 +476,7 @@ impl ChatServer {
       let data = &json["data"].to_string();
       let op = &json["op"]
         .as_str()
-        .ok_or_else(|| ApiError::err_plain("missing op"))?;
+        .ok_or_else(|| LemmyError::from_message("missing op".into()))?;
 
       if let Ok(user_operation_crud) = UserOperationCrud::from_str(op) {
         let fut = (message_handler_crud)(context, msg.id, user_operation_crud.clone(), data);

--- a/crates/websocket/src/chat_server.rs
+++ b/crates/websocket/src/chat_server.rs
@@ -476,7 +476,7 @@ impl ChatServer {
       let data = &json["data"].to_string();
       let op = &json["op"]
         .as_str()
-        .ok_or_else(|| LemmyError::from_message("missing op".into()))?;
+        .ok_or_else(|| LemmyError::from_message("missing op"))?;
 
       if let Ok(user_operation_crud) = UserOperationCrud::from_str(op) {
         let fut = (message_handler_crud)(context, msg.id, user_operation_crud.clone(), data);

--- a/crates/websocket/src/handlers.rs
+++ b/crates/websocket/src/handlers.rs
@@ -76,7 +76,10 @@ impl Handler<StandardMessage> for ChatServer {
         }
         Err(e) => {
           error!("Error during message handling {}", e);
-          Ok(e.to_string())
+          Ok(
+            e.to_json()
+              .unwrap_or_else(|_| String::from(r#"{"error":"failed to serialize json"}"#)),
+          )
         }
       }
     })

--- a/crates/websocket/src/routes.rs
+++ b/crates/websocket/src/routes.rs
@@ -115,7 +115,6 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WsSession {
       }
       ws::Message::Text(text) => {
         let m = text.trim().to_owned();
-        info!("Message received: {:?} from id: {}", &m, self.id);
 
         self
           .cs_addr

--- a/src/api_routes.rs
+++ b/src/api_routes.rs
@@ -1,4 +1,4 @@
-use actix_web::{error::ErrorBadRequest, *};
+use actix_web::*;
 use lemmy_api::Perform;
 use lemmy_api_common::{comment::*, community::*, person::*, post::*, site::*, websocket::*};
 use lemmy_api_crud::PerformCrud;
@@ -232,8 +232,7 @@ where
   let res = data
     .perform(&context, None)
     .await
-    .map(|json| HttpResponse::Ok().json(json))
-    .map_err(ErrorBadRequest)?;
+    .map(|json| HttpResponse::Ok().json(json))?;
   Ok(res)
 }
 
@@ -268,8 +267,7 @@ where
   let res = data
     .perform(&context, None)
     .await
-    .map(|json| HttpResponse::Ok().json(json))
-    .map_err(ErrorBadRequest)?;
+    .map(|json| HttpResponse::Ok().json(json))?;
   Ok(res)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![recursion_limit = "512"]
 pub mod api_routes;
 pub mod code_migrations;
+pub mod root_span_builder;
 pub mod scheduled_tasks;
 
 use lemmy_utils::LemmyError;
@@ -13,7 +14,7 @@ pub fn init_tracing() -> Result<(), LemmyError> {
   LogTracer::init()?;
 
   let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-  let format_layer = tracing_subscriber::fmt::layer().pretty();
+  let format_layer = tracing_subscriber::fmt::layer();
 
   let subscriber = Registry::default()
     .with(env_filter)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub fn init_tracing() -> Result<(), LemmyError> {
 
   let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
   let format_layer = tracing_subscriber::fmt::layer()
-    .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+    .with_span_events(FmtSpan::CLOSE)
     .pretty();
 
   let subscriber = Registry::default()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,15 +7,13 @@ use lemmy_utils::LemmyError;
 use tracing::subscriber::set_global_default;
 use tracing_error::ErrorLayer;
 use tracing_log::LogTracer;
-use tracing_subscriber::{fmt::format::FmtSpan, layer::SubscriberExt, EnvFilter, Registry};
+use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Registry};
 
 pub fn init_tracing() -> Result<(), LemmyError> {
   LogTracer::init()?;
 
   let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-  let format_layer = tracing_subscriber::fmt::layer()
-    .with_span_events(FmtSpan::CLOSE)
-    .pretty();
+  let format_layer = tracing_subscriber::fmt::layer().pretty();
 
   let subscriber = Registry::default()
     .with(env_filter)

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,6 +123,7 @@ async fn main() -> Result<(), LemmyError> {
     );
     let rate_limiter = rate_limiter.clone();
     App::new()
+      .wrap(actix_web::middleware::Logger::default())
       .wrap(TracingLogger::default())
       .app_data(Data::new(context))
       // The routes

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use lemmy_server::{
   api_routes,
   code_migrations::run_advanced_migrations,
   init_tracing,
+  root_span_builder::QuieterRootSpanBuilder,
   scheduled_tasks,
 };
 use lemmy_utils::{
@@ -124,7 +125,7 @@ async fn main() -> Result<(), LemmyError> {
     let rate_limiter = rate_limiter.clone();
     App::new()
       .wrap(actix_web::middleware::Logger::default())
-      .wrap(TracingLogger::default())
+      .wrap(TracingLogger::<QuieterRootSpanBuilder>::new())
       .app_data(Data::new(context))
       // The routes
       .configure(|cfg| api_routes::config(cfg, &rate_limiter))

--- a/src/root_span_builder.rs
+++ b/src/root_span_builder.rs
@@ -1,0 +1,71 @@
+use actix_web::{http::StatusCode, ResponseError};
+use tracing::Span;
+use tracing_actix_web::RootSpanBuilder;
+
+// Code in this module adapted from DefaultRootSpanBuilder
+// https://github.com/LukeMathWalker/tracing-actix-web/blob/main/src/root_span_builder.rs
+// and root_span!
+// https://github.com/LukeMathWalker/tracing-actix-web/blob/main/src/root_span_macro.rs
+
+pub struct QuieterRootSpanBuilder;
+
+impl RootSpanBuilder for QuieterRootSpanBuilder {
+  fn on_request_start(request: &actix_web::dev::ServiceRequest) -> Span {
+    let request_id = tracing_actix_web::root_span_macro::private::get_request_id(request);
+
+    tracing::info_span!(
+        "HTTP request",
+        http.method = %request.method(),
+        http.scheme = request.connection_info().scheme(),
+        http.host = %request.connection_info().host(),
+        http.target = %request.uri().path(),
+        http.status_code = tracing::field::Empty,
+        otel.kind = "server",
+        otel.status_code = tracing::field::Empty,
+        trace_id = tracing::field::Empty,
+        request_id = %request_id,
+        exception.message = tracing::field::Empty,
+        // Not proper OpenTelemetry, but their terminology is fairly exception-centric
+        exception.details = tracing::field::Empty,
+    )
+  }
+
+  fn on_request_end<B>(
+    span: tracing::Span,
+    outcome: &Result<actix_web::dev::ServiceResponse<B>, actix_web::Error>,
+  ) {
+    match &outcome {
+      Ok(response) => {
+        if let Some(error) = response.response().error() {
+          // use the status code already constructed for the outgoing HTTP response
+          handle_error(span, response.status(), error.as_response_error());
+        } else {
+          let code: i32 = response.response().status().as_u16().into();
+          span.record("http.status_code", &code);
+          span.record("otel.status_code", &"OK");
+        }
+      }
+      Err(error) => {
+        let response_error = error.as_response_error();
+        handle_error(span, response_error.status_code(), response_error);
+      }
+    };
+  }
+}
+
+fn handle_error(span: Span, status_code: StatusCode, response_error: &dyn ResponseError) {
+  // pre-formatting errors is a workaround for https://github.com/tokio-rs/tracing/issues/1565
+  let display = format!("{}", response_error);
+  let debug = format!("{:?}", response_error);
+  span.record("exception.message", &tracing::field::display(display));
+  span.record("exception.details", &tracing::field::display(debug));
+  let code: i32 = status_code.as_u16().into();
+
+  span.record("http.status_code", &code);
+
+  if status_code.is_client_error() {
+    span.record("otel.status_code", &"OK");
+  } else {
+    span.record("otel.status_code", &"ERROR");
+  }
+}


### PR DESCRIPTION
- Replace ApiError references with LemmyError directly
- Instrument implementations of Perform and PerformCrud with Tracing for more context in errors
- Instrument Feeds with Tracing
- Instrument apub with Tracing
- Respond to requests with LemmyError rather than turning all errors into BadRequest
- Default LemmyError to respond with Bad Request status code
- Stop logging new & closing spans
- Don't pretty-print logs
- Mark passwords, emails, jwts as "sensitive"
- Reduce the number of logged HTTP fields
- Update Actix Web & friends