### PR TITLE
Use doku(skip) for opentelemetry_url config value (ref #2085)

### DIFF
--- a/config/defaults.hjson
+++ b/config/defaults.hjson
@@ -117,6 +117,4 @@
   actor_name_max_length: 20
   # Maximum number of HTTP requests allowed to handle a single incoming activity (or a single object fetch through the search).
   http_fetch_retry_limit: 25
-  # Set the URL for opentelemetry exports. If you do not have an opentelemetry collector, do not set this option
-  opentelemetry_url: "http://localhost:4317"
 }

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -52,7 +52,7 @@ pub struct Settings {
 
   /// Set the URL for opentelemetry exports. If you do not have an opentelemetry collector, do not set this option
   #[default(None)]
-  #[doku(example = "http://localhost:4317")]
+  #[doku(skip)]
   pub opentelemetry_url: Option<String>,
 }
 


### PR DESCRIPTION
Fields can be excluded from default config like this. cc @asonix 