### PR TITLE
Initial working blacklisting of communities

### DIFF
--- a/crates/api_common/src/blacklist_community.rs
+++ b/crates/api_common/src/blacklist_community.rs
@@ -18,5 +18,3 @@ pub struct DeleteBlackListCommunity {
   pub community_id: i32,
   pub auth: String,
 }
-
-

--- a/crates/api_common/src/blacklist_community.rs
+++ b/crates/api_common/src/blacklist_community.rs
@@ -1,0 +1,22 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct BlackListCommunityResponse {
+  pub blacklist_id: i32,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct BlackListCommunity {
+  /// Example: star_trek , or star_trek@xyz.tld
+  pub community_id: i32,
+  pub reason: Option<String>,
+  pub auth: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DeleteBlackListCommunity {
+  pub community_id: i32,
+  pub auth: String,
+}
+
+

--- a/crates/api_common/src/lib.rs
+++ b/crates/api_common/src/lib.rs
@@ -4,6 +4,7 @@ pub mod person;
 pub mod post;
 pub mod site;
 pub mod websocket;
+pub mod blacklist_community;
 
 use crate::site::FederatedInstances;
 use lemmy_db_schema::{

--- a/crates/api_common/src/lib.rs
+++ b/crates/api_common/src/lib.rs
@@ -1,10 +1,10 @@
+pub mod blacklist_community;
 pub mod comment;
 pub mod community;
 pub mod person;
 pub mod post;
 pub mod site;
 pub mod websocket;
-pub mod blacklist_community;
 
 use crate::site::FederatedInstances;
 use lemmy_db_schema::{

--- a/crates/api_crud/src/blacklist_community/create.rs
+++ b/crates/api_crud/src/blacklist_community/create.rs
@@ -1,0 +1,88 @@
+use crate::PerformCrud;
+use actix_web::web::Data;
+
+use lemmy_api_common::{
+    blacklist_community::*,
+  };
+use lemmy_utils::{
+  ConnectionId,
+  LemmyError,
+};
+
+use lemmy_websocket::{
+  LemmyContext,
+};
+
+use lemmy_api_common::{
+  blocking,
+  blacklist_community::{BlackListCommunity}, 
+  get_local_user_view_from_jwt,
+  is_admin,
+};
+
+use lemmy_db_schema::{
+  source::{
+    blacklist_community::{BlackList, BlackListForm},
+  },
+  traits::{Crud},
+};
+
+#[async_trait::async_trait(?Send)]
+impl PerformCrud for BlackListCommunity {
+    type Response = BlackListCommunityResponse;
+    async fn perform(
+      &self,
+      context: &Data<LemmyContext>,
+      _: Option<ConnectionId>,
+    ) -> Result<BlackListCommunityResponse, LemmyError> {
+      let data: &BlackListCommunity = self;
+      let local_user_view =
+      get_local_user_view_from_jwt(&data.auth, context.pool(), context.secret()).await?;
+      is_admin(&local_user_view)?;
+      
+      let blacklist_form =  BlackListForm {
+         community_id: data.community_id,
+        reason: data.reason.clone(),
+        creator_id: local_user_view.person.id,
+        ..BlackListForm::default()
+      };
+
+      let inserted_blacklist = blocking(context.pool(), move |conn| {
+        BlackList::create(conn, &blacklist_form)
+      })
+      .await? 
+      .map_err(LemmyError::from)
+      .map_err(|e| e.with_message("couldn't create blacklist community"))?;
+      let response: BlackListCommunityResponse = BlackListCommunityResponse{blacklist_id:inserted_blacklist.id.clone()};
+      
+      return Ok(response);
+    }
+    
+}
+
+
+#[async_trait::async_trait(?Send)]
+impl PerformCrud for  DeleteBlackListCommunity {
+  type Response = bool;
+    async fn perform(
+      &self,
+      context: &Data<LemmyContext>,
+      _: Option<ConnectionId>,
+    ) -> Result<bool, LemmyError> {
+      let data: &DeleteBlackListCommunity = self;
+      let local_user_view =
+      get_local_user_view_from_jwt(&data.auth, context.pool(), context.secret()).await?;
+      is_admin(&local_user_view)?;
+      
+      let community_id = data.community_id;
+
+      blocking(context.pool(), move |conn| {
+        BlackList::delete(conn, community_id)
+      })
+      .await? 
+      .map_err(LemmyError::from)
+      .map_err(|e| e.with_message("couldn't delete blacklist community"))?;
+      
+      return Ok(true);
+    }
+}

--- a/crates/api_crud/src/blacklist_community/create.rs
+++ b/crates/api_crud/src/blacklist_community/create.rs
@@ -1,88 +1,79 @@
 use crate::PerformCrud;
 use actix_web::web::Data;
 
-use lemmy_api_common::{
-    blacklist_community::*,
-  };
-use lemmy_utils::{
-  ConnectionId,
-  LemmyError,
-};
+use lemmy_api_common::blacklist_community::*;
+use lemmy_utils::{ConnectionId, LemmyError};
 
-use lemmy_websocket::{
-  LemmyContext,
-};
+use lemmy_websocket::LemmyContext;
 
 use lemmy_api_common::{
+  blacklist_community::BlackListCommunity,
   blocking,
-  blacklist_community::{BlackListCommunity}, 
   get_local_user_view_from_jwt,
   is_admin,
 };
 
 use lemmy_db_schema::{
-  source::{
-    blacklist_community::{BlackList, BlackListForm},
-  },
-  traits::{Crud},
+  source::blacklist_community::{BlackList, BlackListForm},
+  traits::Crud,
 };
 
 #[async_trait::async_trait(?Send)]
 impl PerformCrud for BlackListCommunity {
-    type Response = BlackListCommunityResponse;
-    async fn perform(
-      &self,
-      context: &Data<LemmyContext>,
-      _: Option<ConnectionId>,
-    ) -> Result<BlackListCommunityResponse, LemmyError> {
-      let data: &BlackListCommunity = self;
-      let local_user_view =
+  type Response = BlackListCommunityResponse;
+  async fn perform(
+    &self,
+    context: &Data<LemmyContext>,
+    _: Option<ConnectionId>,
+  ) -> Result<BlackListCommunityResponse, LemmyError> {
+    let data: &BlackListCommunity = self;
+    let local_user_view =
       get_local_user_view_from_jwt(&data.auth, context.pool(), context.secret()).await?;
-      is_admin(&local_user_view)?;
-      
-      let blacklist_form =  BlackListForm {
-         community_id: data.community_id,
-        reason: data.reason.clone(),
-        creator_id: local_user_view.person.id,
-        ..BlackListForm::default()
-      };
+    is_admin(&local_user_view)?;
 
-      let inserted_blacklist = blocking(context.pool(), move |conn| {
-        BlackList::create(conn, &blacklist_form)
-      })
-      .await? 
-      .map_err(LemmyError::from)
-      .map_err(|e| e.with_message("couldn't create blacklist community"))?;
-      let response: BlackListCommunityResponse = BlackListCommunityResponse{blacklist_id:inserted_blacklist.id.clone()};
-      
-      return Ok(response);
-    }
-    
+    let blacklist_form = BlackListForm {
+      community_id: data.community_id,
+      reason: data.reason.clone(),
+      creator_id: local_user_view.person.id,
+      ..BlackListForm::default()
+    };
+
+    let inserted_blacklist = blocking(context.pool(), move |conn| {
+      BlackList::create(conn, &blacklist_form)
+    })
+    .await?
+    .map_err(LemmyError::from)
+    .map_err(|e| e.with_message("couldn't create blacklist community"))?;
+    let response: BlackListCommunityResponse = BlackListCommunityResponse {
+      blacklist_id: inserted_blacklist.id,
+    };
+
+    return Ok(response);
+  }
 }
 
-
 #[async_trait::async_trait(?Send)]
-impl PerformCrud for  DeleteBlackListCommunity {
+impl PerformCrud for DeleteBlackListCommunity {
   type Response = bool;
-    async fn perform(
-      &self,
-      context: &Data<LemmyContext>,
-      _: Option<ConnectionId>,
-    ) -> Result<bool, LemmyError> {
-      let data: &DeleteBlackListCommunity = self;
-      let local_user_view =
+  async fn perform(
+    &self,
+    context: &Data<LemmyContext>,
+    _: Option<ConnectionId>,
+  ) -> Result<bool, LemmyError> {
+    let data: &DeleteBlackListCommunity = self;
+    let local_user_view =
       get_local_user_view_from_jwt(&data.auth, context.pool(), context.secret()).await?;
-      is_admin(&local_user_view)?;
-      
-      let community_id = data.community_id;
+    is_admin(&local_user_view)?;
 
-      blocking(context.pool(), move |conn| {
-        BlackList::delete(conn, community_id)
-      })
-      .await? 
-      .map_err(LemmyError::from)
-      .map_err(|e| e.with_message("couldn't delete blacklist community"))?;
-      
-      return Ok(true);
-    }
+    let community_id = data.community_id;
+
+    blocking(context.pool(), move |conn| {
+      BlackList::delete(conn, community_id)
+    })
+    .await?
+    .map_err(LemmyError::from)
+    .map_err(|e| e.with_message("couldn't delete blacklist community"))?;
+
+    return Ok(true);
+  }
 }

--- a/crates/api_crud/src/blacklist_community/mod.rs
+++ b/crates/api_crud/src/blacklist_community/mod.rs
@@ -1,0 +1,1 @@
+mod create;

--- a/crates/api_crud/src/lib.rs
+++ b/crates/api_crud/src/lib.rs
@@ -4,13 +4,13 @@ use lemmy_utils::{ConnectionId, LemmyError};
 use lemmy_websocket::{serialize_websocket_message, LemmyContext, UserOperationCrud};
 use serde::Deserialize;
 
+mod blacklist_community;
 mod comment;
 mod community;
 mod post;
 mod private_message;
 mod site;
 mod user;
-mod blacklist_community;
 
 #[async_trait::async_trait(?Send)]
 pub trait PerformCrud {

--- a/crates/api_crud/src/lib.rs
+++ b/crates/api_crud/src/lib.rs
@@ -10,6 +10,7 @@ mod post;
 mod private_message;
 mod site;
 mod user;
+mod blacklist_community;
 
 #[async_trait::async_trait(?Send)]
 pub trait PerformCrud {

--- a/crates/db_schema/src/impls/blacklist.rs
+++ b/crates/db_schema/src/impls/blacklist.rs
@@ -1,44 +1,37 @@
-//to do 
-//implment blacklist
-
 use crate::{
-    source::blacklist_community::{
-       BlackListForm,
-       BlackList
-      },
-    traits::{Crud},
+  source::blacklist_community::{BlackList, BlackListForm},
+  traits::Crud,
 };
 use diesel::{dsl::*, result::Error, *};
 
-impl Crud for BlackList  {
-    type Form = BlackListForm;
-    type IdType = i32;
+impl Crud for BlackList {
+  type Form = BlackListForm;
+  type IdType = i32;
 
-    fn create(conn: &PgConnection, new_blacklist: &BlackListForm) -> Result<Self, Error> {
-        use crate::schema::blacklist_community::dsl::*;
-        insert_into(blacklist_community)
-          .values(new_blacklist)
-          .get_result::<Self>(conn)
-    }
-    fn read(conn: &PgConnection, blacklist_id: i32) -> Result<Self, Error> {
-        use crate::schema::blacklist_community::dsl::*;
-        blacklist_community.find(blacklist_id).first::<Self>(conn)
-    }
+  fn create(conn: &PgConnection, new_blacklist: &BlackListForm) -> Result<Self, Error> {
+    use crate::schema::blacklist_community::dsl::*;
+    insert_into(blacklist_community)
+      .values(new_blacklist)
+      .get_result::<Self>(conn)
+  }
+  fn read(conn: &PgConnection, blacklist_id: i32) -> Result<Self, Error> {
+    use crate::schema::blacklist_community::dsl::*;
+    blacklist_community.find(blacklist_id).first::<Self>(conn)
+  }
 
-    fn update(
-        conn: &PgConnection,
-        blacklist_id: i32,
-        updateblacklistform_community: &BlackListForm,
-      ) -> Result<Self, Error> {
-        use crate::schema::blacklist_community::dsl::*;
-        diesel::update(blacklist_community.find(blacklist_id))
-          .set(updateblacklistform_community)
-          .get_result::<Self>(conn)
-      }
+  fn update(
+    conn: &PgConnection,
+    blacklist_id: i32,
+    updateblacklistform_community: &BlackListForm,
+  ) -> Result<Self, Error> {
+    use crate::schema::blacklist_community::dsl::*;
+    diesel::update(blacklist_community.find(blacklist_id))
+      .set(updateblacklistform_community)
+      .get_result::<Self>(conn)
+  }
 
-    fn delete(conn: &PgConnection, community_key: i32) -> Result<usize, Error> {
-      use crate::schema::blacklist_community::dsl::*;
-      diesel::delete(blacklist_community.filter(community_id.eq(community_key))).execute(conn)
-    }
+  fn delete(conn: &PgConnection, community_key: i32) -> Result<usize, Error> {
+    use crate::schema::blacklist_community::dsl::*;
+    diesel::delete(blacklist_community.filter(community_id.eq(community_key))).execute(conn)
+  }
 }
-

--- a/crates/db_schema/src/impls/blacklist.rs
+++ b/crates/db_schema/src/impls/blacklist.rs
@@ -1,0 +1,44 @@
+//to do 
+//implment blacklist
+
+use crate::{
+    source::blacklist_community::{
+       BlackListForm,
+       BlackList
+      },
+    traits::{Crud},
+};
+use diesel::{dsl::*, result::Error, *};
+
+impl Crud for BlackList  {
+    type Form = BlackListForm;
+    type IdType = i32;
+
+    fn create(conn: &PgConnection, new_blacklist: &BlackListForm) -> Result<Self, Error> {
+        use crate::schema::blacklist_community::dsl::*;
+        insert_into(blacklist_community)
+          .values(new_blacklist)
+          .get_result::<Self>(conn)
+    }
+    fn read(conn: &PgConnection, blacklist_id: i32) -> Result<Self, Error> {
+        use crate::schema::blacklist_community::dsl::*;
+        blacklist_community.find(blacklist_id).first::<Self>(conn)
+    }
+
+    fn update(
+        conn: &PgConnection,
+        blacklist_id: i32,
+        updateblacklistform_community: &BlackListForm,
+      ) -> Result<Self, Error> {
+        use crate::schema::blacklist_community::dsl::*;
+        diesel::update(blacklist_community.find(blacklist_id))
+          .set(updateblacklistform_community)
+          .get_result::<Self>(conn)
+      }
+
+    fn delete(conn: &PgConnection, community_key: i32) -> Result<usize, Error> {
+      use crate::schema::blacklist_community::dsl::*;
+      diesel::delete(blacklist_community.filter(community_id.eq(community_key))).execute(conn)
+    }
+}
+

--- a/crates/db_schema/src/impls/mod.rs
+++ b/crates/db_schema/src/impls/mod.rs
@@ -1,4 +1,5 @@
 pub mod activity;
+pub mod blacklist;
 pub mod comment;
 pub mod comment_report;
 pub mod community;
@@ -16,4 +17,3 @@ pub mod private_message;
 pub mod registration_application;
 pub mod secret;
 pub mod site;
-pub mod blacklist;

--- a/crates/db_schema/src/impls/mod.rs
+++ b/crates/db_schema/src/impls/mod.rs
@@ -16,3 +16,4 @@ pub mod private_message;
 pub mod registration_application;
 pub mod secret;
 pub mod site;
+pub mod blacklist;

--- a/crates/db_schema/src/schema.rs
+++ b/crates/db_schema/src/schema.rs
@@ -585,6 +585,16 @@ table! {
     }
 }
 
+table! {
+    blacklist_community (id) {
+        id -> Int4,
+        community_id -> Int4,
+        reason -> Nullable<Text>,
+        published -> Timestamp,
+        creator_id -> Int4,
+    }
+}
+
 joinable!(comment_alias_1 -> person_alias_1 (creator_id));
 joinable!(comment -> comment_alias_1 (parent_id));
 joinable!(person_mention -> person_alias_1 (recipient_id));
@@ -649,6 +659,7 @@ joinable!(site_aggregates -> site (site_id));
 joinable!(email_verification -> local_user (local_user_id));
 joinable!(registration_application -> local_user (local_user_id));
 joinable!(registration_application -> person (admin_id));
+joinable!(blacklist_community -> community (community_id));
 
 allow_tables_to_appear_in_same_query!(
   activity,
@@ -693,5 +704,6 @@ allow_tables_to_appear_in_same_query!(
   person_alias_1,
   person_alias_2,
   email_verification,
-  registration_application
+  registration_application,
+  blacklist_community
 );

--- a/crates/db_schema/src/source/blacklist_community.rs
+++ b/crates/db_schema/src/source/blacklist_community.rs
@@ -1,12 +1,9 @@
-use crate::{
-     newtypes::{ PersonId},
-    schema::{blacklist_community},
-  };
-  use serde::{Deserialize, Serialize};
+use crate::{newtypes::PersonId, schema::blacklist_community};
+use serde::{Deserialize, Serialize};
 
-  #[derive(
-    Clone, Queryable, Associations, Identifiable, PartialEq, Debug, Serialize, Deserialize,
-  )]
+#[derive(
+  Clone, Queryable, Associations, Identifiable, PartialEq, Debug, Serialize, Deserialize,
+)]
 #[table_name = "blacklist_community"]
 pub struct BlackList {
   pub id: i32,
@@ -22,5 +19,5 @@ pub struct BlackListForm {
   pub reason: Option<String>,
   pub published: Option<chrono::NaiveDateTime>,
   pub creator_id: PersonId,
-  pub community_id: i32
+  pub community_id: i32,
 }

--- a/crates/db_schema/src/source/blacklist_community.rs
+++ b/crates/db_schema/src/source/blacklist_community.rs
@@ -1,0 +1,26 @@
+use crate::{
+     newtypes::{ PersonId},
+    schema::{blacklist_community},
+  };
+  use serde::{Deserialize, Serialize};
+
+  #[derive(
+    Clone, Queryable, Associations, Identifiable, PartialEq, Debug, Serialize, Deserialize,
+  )]
+#[table_name = "blacklist_community"]
+pub struct BlackList {
+  pub id: i32,
+  pub community_id: i32,
+  pub reason: Option<String>,
+  pub published: chrono::NaiveDateTime,
+  pub creator_id: PersonId,
+}
+
+#[derive(Insertable, AsChangeset, Clone, Default)]
+#[table_name = "blacklist_community"]
+pub struct BlackListForm {
+  pub reason: Option<String>,
+  pub published: Option<chrono::NaiveDateTime>,
+  pub creator_id: PersonId,
+  pub community_id: i32
+}

--- a/crates/db_schema/src/source/mod.rs
+++ b/crates/db_schema/src/source/mod.rs
@@ -16,3 +16,4 @@ pub mod private_message;
 pub mod registration_application;
 pub mod secret;
 pub mod site;
+pub mod blacklist_community;

--- a/crates/db_schema/src/source/mod.rs
+++ b/crates/db_schema/src/source/mod.rs
@@ -1,4 +1,5 @@
 pub mod activity;
+pub mod blacklist_community;
 pub mod comment;
 pub mod comment_report;
 pub mod community;
@@ -16,4 +17,3 @@ pub mod private_message;
 pub mod registration_application;
 pub mod secret;
 pub mod site;
-pub mod blacklist_community;

--- a/crates/db_views_actor/src/community_view.rs
+++ b/crates/db_views_actor/src/community_view.rs
@@ -6,7 +6,13 @@ use lemmy_db_schema::{
   fuzzy_search,
   limit_and_offset,
   newtypes::{CommunityId, PersonId},
-  schema::{community, community_aggregates, community_block, community_follower,blacklist_community},
+  schema::{
+    blacklist_community,
+    community,
+    community_aggregates,
+    community_block,
+    community_follower,
+  },
   source::{
     community::{Community, CommunityFollower, CommunitySafe},
     community_block::CommunityBlock,
@@ -181,12 +187,7 @@ impl<'a> CommunityQueryBuilder<'a> {
             .and(community_block::person_id.eq(person_id_join)),
         ),
       )
-      .left_join(
-        blacklist_community::table.on(
-          community::id
-            .eq(blacklist_community::community_id)
-        )
-      )
+      .left_join(blacklist_community::table.on(community::id.eq(blacklist_community::community_id)))
       .select((
         Community::safe_columns_tuple(),
         community_aggregates::all_columns,
@@ -226,7 +227,11 @@ impl<'a> CommunityQueryBuilder<'a> {
     };
 
     // Hide if blacklisted unless subscribed
-    query =  query.filter(blacklist_community::id.is_null().or(community_follower::person_id.eq(person_id_join)));
+    query = query.filter(
+      blacklist_community::id
+        .is_null()
+        .or(community_follower::person_id.eq(person_id_join)),
+    );
 
     if let Some(listing_type) = self.listing_type {
       query = match listing_type {

--- a/migrations/2021-12-14-230218_create_blacklist_community_table/down.sql
+++ b/migrations/2021-12-14-230218_create_blacklist_community_table/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+
+drop table blacklist_community

--- a/migrations/2021-12-14-230218_create_blacklist_community_table/up.sql
+++ b/migrations/2021-12-14-230218_create_blacklist_community_table/up.sql
@@ -1,0 +1,18 @@
+-- Your SQL goes here
+
+CREATE TABLE blacklist_community (
+	id serial PRIMARY KEY,
+	reason text,
+	published timestamp not null default now(),
+	creator_id int,
+	community_id int UNIQUE,
+    CONSTRAINT fk_creator
+      FOREIGN KEY(creator_id)
+	  REFERENCES person(id)
+	  ON DELETE SET NULL,
+
+	CONSTRAINT fk_community
+      FOREIGN KEY(community_id)
+	  REFERENCES community(id)
+	  ON DELETE SET NULL
+);

--- a/src/api_routes.rs
+++ b/src/api_routes.rs
@@ -1,6 +1,6 @@
 use actix_web::*;
 use lemmy_api::Perform;
-use lemmy_api_common::{comment::*, community::*, person::*, post::*, site::*, websocket::*};
+use lemmy_api_common::{comment::*, community::*, person::*, post::*, site::*, websocket::*,blacklist_community::*};
 use lemmy_api_crud::PerformCrud;
 use lemmy_utils::rate_limit::RateLimit;
 use lemmy_websocket::{routes::chat_route, LemmyContext};
@@ -22,6 +22,13 @@ pub fn config(cfg: &mut web::ServiceConfig, rate_limit: &RateLimit) {
           .route("/transfer", web::post().to(route_post::<TransferSite>))
           .route("/config", web::get().to(route_get::<GetSiteConfig>))
           .route("/config", web::put().to(route_post::<SaveSiteConfig>)),
+      )
+      .service(
+        web::scope("/blacklist")
+        .guard(guard::Post())
+        .wrap(rate_limit.register())
+        .route("",web::post().to(route_post_crud::<BlackListCommunity>))
+        .route("/delete",web::post().to(route_post_crud::<DeleteBlackListCommunity>)),
       )
       .service(
         web::resource("/modlog")

--- a/src/api_routes.rs
+++ b/src/api_routes.rs
@@ -1,6 +1,14 @@
 use actix_web::*;
 use lemmy_api::Perform;
-use lemmy_api_common::{comment::*, community::*, person::*, post::*, site::*, websocket::*,blacklist_community::*};
+use lemmy_api_common::{
+  blacklist_community::*,
+  comment::*,
+  community::*,
+  person::*,
+  post::*,
+  site::*,
+  websocket::*,
+};
 use lemmy_api_crud::PerformCrud;
 use lemmy_utils::rate_limit::RateLimit;
 use lemmy_websocket::{routes::chat_route, LemmyContext};
@@ -25,10 +33,13 @@ pub fn config(cfg: &mut web::ServiceConfig, rate_limit: &RateLimit) {
       )
       .service(
         web::scope("/blacklist")
-        .guard(guard::Post())
-        .wrap(rate_limit.register())
-        .route("",web::post().to(route_post_crud::<BlackListCommunity>))
-        .route("/delete",web::post().to(route_post_crud::<DeleteBlackListCommunity>)),
+          .guard(guard::Post())
+          .wrap(rate_limit.register())
+          .route("", web::post().to(route_post_crud::<BlackListCommunity>))
+          .route(
+            "/delete",
+            web::post().to(route_post_crud::<DeleteBlackListCommunity>),
+          ),
       )
       .service(
         web::resource("/modlog")


### PR DESCRIPTION
For issue https://github.com/LemmyNet/lemmy/issues/1980

Backend code to add the concept of a blacklisted community.

When a community is blacklisted, users who are not subscribed to it will not see it in the trending section or local post. If a user is subscribed to it, it continues to show up in trending (If it fits the trending query) and continues to show up in their timeline as usual. In this way a community can continue to exist but the lemmy code does not promote it. It stops it's growth unless the community themselves do outreach to grow it themselves. It's basically a purgatory for communities. 

This is my first backend pr, I request a close code review paying special attention to naming conventions, lemmy endpoint conventions ect...

This PR ads two new post endpoints one for create and one for delete. Since auth seems to be passed in as data and not in header I did not use DELETE but instead used post. This seemed to be what other endpoints used.

Example curl for create

```
curl -X POST localhost:8536/api/v3/blacklist \
-H "Content-Type: application/json" \
-d \
'{"community_id": 3,"reason":"to controversal","auth":"Foo"}'
```

This will create a blacklist for the community with primary key 2 and record the reason for it's blacklistedness

Example curl to delete prev created blacklist,


```
curl -X POST localhost:8536/api/v3/blacklist/delete \
-H "Content-Type: application/json" \
-d \
'{"community_id": 3,"auth":"Foo"}'
```

This deletes the row entirely.