### PR TITLE
Add tombstone tests, better test errors

### DIFF
--- a/crates/apub/assets/lemmy/objects/tombstone.json
+++ b/crates/apub/assets/lemmy/objects/tombstone.json
@@ -1,0 +1,4 @@
+{
+  "id": "https://lemmy.ml/comment/110273",
+  "type": "Tombstone"
+}

--- a/crates/apub/assets/lotide/activities/delete_note.json
+++ b/crates/apub/assets/lotide/activities/delete_note.json
@@ -1,0 +1,7 @@
+{
+  "actor": "https://narwhal.city/users/3",
+  "object": "https://narwhal.city/posts/12",
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "id": "https://narwhal.city/posts/12/delete",
+  "type": "Delete"
+}

--- a/crates/apub/assets/lotide/objects/tombstone.json
+++ b/crates/apub/assets/lotide/objects/tombstone.json
@@ -1,0 +1,6 @@
+{
+  "former_type": "Note",
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "id": "https://narwhal.city/posts/12",
+  "type": "Tombstone"
+}

--- a/crates/apub/assets/mastodon/objects/note.json
+++ b/crates/apub/assets/mastodon/objects/note.json
@@ -1,4 +1,16 @@
 {
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    {
+      "ostatus": "http://ostatus.org#",
+      "atomUri": "ostatus:atomUri",
+      "inReplyToAtomUri": "ostatus:inReplyToAtomUri",
+      "conversation": "ostatus:conversation",
+      "sensitive": "as:sensitive",
+      "toot": "http://joinmastodon.org/ns#",
+      "votersCount": "toot:votersCount"
+    }
+  ],
   "id": "https://mastodon.madrid/users/felix/statuses/107224289116410645",
   "type": "Note",
   "summary": null,
@@ -19,7 +31,7 @@
   "conversation": "tag:mamot.fr,2021-11-05:objectId=64635960:objectType=Conversation",
   "content": "<p><span class=\"h-card\"><a href=\"https://mamot.fr/@retiolus\" class=\"u-url mention\">@<span>retiolus</span></a></span> i have never been disappointed by a thinkpad. if you want to save money, get a model from a few years ago, there isnt a huge difference anyway.</p>",
   "contentMap": {
-    "en": "<p><span class=\"h-card\"><a href=\"https://mamot.fr/@retiolus\" class=\"u-url mention\">@<span>retiolus</span></a></span> i have neverbeendisappointed by a thinkpad. if you want to save money, get a model from a few years ago, there isnt a huge difference anyway.</p>"
+    "en": "<p><span class=\"h-card\"><a href=\"https://mamot.fr/@retiolus\" class=\"u-url mention\">@<span>retiolus</span></a></span> i have never been disappointed by a thinkpad. if you want to save money, get a model from a few years ago, there isnt a huge difference anyway.</p>"
   },
   "attachment": [],
   "tag": [

--- a/crates/apub/src/objects/mod.rs
+++ b/crates/apub/src/objects/mod.rs
@@ -90,11 +90,9 @@ pub(crate) mod tests {
     LemmyContext::create(pool, chat_server, client, activity_queue, settings, secret)
   }
 
-  pub(crate) fn file_to_json_object<T: DeserializeOwned>(
-    path: &str,
-  ) -> serde_json::error::Result<T> {
-    let file = File::open(path).unwrap();
+  pub(crate) fn file_to_json_object<T: DeserializeOwned>(path: &str) -> Result<T, LemmyError> {
+    let file = File::open(path)?;
     let reader = BufReader::new(file);
-    serde_json::from_reader(reader)
+    Ok(serde_json::from_reader(reader)?)
   }
 }

--- a/crates/apub/src/protocol/activities/community/mod.rs
+++ b/crates/apub/src/protocol/activities/community/mod.rs
@@ -25,22 +25,27 @@ mod tests {
   async fn test_parse_lemmy_community() {
     test_parse_lemmy_item::<AnnounceActivity>(
       "assets/lemmy/activities/community/announce_create_page.json",
-    );
+    )
+    .unwrap();
 
-    test_parse_lemmy_item::<AddMod>("assets/lemmy/activities/community/add_mod.json");
-    test_parse_lemmy_item::<RemoveMod>("assets/lemmy/activities/community/remove_mod.json");
+    test_parse_lemmy_item::<AddMod>("assets/lemmy/activities/community/add_mod.json").unwrap();
+    test_parse_lemmy_item::<RemoveMod>("assets/lemmy/activities/community/remove_mod.json")
+      .unwrap();
 
     test_parse_lemmy_item::<BlockUserFromCommunity>(
       "assets/lemmy/activities/community/block_user.json",
-    );
+    )
+    .unwrap();
     test_parse_lemmy_item::<UndoBlockUserFromCommunity>(
       "assets/lemmy/activities/community/undo_block_user.json",
-    );
+    )
+    .unwrap();
 
     test_parse_lemmy_item::<UpdateCommunity>(
       "assets/lemmy/activities/community/update_community.json",
-    );
+    )
+    .unwrap();
 
-    test_parse_lemmy_item::<Report>("assets/lemmy/activities/community/report_page.json");
+    test_parse_lemmy_item::<Report>("assets/lemmy/activities/community/report_page.json").unwrap();
   }
 }

--- a/crates/apub/src/protocol/activities/create_or_update/mod.rs
+++ b/crates/apub/src/protocol/activities/create_or_update/mod.rs
@@ -16,13 +16,16 @@ mod tests {
   async fn test_parse_create_or_update() {
     test_parse_lemmy_item::<CreateOrUpdatePost>(
       "assets/lemmy/activities/create_or_update/create_page.json",
-    );
+    )
+    .unwrap();
     test_parse_lemmy_item::<CreateOrUpdatePost>(
       "assets/lemmy/activities/create_or_update/update_page.json",
-    );
+    )
+    .unwrap();
     test_parse_lemmy_item::<CreateOrUpdateComment>(
       "assets/lemmy/activities/create_or_update/create_note.json",
-    );
+    )
+    .unwrap();
 
     file_to_json_object::<WithContext<CreateOrUpdateComment>>(
       "assets/pleroma/activities/create_note.json",

--- a/crates/apub/src/protocol/activities/deletion/mod.rs
+++ b/crates/apub/src/protocol/activities/deletion/mod.rs
@@ -10,10 +10,12 @@ mod tests {
 
   #[actix_rt::test]
   async fn test_parse_lemmy_deletion() {
-    test_parse_lemmy_item::<Delete>("assets/lemmy/activities/deletion/remove_note.json");
-    test_parse_lemmy_item::<Delete>("assets/lemmy/activities/deletion/delete_page.json");
+    test_parse_lemmy_item::<Delete>("assets/lemmy/activities/deletion/remove_note.json").unwrap();
+    test_parse_lemmy_item::<Delete>("assets/lemmy/activities/deletion/delete_page.json").unwrap();
 
-    test_parse_lemmy_item::<UndoDelete>("assets/lemmy/activities/deletion/undo_remove_note.json");
-    test_parse_lemmy_item::<UndoDelete>("assets/lemmy/activities/deletion/undo_delete_page.json");
+    test_parse_lemmy_item::<UndoDelete>("assets/lemmy/activities/deletion/undo_remove_note.json")
+      .unwrap();
+    test_parse_lemmy_item::<UndoDelete>("assets/lemmy/activities/deletion/undo_delete_page.json")
+      .unwrap();
   }
 }

--- a/crates/apub/src/protocol/activities/following/mod.rs
+++ b/crates/apub/src/protocol/activities/following/mod.rs
@@ -19,11 +19,14 @@ mod tests {
 
   #[actix_rt::test]
   async fn test_parse_lemmy_accept_follow() {
-    test_parse_lemmy_item::<FollowCommunity>("assets/lemmy/activities/following/follow.json");
-    test_parse_lemmy_item::<AcceptFollowCommunity>("assets/lemmy/activities/following/accept.json");
+    test_parse_lemmy_item::<FollowCommunity>("assets/lemmy/activities/following/follow.json")
+      .unwrap();
+    test_parse_lemmy_item::<AcceptFollowCommunity>("assets/lemmy/activities/following/accept.json")
+      .unwrap();
     test_parse_lemmy_item::<UndoFollowCommunity>(
       "assets/lemmy/activities/following/undo_follow.json",
-    );
+    )
+    .unwrap();
 
     file_to_json_object::<WithContext<FollowCommunity>>("assets/pleroma/activities/follow.json")
       .unwrap();

--- a/crates/apub/src/protocol/activities/private_message/mod.rs
+++ b/crates/apub/src/protocol/activities/private_message/mod.rs
@@ -17,12 +17,15 @@ mod tests {
   async fn test_parse_lemmy_private_message() {
     test_parse_lemmy_item::<CreateOrUpdatePrivateMessage>(
       "assets/lemmy/activities/private_message/create.json",
-    );
+    )
+    .unwrap();
     test_parse_lemmy_item::<DeletePrivateMessage>(
       "assets/lemmy/activities/private_message/delete.json",
-    );
+    )
+    .unwrap();
     test_parse_lemmy_item::<UndoDeletePrivateMessage>(
       "assets/lemmy/activities/private_message/undo_delete.json",
-    );
+    )
+    .unwrap();
   }
 }

--- a/crates/apub/src/protocol/activities/voting/mod.rs
+++ b/crates/apub/src/protocol/activities/voting/mod.rs
@@ -10,10 +10,12 @@ mod tests {
 
   #[actix_rt::test]
   async fn test_parse_lemmy_voting() {
-    test_parse_lemmy_item::<Vote>("assets/lemmy/activities/voting/like_note.json");
-    test_parse_lemmy_item::<Vote>("assets/lemmy/activities/voting/dislike_page.json");
+    test_parse_lemmy_item::<Vote>("assets/lemmy/activities/voting/like_note.json").unwrap();
+    test_parse_lemmy_item::<Vote>("assets/lemmy/activities/voting/dislike_page.json").unwrap();
 
-    test_parse_lemmy_item::<UndoVote>("assets/lemmy/activities/voting/undo_like_note.json");
-    test_parse_lemmy_item::<UndoVote>("assets/lemmy/activities/voting/undo_dislike_page.json");
+    test_parse_lemmy_item::<UndoVote>("assets/lemmy/activities/voting/undo_like_note.json")
+      .unwrap();
+    test_parse_lemmy_item::<UndoVote>("assets/lemmy/activities/voting/undo_dislike_page.json")
+      .unwrap();
   }
 }

--- a/crates/apub/src/protocol/collections/mod.rs
+++ b/crates/apub/src/protocol/collections/mod.rs
@@ -17,10 +17,13 @@ mod tests {
 
   #[actix_rt::test]
   async fn test_parse_lemmy_collections() {
-    test_parse_lemmy_item::<GroupFollowers>("assets/lemmy/collections/group_followers.json");
-    let outbox = test_parse_lemmy_item::<GroupOutbox>("assets/lemmy/collections/group_outbox.json");
+    test_parse_lemmy_item::<GroupFollowers>("assets/lemmy/collections/group_followers.json")
+      .unwrap();
+    let outbox =
+      test_parse_lemmy_item::<GroupOutbox>("assets/lemmy/collections/group_outbox.json").unwrap();
     assert_eq!(outbox.ordered_items.len() as i32, outbox.total_items);
-    test_parse_lemmy_item::<GroupModerators>("assets/lemmy/collections/group_moderators.json");
-    test_parse_lemmy_item::<PersonOutbox>("assets/lemmy/collections/person_outbox.json");
+    test_parse_lemmy_item::<GroupModerators>("assets/lemmy/collections/group_moderators.json")
+      .unwrap();
+    test_parse_lemmy_item::<PersonOutbox>("assets/lemmy/collections/person_outbox.json").unwrap();
   }
 }

--- a/crates/apub/src/protocol/mod.rs
+++ b/crates/apub/src/protocol/mod.rs
@@ -42,6 +42,7 @@ pub struct Unparsed(HashMap<String, serde_json::Value>);
 pub(crate) mod tests {
   use crate::objects::tests::file_to_json_object;
   use assert_json_diff::assert_json_include;
+  use lemmy_utils::LemmyError;
   use serde::{de::DeserializeOwned, Serialize};
   use std::collections::HashMap;
 
@@ -49,14 +50,14 @@ pub(crate) mod tests {
   /// Ensures that there are no breaking changes in sent data.
   pub(crate) fn test_parse_lemmy_item<T: Serialize + DeserializeOwned + std::fmt::Debug>(
     path: &str,
-  ) -> T {
+  ) -> Result<T, LemmyError> {
     // parse file as T
-    let parsed = file_to_json_object::<T>(path).unwrap();
+    let parsed = file_to_json_object::<T>(path)?;
 
     // parse file into hashmap, which ensures that every field is included
-    let raw = file_to_json_object::<HashMap<String, serde_json::Value>>(path).unwrap();
+    let raw = file_to_json_object::<HashMap<String, serde_json::Value>>(path)?;
     // assert that all fields are identical, otherwise print diff
     assert_json_include!(actual: &parsed, expected: raw);
-    parsed
+    Ok(parsed)
   }
 }

--- a/crates/apub/src/protocol/objects/mod.rs
+++ b/crates/apub/src/protocol/objects/mod.rs
@@ -20,18 +20,26 @@ mod tests {
     context::WithContext,
     objects::tests::file_to_json_object,
     protocol::{
-      objects::{chat_message::ChatMessage, group::Group, note::Note, page::Page, person::Person},
+      objects::{
+        chat_message::ChatMessage,
+        group::Group,
+        note::Note,
+        page::Page,
+        person::Person,
+        tombstone::Tombstone,
+      },
       tests::test_parse_lemmy_item,
     },
   };
 
   #[actix_rt::test]
   async fn test_parse_object_lemmy() {
-    test_parse_lemmy_item::<Person>("assets/lemmy/objects/person.json");
-    test_parse_lemmy_item::<Group>("assets/lemmy/objects/group.json");
-    test_parse_lemmy_item::<Page>("assets/lemmy/objects/page.json");
-    test_parse_lemmy_item::<Note>("assets/lemmy/objects/note.json");
-    test_parse_lemmy_item::<ChatMessage>("assets/lemmy/objects/chat_message.json");
+    test_parse_lemmy_item::<Person>("assets/lemmy/objects/person.json").unwrap();
+    test_parse_lemmy_item::<Group>("assets/lemmy/objects/group.json").unwrap();
+    test_parse_lemmy_item::<Page>("assets/lemmy/objects/page.json").unwrap();
+    test_parse_lemmy_item::<Note>("assets/lemmy/objects/note.json").unwrap();
+    test_parse_lemmy_item::<ChatMessage>("assets/lemmy/objects/chat_message.json").unwrap();
+    test_parse_lemmy_item::<Tombstone>("assets/lemmy/objects/tombstone.json").unwrap();
   }
 
   #[actix_rt::test]
@@ -50,8 +58,8 @@ mod tests {
 
   #[actix_rt::test]
   async fn test_parse_object_mastodon() {
-    file_to_json_object::<Person>("assets/mastodon/objects/person.json").unwrap();
-    file_to_json_object::<Note>("assets/mastodon/objects/note.json").unwrap();
+    file_to_json_object::<WithContext<Person>>("assets/mastodon/objects/person.json").unwrap();
+    file_to_json_object::<WithContext<Note>>("assets/mastodon/objects/note.json").unwrap();
   }
 
   #[actix_rt::test]
@@ -60,5 +68,6 @@ mod tests {
     file_to_json_object::<WithContext<Person>>("assets/lotide/objects/person.json").unwrap();
     file_to_json_object::<WithContext<Note>>("assets/lotide/objects/note.json").unwrap();
     file_to_json_object::<WithContext<Page>>("assets/lotide/objects/page.json").unwrap();
+    file_to_json_object::<WithContext<Tombstone>>("assets/lotide/objects/tombstone.json").unwrap();
   }
 }


### PR DESCRIPTION
Adds test cases for Lemmy and Lotide tombstones. Also improves error reporting for failed tests.

@vpzomtrrfrt I tried to add tests for lotide Delete, Vote, Undo/Vote as well, but it seems like all of those are treated as private (i couldnt even access `/comments/{commentID}/likes` without auth). In Lemmy all of those are explicitly marked as public ([vote](https://github.com/LemmyNet/lemmy/blob/main/crates/apub/assets/lemmy/activities/voting/like_note.json), [delete](https://github.com/LemmyNet/lemmy/blob/main/crates/apub/assets/lemmy/activities/deletion/delete_page.json)). Thats because votes are federated to other instances (only sent as activity, not over any HTTP endpoint). For deletions there seems to be no reason to keep it private, as it contains only the Url.