### PR TITLE
Correctly read local SiteView

### DIFF
--- a/crates/api/src/site.rs
+++ b/crates/api/src/site.rs
@@ -502,7 +502,7 @@ impl Perform for LeaveAdmin {
     blocking(context.pool(), move |conn| ModAdd::create(conn, &form)).await??;
 
     // Reread site and admins
-    let site_view = blocking(context.pool(), SiteView::read).await??;
+    let site_view = blocking(context.pool(), SiteView::read_local).await??;
     let admins = blocking(context.pool(), PersonViewSafe::admins).await??;
 
     let federated_instances = build_federated_instances(

--- a/crates/api_crud/src/site/create.rs
+++ b/crates/api_crud/src/site/create.rs
@@ -89,7 +89,7 @@ impl PerformCrud for CreateSite {
       return Err(LemmyError::from_message("site_already_exists"));
     }
 
-    let site_view = blocking(context.pool(), SiteView::read).await??;
+    let site_view = blocking(context.pool(), SiteView::read_local).await??;
 
     Ok(SiteResponse { site_view })
   }

--- a/crates/api_crud/src/site/read.rs
+++ b/crates/api_crud/src/site/read.rs
@@ -31,7 +31,7 @@ impl PerformCrud for GetSite {
   ) -> Result<GetSiteResponse, LemmyError> {
     let data: &GetSite = self;
 
-    let site_view = match blocking(context.pool(), SiteView::read).await? {
+    let site_view = match blocking(context.pool(), SiteView::read_local).await? {
       Ok(site_view) => Some(site_view),
       // If the site isn't created yet, check the setup
       Err(_) => {
@@ -73,7 +73,7 @@ impl PerformCrud for GetSite {
           };
           create_site.perform(context, websocket_id).await?;
           info!("Site {} created", setup.site_name);
-          Some(blocking(context.pool(), SiteView::read).await??)
+          Some(blocking(context.pool(), SiteView::read_local).await??)
         } else {
           None
         }

--- a/crates/api_crud/src/site/update.rs
+++ b/crates/api_crud/src/site/update.rs
@@ -103,7 +103,7 @@ impl PerformCrud for EditSite {
       .map_err(|e| e.with_message("couldnt_set_all_email_verified"))?;
     }
 
-    let site_view = blocking(context.pool(), SiteView::read).await??;
+    let site_view = blocking(context.pool(), SiteView::read_local).await??;
 
     let res = SiteResponse { site_view };
 

--- a/crates/db_views/src/site_view.rs
+++ b/crates/db_views/src/site_view.rs
@@ -13,10 +13,11 @@ pub struct SiteView {
 }
 
 impl SiteView {
-  pub fn read(conn: &PgConnection) -> Result<Self, Error> {
+  pub fn read_local(conn: &PgConnection) -> Result<Self, Error> {
     let (mut site, counts) = site::table
       .inner_join(site_aggregates::table)
       .select((site::all_columns, site_aggregates::all_columns))
+      .order_by(site::id)
       .first::<(Site, SiteAggregates)>(conn)?;
 
     site.private_key = None;

--- a/crates/routes/src/feeds.rs
+++ b/crates/routes/src/feeds.rs
@@ -82,7 +82,7 @@ async fn get_feed_data(
   listing_type: ListingType,
   sort_type: SortType,
 ) -> Result<HttpResponse, LemmyError> {
-  let site_view = blocking(context.pool(), SiteView::read).await??;
+  let site_view = blocking(context.pool(), SiteView::read_local).await??;
 
   let posts = blocking(context.pool(), move |conn| {
     PostQueryBuilder::create(conn)
@@ -174,7 +174,7 @@ fn get_feed_user(
   user_name: &str,
   protocol_and_hostname: &str,
 ) -> Result<ChannelBuilder, LemmyError> {
-  let site_view = SiteView::read(conn)?;
+  let site_view = SiteView::read_local(conn)?;
   let person = Person::read_from_name(conn, user_name)?;
 
   let posts = PostQueryBuilder::create(conn)
@@ -202,7 +202,7 @@ fn get_feed_community(
   community_name: &str,
   protocol_and_hostname: &str,
 ) -> Result<ChannelBuilder, LemmyError> {
-  let site_view = SiteView::read(conn)?;
+  let site_view = SiteView::read_local(conn)?;
   let community = Community::read_from_name(conn, community_name)?;
 
   let posts = PostQueryBuilder::create(conn)
@@ -235,7 +235,7 @@ fn get_feed_front(
   jwt: &str,
   protocol_and_hostname: &str,
 ) -> Result<ChannelBuilder, LemmyError> {
-  let site_view = SiteView::read(conn)?;
+  let site_view = SiteView::read_local(conn)?;
   let local_user_id = LocalUserId(Claims::decode(jwt, jwt_secret)?.claims.sub);
   let local_user = LocalUser::read(conn, local_user_id)?;
 
@@ -270,7 +270,7 @@ fn get_feed_inbox(
   jwt: &str,
   protocol_and_hostname: &str,
 ) -> Result<ChannelBuilder, LemmyError> {
-  let site_view = SiteView::read(conn)?;
+  let site_view = SiteView::read_local(conn)?;
   let local_user_id = LocalUserId(Claims::decode(jwt, jwt_secret)?.claims.sub);
   let local_user = LocalUser::read(conn, local_user_id)?;
   let person_id = local_user.person_id;

--- a/crates/routes/src/nodeinfo.rs
+++ b/crates/routes/src/nodeinfo.rs
@@ -29,7 +29,7 @@ async fn node_info_well_known(
 }
 
 async fn node_info(context: web::Data<LemmyContext>) -> Result<HttpResponse, Error> {
-  let site_view = blocking(context.pool(), SiteView::read)
+  let site_view = blocking(context.pool(), SiteView::read_local)
     .await?
     .map_err(|_| ErrorBadRequest(LemmyError::from(anyhow!("not_found"))))?;
 


### PR DESCRIPTION
Happens because Lemmy now fetches site metadata from other instances, and SiteView::read wasnt sorting by id to get local site.

```
# select id, name from site;
id | name
----+-------
2 | DS9
1 | Lemmy
```

Deployed this code to enterprise.lemmy.ml (which had the same problem), and confirmed that it fixed the issue.