### PR TITLE
Dont update default config in commit hook

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -7,6 +7,3 @@ cargo clippy --workspace --tests --all-targets --all-features -- \
     -D warnings -D deprecated -D clippy::perf -D clippy::complexity -D clippy::dbg_macro
 cargo clippy --workspace -- \
     -D clippy::unwrap_used
-
-./scripts/update_config_defaults.sh
-git add config/defaults.hjson


### PR DESCRIPTION
Its just too slow, takes 2m 23s for me to run. This is in addition to the clippy commands, which run for 1m 21s and 1m 16s respectively. Maybe we should just remove the commit hook entirely and rely on CI, because i waste a lot of time waiting for the commit to be finished.