### PR TITLE
Use correct encoding when fetching non-UTF-8 site metadata

### DIFF
--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -45,3 +45,4 @@ webpage = { version = "1.4.0", default-features = false, features = ["serde"] }
 jsonwebtoken = "7.2.0"
 doku = "0.10.2"
 uuid = { version = "0.8.2", features = ["serde", "v4"] }
+encoding = "0.2.33"


### PR DESCRIPTION
When the site metadata is fetched, the default assumption is that it will be encoded in UTF-8, but this is not always the case. The result is that the metadata will be displayed in the frontend as garbled characters. This PR adds an additional check on the `charset` property of the fetched page if present, and will re-decode the fetched bytes with the specified encoding if possible. Should an unknown encoding be specified, it will fall back to the original UTF-8 data.

Fixes #1858 

**NOTE**: An unrelated fix is also included, as the website in the original issue started its response with a blank line before the DOCTYPE declaration. For this purpose, `trim_start()` was added to the HTML parsing.