### PR TITLE
Dont log errors when rate limit is hit (fixes #2157)

### DIFF
--- a/crates/websocket/src/chat_server.rs
+++ b/crates/websocket/src/chat_server.rs
@@ -478,26 +478,30 @@ impl ChatServer {
         .as_str()
         .ok_or_else(|| LemmyError::from_message("missing op"))?;
 
-      let res = if let Ok(user_operation_crud) = UserOperationCrud::from_str(op) {
-        let fut = (message_handler_crud)(context, msg.id, user_operation_crud.clone(), data);
-        match user_operation_crud {
-          UserOperationCrud::Register => rate_limiter.register().wrap(ip, fut).await,
-          UserOperationCrud::CreatePost => rate_limiter.post().wrap(ip, fut).await,
-          UserOperationCrud::CreateCommunity => rate_limiter.register().wrap(ip, fut).await,
-          UserOperationCrud::CreateComment => rate_limiter.comment().wrap(ip, fut).await,
-          _ => rate_limiter.message().wrap(ip, fut).await,
-        }
+      // check if api call passes the rate limit, and generate future for later execution
+      let (passed, fut) = if let Ok(user_operation_crud) = UserOperationCrud::from_str(op) {
+        let passed = match user_operation_crud {
+          UserOperationCrud::Register => rate_limiter.register().check(ip).await,
+          UserOperationCrud::CreatePost => rate_limiter.post().check(ip).await,
+          UserOperationCrud::CreateCommunity => rate_limiter.register().check(ip).await,
+          UserOperationCrud::CreateComment => rate_limiter.comment().check(ip).await,
+          _ => rate_limiter.message().check(ip).await,
+        };
+        let fut = (message_handler_crud)(context, msg.id, user_operation_crud, data);
+        (passed, fut)
       } else {
         let user_operation = UserOperation::from_str(op)?;
-        let fut = (message_handler)(context, msg.id, user_operation.clone(), data);
-        match user_operation {
-          UserOperation::GetCaptcha => rate_limiter.post().wrap(ip, fut).await,
-          _ => rate_limiter.message().wrap(ip, fut).await,
-        }
-      }?;
+        let passed = match user_operation {
+          UserOperation::GetCaptcha => rate_limiter.post().check(ip).await,
+          _ => rate_limiter.message().check(ip).await,
+        };
+        let fut = (message_handler)(context, msg.id, user_operation, data);
+        (passed, fut)
+      };
 
-      if let Some(r) = res {
-        Ok(r)
+      // if rate limit passed, execute api call future
+      if passed {
+        fut.await
       } else {
         // if rate limit was hit, respond with empty message
         Ok("".to_string())


### PR DESCRIPTION
This should be a pretty straightforward change, as it only changes some return types. But in fact, every api call results in the same strange error:

```
thread 'actix-rt|system:0|arbiter:2' panicked at 'called `Option::unwrap()` on a `None` value', /home/felix/.cargo/registry/src/github.com-1ecc6299db9ec823/actix-web-4.0.1/src/request.rs:148:43
stack backtrace:
0:     0x55745d6ad45c - std::backtrace_rs::backtrace::libunwind::trace::h09f7e4e089375279
at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/../../backtrace/src/backtrace/libunwind.rs:93:5
1:     0x55745d6ad45c - std::backtrace_rs::backtrace::trace_unsynchronized::h1ec96f1c7087094e
at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
2:     0x55745d6ad45c - std::sys_common::backtrace::_print_fmt::h317b71fc9a5cf964
at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/sys_common/backtrace.rs:67:5
3:     0x55745d6ad45c - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::he3555b48e7dfe7f0
at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/sys_common/backtrace.rs:46:22
4:     0x55745d6d169c - core::fmt::write::h513b07ca38f4fb1b
at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/fmt/mod.rs:1149:17
5:     0x55745d6a6055 - std::io::Write::write_fmt::haf8c932b52111354
at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/io/mod.rs:1697:15
6:     0x55745d6af080 - std::sys_common::backtrace::_print::h195c38364780a303
at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/sys_common/backtrace.rs:49:5
7:     0x55745d6af080 - std::sys_common::backtrace::print::hc09dfdea923b6730
at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/sys_common/backtrace.rs:36:9
8:     0x55745d6af080 - std::panicking::default_hook::{{closure}}::hb2e38ec0d91046a3
at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/panicking.rs:211:50
9:     0x55745d6aec35 - std::panicking::default_hook::h60284635b0ad54a8
at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/panicking.rs:228:9
10:     0x55745d6af734 - std::panicking::rust_panic_with_hook::ha677a669fb275654
at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/panicking.rs:606:17
11:     0x55745d6af1e2 - std::panicking::begin_panic_handler::{{closure}}::h976246fb95d93c31
at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/panicking.rs:500:13
12:     0x55745d6ad904 - std::sys_common::backtrace::__rust_end_short_backtrace::h38077ee5b7b9f99a
at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/sys_common/backtrace.rs:139:18
13:     0x55745d6af179 - rust_begin_unwind
at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/panicking.rs:498:5
14:     0x5574594be5c1 - core::panicking::panic_fmt::h35f3a62252ba0fd2
at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/panicking.rs:107:14
15:     0x5574594be50d - core::panicking::panic::h86fc01e270142a61
at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/panicking.rs:48:5
16:     0x55745cf5b60e - core::option::Option<T>::unwrap::hdb6cfbcd5f45037b
17:     0x55745cf66f31 - actix_web::request::HttpRequest::match_info_mut::h62bcc8986324593d
18:     0x55745cf1e236 - actix_web::service::ServiceRequest::match_info_mut::h38601c26070e0f83
19:     0x55745cf1e2f6 - <actix_web::service::ServiceRequest as actix_router::resource_path::Resource>::resource_path::h232aa684f080715e
20:     0x55745cf17daf - actix_router::resource::ResourceDef::capture_match_info_fn::hb10f870be3da0e91
21:     0x55745cf4d567 - actix_router::router::Router<T,U>::recognize_fn::hbe2d11da95dd1434
22:     0x55745cf23cea - <actix_web::scope::ScopeService as actix_service::Service<actix_web::service::ServiceRequest>>::call::h1056f2baeb0b18e2
23:     0x5574597da81d - <lemmy_utils::rate_limit::RateLimitedMiddleware<S> as actix_service::Service<actix_web::service::ServiceRequest>>::call::he0b6dabcfdc76612
24:     0x5574598264db - <actix_web::scope::Scope<T> as actix_web::service::HttpServiceFactory>::register::{{closure}}::h889a12e436ab2efc
25:     0x55745985aed6 - <actix_service::apply::Apply<S,F,Req,In,Res,Err> as actix_service::Service<Req>>::call::h5757cf085e2d7898
26:     0x55745984085d - <actix_service::boxed::ServiceWrapper<S> as actix_service::Service<Req>>::call::h2abed384ee3aaa97
27:     0x55745cf4baa9 - <alloc::boxed::Box<S> as actix_service::Service<Req>>::call::h6514dae745f534ca
28:     0x55745cf23d7d - <actix_web::scope::ScopeService as actix_service::Service<actix_web::service::ServiceRequest>>::call::h1056f2baeb0b18e2
29:     0x55745982606b - <actix_web::scope::Scope<T> as actix_web::service::HttpServiceFactory>::register::{{closure}}::h0e3b6d737b6e4ea1
30:     0x55745985afd6 - <actix_service::apply::Apply<S,F,Req,In,Res,Err> as actix_service::Service<Req>>::call::he7bd559f3175dd50
31:     0x557459844b1d - <actix_service::boxed::ServiceWrapper<S> as actix_service::Service<Req>>::call::hf7ff22d012d56f6a
32:     0x55745cf4baa9 - <alloc::boxed::Box<S> as actix_service::Service<Req>>::call::h6514dae745f534ca
33:     0x55745cf2251d - <actix_web::app_service::AppRouting as actix_service::Service<actix_web::service::ServiceRequest>>::call::hdebc94bfc69e7823
34:     0x5574594f2467 - <actix_web::middleware::logger::LoggerMiddleware<S> as actix_service::Service<actix_web::service::ServiceRequest>>::call::h531b121e31fa9621
35:     0x5574594e5002 - <tracing_actix_web::middleware::TracingLoggerMiddleware<S,RootSpanType> as actix_service::Service<actix_web::service::ServiceRequest>>::call::{{closure}}::hdfd0531c4ef58b56
36:     0x5574596da321 - tracing::span::Span::in_scope::h542471deb5aad360
37:     0x5574594e4ec6 - <tracing_actix_web::middleware::TracingLoggerMiddleware<S,RootSpanType> as actix_service::Service<actix_web::service::ServiceRequest>>::call::hddf6f767acd4ec75
38:     0x557459588b18 - <actix_web::app_service::AppInitService<T,B> as actix_service::Service<actix_http::requests::request::Request>>::call::ha2e3fcd0228f14dc
39:     0x557459570747 - <actix_service::map_err::MapErr<A,Req,F,E> as actix_service::Service<Req>>::call::haa341b7cf87fc1a5
40:     0x557459551a74 - actix_http::h1::dispatcher::InnerDispatcher<T,S,B,X,U>::handle_request::h2ef409b4ea3c7592
41:     0x55745954d9c8 - actix_http::h1::dispatcher::InnerDispatcher<T,S,B,X,U>::poll_request::hc6065888a534736d
42:     0x5574595557bc - <actix_http::h1::dispatcher::Dispatcher<T,S,B,X,U> as core::future::future::Future>::poll::h38bd70d8f96f7770
43:     0x557459501cd4 - <actix_http::service::HttpServiceHandlerResponse<T,S,B,X,U> as core::future::future::Future>::poll::h5ffb375fd8f70ad3
44:     0x5574595cf9cd - <actix_service::and_then::AndThenServiceResponse<A,B,Req> as core::future::future::Future>::poll::h00f9e6c119ad69b8
45:     0x5574595805f7 - <actix_server::service::StreamService<S,I> as actix_service::Service<(actix_server::worker::WorkerCounterGuard,actix_server::socket::MioStream)>>::call::{{closure}}::hb75f098934a77d3a
46:     0x557459694b9c - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h464a2e0ed1821d12
47:     0x55745955c0b6 - <tracing::instrument::Instrumented<T> as core::future::future::Future>::poll::h126bebb8023f20cf
48:     0x5574594e3688 - tokio::runtime::task::core::CoreStage<T>::poll::{{closure}}::h0772904072c88c1b
49:     0x5574596d3e36 - tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut::h57285d1f03785a85
50:     0x5574594e34e2 - tokio::runtime::task::core::CoreStage<T>::poll::hb8c43cace5aabaf7
51:     0x5574596d5ab0 - tokio::runtime::task::harness::poll_future::{{closure}}::hd836fe828f614de6
52:     0x5574594e40d9 - <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once::hd290571433ec7e66
53:     0x5574595fb5a7 - std::panicking::try::do_call::h834ee7f49f81652f
54:     0x5574595fc32b - __rust_try
55:     0x5574595fa038 - std::panicking::try::h1d459be1bae387c9
56:     0x5574596a9a4d - std::panic::catch_unwind::h0bddf5f9de1a25e1
57:     0x5574596d5053 - tokio::runtime::task::harness::poll_future::h22b7e6f0ca90a3b7
58:     0x5574596d605a - tokio::runtime::task::harness::Harness<T,S>::poll_inner::h56badd1c897f9daf
59:     0x5574596d83d3 - tokio::runtime::task::harness::Harness<T,S>::poll::h162752eab0537868
60:     0x557459573c43 - tokio::runtime::task::raw::poll::h4cb9d3f2e8138594
61:     0x55745d57660c - tokio::runtime::task::raw::RawTask::poll::haa56a1ca0bb93760
62:     0x55745d51aca5 - tokio::runtime::task::LocalNotified<S>::run::h57d21169836a0b26
63:     0x55745d4f1c57 - tokio::task::local::LocalSet::tick::{{closure}}::h6f283614d83cf64f
64:     0x55745d54e021 - tokio::coop::with_budget::{{closure}}::h93f98ed685d51e86
65:     0x55745d4f779b - std::thread::local::LocalKey<T>::try_with::h0ec62bf8aa0ff3f1
66:     0x55745d4f7085 - std::thread::local::LocalKey<T>::with::h752233eb11411808
67:     0x55745d4f1bf9 - tokio::task::local::LocalSet::tick::h28f76aaf402d4bce
68:     0x55745d48d591 - <tokio::task::local::RunUntil<T> as core::future::future::Future>::poll::{{closure}}::hefd05c2445dab754
69:     0x55745d483d5f - tokio::macros::scoped_tls::ScopedKey<T>::set::h2f623c50933602a0
70:     0x55745d48bb56 - tokio::task::local::LocalSet::with::h5cab2efb4700b2dc
71:     0x55745d48d105 - <tokio::task::local::RunUntil<T> as core::future::future::Future>::poll::h407a94e72f7ed6b1
72:     0x55745d48bfa7 - tokio::task::local::LocalSet::run_until::{{closure}}::h820a0075bc6f61c4
73:     0x55745d4ab1be - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h43f75a99960eff1e
74:     0x55745d4c4f5b - <tracing::instrument::Instrumented<T> as core::future::future::Future>::poll::h1e015ac03b75e9bd
75:     0x55745d484e0e - <core::pin::Pin<P> as core::future::future::Future>::poll::h25f8725693a9bdfc
76:     0x55745d4995ae - tokio::runtime::basic_scheduler::Inner<P>::block_on::{{closure}}::{{closure}}::hccc7541fc03ed397
77:     0x55745d4c47ec - tokio::coop::with_budget::{{closure}}::hdc11f90726ebd715
78:     0x55745d497321 - std::thread::local::LocalKey<T>::try_with::he51e07e5b6cf5a54
79:     0x55745d495979 - std::thread::local::LocalKey<T>::with::ha3c96e0e55731cb7
80:     0x55745d498070 - tokio::runtime::basic_scheduler::Inner<P>::block_on::{{closure}}::hb750ef6cbbcb4aa8
81:     0x55745d49a8d2 - tokio::runtime::basic_scheduler::enter::{{closure}}::hbd7d9f2f80042432
82:     0x55745d483f3f - tokio::macros::scoped_tls::ScopedKey<T>::set::hc4bd1e58b9a0d769
83:     0x55745d49a500 - tokio::runtime::basic_scheduler::enter::h19906825a5761aab
84:     0x55745d497d6f - tokio::runtime::basic_scheduler::Inner<P>::block_on::hf1a2995b0c910efa
85:     0x55745d4996c0 - tokio::runtime::basic_scheduler::InnerGuard<P>::block_on::haaaf7db6bb360b67
86:     0x55745d4999b4 - tokio::runtime::basic_scheduler::BasicScheduler<P>::block_on::h1e7e3855de711658
87:     0x55745d4aad03 - tokio::runtime::Runtime::block_on::hf656e88b83e69989
88:     0x55745d48bbf1 - tokio::task::local::LocalSet::block_on::h182462493ec2e6b7
89:     0x55745d4ab554 - actix_rt::runtime::Runtime::block_on::he680e683a8928aee
90:     0x55745d006ece - actix_rt::arbiter::Arbiter::with_tokio_rt::{{closure}}::h2bb1d8e1dd46693d
91:     0x55745d01a121 - std::sys_common::backtrace::__rust_begin_short_backtrace::h6c34074e5d18d8d3
92:     0x55745d004bd1 - std::thread::Builder::spawn_unchecked::{{closure}}::{{closure}}::hc71666d62d85fb3d
93:     0x55745d000931 - <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once::hc921eb5fa09a7957
94:     0x55745d0659d0 - std::panicking::try::do_call::h322c59a886d855a5
95:     0x55745d06af1b - __rust_try
96:     0x55745d06544f - std::panicking::try::h68e707524d4ca301
97:     0x55745d01a3b1 - std::panic::catch_unwind::h770be64f66545555
98:     0x55745d0041b1 - std::thread::Builder::spawn_unchecked::{{closure}}::h07bb33d86941bdb9
99:     0x55745d05b377 - core::ops::function::FnOnce::call_once{{vtable.shim}}::h90738beb751da339
100:     0x55745d6b28e3 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::hcbc6d2d80772be64
at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/alloc/src/boxed.rs:1694:9
101:     0x55745d6b28e3 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::h9bffa2ca65a1d6e6
at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/alloc/src/boxed.rs:1694:9
102:     0x55745d6b28e3 - std::sys::unix::thread::Thread::new::thread_start::ha678a8b0caec8f55
at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/sys/unix/thread.rs:106:17
103:     0x7f37568b35c2 - start_thread
104:     0x7f3756938584 - __clone
105:                0x0 - <unknown>
```