### PR TITLE
uses compatable images - fixes GLIBC_2.29 not found issue on arm

### DIFF
--- a/docker/prod/Dockerfile.arm
+++ b/docker/prod/Dockerfile.arm
@@ -1,4 +1,4 @@
-ARG RUST_BUILDER_IMAGE=rust:1.56-slim
+ARG RUST_BUILDER_IMAGE=rust:1.56-slim-buster
 
 # Build Lemmy
 FROM $RUST_BUILDER_IMAGE as builder


### PR DESCRIPTION
matches glibc version to be the same in both builder and runner