### PR TITLE
Adjust retry interval for sending activities

### DIFF
--- a/crates/apub_lib/src/activity_queue.rs
+++ b/crates/apub_lib/src/activity_queue.rs
@@ -72,8 +72,19 @@ impl ActixJob for SendActivityTask {
   type Future = Pin<Box<dyn Future<Output = Result<(), Error>>>>;
   const NAME: &'static str = "SendActivityTask";
 
+  /// With these params, retries are made at the following intervals:
+  ///          3s
+  ///          9s
+  ///         27s
+  ///      1m 21s
+  ///      4m  3s
+  ///     12m  9s
+  ///     36m 27s
+  ///  1h 49m 21s
+  ///  5h 28m  3s
+  /// 16h 24m  9s
   const MAX_RETRIES: MaxRetries = MaxRetries::Count(10);
-  const BACKOFF: Backoff = Backoff::Exponential(2);
+  const BACKOFF: Backoff = Backoff::Exponential(3);
 
   fn run(self, state: Self::State) -> Self::Future {
     Box::pin(async move { do_send(self, &state.client).await })


### PR DESCRIPTION
This might look like a very minor change, but in fact its a big difference. With the previous value for exponential backoff, the last resend would be attempted after 2^10=1024s (17m 4s). Thats not much time when an instance goes down for maintenance or some other reason. With the new value, last retry is after 16h, which makes it much more likely that activities will actually be delivered (though possibly with more delay).

I'm also wondering if we should make this configurable for admins, but it seems relatively complicated to explain, and very easy to mess something up, so probably better not.