### PR TITLE
Make opentelemetry dependency optional

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -22,10 +22,15 @@ steps:
     commands:
       - /root/.cargo/bin/cargo fmt -- --check
 
-  - name: check lemmy_api_common with minimal deps
+  - name: check with different features
     image: clux/muslrust:1.60.0
     commands:
+      # api with minimal deps
       - cargo check -p lemmy_api_common
+      # opentelemetry console
+      - cargo check --features console
+      # default features
+      - cargo check
 
   - name: cargo clippy
     image: clux/muslrust:1.60.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ doctest = false
 debug = 0
 
 [features]
-console = ["console-subscriber"]
+console = ["console-subscriber", "opentelemetry", "opentelemetry-otlp", "tracing-opentelemetry",
+    "reqwest-tracing/opentelemetry_0_16"]
 default = []
 
 [workspace]
@@ -54,14 +55,14 @@ tracing-actix-web = { version = "0.5.1", default-features = false }
 tracing-error = "0.2.0"
 tracing-log = "0.1.2"
 tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
-console-subscriber = { version = "0.1.3", optional = true }
 url = { version = "2.2.2", features = ["serde"] }
 reqwest = { version = "0.11.10", features = ["json"] }
 reqwest-middleware = "0.1.5"
-reqwest-tracing = { version = "0.2.1", features = ["opentelemetry_0_16"] }
+reqwest-tracing = "0.2.1"
 clokwerk = "0.3.5"
 doku = "0.11.0"
-opentelemetry = { version = "0.17.0", features = ["rt-tokio"] }
-opentelemetry-otlp = "0.10.0"
-tracing-opentelemetry = "0.17.2"
 parking_lot = "0.12.0"
+console-subscriber = { version = "0.1.3", optional = true }
+opentelemetry = { version = "0.17.0", features = ["rt-tokio"], optional = true }
+opentelemetry-otlp = { version = "0.10.0", optional = true }
+tracing-opentelemetry = { version = "0.17.2", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,24 +3,17 @@ pub mod api_routes;
 pub mod code_migrations;
 pub mod root_span_builder;
 pub mod scheduled_tasks;
-
 #[cfg(feature = "console")]
-use console_subscriber::ConsoleLayer;
+pub mod telemetry;
+
 use lemmy_utils::LemmyError;
-use opentelemetry::{
-  sdk::{propagation::TraceContextPropagator, Resource},
-  KeyValue,
-};
-use opentelemetry_otlp::WithExportConfig;
 use tracing::subscriber::set_global_default;
 use tracing_error::ErrorLayer;
 use tracing_log::LogTracer;
 use tracing_subscriber::{filter::Targets, layer::SubscriberExt, Layer, Registry};
 
-pub fn init_tracing(opentelemetry_url: Option<&str>) -> Result<(), LemmyError> {
+pub fn init_logging(opentelemetry_url: Option<&str>) -> Result<(), LemmyError> {
   LogTracer::init()?;
-
-  opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
 
   let log_description = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".into());
 
@@ -31,41 +24,15 @@ pub fn init_tracing(opentelemetry_url: Option<&str>) -> Result<(), LemmyError> {
 
   let format_layer = tracing_subscriber::fmt::layer().with_filter(targets.clone());
 
-  #[cfg(feature = "console")]
-  let console_layer = ConsoleLayer::builder()
-    .with_default_env()
-    .server_addr(([0, 0, 0, 0], 6669))
-    .event_buffer_capacity(1024 * 1024)
-    .spawn();
-
   let subscriber = Registry::default()
     .with(format_layer)
     .with(ErrorLayer::default());
 
-  #[cfg(feature = "console")]
-  let subscriber = subscriber.with(console_layer);
-
-  if let Some(url) = opentelemetry_url {
-    let tracer = opentelemetry_otlp::new_pipeline()
-      .tracing()
-      .with_trace_config(
-        opentelemetry::sdk::trace::config()
-          .with_resource(Resource::new(vec![KeyValue::new("service.name", "lemmy")])),
-      )
-      .with_exporter(
-        opentelemetry_otlp::new_exporter()
-          .tonic()
-          .with_endpoint(url),
-      )
-      .install_batch(opentelemetry::runtime::Tokio)?;
-
-    let otel_layer = tracing_opentelemetry::layer()
-      .with_tracer(tracer)
-      .with_filter(targets);
-
-    let subscriber = subscriber.with(otel_layer);
-
-    set_global_default(subscriber)?;
+  if let Some(_url) = opentelemetry_url {
+    #[cfg(feature = "console")]
+    crate::telemetry::init_tracing(_url, subscriber, targets)?;
+    #[cfg(not(feature = "console"))]
+    tracing::error!("Feature `console` must be enabled for opentelemetry tracing");
   } else {
     set_global_default(subscriber)?;
   }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use lemmy_routes::{feeds, images, nodeinfo, webfinger};
 use lemmy_server::{
   api_routes,
   code_migrations::run_advanced_migrations,
-  init_tracing,
+  init_logging,
   root_span_builder::QuieterRootSpanBuilder,
   scheduled_tasks,
 };
@@ -54,7 +54,7 @@ async fn main() -> Result<(), LemmyError> {
 
   let settings = Settings::init().expect("Couldn't initialize settings.");
 
-  init_tracing(settings.opentelemetry_url.as_deref())?;
+  init_logging(settings.opentelemetry_url.as_deref())?;
 
   // Set up the r2d2 connection pool
   let db_url = match get_database_url_from_env() {

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,51 @@
+use console_subscriber::ConsoleLayer;
+use lemmy_utils::LemmyError;
+use opentelemetry::{
+  sdk::{propagation::TraceContextPropagator, Resource},
+  KeyValue,
+};
+use opentelemetry_otlp::WithExportConfig;
+use tracing::{subscriber::set_global_default, Subscriber};
+use tracing_subscriber::{filter::Targets, layer::SubscriberExt, registry::LookupSpan, Layer};
+
+pub fn init_tracing<S>(
+  opentelemetry_url: &str,
+  subscriber: S,
+  targets: Targets,
+) -> Result<(), LemmyError>
+where
+  S: Subscriber + for<'a> LookupSpan<'a> + Send + Sync + 'static,
+{
+  opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+
+  let console_layer = ConsoleLayer::builder()
+    .with_default_env()
+    .server_addr(([0, 0, 0, 0], 6669))
+    .event_buffer_capacity(1024 * 1024)
+    .spawn();
+
+  let subscriber = subscriber.with(console_layer);
+
+  let tracer = opentelemetry_otlp::new_pipeline()
+    .tracing()
+    .with_trace_config(
+      opentelemetry::sdk::trace::config()
+        .with_resource(Resource::new(vec![KeyValue::new("service.name", "lemmy")])),
+    )
+    .with_exporter(
+      opentelemetry_otlp::new_exporter()
+        .tonic()
+        .with_endpoint(opentelemetry_url),
+    )
+    .install_batch(opentelemetry::runtime::Tokio)?;
+
+  let otel_layer = tracing_opentelemetry::layer()
+    .with_tracer(tracer)
+    .with_filter(targets);
+
+  let subscriber = subscriber.with(otel_layer);
+
+  set_global_default(subscriber)?;
+
+  Ok(())
+}


### PR DESCRIPTION
Reduces number of dependencies from 536 to 494. Reduces time of clean build on my computer from 4m 21s to 3m 43s.