### PR TITLE
Dont federate initial upvote

### DIFF
--- a/crates/api_crud/src/comment/create.rs
+++ b/crates/api_crud/src/comment/create.rs
@@ -10,14 +10,9 @@ use lemmy_api_common::{
   get_post,
 };
 use lemmy_apub::{
-  fetcher::post_or_comment::PostOrComment,
   generate_local_apub_endpoint,
   objects::comment::ApubComment,
-  protocol::activities::{
-    create_or_update::comment::CreateOrUpdateComment,
-    voting::vote::{Vote, VoteType},
-    CreateOrUpdateType,
-  },
+  protocol::activities::{create_or_update::comment::CreateOrUpdateComment, CreateOrUpdateType},
   EndpointType,
 };
 use lemmy_db_schema::{
@@ -148,15 +143,6 @@ impl PerformCrud for CreateComment {
       CreateOrUpdateType::Create,
       context,
       &mut 0,
-    )
-    .await?;
-    let object = PostOrComment::Comment(Box::new(apub_comment));
-    Vote::send(
-      &object,
-      &local_user_view.person.clone().into(),
-      community_id,
-      VoteType::Like,
-      context,
     )
     .await?;
 

--- a/crates/api_crud/src/post/create.rs
+++ b/crates/api_crud/src/post/create.rs
@@ -10,14 +10,9 @@ use lemmy_api_common::{
   post::*,
 };
 use lemmy_apub::{
-  fetcher::post_or_comment::PostOrComment,
   generate_local_apub_endpoint,
   objects::post::ApubPost,
-  protocol::activities::{
-    create_or_update::post::CreateOrUpdatePost,
-    voting::vote::{Vote, VoteType},
-    CreateOrUpdateType,
-  },
+  protocol::activities::{create_or_update::post::CreateOrUpdatePost, CreateOrUpdateType},
   EndpointType,
 };
 use lemmy_db_schema::{
@@ -153,15 +148,6 @@ impl PerformCrud for CreatePost {
       apub_post.clone(),
       &local_user_view.person.clone().into(),
       CreateOrUpdateType::Create,
-      context,
-    )
-    .await?;
-    let object = PostOrComment::Post(Box::new(apub_post));
-    Vote::send(
-      &object,
-      &local_user_view.person.clone().into(),
-      inserted_post.community_id,
-      VoteType::Like,
       context,
     )
     .await?;


### PR DESCRIPTION
This change makes it so that the initial self upvote is not federated as a separate action, but is applied automatically when a new post/comment is received. This is good for other software like Mastodon which doesnt send any Lemmy compatible votes, so its comments currently start at 0 points.

Already tested that it works well, and its fully backwards compatible.