### PR TITLE
Fix: Use correctly parseable JSON-LD context

### DIFF
--- a/crates/apub/assets/lemmy/context.json
+++ b/crates/apub/assets/lemmy/context.json
@@ -8,7 +8,7 @@
     "commentsEnabled": "pt:commentsEnabled",
     "sensitive": "as:sensitive",
     "matrixUserId": {
-      "@type": "sc:Text",
+      "@type": "xsd:string",
       "@id": "lemmy:matrixUserId"
     },
     "moderators": {
@@ -16,7 +16,7 @@
       "@id": "lemmy:moderators"
     },
     "stickied": {
-      "@type": "sc:Boolean",
+      "@type": "xsd:boolean",
       "@id": "lemmy:stickied"
     }
   }

--- a/crates/apub/assets/lemmy/context.json
+++ b/crates/apub/assets/lemmy/context.json
@@ -3,21 +3,19 @@
   "https://w3id.org/security/v1",
   {
     "lemmy": "https://join-lemmy.org/ns#",
+    "litepub": "http://litepub.social/ns#",
     "pt": "https://joinpeertube.org/ns#",
-    "sc": "http://schema.org/",
+    "ChatMessage": "litepub:ChatMessage",
     "commentsEnabled": "pt:commentsEnabled",
     "sensitive": "as:sensitive",
-    "matrixUserId": {
-      "@type": "xsd:string",
-      "@id": "lemmy:matrixUserId"
-    },
+    "matrixUserId": "lemmy:matrixUserId",
+    "posting_restricted_to_mods": "lemmy:posting_restricted_to_mods",
+    "remove_data": "lemmy:remove_data",
+    "stickied": "lemmy:stickied",
     "moderators": {
       "@type": "@id",
       "@id": "lemmy:moderators"
     },
-    "stickied": {
-      "@type": "xsd:boolean",
-      "@id": "lemmy:stickied"
-    }
+    "expires": "as:endTime"
   }
 ]

--- a/crates/apub/assets/lemmy/context.json
+++ b/crates/apub/assets/lemmy/context.json
@@ -1,19 +1,23 @@
 [
   "https://www.w3.org/ns/activitystreams",
   {
-    "stickied": "as:stickied",
-    "pt": "https://join-lemmy.org#",
-    "sc": "http://schema.org#",
-    "matrixUserId": {
-      "type": "sc:Text",
-      "id": "as:alsoKnownAs"
-    },
+    "pt": "https://joinpeertube.org/ns#",
+    "lemmy": "https://join-lemmy.org/ns#",
+    "sc": "http://schema.org/",
     "sensitive": "as:sensitive",
-    "comments_enabled": {
-      "type": "sc:Boolean",
-      "id": "pt:commentsEnabled"
+    "stickied": {
+      "@type": "sc:Boolean",
+      "@id": "lemmy:stickied"
     },
-    "moderators": "as:moderators"
+    "matrixUserId": {
+      "@type": "sc:Text",
+      "@id": "lemmy:matrixUserId"
+    },
+    "commentsEnabled": "pt:commentsEnabled",
+    "moderators": {
+      "@type": "@id",
+      "@id": "lemmy:moderators"
+    }
   },
   "https://w3id.org/security/v1"
 ]

--- a/crates/apub/assets/lemmy/context.json
+++ b/crates/apub/assets/lemmy/context.json
@@ -1,23 +1,23 @@
 [
   "https://www.w3.org/ns/activitystreams",
+  "https://w3id.org/security/v1",
   {
-    "pt": "https://joinpeertube.org/ns#",
     "lemmy": "https://join-lemmy.org/ns#",
+    "pt": "https://joinpeertube.org/ns#",
     "sc": "http://schema.org/",
+    "commentsEnabled": "pt:commentsEnabled",
     "sensitive": "as:sensitive",
-    "stickied": {
-      "@type": "sc:Boolean",
-      "@id": "lemmy:stickied"
-    },
     "matrixUserId": {
       "@type": "sc:Text",
       "@id": "lemmy:matrixUserId"
     },
-    "commentsEnabled": "pt:commentsEnabled",
     "moderators": {
       "@type": "@id",
       "@id": "lemmy:moderators"
+    },
+    "stickied": {
+      "@type": "sc:Boolean",
+      "@id": "lemmy:stickied"
     }
-  },
-  "https://w3id.org/security/v1"
+  }
 ]


### PR DESCRIPTION
Relevant discussion: https://socialhub.activitypub.rocks/t/we-have-created-documentation-on-how-exactly-lemmy-federation-works/1085/20?u=trwnh

This PR contains the following changes:

- Add Peertube namespace as `pt`
- Add Lemmy namespace as `lemmy`
- Fix Schema.org namespace
- Fix definitions for `matrixUserId` and `stickied` and `moderators`
- Fix `commentsEnabled` not correctly aliasing to peertube property
- Changed: Context document is now ordered alphabetically

TODO:

- [x] Identify non-standard properties being sent out over ActivityPub