### PR TITLE
Add drone task for nightly build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -75,6 +75,21 @@ steps:
       - yarn
       - yarn api-test
 
+  - name: nightly build
+    image: plugins/docker
+    settings:
+      dockerfile: docker/dev/Dockerfile
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      repo: dessalines/lemmy
+      tags:
+        - dev
+    when:
+      event:
+        - cron
+
   - name: publish release docker image
     image: plugins/docker
     settings:


### PR DESCRIPTION
For automatic deployment of main branch to ds9.lemmy.ml and other test instances.