### PR TITLE
Fix lemmy version in prod docker-compose.yml

### DIFF
--- a/docker/prod/docker-compose.yml
+++ b/docker/prod/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     restart: always
 
   lemmy:
-    image: dessalines/lemmy:0.16.5
+    image: dessalines/lemmy:0.16.4
     ports:
       - "127.0.0.1:8536:8536"
       - "127.0.0.1:6669:6669"


### PR DESCRIPTION
This would only be a partial solution because [lemmy-ansible](https://github.com/LemmyNet/lemmy-ansible/blob/main/VERSION) still points to 0.16.4 for both backend and frontend. It would be easier to publish a 0.16.5 for lemmy to make things consistent.