### PR TITLE
Instance with registration applications active shouldnt count as open

### DIFF
--- a/crates/routes/src/nodeinfo.rs
+++ b/crates/routes/src/nodeinfo.rs
@@ -55,7 +55,7 @@ async fn node_info(context: web::Data<LemmyContext>) -> Result<HttpResponse, Err
       local_posts: site_view.counts.posts,
       local_comments: site_view.counts.comments,
     },
-    open_registrations: site_view.site.open_registration,
+    open_registrations: site_view.site.open_registration && !site_view.site.require_application,
   };
 
   Ok(HttpResponse::Ok().json(json))


### PR DESCRIPTION
When a user is looking for an instance with open registration (eg on join-lemmy.org), she is probably looking for one to sign up, possibly verify email, and then start commenting immediately. Having to fill in an application form and waiting for approval adds a lot of friction, and makes it more likely that the user will ignore Lemmy. Besides, getting a lot of applications would create too much work for admins.