### PR TITLE
Remove unused setup config vars

### DIFF
--- a/config/defaults.hjson
+++ b/config/defaults.hjson
@@ -91,25 +91,11 @@
     # Username for the admin user
     admin_username: "admin"
     # Password for the admin user. It must be at least 10 characters.
-    admin_password: "my_passwd_longer_than_ten_characters"
+    admin_password: "tf6HHDS4RolWfFhk4Rq9"
     # Name of the site (can be changed later)
     site_name: "My Lemmy Instance"
     # Email for the admin user (optional, can be omitted and set later through the website)
-    admin_email: "string"
-    sidebar: "string"
-    description: "string"
-    icon: "string"
-    banner: "string"
-    enable_downvotes: true
-    open_registration: true
-    enable_nsfw: true
-    community_creation_admin_only: true
-    require_email_verification: true
-    require_application: true
-    application_question: "string"
-    private_instance: true
-    default_theme: "string"
-    default_post_listing_type: "string"
+    admin_email: "user@example.com"
   }
   # the domain name of your instance (mandatory)
   hostname: "unset"

--- a/crates/api_crud/src/site/read.rs
+++ b/crates/api_crud/src/site/read.rs
@@ -54,21 +54,8 @@ impl PerformCrud for GetSite {
 
           let create_site = CreateSite {
             name: setup.site_name.to_owned(),
-            sidebar: setup.sidebar.to_owned(),
-            description: setup.description.to_owned(),
-            icon: setup.icon.to_owned(),
-            banner: setup.banner.to_owned(),
-            enable_downvotes: setup.enable_downvotes,
-            open_registration: setup.open_registration,
-            enable_nsfw: setup.enable_nsfw,
-            community_creation_admin_only: setup.community_creation_admin_only,
-            require_email_verification: setup.require_email_verification,
-            require_application: setup.require_application,
-            application_question: setup.application_question.to_owned(),
-            private_instance: setup.private_instance,
-            default_theme: setup.default_theme.to_owned(),
-            default_post_listing_type: setup.default_post_listing_type.to_owned(),
             auth: admin_jwt,
+            ..CreateSite::default()
           };
           create_site.perform(context, websocket_id).await?;
           info!("Site {} created", setup.site_name);

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -183,40 +183,13 @@ pub struct SetupConfig {
   #[doku(example = "admin")]
   pub admin_username: String,
   /// Password for the admin user. It must be at least 10 characters.
-  #[doku(example = "my_passwd_longer_than_ten_characters")]
+  #[doku(example = "tf6HHDS4RolWfFhk4Rq9")]
   pub admin_password: String,
   /// Name of the site (can be changed later)
   #[doku(example = "My Lemmy Instance")]
   pub site_name: String,
   /// Email for the admin user (optional, can be omitted and set later through the website)
+  #[doku(example = "user@example.com")]
   #[default(None)]
   pub admin_email: Option<String>,
-  #[default(None)]
-  pub sidebar: Option<String>,
-  #[default(None)]
-  pub description: Option<String>,
-  #[default(None)]
-  pub icon: Option<String>,
-  #[default(None)]
-  pub banner: Option<String>,
-  #[default(None)]
-  pub enable_downvotes: Option<bool>,
-  #[default(None)]
-  pub open_registration: Option<bool>,
-  #[default(None)]
-  pub enable_nsfw: Option<bool>,
-  #[default(None)]
-  pub community_creation_admin_only: Option<bool>,
-  #[default(None)]
-  pub require_email_verification: Option<bool>,
-  #[default(None)]
-  pub require_application: Option<bool>,
-  #[default(None)]
-  pub application_question: Option<String>,
-  #[default(None)]
-  pub private_instance: Option<bool>,
-  #[default(None)]
-  pub default_theme: Option<String>,
-  #[default(None)]
-  pub default_post_listing_type: Option<String>,
 }


### PR DESCRIPTION
I dont think anyone is using these, which makes it annoying and unnecessary to keep updated with new fields. The main purpose of SetupConfig as discussed in https://github.com/LemmyNet/lemmy/issues/404 was to make the initial Lemmy setup secure, by so that only the admin can do instance setup, based on provided auth. 

The only reason for other fields to be added to SetupConfig seems to be [might as well add all the site fields, like description, enable_downvotes, etc.](https://github.com/LemmyNet/lemmy/issues/678). That sounds like its not actually needed or used anywhere, and is easy to break as no one checks for bugs in it. Or it should actually be implemented in a different way to be useful. 

So i say remove these fields, and we can add them back when there is a real use case for them.