### PR TITLE
Add legal information (fixes #721)

### DIFF
--- a/crates/api_common/src/site.rs
+++ b/crates/api_common/src/site.rs
@@ -133,6 +133,7 @@ pub struct EditSite {
   pub private_instance: Option<bool>,
   pub default_theme: Option<String>,
   pub default_post_listing_type: Option<String>,
+  pub legal_information: Option<String>,
   pub auth: Sensitive<String>,
 }
 

--- a/crates/api_crud/src/site/update.rs
+++ b/crates/api_crud/src/site/update.rs
@@ -84,6 +84,7 @@ impl PerformCrud for EditSite {
       private_instance: data.private_instance,
       default_theme: data.default_theme.clone(),
       default_post_listing_type: data.default_post_listing_type.clone(),
+      legal_information: data.legal_information.clone(),
       ..SiteForm::default()
     };
 

--- a/crates/db_schema/src/schema.rs
+++ b/crates/db_schema/src/schema.rs
@@ -463,6 +463,7 @@ table! {
         public_key -> Text,
         default_theme -> Text,
         default_post_listing_type -> Text,
+        legal_information -> Nullable<Text>,
     }
 }
 

--- a/crates/db_schema/src/source/site.rs
+++ b/crates/db_schema/src/source/site.rs
@@ -31,6 +31,7 @@ pub struct Site {
   pub public_key: String,
   pub default_theme: String,
   pub default_post_listing_type: String,
+  pub legal_information: Option<String>,
 }
 
 #[derive(Default)]
@@ -59,4 +60,5 @@ pub struct SiteForm {
   pub public_key: Option<String>,
   pub default_theme: Option<String>,
   pub default_post_listing_type: Option<String>,
+  pub legal_information: Option<String>,
 }

--- a/migrations/2022-05-19-153931_legal-information/down.sql
+++ b/migrations/2022-05-19-153931_legal-information/down.sql
@@ -1,0 +1,1 @@
+alter table site drop column legal_information;

--- a/migrations/2022-05-19-153931_legal-information/up.sql
+++ b/migrations/2022-05-19-153931_legal-information/up.sql
@@ -1,0 +1,1 @@
+alter table site add column legal_information text;


### PR DESCRIPTION
This adds a new database field which can be used by admins to write legal information, such as terms of service or privacy policy. It will be editable via /admin, and displayed as a link in the site footer (next to mod log etc). 

I am unsure if the link title "Legal information" in the footer is appropriate, orif another title should be used. 

I dont think it would make sense to include a default text, as it would have to be valid for the entire world, and laws can be completely different in each country. Besides, the field is only in a single language now, so there would be no way to localize the default text.