### PR TITLE
Run cargo check for each crate with different features (ref #2284)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -25,12 +25,9 @@ steps:
   - name: check with different features
     image: clux/muslrust:1.59.0
     commands:
-      # api with minimal deps
-      - cargo check -p lemmy_api_common
-      # opentelemetry console
-      - cargo check --features console
-      # default features
-      - cargo check
+      - cargo install cargo-workspaces
+      - cargo workspaces exec cargo check --no-default-features
+      - cargo workspaces exec cargo check --all-features
 
   - name: cargo clippy
     image: clux/muslrust:1.59.0

--- a/crates/websocket/Cargo.toml
+++ b/crates/websocket/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 
 [dependencies]
 lemmy_utils = { version = "=0.16.5", path = "../utils" }
-lemmy_api_common = { version = "=0.16.5", path = "../api_common" }
+lemmy_api_common = { version = "=0.16.5", path = "../api_common", features = ["full"] }
 lemmy_db_schema = { version = "=0.16.5", path = "../db_schema", features = ["full"] }
 lemmy_db_views = { version = "=0.16.5", path = "../db_views", features = ["full"] }
 lemmy_db_views_actor = { version = "=0.16.5", path = "../db_views_actor", features = ["full"] }


### PR DESCRIPTION
Hope this doesnt slow down builds too much. Maybe it would be better to run this as the last step.

There is also another command `cargo install cargo-workspaces` further down, but im not sure if the binary is persisted between steps.