### PR TITLE
Make websocket opentelemetry dependency optional (ref #2253)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ debug = 0
 
 [features]
 console = ["console-subscriber", "opentelemetry", "opentelemetry-otlp", "tracing-opentelemetry",
-    "reqwest-tracing/opentelemetry_0_16"]
+    "reqwest-tracing/opentelemetry_0_16", "lemmy_websocket/console"]
 default = []
 
 [workspace]

--- a/crates/websocket/Cargo.toml
+++ b/crates/websocket/Cargo.toml
@@ -12,9 +12,13 @@ name = "lemmy_websocket"
 path = "src/lib.rs"
 doctest = false
 
+[features]
+console = ["opentelemetry", "tracing-opentelemetry"]
+default = []
+
 [dependencies]
 lemmy_utils = { version = "=0.16.3", path = "../utils" }
-lemmy_api_common = { version = "=0.16.3", path = "../api_common" }
+lemmy_api_common = { version = "=0.16.3", path = "../api_common", features = ["full"] }
 lemmy_db_schema = { version = "=0.16.3", path = "../db_schema", features = ["full"] }
 lemmy_db_views = { version = "=0.16.3", path = "../db_views", features = ["full"] }
 lemmy_db_views_actor = { version = "=0.16.3", path = "../db_views_actor", features = ["full"] }
@@ -33,5 +37,5 @@ strum_macros = "0.24.0"
 chrono = { version = "0.4.19", features = ["serde"], default-features = false }
 actix-web = { version = "4.0.1", default-features = false, features = ["rustls"] }
 actix-web-actors = { version = "4.1.0", default-features = false }
-opentelemetry = "0.17.0"
-tracing-opentelemetry = "0.17.2"
+opentelemetry = { version = "0.17.0", optional = true }
+tracing-opentelemetry = { version = "0.17.2", optional = true }

--- a/crates/websocket/src/handlers.rs
+++ b/crates/websocket/src/handlers.rs
@@ -6,11 +6,9 @@ use crate::{
 use actix::{Actor, Context, Handler, ResponseFuture};
 use lemmy_db_schema::utils::naive_now;
 use lemmy_utils::ConnectionId;
-use opentelemetry::trace::TraceContextExt;
 use rand::Rng;
 use serde::Serialize;
 use tracing::{error, info};
-use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 /// Make actor from `ChatServer`
 impl Actor for ChatServer {
@@ -70,7 +68,10 @@ fn root_span() -> tracing::Span {
     "Websocket Request",
     trace_id = tracing::field::Empty,
   );
+  #[cfg(feature = "console")]
   {
+    use opentelemetry::trace::TraceContextExt;
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
     let trace_id = span.context().span().span_context().trace_id().to_string();
     span.record("trace_id", &tracing::field::display(trace_id));
   }


### PR DESCRIPTION
It turns out that #2253 was incomplete, and there was still an inconditional dependency on opentelemetry crates in lemmy_websocket.

Edit: This was all for nothing, because `RUSTC_WRAPPER='' cargo build --timings` says that these two deps only take ~4s to build. The big one is opentelemetry-otlp with 44s, and that one is already behind the `console` feature. 