### PR TITLE
Downgrade Rust Docker images to 1.59 to fix CI failures (ref #2263)

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUST_BUILDER_IMAGE=clux/muslrust:1.60.0
+ARG RUST_BUILDER_IMAGE=clux/muslrust:1.59.0
 
 FROM $RUST_BUILDER_IMAGE as chef
 USER root

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -1,5 +1,5 @@
 # Build the project
-FROM clux/muslrust:1.60.0 as builder
+FROM clux/muslrust:1.59.0 as builder
 
 ARG CARGO_BUILD_TARGET=x86_64-unknown-linux-musl
 ARG RUSTRELEASEDIR="release"


### PR DESCRIPTION
In #2263 i forgot to downgrade the version of clux/muslrust used in Dockerfiles. It turns out that the same error is happening during nightly builds (and probably release too). So im also downgradeing them to 1.59. Note that i cant reproduce the errors locally, they seem specific to drone.

https://drone.yerbamate.ml/LemmyNet/lemmy/1128/1/11