### PR TITLE
Make delete activities backwards compatible with 0.15

### DIFF
--- a/crates/apub/src/activities/deletion/delete.rs
+++ b/crates/apub/src/activities/deletion/delete.rs
@@ -6,7 +6,7 @@ use crate::{
     verify_activity,
   },
   objects::{community::ApubCommunity, person::ApubPerson},
-  protocol::activities::deletion::delete::{Delete, IdOrNestedObject},
+  protocol::activities::deletion::delete::{Delete, IdOrNestedObject, NestedObject},
 };
 use activitystreams_kinds::activity::DeleteType;
 use anyhow::anyhow;
@@ -104,7 +104,10 @@ impl Delete {
     Ok(Delete {
       actor: ObjectId::new(actor.actor_id.clone()),
       to: vec![to],
-      object: IdOrNestedObject::Id(object.id()),
+      object: IdOrNestedObject::NestedObject(NestedObject {
+        id: object.id(),
+        kind: Default::default(),
+      }),
       cc: cc.into_iter().collect(),
       kind: DeleteType::Delete,
       summary,

--- a/crates/apub/src/protocol/activities/deletion/delete.rs
+++ b/crates/apub/src/protocol/activities/deletion/delete.rs
@@ -1,5 +1,5 @@
 use crate::{objects::person::ApubPerson, protocol::Unparsed};
-use activitystreams_kinds::activity::DeleteType;
+use activitystreams_kinds::{activity::DeleteType, object::TombstoneType};
 use lemmy_apub_lib::object_id::ObjectId;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -39,7 +39,10 @@ pub(crate) enum IdOrNestedObject {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct NestedObject {
-  id: Url,
+  pub(crate) id: Url,
+  // Backwards compatibility with Lemmy 0.15
+  #[serde(rename = "type")]
+  pub(crate) kind: TombstoneType,
 }
 
 impl IdOrNestedObject {


### PR DESCRIPTION
We can merge this to make federation backwards compatible with Lemmy 0.15. Test it with the following commands:
```
git checkout 0.15.0 -- crates/apub/assets/lemmy/
./scripts/[test.sh](http://test.sh/
```

There is one remaining failure, which is from renaming Person.matrixUserId to matrix_user_id (accidentally used the wrong case before). I dont think its a big problem if this particular field doesnt federate for a few days.