### PR TITLE
Check that config is valid before saving

### DIFF
--- a/crates/utils/src/settings/mod.rs
+++ b/crates/utils/src/settings/mod.rs
@@ -88,6 +88,9 @@ impl Settings {
   }
 
   pub fn save_config_file(data: &str) -> Result<String, LemmyError> {
+    // check that the config is valid
+    from_str::<Settings>(data)?;
+
     fs::write(Settings::get_config_location(), data)?;
 
     // Reload the new settings


### PR DESCRIPTION
It turns out that you can currently set a config that is completely invalid (eg wrong braces), and Lemmy will happily save it, reload the config and then stop working. This adds a simple check to make sure that the config can be parsed before saving.

There are also some other problems with updating the config like this:
- If any error happens, it is simply reported as `couldnt_update_site`. Would be good if this could be more specific, eg indicating that the given config is invalid (and in which place), or that the file is not writable.
- It would be nice if we could pretty print the new config, but thats not supported by `deser-hjson` crate.
- Some config changes (e.g. enabling federation) require a restart of Lemmy. I tried to do that by caling `System::exit()` in `save_config_file()`, but it didnt seem to work. Would be good to mention in lemmy-ui that a restart is necessary.