### PR TITLE
Changing default listing type to Local from Subscribed.

### DIFF
--- a/migrations/2022-04-12-185205_change_default_listing_type_to_local/down.sql
+++ b/migrations/2022-04-12-185205_change_default_listing_type_to_local/down.sql
@@ -1,0 +1,3 @@
+-- 0 is All, 1 is Local, 2 is Subscribed
+
+alter table only local_user alter column default_listing_type set default 2;

--- a/migrations/2022-04-12-185205_change_default_listing_type_to_local/up.sql
+++ b/migrations/2022-04-12-185205_change_default_listing_type_to_local/up.sql
@@ -1,0 +1,3 @@
+-- 0 is All, 1 is Local, 2 is Subscribed
+
+alter table only local_user alter column default_listing_type set default 1;


### PR DESCRIPTION
This would work in conjunction with the other PR, as a fallback.

This def needs some discussion, because its a big change, but let me put forward the case here.

On new / small instances, communities besides the default one, are having a lot of trouble growing. People making new communities and posting to them, are drowned out. A post about movies, to a popular community, has a lot more success than a post to a new community specifically about movies.

On lemmygrad, we're seeing new communities essentially die, in favor of old, established ones. This is also hurting growth, because people aren't seeing the variety of curated communities an instance has to offer. 

Most importantly, defaulting to Subscribed, **in practice** creates a trend that the number of active communities decreases, rather than increases.

This of course doesn't take away the possibility for people to change their default view to Subscribed. But it would mean that even after creating an account, people would see posts from Local communities, instead of only the ones they've subscribed to, as a default.