### PR TITLE
Bump lettre to 0.10.0-rc.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,12 +1145,19 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "email-encoding"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6690291166824e467790ac08ba42f241791567e8337bbf00c5a6e87889629f98"
+checksum = "75b91dddc343e7eaa27f9764e5bffe57370d957017fdd75244f5045e829a8441"
 dependencies = [
  "base64",
+ "memchr",
 ]
+
+[[package]]
+name = "email_address"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8684b7c9cb4857dfa1e5b9629ef584ba618c9b93bae60f58cb23f4f271d0468e"
 
 [[package]]
 name = "encoding"
@@ -2149,12 +2156,13 @@ dependencies = [
 
 [[package]]
 name = "lettre"
-version = "0.10.0-rc.6"
+version = "0.10.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f6c70001f7ee6c93b6687a06607c7a38f9a7ae460139a496c23da21e95bc289"
+checksum = "0f7e87d9d44162eea7abd87b1a7540fcb10d5e58e8bb4f173178f3dc6e453944"
 dependencies = [
  "base64",
  "email-encoding",
+ "email_address",
  "fastrand",
  "futures-util",
  "hostname",
@@ -2165,7 +2173,7 @@ dependencies = [
  "nom 7.1.1",
  "once_cell",
  "quoted_printable",
- "regex",
+ "socket2",
 ]
 
 [[package]]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 [dependencies]
 regex = "1.5.5"
 chrono = { version = "0.4.19", features = ["serde", "clock"], default-features = false }
-lettre = "0.10.0-rc.6"
+lettre = "0.10.0-rc.7"
 tracing = "0.1.32"
 tracing-error = "0.2.0"
 itertools = "0.10.3"


### PR DESCRIPTION
Includes some more email header encoding fixes and improvements since the previous release

Diff: https://github.com/lettre/lettre/compare/v0.10.0-rc.6...v0.10.0-rc.7