### PR TITLE
Accept private like (#1968)

### DIFF
--- a/crates/apub/src/activities/voting/undo_vote.rs
+++ b/crates/apub/src/activities/voting/undo_vote.rs
@@ -2,7 +2,6 @@ use crate::{
   activities::{
     community::{announce::GetCommunity, send_activity_in_community},
     generate_activity_id,
-    verify_is_public,
     verify_person_in_community,
     voting::{undo_vote_comment, undo_vote_post},
   },
@@ -85,7 +84,6 @@ impl ActivityHandler for UndoVote {
     context: &Data<LemmyContext>,
     request_counter: &mut i32,
   ) -> Result<(), LemmyError> {
-    verify_is_public(&self.to, &self.cc)?;
     let community = self.get_community(context, request_counter).await?;
     verify_person_in_community(&self.actor, &community, context, request_counter).await?;
     verify_urls_match(self.actor.inner(), self.object.actor.inner())?;

--- a/crates/apub/src/activities/voting/vote.rs
+++ b/crates/apub/src/activities/voting/vote.rs
@@ -2,7 +2,6 @@ use crate::{
   activities::{
     community::{announce::GetCommunity, send_activity_in_community},
     generate_activity_id,
-    verify_is_public,
     verify_person_in_community,
     voting::{vote_comment, vote_post},
   },
@@ -87,7 +86,6 @@ impl ActivityHandler for Vote {
     context: &Data<LemmyContext>,
     request_counter: &mut i32,
   ) -> Result<(), LemmyError> {
-    verify_is_public(&self.to, &self.cc)?;
     let community = self.get_community(context, request_counter).await?;
     verify_person_in_community(&self.actor, &community, context, request_counter).await?;
     let site = blocking(context.pool(), Site::read_local_site).await??;


### PR DESCRIPTION
After some thinking, I came to the conclusion that it doesnt really make sense for Lemmy to accept only likes which are marked as public. I mainly implemented it that way because most other content in Lemmy is public, but in fact likes are expected to be private. This is a problem in federation with Friendica, which [publicly lists all Lemmy users who liked a post](https://nerdica.net/display/a85d7459-1162-5082-b221-7d7671174230). For that reason, i think it also makes sense to not mark Lemmy likes as public, meaning they will be private. I am adding that change to #2183.