### PR TITLE
Reject federated downvotes if downvotes are disabled (fixes #2124)

### DIFF
--- a/crates/apub/src/protocol/activities/voting/vote.rs
+++ b/crates/apub/src/protocol/activities/voting/vote.rs
@@ -27,7 +27,7 @@ pub struct Vote {
   pub(crate) unparsed: Unparsed,
 }
 
-#[derive(Clone, Debug, Display, Deserialize, Serialize)]
+#[derive(Clone, Debug, Display, Deserialize, Serialize, PartialEq)]
 pub enum VoteType {
   Like,
   Dislike,


### PR DESCRIPTION
@GitOffMyBack This is the easiest possible way to fix federation for the disable downvotes setting. It makes it so that downvotes from other instances will always be rejected. Users on other instances will still be able to downvote posts/comments from your instances, but your instance will ignore them.

I could also change it so that the disable downvotes setting itself gets federated (possibly as a community setting), so that the setting is also respected by other instances. That would be a bit more complicated to implement. What do you think?