### PR TITLE
Try to fix federation test on ci

### DIFF
--- a/crates/apub_lib/src/object_id.rs
+++ b/crates/apub_lib/src/object_id.rs
@@ -134,7 +134,7 @@ where
 }
 
 static ACTOR_REFETCH_INTERVAL_SECONDS: i64 = 24 * 60 * 60;
-static ACTOR_REFETCH_INTERVAL_SECONDS_DEBUG: i64 = 10;
+static ACTOR_REFETCH_INTERVAL_SECONDS_DEBUG: i64 = 20;
 
 /// Determines when a remote actor should be refetched from its instance. In release builds, this is
 /// `ACTOR_REFETCH_INTERVAL_SECONDS` after the last refetch, in debug builds


### PR DESCRIPTION
Increased the amount of time that apub objects are cached. Seems like CI is being so slow that its going over the 10 seconds.