### PR TITLE
Change lemmur repo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,14 +116,14 @@ Each Lemmy server can set its own moderation policy; appointing site-wide admins
 ### Apps
 
 - [lemmy-ui - The official web app for lemmy](https://github.com/LemmyNet/lemmy-ui)
-- [Lemmur - A mobile client for Lemmy (Android, Linux, Windows)](https://github.com/krawieck/lemmur)
+- [Lemmur - A mobile client for Lemmy (Android, Linux, Windows)](https://github.com/LemmurOrg/lemmur)
 - [Remmel - A native iOS app](https://github.com/uuttff8/Lemmy-iOS)
 
 ### Libraries
 
 - [lemmy-js-client](https://github.com/LemmyNet/lemmy-js-client)
 - [Kotlin API ( under development )](https://github.com/eiknat/lemmy-client)
-- [Dart API client](https://github.com/krawieck/lemmy_api_client)
+- [Dart API client](https://github.com/LemmurOrg/lemmy_api_client)
 
 ## Support / Donate
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -625,7 +625,7 @@ Since our last release in October of last year, and we've had [~450](https://git
 
 The biggest changes, as we'll outline below, are a re-work of Lemmy's database structure, a `v2` of Lemmy's API, and activitypub compliance fixes. The new re-worked DB is much faster, easier to maintain, and [now supports hierarchical rather than flat objects in the new API](https://github.com/LemmyNet/lemmy/issues/1275).
 
-We've also seen the first release of [Lemmur](https://github.com/krawieck/lemmur/releases/tag/v0.1.1), an android / iOS (soon) / windows / linux client, as well as [Lemmer](https://github.com/uuttff8/Lemmy-iOS), a native iOS client. Much thanks to @krawieck, @shilangyu, and @uuttff8 for making these great clients. If you can, please contribute to their [patreon](https://www.patreon.com/lemmur) to help fund lemmur development.
+We've also seen the first release of [Lemmur](https://github.com/LemmurOrg/lemmur/releases/tag/v0.1.1), an android / iOS (soon) / windows / linux client, as well as [Lemmer](https://github.com/uuttff8/Lemmy-iOS), a native iOS client. Much thanks to @krawieck, @shilangyu, and @uuttff8 for making these great clients. If you can, please contribute to their [patreon](https://www.patreon.com/lemmur) to help fund lemmur development.
 
 ## LemmyNet projects
 

--- a/readmes/README.es.md
+++ b/readmes/README.es.md
@@ -119,14 +119,14 @@ Cada servidor lemmy puede establecer su propia política de moderación; nombran
 ### Aplicaciones
 
 - [lemmy-ui - La aplicación web oficial para lemmy](https://github.com/LemmyNet/lemmy-ui)
-- [Lemmur - Un cliente móvil para Lemmy (Android, Linux, Windows)](https://github.com/krawieck/lemmur)
+- [Lemmur - Un cliente móvil para Lemmy (Android, Linux, Windows)](https://github.com/LemmurOrg/lemmur)
 - [Remmel - Una aplicación IOS nativa](https://github.com/uuttff8/Lemmy-iOS)
 
 ### Librerías
 
 - [lemmy-js-client](https://github.com/LemmyNet/lemmy-js-client)
 - [Kotlin API ( en desarrollo )](https://github.com/eiknat/lemmy-client)
-- [Dart API client ( en desarrollo )](https://github.com/krawieck/lemmy_api_client)
+- [Dart API client ( en desarrollo )](https://github.com/LemmurOrg/lemmy_api_client)
 
 ## Apoyo / Donación
 

--- a/readmes/README.ru.md
+++ b/readmes/README.ru.md
@@ -117,14 +117,14 @@
 ### Приложения
 
 - [lemmy-ui - Официальное веб приложение для lemmy](https://github.com/LemmyNet/lemmy-ui)
-- [Lemmur - Мобильные клиенты Lemmy для (Android, Linux, Windows)](https://github.com/krawieck/lemmur)
+- [Lemmur - Мобильные клиенты Lemmy для (Android, Linux, Windows)](https://github.com/LemmurOrg/lemmur)
 - [Remmel - Оригинальное приложение для iOS](https://github.com/uuttff8/Lemmy-iOS)
 
 ### Библиотеки
 
 - [lemmy-js-client](https://github.com/LemmyNet/lemmy-js-client)
 - [Kotlin API ( в разработке )](https://github.com/eiknat/lemmy-client)
-- [Dart API client ( в разработке )](https://github.com/krawieck/lemmy_api_client)
+- [Dart API client ( в разработке )](https://github.com/LemmurOrg/lemmy_api_client)
 
 ## Поддержать / Пожертвовать
 


### PR DESCRIPTION
Lemmur transferred to a separate org dedicated to lemmur (due to some permission limitations when under a private account + easier to grow). This PR updates references to the old repo.

Not sure if I should be modifying old release notes, let me know if I should revert it.