### PR TITLE
Fixing malformed rosetta translations. Fixes #2231

### DIFF
--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -401,7 +401,7 @@ pub async fn send_password_reset_email(
   let subject = &lang.password_reset_subject(&user.person.name);
   let protocol_and_hostname = settings.get_protocol_and_hostname();
   let reset_link = format!("{}/password_change/{}", protocol_and_hostname, &token);
-  let body = &lang.password_reset_body(&user.person.name, reset_link);
+  let body = &lang.password_reset_body(reset_link, &user.person.name);
   send_email(subject, email, &user.person.name, body, settings)
 }
 
@@ -426,7 +426,7 @@ pub async fn send_verification_email(
 
   let lang = get_user_lang(user);
   let subject = lang.verify_email_subject(&settings.hostname);
-  let body = lang.verify_email_body(&user.person.name, &settings.hostname, verify_link);
+  let body = lang.verify_email_body(&settings.hostname, &user.person.name, verify_link);
   send_email(&subject, new_email, &user.person.name, &body, settings)?;
 
   Ok(())

--- a/crates/api_crud/src/private_message/create.rs
+++ b/crates/api_crud/src/private_message/create.rs
@@ -113,11 +113,11 @@ impl PerformCrud for CreatePrivateMessage {
       let inbox_link = format!("{}/inbox", context.settings().get_protocol_and_hostname());
       send_email_to_user(
         &local_recipient,
-        &lang.notification_mentioned_by_subject(&local_recipient.person.name),
-        &lang.notification_mentioned_by_body(
-          &local_recipient.person.name,
-          &content_slurs_removed,
+        &lang.notification_private_message_subject(&local_recipient.person.name),
+        &lang.notification_private_message_body(
           &inbox_link,
+          &content_slurs_removed,
+          &local_recipient.person.name,
         ),
         &context.settings(),
       );

--- a/crates/websocket/src/send.rs
+++ b/crates/websocket/src/send.rs
@@ -215,7 +215,7 @@ pub async fn send_local_notifs(
         send_email_to_user(
           &mention_user_view,
           &lang.notification_mentioned_by_subject(&person.name),
-          &lang.notification_mentioned_by_body(&person.name, &comment.content, &inbox_link),
+          &lang.notification_mentioned_by_body(&comment.content, &inbox_link, &person.name),
           &context.settings(),
         )
       }
@@ -249,8 +249,8 @@ pub async fn send_local_notifs(
               let lang = get_user_lang(&parent_user_view);
               send_email_to_user(
                 &parent_user_view,
-                &lang.notification_post_reply_subject(&person.name),
-                &lang.notification_post_reply_body(&person.name, &comment.content, &inbox_link),
+                &lang.notification_comment_reply_subject(&person.name),
+                &lang.notification_comment_reply_body(&comment.content, &inbox_link, &person.name),
                 &context.settings(),
               )
             }
@@ -280,7 +280,7 @@ pub async fn send_local_notifs(
             send_email_to_user(
               &parent_user_view,
               &lang.notification_post_reply_subject(&person.name),
-              &lang.notification_post_reply_body(&person.name, &comment.content, &inbox_link),
+              &lang.notification_post_reply_body(&comment.content, &inbox_link, &person.name),
               &context.settings(),
             )
           }


### PR DESCRIPTION
The only way I could check the correct order was doing a hover via rust-analyzer.