### PR TITLE
Dont make webfinger request when viewing community/user profile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1847,6 +1847,7 @@ dependencies = [
  "actix-web",
  "chrono",
  "diesel",
+ "itertools",
  "lemmy_db_schema",
  "lemmy_db_views",
  "lemmy_db_views_actor",

--- a/crates/api/src/site.rs
+++ b/crates/api/src/site.rs
@@ -8,22 +8,17 @@ use lemmy_api_common::{
   get_local_user_view_from_jwt,
   get_local_user_view_from_jwt_opt,
   is_admin,
+  resolve_actor_identifier,
   send_application_approved_email,
   site::*,
 };
-use lemmy_apub::{
-  fetcher::{
-    search::{search_by_apub_id, SearchableObjects},
-    webfinger::webfinger_resolve,
-  },
-  objects::community::ApubCommunity,
-  EndpointType,
-};
+use lemmy_apub::fetcher::search::{search_by_apub_id, SearchableObjects};
 use lemmy_db_schema::{
   diesel_option_overwrite,
   from_opt_str_to_opt_enum,
   newtypes::PersonId,
   source::{
+    community::Community,
     local_user::{LocalUser, LocalUserForm},
     moderator::*,
     person::Person,
@@ -195,9 +190,10 @@ impl Perform for Search {
     let search_type: SearchType = from_opt_str_to_opt_enum(&data.type_).unwrap_or(SearchType::All);
     let community_id = data.community_id;
     let community_actor_id = if let Some(name) = &data.community_name {
-      webfinger_resolve::<ApubCommunity>(name, EndpointType::Community, context, &mut 0)
+      resolve_actor_identifier::<Community>(name, context.pool())
         .await
         .ok()
+        .map(|c| c.actor_id)
     } else {
       None
     };

--- a/crates/api_common/Cargo.toml
+++ b/crates/api_common/Cargo.toml
@@ -25,3 +25,4 @@ chrono = { version = "0.4.19", features = ["serde"] }
 serde_json = { version = "1.0.72", features = ["preserve_order"] }
 tracing = "0.1.29"
 url = "2.2.2"
+itertools = "0.10.3"

--- a/crates/api_common/src/lib.rs
+++ b/crates/api_common/src/lib.rs
@@ -6,6 +6,7 @@ pub mod site;
 pub mod websocket;
 
 use crate::site::FederatedInstances;
+use itertools::Itertools;
 use lemmy_db_schema::{
   newtypes::{CommunityId, LocalUserId, PersonId, PostId},
   source::{
@@ -18,7 +19,7 @@ use lemmy_db_schema::{
     secret::Secret,
     site::Site,
   },
-  traits::{Crud, Readable},
+  traits::{ApubActor, Crud, Readable},
   DbPool,
 };
 use lemmy_db_views::local_user_view::{LocalUserSettingsView, LocalUserView};
@@ -516,4 +517,37 @@ pub async fn check_private_instance_and_federation_enabled(
     }
   }
   Ok(())
+}
+
+/// Resolve actor identifier (eg `!news@example.com`) from local database to avoid network requests.
+/// This only works for local actors, and remote actors which were previously fetched (so it doesnt
+/// trigger any new fetch).
+#[tracing::instrument(skip_all)]
+pub async fn resolve_actor_identifier<Actor>(
+  identifier: &str,
+  pool: &DbPool,
+) -> Result<Actor, LemmyError>
+where
+  Actor: ApubActor + Send + 'static,
+{
+  // remote actor
+  if identifier.contains('@') {
+    let (name, domain) = identifier
+      .splitn(2, '@')
+      .collect_tuple()
+      .expect("invalid query");
+    let name = name.to_string();
+    let domain = format!("{}://{}", Settings::get().get_protocol_string(), domain);
+    Ok(
+      blocking(pool, move |conn| {
+        Actor::read_from_name_and_domain(conn, &name, &domain)
+      })
+      .await??,
+    )
+  }
+  // local actor
+  else {
+    let identifier = identifier.to_string();
+    Ok(blocking(pool, move |conn| Actor::read_from_name(conn, &identifier)).await??)
+  }
 }

--- a/crates/api_crud/src/comment/read.rs
+++ b/crates/api_crud/src/comment/read.rs
@@ -5,14 +5,11 @@ use lemmy_api_common::{
   check_private_instance,
   comment::*,
   get_local_user_view_from_jwt_opt,
-};
-use lemmy_apub::{
-  fetcher::webfinger::webfinger_resolve,
-  objects::community::ApubCommunity,
-  EndpointType,
+  resolve_actor_identifier,
 };
 use lemmy_db_schema::{
   from_opt_str_to_opt_enum,
+  source::community::Community,
   traits::DeleteableOrRemoveable,
   ListingType,
   SortType,
@@ -82,9 +79,10 @@ impl PerformCrud for GetComments {
 
     let community_id = data.community_id;
     let community_actor_id = if let Some(name) = &data.community_name {
-      webfinger_resolve::<ApubCommunity>(name, EndpointType::Community, context, &mut 0)
+      resolve_actor_identifier::<Community>(name, context.pool())
         .await
         .ok()
+        .map(|c| c.actor_id)
     } else {
       None
     };

--- a/crates/apub/src/fetcher/search.rs
+++ b/crates/apub/src/fetcher/search.rs
@@ -1,8 +1,7 @@
 use crate::{
-  fetcher::webfinger::webfinger_resolve,
+  fetcher::webfinger::webfinger_resolve_actor,
   objects::{comment::ApubComment, community::ApubCommunity, person::ApubPerson, post::ApubPost},
   protocol::objects::{group::Group, note::Note, page::Page, person::Person},
-  EndpointType,
 };
 use chrono::NaiveDateTime;
 use lemmy_apub_lib::{object_id::ObjectId, traits::ApubObject};
@@ -34,13 +33,8 @@ pub async fn search_by_apub_id(
       let (kind, identifier) = query.split_at(1);
       match kind {
         "@" => {
-          let id = webfinger_resolve::<ApubPerson>(
-            identifier,
-            EndpointType::Person,
-            context,
-            request_counter,
-          )
-          .await?;
+          let id =
+            webfinger_resolve_actor::<ApubPerson>(identifier, context, request_counter).await?;
           Ok(SearchableObjects::Person(
             ObjectId::new(id)
               .dereference(context, context.client(), request_counter)
@@ -48,13 +42,8 @@ pub async fn search_by_apub_id(
           ))
         }
         "!" => {
-          let id = webfinger_resolve::<ApubCommunity>(
-            identifier,
-            EndpointType::Community,
-            context,
-            request_counter,
-          )
-          .await?;
+          let id =
+            webfinger_resolve_actor::<ApubCommunity>(identifier, context, request_counter).await?;
           Ok(SearchableObjects::Community(
             ObjectId::new(id)
               .dereference(context, context.client(), request_counter)

--- a/crates/apub/src/fetcher/webfinger.rs
+++ b/crates/apub/src/fetcher/webfinger.rs
@@ -1,4 +1,3 @@
-use crate::{generate_local_apub_endpoint, EndpointType};
 use itertools::Itertools;
 use lemmy_apub_lib::{
   object_id::ObjectId,
@@ -26,37 +25,6 @@ pub struct WebfingerLink {
 pub struct WebfingerResponse {
   pub subject: String,
   pub links: Vec<WebfingerLink>,
-}
-
-/// Takes in a shortname of the type dessalines@xyz.tld or dessalines (assumed to be local), and
-/// outputs the actor id. Used in the API for communities and users.
-///
-/// TODO: later provide a method in ApubObject to generate the endpoint, so that we dont have to
-///       pass in EndpointType
-#[tracing::instrument(skip_all)]
-pub async fn webfinger_resolve<Kind>(
-  identifier: &str,
-  endpoint_type: EndpointType,
-  context: &LemmyContext,
-  request_counter: &mut i32,
-) -> Result<DbUrl, LemmyError>
-where
-  Kind: ApubObject<DataType = LemmyContext> + ActorType + Send + 'static,
-  for<'de2> <Kind as ApubObject>::ApubType: serde::Deserialize<'de2>,
-{
-  // remote actor
-  if identifier.contains('@') {
-    webfinger_resolve_actor::<Kind>(identifier, context, request_counter).await
-  }
-  // local actor
-  else {
-    let domain = context.settings().get_protocol_and_hostname();
-    Ok(generate_local_apub_endpoint(
-      endpoint_type,
-      identifier,
-      &domain,
-    )?)
-  }
 }
 
 /// Turns a person id like `@name@example.com` into an apub ID, like `https://example.com/user/name`,

--- a/crates/apub/src/http/community.rs
+++ b/crates/apub/src/http/community.rs
@@ -24,7 +24,7 @@ use crate::{
 use actix_web::{web, web::Payload, HttpRequest, HttpResponse};
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::{object_id::ObjectId, traits::ApubObject};
-use lemmy_db_schema::source::community::Community;
+use lemmy_db_schema::{source::community::Community, traits::ApubActor};
 use lemmy_utils::LemmyError;
 use lemmy_websocket::LemmyContext;
 use serde::Deserialize;

--- a/crates/apub/src/http/person.rs
+++ b/crates/apub/src/http/person.rs
@@ -14,7 +14,7 @@ use crate::{
 use actix_web::{web, web::Payload, HttpRequest, HttpResponse};
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::traits::ApubObject;
-use lemmy_db_schema::source::person::Person;
+use lemmy_db_schema::{source::person::Person, traits::ApubActor};
 use lemmy_utils::LemmyError;
 use lemmy_websocket::LemmyContext;
 use serde::Deserialize;
@@ -34,7 +34,7 @@ pub(crate) async fn get_apub_person_http(
   let user_name = info.into_inner().user_name;
   // TODO: this needs to be able to read deleted persons, so that it can send tombstones
   let person: ApubPerson = blocking(context.pool(), move |conn| {
-    Person::find_by_name(conn, &user_name)
+    Person::read_from_name(conn, &user_name)
   })
   .await??
   .into();
@@ -77,7 +77,7 @@ pub(crate) async fn get_apub_person_outbox(
   context: web::Data<LemmyContext>,
 ) -> Result<HttpResponse, LemmyError> {
   let person = blocking(context.pool(), move |conn| {
-    Person::find_by_name(conn, &info.user_name)
+    Person::read_from_name(conn, &info.user_name)
   })
   .await??;
   let outbox = PersonOutbox::new(person).await?;

--- a/crates/apub/src/objects/community.rs
+++ b/crates/apub/src/objects/community.rs
@@ -18,7 +18,7 @@ use lemmy_apub_lib::{
   traits::{ActorType, ApubObject},
   values::MediaTypeMarkdown,
 };
-use lemmy_db_schema::source::community::Community;
+use lemmy_db_schema::{source::community::Community, traits::ApubActor};
 use lemmy_db_views_actor::community_follower_view::CommunityFollowerView;
 use lemmy_utils::{
   utils::{convert_datetime, markdown_to_html},

--- a/crates/apub/src/objects/person.rs
+++ b/crates/apub/src/objects/person.rs
@@ -22,6 +22,7 @@ use lemmy_apub_lib::{
 use lemmy_db_schema::{
   naive_now,
   source::person::{Person as DbPerson, PersonForm},
+  traits::ApubActor,
 };
 use lemmy_utils::{
   utils::{check_slurs, check_slurs_opt, convert_datetime, markdown_to_html},

--- a/crates/db_schema/src/traits.rs
+++ b/crates/db_schema/src/traits.rs
@@ -1,5 +1,6 @@
 use crate::newtypes::{CommunityId, PersonId};
 use diesel::{result::Error, PgConnection};
+use url::Url;
 
 pub trait Crud {
   type Form;
@@ -159,6 +160,23 @@ pub trait ToSafeSettings {
 pub trait ViewToVec {
   type DbTuple;
   fn from_tuple_to_vec(tuple: Vec<Self::DbTuple>) -> Vec<Self>
+  where
+    Self: Sized;
+}
+
+pub trait ApubActor {
+  // TODO: this should be in a trait ApubObject (and implemented for Post, Comment, PrivateMessage as well)
+  fn read_from_apub_id(conn: &PgConnection, object_id: Url) -> Result<Option<Self>, Error>
+  where
+    Self: Sized;
+  fn read_from_name(conn: &PgConnection, actor_name: &str) -> Result<Self, Error>
+  where
+    Self: Sized;
+  fn read_from_name_and_domain(
+    conn: &PgConnection,
+    actor_name: &str,
+    protocol_domain: &str,
+  ) -> Result<Self, Error>
   where
     Self: Sized;
 }

--- a/crates/routes/src/feeds.rs
+++ b/crates/routes/src/feeds.rs
@@ -6,7 +6,7 @@ use lemmy_api_common::blocking;
 use lemmy_db_schema::{
   newtypes::LocalUserId,
   source::{community::Community, local_user::LocalUser, person::Person},
-  traits::Crud,
+  traits::{ApubActor, Crud},
   ListingType,
   SortType,
 };
@@ -175,7 +175,7 @@ fn get_feed_user(
   protocol_and_hostname: &str,
 ) -> Result<ChannelBuilder, LemmyError> {
   let site_view = SiteView::read(conn)?;
-  let person = Person::find_by_name(conn, user_name)?;
+  let person = Person::read_from_name(conn, user_name)?;
 
   let posts = PostQueryBuilder::create(conn)
     .listing_type(ListingType::All)

--- a/crates/routes/src/webfinger.rs
+++ b/crates/routes/src/webfinger.rs
@@ -2,7 +2,10 @@ use actix_web::{web, web::Query, HttpResponse};
 use anyhow::Context;
 use lemmy_api_common::blocking;
 use lemmy_apub::fetcher::webfinger::{WebfingerLink, WebfingerResponse};
-use lemmy_db_schema::source::{community::Community, person::Person};
+use lemmy_db_schema::{
+  source::{community::Community, person::Person},
+  traits::ApubActor,
+};
 use lemmy_utils::{location_info, settings::structs::Settings, LemmyError};
 use lemmy_websocket::LemmyContext;
 use serde::Deserialize;
@@ -44,7 +47,7 @@ async fn get_webfinger_response(
 
   let name_ = name.clone();
   let user_id: Option<Url> = blocking(context.pool(), move |conn| {
-    Person::find_by_name(conn, &name_)
+    Person::read_from_name(conn, &name_)
   })
   .await?
   .ok()


### PR DESCRIPTION
Tested and works fine. This makes it so that viewing remote profiles like https://lemmy.ml/c/main@baraza.africa doesnt make any request to the remote instance, and keeps working if the remote instance goes down. There are two side effects of this:
- `ResolveObject` API endpoint doesnt support `!name` for local actors anymore (doesnt seem useful to implement)
- Opening a profile url doesnt trigger a refetch, so the data might be outdated. Fetching still works via search (which uses ResolveObject API call).