### PR TITLE
Migrate towards using page.attachment field for url (ref #2144)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "activitystreams-kinds"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0784e99afd032199d3ed70cefb8eb3a8d1aef15f7f2c4e68d033c4e12bb6079e"
+checksum = "6d014a4fb8828870b7b46bee6257b9a89d06188ae8d435381ba94f14c8c697d8"
 dependencies = [
  "serde",
  "url",

--- a/crates/apub/Cargo.toml
+++ b/crates/apub/Cargo.toml
@@ -21,7 +21,7 @@ lemmy_db_views_actor = { version = "=0.16.2", path = "../db_views_actor" }
 lemmy_api_common = { version = "=0.16.2", path = "../api_common" }
 lemmy_websocket = { version = "=0.16.2", path = "../websocket" }
 diesel = "1.4.8"
-activitystreams-kinds = "0.1.2"
+activitystreams-kinds = "0.2.1"
 bcrypt = "0.10.1"
 chrono = { version = "0.4.19", features = ["serde"] }
 serde_json = { version = "1.0.72", features = ["preserve_order"] }

--- a/crates/apub/assets/lemmy/activities/create_or_update/create_page.json
+++ b/crates/apub/assets/lemmy/activities/create_or_update/create_page.json
@@ -19,6 +19,12 @@
       "mediaType": "text/markdown"
     },
     "url": "https://lemmy.ml/pictrs/image/xl8W7FZfk9.jpg",
+    "attachment": [
+      {
+        "type": "Link",
+        "href": "https://lemmy.ml/pictrs/image/xl8W7FZfk9.jpg"
+      }
+    ],
     "commentsEnabled": true,
     "sensitive": false,
     "stickied": false,

--- a/crates/apub/assets/lemmy/activities/create_or_update/update_page.json
+++ b/crates/apub/assets/lemmy/activities/create_or_update/update_page.json
@@ -19,6 +19,12 @@
       "mediaType": "text/markdown"
     },
     "url": "https://lemmy.ml/pictrs/image/xl8W7FZfk9.jpg",
+    "attachment": [
+      {
+        "type": "Link",
+        "href": "https://lemmy.ml/pictrs/image/xl8W7FZfk9.jpg"
+      }
+    ],
     "commentsEnabled": true,
     "sensitive": false,
     "stickied": false,

--- a/crates/apub/assets/lemmy/objects/page.json
+++ b/crates/apub/assets/lemmy/objects/page.json
@@ -14,6 +14,12 @@
     "mediaType": "text/markdown"
   },
   "url": "https://enterprise.lemmy.ml/pictrs/image/eOtYb9iEiB.png",
+  "attachment": [
+    {
+      "type": "Link",
+      "href": "https://enterprise.lemmy.ml/pictrs/image/eOtYb9iEiB.png"
+    }
+  ],
   "image": {
     "type": "Image",
     "url": "https://enterprise.lemmy.ml/pictrs/image/eOtYb9iEiB.png"

--- a/crates/apub/src/activities/create_or_update/post.rs
+++ b/crates/apub/src/activities/create_or_update/post.rs
@@ -63,7 +63,7 @@ impl CreateOrUpdatePost {
 
     let create_or_update = CreateOrUpdatePost::new(post, actor, &community, kind, context).await?;
     let id = create_or_update.id.clone();
-    let activity = AnnouncableActivities::CreateOrUpdatePost(create_or_update);
+    let activity = AnnouncableActivities::CreateOrUpdatePost(Box::new(create_or_update));
     send_activity_in_community(activity, &id, actor, &community, vec![], context).await
   }
 }

--- a/crates/apub/src/activity_lists.rs
+++ b/crates/apub/src/activity_lists.rs
@@ -70,7 +70,7 @@ pub enum PersonInboxActivities {
 #[activity_handler(LemmyContext)]
 pub enum AnnouncableActivities {
   CreateOrUpdateComment(CreateOrUpdateComment),
-  CreateOrUpdatePost(CreateOrUpdatePost),
+  CreateOrUpdatePost(Box<CreateOrUpdatePost>),
   Vote(Vote),
   UndoVote(UndoVote),
   Delete(Delete),

--- a/crates/apub/src/fetcher/post_or_comment.rs
+++ b/crates/apub/src/fetcher/post_or_comment.rs
@@ -18,7 +18,7 @@ pub enum PostOrComment {
 #[derive(Deserialize)]
 #[serde(untagged)]
 pub enum PageOrNote {
-  Page(Page),
+  Page(Box<Page>),
   Note(Note),
 }
 
@@ -85,7 +85,7 @@ impl ApubObject for PostOrComment {
   ) -> Result<Self, LemmyError> {
     Ok(match apub {
       PageOrNote::Page(p) => PostOrComment::Post(Box::new(
-        ApubPost::from_apub(p, context, request_counter).await?,
+        ApubPost::from_apub(*p, context, request_counter).await?,
       )),
       PageOrNote::Note(n) => PostOrComment::Comment(Box::new(
         ApubComment::from_apub(n, context, request_counter).await?,

--- a/crates/apub/src/lib.rs
+++ b/crates/apub/src/lib.rs
@@ -130,6 +130,18 @@ where
   })
 }
 
+pub(crate) fn deserialize_skip_error<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+  T: Deserialize<'de> + Default,
+  D: Deserializer<'de>,
+{
+  let result = Deserialize::deserialize(deserializer);
+  Ok(match result {
+    Ok(o) => o,
+    Err(_) => Default::default(),
+  })
+}
+
 pub enum EndpointType {
   Community,
   Person,

--- a/crates/apub/src/objects/comment.rs
+++ b/crates/apub/src/objects/comment.rs
@@ -5,7 +5,7 @@ use crate::{
   objects::read_from_string_or_source,
   protocol::{
     objects::{note::Note, tombstone::Tombstone},
-    SourceCompat,
+    Source,
   },
   PostOrComment,
 };
@@ -118,7 +118,7 @@ impl ApubObject for ApubComment {
       cc: maa.ccs,
       content: markdown_to_html(&self.content),
       media_type: Some(MediaTypeHtml::Html),
-      source: Some(SourceCompat::new(self.content.clone())),
+      source: Some(Source::new(self.content.clone())),
       in_reply_to,
       published: Some(convert_datetime(self.published)),
       updated: self.updated.map(convert_datetime),

--- a/crates/apub/src/objects/community.rs
+++ b/crates/apub/src/objects/community.rs
@@ -7,7 +7,7 @@ use crate::{
   protocol::{
     objects::{group::Group, tombstone::Tombstone, Endpoints},
     ImageObject,
-    SourceCompat,
+    Source,
   },
 };
 use activitystreams_kinds::actor::GroupType;
@@ -87,7 +87,7 @@ impl ApubObject for ApubCommunity {
       preferred_username: self.name.clone(),
       name: Some(self.title.clone()),
       summary: self.description.as_ref().map(|b| markdown_to_html(b)),
-      source: self.description.clone().map(SourceCompat::new),
+      source: self.description.clone().map(Source::new),
       icon: self.icon.clone().map(ImageObject::new),
       image: self.banner.clone().map(ImageObject::new),
       sensitive: Some(self.nsfw),

--- a/crates/apub/src/objects/instance.rs
+++ b/crates/apub/src/objects/instance.rs
@@ -1,7 +1,7 @@
 use crate::{
   check_is_apub_id_valid,
   objects::{read_from_string_or_source_opt, verify_image_domain_matches},
-  protocol::{objects::instance::Instance, ImageObject, SourceCompat},
+  protocol::{objects::instance::Instance, ImageObject, Source},
 };
 use activitystreams_kinds::actor::ServiceType;
 use chrono::NaiveDateTime;
@@ -77,7 +77,7 @@ impl ApubObject for ApubSite {
       id: ObjectId::new(self.actor_id()),
       name: self.name.clone(),
       content: self.sidebar.as_ref().map(|d| markdown_to_html(d)),
-      source: self.sidebar.clone().map(SourceCompat::new),
+      source: self.sidebar.clone().map(Source::new),
       summary: self.description.clone(),
       media_type: self.sidebar.as_ref().map(|_| MediaTypeHtml::Html),
       icon: self.icon.clone().map(ImageObject::new),

--- a/crates/apub/src/objects/mod.rs
+++ b/crates/apub/src/objects/mod.rs
@@ -1,4 +1,4 @@
-use crate::protocol::{ImageObject, SourceCompat};
+use crate::protocol::{ImageObject, Source};
 use html2md::parse_html;
 use lemmy_apub_lib::verify::verify_domains_match;
 use lemmy_utils::LemmyError;
@@ -11,8 +11,8 @@ pub mod person;
 pub mod post;
 pub mod private_message;
 
-pub(crate) fn read_from_string_or_source(raw: &str, source: &Option<SourceCompat>) -> String {
-  if let Some(SourceCompat::Lemmy(s)) = source {
+pub(crate) fn read_from_string_or_source(raw: &str, source: &Option<Source>) -> String {
+  if let Some(s) = source {
     s.content.clone()
   } else {
     parse_html(raw)
@@ -21,9 +21,9 @@ pub(crate) fn read_from_string_or_source(raw: &str, source: &Option<SourceCompat
 
 pub(crate) fn read_from_string_or_source_opt(
   raw: &Option<String>,
-  source: &Option<SourceCompat>,
+  source: &Option<Source>,
 ) -> Option<String> {
-  if let Some(SourceCompat::Lemmy(s2)) = source {
+  if let Some(s2) = source {
     Some(s2.content.clone())
   } else {
     raw.as_ref().map(|s| parse_html(s))

--- a/crates/apub/src/objects/person.rs
+++ b/crates/apub/src/objects/person.rs
@@ -12,7 +12,7 @@ use crate::{
       Endpoints,
     },
     ImageObject,
-    SourceCompat,
+    Source,
   },
 };
 use chrono::NaiveDateTime;
@@ -99,7 +99,7 @@ impl ApubObject for ApubPerson {
       preferred_username: self.name.clone(),
       name: self.display_name.clone(),
       summary: self.bio.as_ref().map(|b| markdown_to_html(b)),
-      source: self.bio.clone().map(SourceCompat::new),
+      source: self.bio.clone().map(Source::new),
       icon: self.avatar.clone().map(ImageObject::new),
       image: self.banner.clone().map(ImageObject::new),
       matrix_user_id: self.matrix_user_id.clone(),

--- a/crates/apub/src/objects/private_message.rs
+++ b/crates/apub/src/objects/private_message.rs
@@ -2,7 +2,7 @@ use crate::{
   objects::read_from_string_or_source,
   protocol::{
     objects::chat_message::{ChatMessage, ChatMessageType},
-    SourceCompat,
+    Source,
   },
 };
 use chrono::NaiveDateTime;
@@ -90,7 +90,7 @@ impl ApubObject for ApubPrivateMessage {
       to: [ObjectId::new(recipient.actor_id)],
       content: markdown_to_html(&self.content),
       media_type: Some(MediaTypeHtml::Html),
-      source: Some(SourceCompat::new(self.content.clone())),
+      source: Some(Source::new(self.content.clone())),
       published: Some(convert_datetime(self.published)),
       updated: self.updated.map(convert_datetime),
     };

--- a/crates/apub/src/protocol/mod.rs
+++ b/crates/apub/src/protocol/mod.rs
@@ -1,11 +1,9 @@
 use activitystreams_kinds::object::ImageType;
-use serde::{Deserialize, Serialize};
-use url::Url;
-
 use lemmy_apub_lib::values::MediaTypeMarkdown;
 use lemmy_db_schema::newtypes::DbUrl;
-use serde_json::Value;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use url::Url;
 
 pub mod activities;
 pub(crate) mod collections;
@@ -18,20 +16,12 @@ pub struct Source {
   pub(crate) media_type: MediaTypeMarkdown,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-#[serde(untagged)]
-pub(crate) enum SourceCompat {
-  Lemmy(Source),
-  Other(Value),
-}
-
-impl SourceCompat {
+impl Source {
   pub(crate) fn new(content: String) -> Self {
-    SourceCompat::Lemmy(Source {
+    Source {
       content,
       media_type: MediaTypeMarkdown::Markdown,
-    })
+    }
   }
 }
 

--- a/crates/apub/src/protocol/objects/chat_message.rs
+++ b/crates/apub/src/protocol/objects/chat_message.rs
@@ -1,6 +1,6 @@
 use crate::{
   objects::{person::ApubPerson, private_message::ApubPrivateMessage},
-  protocol::SourceCompat,
+  protocol::Source,
 };
 use chrono::{DateTime, FixedOffset};
 use lemmy_apub_lib::{object_id::ObjectId, values::MediaTypeHtml};
@@ -19,7 +19,9 @@ pub struct ChatMessage {
   pub(crate) content: String,
 
   pub(crate) media_type: Option<MediaTypeHtml>,
-  pub(crate) source: Option<SourceCompat>,
+  #[serde(default)]
+  #[serde(deserialize_with = "crate::deserialize_skip_error")]
+  pub(crate) source: Option<Source>,
   pub(crate) published: Option<DateTime<FixedOffset>>,
   pub(crate) updated: Option<DateTime<FixedOffset>>,
 }

--- a/crates/apub/src/protocol/objects/group.rs
+++ b/crates/apub/src/protocol/objects/group.rs
@@ -9,7 +9,7 @@ use crate::{
     read_from_string_or_source_opt,
     verify_image_domain_matches,
   },
-  protocol::{objects::Endpoints, ImageObject, SourceCompat},
+  protocol::{objects::Endpoints, ImageObject, Source},
 };
 use activitystreams_kinds::actor::GroupType;
 use chrono::{DateTime, FixedOffset};
@@ -40,7 +40,9 @@ pub struct Group {
   /// title
   pub(crate) name: Option<String>,
   pub(crate) summary: Option<String>,
-  pub(crate) source: Option<SourceCompat>,
+  #[serde(default)]
+  #[serde(deserialize_with = "crate::deserialize_skip_error")]
+  pub(crate) source: Option<Source>,
   pub(crate) icon: Option<ImageObject>,
   /// banner
   pub(crate) image: Option<ImageObject>,

--- a/crates/apub/src/protocol/objects/instance.rs
+++ b/crates/apub/src/protocol/objects/instance.rs
@@ -1,6 +1,6 @@
 use crate::{
   objects::instance::ApubSite,
-  protocol::{ImageObject, SourceCompat},
+  protocol::{ImageObject, Source},
 };
 use activitystreams_kinds::actor::ServiceType;
 use chrono::{DateTime, FixedOffset};
@@ -25,7 +25,9 @@ pub struct Instance {
 
   // sidebar
   pub(crate) content: Option<String>,
-  pub(crate) source: Option<SourceCompat>,
+  #[serde(default)]
+  #[serde(deserialize_with = "crate::deserialize_skip_error")]
+  pub(crate) source: Option<Source>,
   // short instance description
   pub(crate) summary: Option<String>,
   pub(crate) media_type: Option<MediaTypeHtml>,

--- a/crates/apub/src/protocol/objects/note.rs
+++ b/crates/apub/src/protocol/objects/note.rs
@@ -2,7 +2,7 @@ use crate::{
   fetcher::post_or_comment::PostOrComment,
   mentions::Mention,
   objects::{comment::ApubComment, person::ApubPerson, post::ApubPost},
-  protocol::SourceCompat,
+  protocol::Source,
 };
 use activitystreams_kinds::object::NoteType;
 use chrono::{DateTime, FixedOffset};
@@ -32,7 +32,9 @@ pub struct Note {
   pub(crate) in_reply_to: ObjectId<PostOrComment>,
 
   pub(crate) media_type: Option<MediaTypeHtml>,
-  pub(crate) source: Option<SourceCompat>,
+  #[serde(default)]
+  #[serde(deserialize_with = "crate::deserialize_skip_error")]
+  pub(crate) source: Option<Source>,
   pub(crate) published: Option<DateTime<FixedOffset>>,
   pub(crate) updated: Option<DateTime<FixedOffset>>,
   #[serde(default)]

--- a/crates/apub/src/protocol/objects/person.rs
+++ b/crates/apub/src/protocol/objects/person.rs
@@ -1,6 +1,6 @@
 use crate::{
   objects::person::ApubPerson,
-  protocol::{objects::Endpoints, ImageObject, SourceCompat},
+  protocol::{objects::Endpoints, ImageObject, Source},
 };
 use chrono::{DateTime, FixedOffset};
 use lemmy_apub_lib::{object_id::ObjectId, signatures::PublicKey};
@@ -31,7 +31,9 @@ pub struct Person {
   /// displayname
   pub(crate) name: Option<String>,
   pub(crate) summary: Option<String>,
-  pub(crate) source: Option<SourceCompat>,
+  #[serde(default)]
+  #[serde(deserialize_with = "crate::deserialize_skip_error")]
+  pub(crate) source: Option<Source>,
   /// user avatar
   pub(crate) icon: Option<ImageObject>,
   /// user banner


### PR DESCRIPTION
As discussed in #2144 and on [SocialHub](https://socialhub.activitypub.rocks/t/explicitly-attached-links/2357/13), we should really use the `attachment` field to federate post urls, in order to be standard compliant.

This PR is fully backwards compatible.