### PR TITLE
Add console feature flag, not default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ doctest = false
 [profile.dev]
 debug = 0
 
+[features]
+console = ["console-subscriber"]
+default = []
+
 [workspace]
 members = [
     "crates/api",
@@ -54,7 +58,7 @@ tracing-actix-web = { version = "0.5.0-beta.8", default-features = false }
 tracing-error = "0.2.0"
 tracing-log = "0.1.2"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
-console-subscriber = "0.1.0"
+console-subscriber = { version = "0.1.0", optional = true }
 strum = "0.23.0"
 url = { version = "2.2.2", features = ["serde"] }
 openssl = "0.10.38"

--- a/crates/utils/src/request.rs
+++ b/crates/utils/src/request.rs
@@ -288,15 +288,22 @@ mod tests {
       .build()
       .unwrap()
       .into();
-    let sample_url = Url::parse("https://www.redspark.nu/en/peoples-war/district-leader-of-chand-led-cpn-arrested-in-bhojpur/").unwrap();
+    let sample_url = Url::parse("https://gitlab.com/IzzyOnDroid/repo/-/wikis/FAQ").unwrap();
     let sample_res = fetch_site_metadata(&client, &sample_url).await.unwrap();
     assert_eq!(
       SiteMetadata {
-        title: Some("District Leader Of Chand Led CPN Arrested In Bhojpur - Redspark".to_string()),
-        description: Some("BHOJPUR: A district leader of the outlawed Netra Bikram Chand alias Biplav-led outfit has been arrested. According to District Police".to_string()),
-        image: Some(Url::parse("https://www.redspark.nu/wp-content/uploads/2020/03/netra-bikram-chand-attends-program-1272019033653-1000x0-845x653-1.jpg").unwrap()),
+        title: Some("FAQ · Wiki · IzzyOnDroid / repo".to_string()),
+        description: Some(
+          "The F-Droid compatible repo at https://apt.izzysoft.de/fdroid/".to_string()
+        ),
+        image: Some(
+          Url::parse("https://gitlab.com/uploads/-/system/project/avatar/4877469/iod_logo.png")
+            .unwrap()
+        ),
         html: None,
-      }, sample_res);
+      },
+      sample_res
+    );
 
     let youtube_url = Url::parse("https://www.youtube.com/watch?v=IquO_TcMZIQ").unwrap();
     let youtube_res = fetch_site_metadata(&client, &youtube_url).await.unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod code_migrations;
 pub mod root_span_builder;
 pub mod scheduled_tasks;
 
+#[cfg(feature = "console")]
 use console_subscriber::ConsoleLayer;
 use lemmy_utils::LemmyError;
 use opentelemetry::{
@@ -30,6 +31,7 @@ pub fn init_tracing(opentelemetry_url: Option<&str>) -> Result<(), LemmyError> {
 
   let format_layer = tracing_subscriber::fmt::layer().with_filter(targets.clone());
 
+  #[cfg(feature = "console")]
   let console_layer = ConsoleLayer::builder()
     .with_default_env()
     .server_addr(([0, 0, 0, 0], 6669))
@@ -38,8 +40,10 @@ pub fn init_tracing(opentelemetry_url: Option<&str>) -> Result<(), LemmyError> {
 
   let subscriber = Registry::default()
     .with(format_layer)
-    .with(ErrorLayer::default())
-    .with(console_layer);
+    .with(ErrorLayer::default());
+
+  #[cfg(feature = "console")]
+  let subscriber = subscriber.with(console_layer);
 
   if let Some(url) = opentelemetry_url {
     let tracer = opentelemetry_otlp::new_pipeline()


### PR DESCRIPTION
The most recent tracing-core changed the number of variants on metadata::Kind, which broke console-api 0.1.1, and no fix has been applied yet. To avoid build failures, disable console-subscriber for now