### PR TITLE
Dont log error if duplicate activity is received (fixes #2146)

### DIFF
--- a/crates/apub/src/lib.rs
+++ b/crates/apub/src/lib.rs
@@ -201,11 +201,12 @@ async fn insert_activity(
   local: bool,
   sensitive: bool,
   pool: &DbPool,
-) -> Result<(), LemmyError> {
+) -> Result<bool, LemmyError> {
   let ap_id = ap_id.to_owned().into();
-  blocking(pool, move |conn| {
-    Activity::insert(conn, ap_id, activity, local, sensitive)
-  })
-  .await??;
-  Ok(())
+  Ok(
+    blocking(pool, move |conn| {
+      Activity::insert(conn, ap_id, activity, local, sensitive)
+    })
+    .await??,
+  )
 }


### PR DESCRIPTION
Found a clean way to implement this.

Postgres will still log an error, but i guess thats less important than an error logged by Lemmy.