### PR TITLE
Add timeout for sending activities

### DIFF
--- a/crates/apub_lib/src/signatures.rs
+++ b/crates/apub_lib/src/signatures.rs
@@ -15,7 +15,7 @@ use reqwest::Response;
 use reqwest_middleware::ClientWithMiddleware;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::str::FromStr;
+use std::{str::FromStr, time::Duration};
 use tracing::debug;
 use url::Url;
 
@@ -46,6 +46,8 @@ pub async fn sign_and_send(
 
   let request = client
     .post(&inbox_url.to_string())
+    // signature is only valid for 10 seconds, so no reason to wait any longer
+    .timeout(Duration::from_secs(10))
     .headers(headers)
     .signature_with_digest(
       HTTP_SIG_CONFIG.clone(),


### PR DESCRIPTION
Had a look through the server logs and noticed many warnings like this. If we're lucky this will help with federation issues.

`2022-03-03T11:35:46.223374Z  WARN Worker{worker.id=d691c720-948a-42ac-b0c0-25dd9d35bda2 worker.queue=default worker.operation.id=588bb2dd-bb69-4c5f-93e3-de1fb766134c worker.operation.name=process}: background_jobs_actix::worker: Job 414c96b9-049b-4384-b8cf-ced4c257e0cf is taking a long time: 1 minutes`