### PR TITLE
Add comment about opentelemetry_url

### DIFF
--- a/config/defaults.hjson
+++ b/config/defaults.hjson
@@ -117,5 +117,6 @@
   actor_name_max_length: 20
   # Maximum number of HTTP requests allowed to handle a single incoming activity (or a single object fetch through the search).
   http_fetch_retry_limit: 25
+  # Set the URL for opentelemetry exports. If you do not have an opentelemetry collector, do not set this option
   opentelemetry_url: "http://localhost:4317"
 }

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -50,6 +50,7 @@ pub struct Settings {
   #[default(25)]
   pub http_fetch_retry_limit: i32,
 
+  /// Set the URL for opentelemetry exports. If you do not have an opentelemetry collector, do not set this option
   #[default(None)]
   #[doku(example = "http://localhost:4317")]
   pub opentelemetry_url: Option<String>,


### PR DESCRIPTION
This config option should not be set by default, so I added a comment about it. I didn't find a way to make doku ignore this field when generating the default configuration file.