### PR TITLE
Fix CI failures

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,13 +9,13 @@ platform:
 steps:
 
   - name: prepare repo
-    image: clux/muslrust:1.60.0
+    image: clux/muslrust:1.59.0
     user: root
     commands:
-      - chown 1000:1000 . -R
       - git fetch --tags
       - git submodule init
       - git submodule update --recursive --remote
+      - chown 1000:1000 . -R
 
   - name: check formatting
     image: rustdocker/rust:nightly
@@ -23,7 +23,7 @@ steps:
       - /root/.cargo/bin/cargo fmt -- --check
 
   - name: check with different features
-    image: clux/muslrust:1.60.0
+    image: clux/muslrust:1.59.0
     commands:
       # api with minimal deps
       - cargo check -p lemmy_api_common
@@ -33,14 +33,14 @@ steps:
       - cargo check
 
   - name: cargo clippy
-    image: clux/muslrust:1.60.0
+    image: clux/muslrust:1.59.0
     commands:
       - rustup component add clippy
       - cargo clippy --workspace --tests --all-targets --all-features -- -D warnings -D deprecated -D clippy::perf -D clippy::complexity -D clippy::dbg_macro
       - cargo clippy --workspace -- -D clippy::unwrap_used
 
   - name: cargo test
-    image: clux/muslrust:1.60.0
+    image: clux/muslrust:1.59.0
     environment:
       LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
       LEMMY_CONFIG_LOCATION: ../../config/config.hjson
@@ -52,13 +52,13 @@ steps:
       - cargo test --workspace --no-fail-fast
 
   - name: check defaults.hjson updated
-    image: clux/muslrust:1.60.0
+    image: clux/muslrust:1.59.0
     commands:
       - ./scripts/update_config_defaults.sh config/defaults_current.hjson
       - diff config/defaults.hjson config/defaults_current.hjson
 
   - name: cargo build
-    image: clux/muslrust:1.60.0
+    image: clux/muslrust:1.59.0
     commands:
       - cargo build
       - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -252,16 +252,6 @@ mod tests {
       },
       sample_res
     );
-
-    let youtube_url = Url::parse("https://www.youtube.com/watch?v=IquO_TcMZIQ").unwrap();
-    let youtube_res = fetch_site_metadata(&client, &youtube_url).await.unwrap();
-    assert_eq!(
-      SiteMetadata {
-        title: Some("A Hard Look at Rent and Rent Seeking with Michael Hudson & Pepe Escobar".to_string()),
-        description: Some("An interactive discussion on wealth inequality and the “Great Game” on the control of natural resources.In this webinar organized jointly by the Henry George...".to_string()),
-        image: Some(Url::parse("https://i.ytimg.com/vi/IquO_TcMZIQ/maxresdefault.jpg").unwrap()),
-        html: None,
-      }, youtube_res);
   }
 
   // #[test]


### PR DESCRIPTION
I noticed that CI was failing on main with the following error:
```
+ git fetch --tags
fatal: unsafe repository ('/drone/src' is owned by someone else)

To add an exception for this directory, call:
	git config --global --add safe.directory /drone/src
```
Because there is a new git security feature, which complains about incorrect permissions on the ci working directory. Moving the chown command was enough to fix that.

After that, there were some more weird errors which seem to be caused by clux/muslrust:1.60.0 being broken (https://github.com/clux/muslrust/issues/94). For now i downgraded to 1.59.0 which fixes it.