### PR TITLE
Add logging to debug federation issues (ref #2096)

### DIFF
--- a/crates/apub/src/activities/community/announce.rs
+++ b/crates/apub/src/activities/community/announce.rs
@@ -14,6 +14,7 @@ use lemmy_apub_lib::{
 };
 use lemmy_utils::LemmyError;
 use lemmy_websocket::LemmyContext;
+use tracing::info;
 
 #[async_trait::async_trait(?Send)]
 pub(crate) trait GetCommunity {
@@ -51,6 +52,14 @@ impl AnnounceActivity {
     context: &LemmyContext,
   ) -> Result<(), LemmyError> {
     let announce = AnnounceActivity::new(object.clone(), community, context)?;
+    // temporary hack to get activity id of object
+    let object_fields: ActivityCommonFields =
+      serde_json::from_value(serde_json::to_value(&object)?)?;
+    info!(
+      "Announcing activity {} as {}",
+      object_fields.id, announce.id
+    );
+
     let inboxes = community.get_follower_inboxes(context).await?;
     send_lemmy_activity(
       context,

--- a/crates/apub/src/activities/create_or_update/comment.rs
+++ b/crates/apub/src/activities/create_or_update/comment.rs
@@ -26,6 +26,7 @@ use lemmy_db_schema::{
 };
 use lemmy_utils::LemmyError;
 use lemmy_websocket::{send::send_comment_ws_message, LemmyContext, UserOperationCrud};
+use tracing::info;
 
 impl CreateOrUpdateComment {
   #[tracing::instrument(skip(comment, actor, kind, context))]
@@ -50,6 +51,7 @@ impl CreateOrUpdateComment {
       kind.clone(),
       &context.settings().get_protocol_and_hostname(),
     )?;
+    info!("Sending Create/Comment for {} as {}", comment.ap_id, id);
     let note = comment.into_apub(context).await?;
 
     let create_or_update = CreateOrUpdateComment {

--- a/crates/apub/src/activities/mod.rs
+++ b/crates/apub/src/activities/mod.rs
@@ -6,6 +6,7 @@ use crate::{
   objects::{community::ApubCommunity, person::ApubPerson},
 };
 use activitystreams_kinds::public;
+use itertools::Itertools;
 use lemmy_api_common::blocking;
 use lemmy_apub_lib::{
   activity_queue::send_activity,
@@ -170,8 +171,6 @@ async fn send_lemmy_activity<T: Serialize>(
   }
   let activity = WithContext::new(activity);
 
-  info!("Sending activity {}", activity_id.to_string());
-
   // Don't send anything to ourselves
   // TODO: this should be a debug assert
   let hostname = context.settings().get_hostname_without_port()?;
@@ -179,6 +178,12 @@ async fn send_lemmy_activity<T: Serialize>(
     .iter()
     .filter(|i| i.domain().expect("valid inbox url") != hostname)
     .collect();
+
+  info!(
+    "Sending activity {} to [{}]",
+    activity_id.to_string(),
+    inboxes.iter().join(",")
+  );
 
   let serialised_activity = serde_json::to_string(&activity)?;
 

--- a/crates/apub_lib/src/activity_queue.rs
+++ b/crates/apub_lib/src/activity_queue.rs
@@ -1,5 +1,5 @@
 use crate::{signatures::sign_and_send, traits::ActorType};
-use anyhow::{anyhow, Context, Error};
+use anyhow::{Context, Error};
 use background_jobs::{
   memory_storage::Storage,
   ActixJob,
@@ -90,12 +90,10 @@ async fn do_send(task: SendActivityTask, client: &ClientWithMiddleware) -> Resul
       }
     }
     Err(e) => {
-      return Err(anyhow!(
+      warn!(
         "Failed to send activity {} to {}: {}",
-        &task.activity_id,
-        task.inbox,
-        e
-      ));
+        &task.activity_id, task.inbox, e
+      );
     }
   }
   Ok(())


### PR DESCRIPTION
The problem happens not only with votes, but also with comments. So i'm logging Create/Note activities, as its easier to find out the id of a missing comment, than figuring out a specific vote that wasnt federated.