### PR TITLE
Case-insensitive webfinger response. Fixes #1955 & #1986

### DIFF
--- a/api_tests/src/shared.ts
+++ b/api_tests/src/shared.ts
@@ -649,7 +649,7 @@ export function wrapper(form: any): string {
 
 export function randomString(length: number): string {
   var result = '';
-  var characters = 'abcdefghijklmnopqrstuvwxyz0123456789_';
+  var characters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKMNLOPQRSTUVWXYZ0123456789_';
   var charactersLength = characters.length;
   for (var i = 0; i < length; i++) {
     result += characters.charAt(Math.floor(Math.random() * charactersLength));

--- a/api_tests/src/shared.ts
+++ b/api_tests/src/shared.ts
@@ -649,7 +649,7 @@ export function wrapper(form: any): string {
 
 export function randomString(length: number): string {
   var result = '';
-  var characters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKMNLOPQRSTUVWXYZ0123456789_';
+  var characters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_';
   var charactersLength = characters.length;
   for (var i = 0; i < length; i++) {
     result += characters.charAt(Math.floor(Math.random() * charactersLength));

--- a/crates/db_schema/Cargo.toml
+++ b/crates/db_schema/Cargo.toml
@@ -8,6 +8,8 @@ homepage = "https://join-lemmy.org/"
 documentation = "https://join-lemmy.org/docs/en/index.html"
 
 [lib]
+name = "lemmy_db_schema"
+path = "src/lib.rs"
 doctest = false
 
 [dependencies]

--- a/crates/db_schema/src/impls/community.rs
+++ b/crates/db_schema/src/impls/community.rs
@@ -13,6 +13,7 @@ use crate::{
     CommunitySafe,
   },
   traits::{Bannable, Crud, DeleteableOrRemoveable, Followable, Joinable},
+  functions::lower,
 };
 use diesel::{dsl::*, result::Error, ExpressionMethods, PgConnection, QueryDsl, RunQueryDsl};
 use url::Url;
@@ -95,7 +96,7 @@ impl Community {
     use crate::schema::community::dsl::*;
     community
       .filter(local.eq(true))
-      .filter(name.eq(community_name))
+      .filter(lower(name).eq(lower(community_name)))
       .first::<Self>(conn)
   }
 

--- a/crates/db_schema/src/impls/community.rs
+++ b/crates/db_schema/src/impls/community.rs
@@ -1,4 +1,5 @@
 use crate::{
+  functions::lower,
   naive_now,
   newtypes::{CommunityId, DbUrl, PersonId},
   source::community::{
@@ -13,7 +14,6 @@ use crate::{
     CommunitySafe,
   },
   traits::{Bannable, Crud, DeleteableOrRemoveable, Followable, Joinable},
-  functions::lower,
 };
 use diesel::{dsl::*, result::Error, ExpressionMethods, PgConnection, QueryDsl, RunQueryDsl};
 use url::Url;

--- a/crates/db_schema/src/impls/person.rs
+++ b/crates/db_schema/src/impls/person.rs
@@ -1,10 +1,10 @@
 use crate::{
+  functions::lower,
   naive_now,
   newtypes::{DbUrl, PersonId},
   schema::person::dsl::*,
   source::person::{Person, PersonForm},
   traits::Crud,
-  functions::lower,
 };
 use diesel::{dsl::*, result::Error, ExpressionMethods, PgConnection, QueryDsl, RunQueryDsl};
 use url::Url;

--- a/crates/db_schema/src/impls/person.rs
+++ b/crates/db_schema/src/impls/person.rs
@@ -4,6 +4,7 @@ use crate::{
   schema::person::dsl::*,
   source::person::{Person, PersonForm},
   traits::Crud,
+  functions::lower,
 };
 use diesel::{dsl::*, result::Error, ExpressionMethods, PgConnection, QueryDsl, RunQueryDsl};
 use url::Url;
@@ -194,7 +195,7 @@ impl Person {
     person
       .filter(deleted.eq(false))
       .filter(local.eq(true))
-      .filter(name.eq(from_name))
+      .filter(lower(name).eq(lower(from_name)))
       .first::<Person>(conn)
   }
 

--- a/crates/db_schema/src/lib.rs
+++ b/crates/db_schema/src/lib.rs
@@ -143,6 +143,9 @@ pub mod functions {
   sql_function! {
     fn hot_rank(score: BigInt, time: Timestamp) -> Integer;
   }
+
+  sql_function!(fn lower(x: Text) -> Text);
+
 }
 
 #[cfg(test)]

--- a/crates/db_schema/src/lib.rs
+++ b/crates/db_schema/src/lib.rs
@@ -145,7 +145,6 @@ pub mod functions {
   }
 
   sql_function!(fn lower(x: Text) -> Text);
-
 }
 
 #[cfg(test)]

--- a/crates/utils/src/settings/mod.rs
+++ b/crates/utils/src/settings/mod.rs
@@ -14,7 +14,7 @@ static SETTINGS: Lazy<RwLock<Settings>> =
 static WEBFINGER_REGEX: Lazy<Regex> = Lazy::new(|| {
   Regex::new(&format!(
     "^acct:([a-zA-Z0-9_]{{3,}})@{}$",
-    Settings::get().hostname
+    Settings::get().hostname.to_lowercase()
   ))
   .expect("compile webfinger regex")
 });

--- a/crates/utils/src/settings/mod.rs
+++ b/crates/utils/src/settings/mod.rs
@@ -14,7 +14,7 @@ static SETTINGS: Lazy<RwLock<Settings>> =
 static WEBFINGER_REGEX: Lazy<Regex> = Lazy::new(|| {
   Regex::new(&format!(
     "^acct:([a-zA-Z0-9_]{{3,}})@{}$",
-    Settings::get().hostname.to_lowercase()
+    Settings::get().hostname
   ))
   .expect("compile webfinger regex")
 });

--- a/crates/utils/src/settings/mod.rs
+++ b/crates/utils/src/settings/mod.rs
@@ -13,7 +13,7 @@ static SETTINGS: Lazy<RwLock<Settings>> =
   Lazy::new(|| RwLock::new(Settings::init().expect("Failed to load settings file")));
 static WEBFINGER_REGEX: Lazy<Regex> = Lazy::new(|| {
   Regex::new(&format!(
-    "^acct:([a-z0-9_]{{3,}})@{}$",
+    "^acct:([a-zA-Z0-9_]{{3,}})@{}$",
     Settings::get().hostname
   ))
   .expect("compile webfinger regex")


### PR DESCRIPTION
**Case-insensitive webfinger response**

- The webfinger regex in crates/utils/src/settings/mod.rs has been modified so that the server will no longer reject requests containing A-Z characters. 

**Case-insensitive database search**  

- The [sql_function “lower”](http://docs.diesel.rs/diesel/macro.sql_function.html) has been added to  crates/db_schema/src/lib.rs. This function allows one to perform a database searches applying lower(column) operations with diesel. 

- In /crates/db_schema/Cargo.toml, the [lib] block has been updated to be able to import the lib.rs functions.

- The lower function is loaded by lemmy/crates/db_schema/src/impls/person.rs and lemmy/crates/db_schema/src/impls/community.rs, and used to perform a case-insensitive database searches via find_by_name and read_from_name, respectively. This allows the webfinger response to be case insensitive.  

**Include uppercase characters in the API_tests**

- The randomString generation function in api_tests/src/shared.ts has been updated to include uppercase characters when running tests.



**Field tests**

The user Sal can now be viewed in lemmy.ml:
https://lemmy.ml/u/Sal@mander.xyz

The following curls will trigger the correct webfinger responses for the user Sal and for the community main. 



curl "https://mander.xyz/.well-known/webfinger?resource=acct:SaL@mander.xyz"
curl "https://mander.xyz/.well-known/webfinger?resource=acct:sal@mander.xyz"

curl "https://mander.xyz/.well-known/webfinger?resource=acct:main@mander.xyz"
curl "https://mander.xyz/.well-known/webfinger?resource=acct:MAIN@mander.xyz"

I have performed mastodon searches to fetch content as well, and the searches are now case-insensitive. 


This commit would replace  #2000. LemmyNet/lemmy-ui#525 can be reversed as users should be able to use uppercase names without problem. Issues #1955 and #1986 will be solved.


