### PR TITLE
Bump lettre to 0.10.0-rc.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,6 +1070,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "email-encoding"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6690291166824e467790ac08ba42f241791567e8337bbf00c5a6e87889629f98"
+dependencies = [
+ "base64",
+]
+
+[[package]]
 name = "encoding"
 version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,11 +2139,12 @@ dependencies = [
 
 [[package]]
 name = "lettre"
-version = "0.10.0-rc.4"
+version = "0.10.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d8da8f34d086b081c9cc3b57d3bb3b51d16fc06b5c848a188e2f14d58ac2a5"
+checksum = "2f6c70001f7ee6c93b6687a06607c7a38f9a7ae460139a496c23da21e95bc289"
 dependencies = [
  "base64",
+ "email-encoding",
  "fastrand",
  "futures-util",
  "hostname",

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 [dependencies]
 regex = "1.5.5"
 chrono = { version = "0.4.19", features = ["serde"], default-features = false }
-lettre = "0.10.0-rc.4"
+lettre = "0.10.0-rc.6"
 tracing = "0.1.32"
 tracing-error = "0.2.0"
 itertools = "0.10.3"


### PR DESCRIPTION
The last two releases of lettre have had some very important fixes. This updates it

Changes: https://github.com/lettre/lettre/compare/v0.10.0-rc.4...v0.10.0-rc.6