### PR TITLE
Add Modlog Filters

### DIFF
--- a/crates/api/src/site/mod_log.rs
+++ b/crates/api/src/site/mod_log.rs
@@ -80,12 +80,12 @@ impl Perform for GetModlog {
     };
     let other_person_id = data.other_person_id;
     let params = ModlogListParams {
-      community_id: community_id,
-      mod_person_id: mod_person_id,
-      other_person_id: other_person_id,
+      community_id,
+      mod_person_id,
+      other_person_id,
       page: data.page,
       limit: data.limit,
-      hide_modlog_names: hide_modlog_names,
+      hide_modlog_names,
     };
     let removed_posts = match type_ {
       All | ModRemovePost => {

--- a/crates/api/src/site/mod_log.rs
+++ b/crates/api/src/site/mod_log.rs
@@ -2,7 +2,18 @@ use crate::Perform;
 use actix_web::web::Data;
 use lemmy_api_common::{
   site::{GetModlog, GetModlogResponse},
-  utils::{blocking, check_private_instance, get_local_user_view_from_jwt_opt},
+  utils::{
+    blocking,
+    check_private_instance,
+    get_local_user_view_from_jwt_opt,
+    is_admin,
+    is_mod_or_admin,
+  },
+};
+use lemmy_db_schema::{
+  newtypes::{CommunityId, PersonId},
+  source::site::Site,
+  ModlogActionType,
 };
 use lemmy_db_views_moderator::structs::{
   AdminPurgeCommentView,
@@ -42,55 +53,184 @@ impl Perform for GetModlog {
 
     check_private_instance(&local_user_view, context.pool()).await?;
 
+    let type_ = data.type_.unwrap_or(ModlogActionType::All);
     let community_id = data.community_id;
-    let mod_person_id = data.mod_person_id;
+
+    let site = blocking(context.pool(), Site::read_local_site).await??;
+    let (local_person_id, is_admin) = match local_user_view {
+      Some(s) => (s.person.id, is_admin(&s).is_ok()),
+      None => (PersonId(-1), false),
+    };
+    let community_id_value = match community_id {
+      Some(s) => s,
+      None => CommunityId(-1),
+    };
+    let is_mod_of_community = data.community_id.is_some()
+      && is_mod_or_admin(context.pool(), local_person_id, community_id_value)
+        .await
+        .is_ok();
+    let hide_modlog_names = site.hide_modlog_mod_names && !is_mod_of_community && !is_admin;
+
+    let mod_person_id = if hide_modlog_names {
+      None
+    } else {
+      data.mod_person_id
+    };
+    let other_person_id = data.other_person_id;
     let page = data.page;
     let limit = data.limit;
-    let removed_posts = blocking(context.pool(), move |conn| {
-      ModRemovePostView::list(conn, community_id, mod_person_id, page, limit)
-    })
-    .await??;
+    let removed_posts = match type_ {
+      ModlogActionType::All | ModlogActionType::ModRemovePost => {
+        blocking(context.pool(), move |conn| {
+          ModRemovePostView::list(
+            conn,
+            community_id,
+            mod_person_id,
+            other_person_id,
+            page,
+            limit,
+            hide_modlog_names,
+          )
+        })
+        .await??
+      }
+      _ => Default::default(),
+    };
 
-    let locked_posts = blocking(context.pool(), move |conn| {
-      ModLockPostView::list(conn, community_id, mod_person_id, page, limit)
-    })
-    .await??;
+    let locked_posts = match type_ {
+      ModlogActionType::All | ModlogActionType::ModLockPost => {
+        blocking(context.pool(), move |conn| {
+          ModLockPostView::list(
+            conn,
+            community_id,
+            mod_person_id,
+            other_person_id,
+            page,
+            limit,
+            hide_modlog_names,
+          )
+        })
+        .await??
+      }
+      _ => Default::default(),
+    };
 
-    let stickied_posts = blocking(context.pool(), move |conn| {
-      ModStickyPostView::list(conn, community_id, mod_person_id, page, limit)
-    })
-    .await??;
+    let stickied_posts = match type_ {
+      ModlogActionType::All | ModlogActionType::ModStickyPost => {
+        blocking(context.pool(), move |conn| {
+          ModStickyPostView::list(
+            conn,
+            community_id,
+            mod_person_id,
+            other_person_id,
+            page,
+            limit,
+            hide_modlog_names,
+          )
+        })
+        .await??
+      }
+      _ => Default::default(),
+    };
 
-    let removed_comments = blocking(context.pool(), move |conn| {
-      ModRemoveCommentView::list(conn, community_id, mod_person_id, page, limit)
-    })
-    .await??;
+    let removed_comments = match type_ {
+      ModlogActionType::All | ModlogActionType::ModRemoveComment => {
+        blocking(context.pool(), move |conn| {
+          ModRemoveCommentView::list(
+            conn,
+            community_id,
+            mod_person_id,
+            other_person_id,
+            page,
+            limit,
+            hide_modlog_names,
+          )
+        })
+        .await??
+      }
+      _ => Default::default(),
+    };
 
-    let banned_from_community = blocking(context.pool(), move |conn| {
-      ModBanFromCommunityView::list(conn, community_id, mod_person_id, page, limit)
-    })
-    .await??;
+    let banned_from_community = match type_ {
+      ModlogActionType::All | ModlogActionType::ModBanFromCommunity => {
+        blocking(context.pool(), move |conn| {
+          ModBanFromCommunityView::list(
+            conn,
+            community_id,
+            mod_person_id,
+            other_person_id,
+            page,
+            limit,
+            hide_modlog_names,
+          )
+        })
+        .await??
+      }
+      _ => Default::default(),
+    };
 
-    let added_to_community = blocking(context.pool(), move |conn| {
-      ModAddCommunityView::list(conn, community_id, mod_person_id, page, limit)
-    })
-    .await??;
+    let added_to_community = match type_ {
+      ModlogActionType::All | ModlogActionType::ModAddCommunity => {
+        blocking(context.pool(), move |conn| {
+          ModAddCommunityView::list(
+            conn,
+            community_id,
+            mod_person_id,
+            other_person_id,
+            page,
+            limit,
+            hide_modlog_names,
+          )
+        })
+        .await??
+      }
+      _ => Default::default(),
+    };
 
-    let transferred_to_community = blocking(context.pool(), move |conn| {
-      ModTransferCommunityView::list(conn, community_id, mod_person_id, page, limit)
-    })
-    .await??;
+    let transferred_to_community = match type_ {
+      ModlogActionType::All | ModlogActionType::ModTransferCommunity => {
+        blocking(context.pool(), move |conn| {
+          ModTransferCommunityView::list(
+            conn,
+            community_id,
+            mod_person_id,
+            other_person_id,
+            page,
+            limit,
+            hide_modlog_names,
+          )
+        })
+        .await??
+      }
+      _ => Default::default(),
+    };
 
-    let hidden_communities = blocking(context.pool(), move |conn| {
-      ModHideCommunityView::list(conn, community_id, mod_person_id, page, limit)
-    })
-    .await??;
+    let hidden_communities = match type_ {
+      ModlogActionType::All | ModlogActionType::ModHideCommunity => {
+        if other_person_id.is_none() {
+          blocking(context.pool(), move |conn| {
+            ModHideCommunityView::list(
+              conn,
+              community_id,
+              mod_person_id,
+              page,
+              limit,
+              hide_modlog_names,
+            )
+          })
+          .await??
+        } else {
+          Default::default()
+        }
+      }
+      _ => Default::default(),
+    };
 
     // These arrays are only for the full modlog, when a community isn't given
     let (
-      removed_communities,
       banned,
       added,
+      removed_communities,
       admin_purged_persons,
       admin_purged_communities,
       admin_purged_posts,
@@ -98,13 +238,83 @@ impl Perform for GetModlog {
     ) = if data.community_id.is_none() {
       blocking(context.pool(), move |conn| {
         Ok((
-          ModRemoveCommunityView::list(conn, mod_person_id, page, limit)?,
-          ModBanView::list(conn, mod_person_id, page, limit)?,
-          ModAddView::list(conn, mod_person_id, page, limit)?,
-          AdminPurgePersonView::list(conn, mod_person_id, page, limit)?,
-          AdminPurgeCommunityView::list(conn, mod_person_id, page, limit)?,
-          AdminPurgePostView::list(conn, mod_person_id, page, limit)?,
-          AdminPurgeCommentView::list(conn, mod_person_id, page, limit)?,
+          match type_ {
+            ModlogActionType::All | ModlogActionType::ModBan => ModBanView::list(
+              conn,
+              mod_person_id,
+              other_person_id,
+              page,
+              limit,
+              hide_modlog_names,
+            )?,
+            _ => Default::default(),
+          },
+          match type_ {
+            ModlogActionType::All | ModlogActionType::ModAdd => ModAddView::list(
+              conn,
+              mod_person_id,
+              other_person_id,
+              page,
+              limit,
+              hide_modlog_names,
+            )?,
+            _ => Default::default(),
+          },
+          match type_ {
+            ModlogActionType::All | ModlogActionType::ModRemoveCommunity => {
+              if other_person_id.is_none() {
+                ModRemoveCommunityView::list(conn, mod_person_id, page, limit, hide_modlog_names)?
+              } else {
+                Default::default()
+              }
+            }
+
+            _ => Default::default(),
+          },
+          match type_ {
+            ModlogActionType::All | ModlogActionType::AdminPurgePerson => {
+              if other_person_id.is_none() {
+                AdminPurgePersonView::list(conn, mod_person_id, page, limit, hide_modlog_names)?
+              } else {
+                Default::default()
+              }
+            }
+
+            _ => Default::default(),
+          },
+          match type_ {
+            ModlogActionType::All | ModlogActionType::AdminPurgeCommunity => {
+              if other_person_id.is_none() {
+                AdminPurgeCommunityView::list(conn, mod_person_id, page, limit, hide_modlog_names)?
+              } else {
+                Default::default()
+              }
+            }
+
+            _ => Default::default(),
+          },
+          match type_ {
+            ModlogActionType::All | ModlogActionType::AdminPurgePost => {
+              if other_person_id.is_none() {
+                AdminPurgePostView::list(conn, mod_person_id, page, limit, hide_modlog_names)?
+              } else {
+                Default::default()
+              }
+            }
+
+            _ => Default::default(),
+          },
+          match type_ {
+            ModlogActionType::All | ModlogActionType::AdminPurgeComment => {
+              if other_person_id.is_none() {
+                AdminPurgeCommentView::list(conn, mod_person_id, page, limit, hide_modlog_names)?
+              } else {
+                Default::default()
+              }
+            }
+
+            _ => Default::default(),
+          },
         )) as Result<_, LemmyError>
       })
       .await??

--- a/crates/api/src/site/mod_log.rs
+++ b/crates/api/src/site/mod_log.rs
@@ -158,15 +158,11 @@ impl Perform for GetModlog {
     };
 
     let hidden_communities = match type_ {
-      All | ModHideCommunity => {
-        if other_person_id.is_none() {
-          blocking(context.pool(), move |conn| {
-            ModHideCommunityView::list(conn, params)
-          })
-          .await??
-        } else {
-          Default::default()
-        }
+      All | ModHideCommunity if other_person_id.is_none() => {
+        blocking(context.pool(), move |conn| {
+          ModHideCommunityView::list(conn, params)
+        })
+        .await??
       }
       _ => Default::default(),
     };
@@ -192,58 +188,33 @@ impl Perform for GetModlog {
             _ => Default::default(),
           },
           match type_ {
-            All | ModRemoveCommunity => {
-              if other_person_id.is_none() {
-                ModRemoveCommunityView::list(conn, params)?
-              } else {
-                Default::default()
-              }
+            All | ModRemoveCommunity if other_person_id.is_none() => {
+              ModRemoveCommunityView::list(conn, params)?
             }
-
             _ => Default::default(),
           },
           match type_ {
-            All | AdminPurgePerson => {
-              if other_person_id.is_none() {
-                AdminPurgePersonView::list(conn, params)?
-              } else {
-                Default::default()
-              }
+            All | AdminPurgePerson if other_person_id.is_none() => {
+              AdminPurgePersonView::list(conn, params)?
             }
-
             _ => Default::default(),
           },
           match type_ {
-            All | AdminPurgeCommunity => {
-              if other_person_id.is_none() {
-                AdminPurgeCommunityView::list(conn, params)?
-              } else {
-                Default::default()
-              }
+            All | AdminPurgeCommunity if other_person_id.is_none() => {
+              AdminPurgeCommunityView::list(conn, params)?
             }
-
             _ => Default::default(),
           },
           match type_ {
-            All | AdminPurgePost => {
-              if other_person_id.is_none() {
-                AdminPurgePostView::list(conn, params)?
-              } else {
-                Default::default()
-              }
+            All | AdminPurgePost if other_person_id.is_none() => {
+              AdminPurgePostView::list(conn, params)?
             }
-
             _ => Default::default(),
           },
           match type_ {
-            All | AdminPurgeComment => {
-              if other_person_id.is_none() {
-                AdminPurgeCommentView::list(conn, params)?
-              } else {
-                Default::default()
-              }
+            All | AdminPurgeComment if other_person_id.is_none() => {
+              AdminPurgeCommentView::list(conn, params)?
             }
-
             _ => Default::default(),
           },
         )) as Result<_, LemmyError>

--- a/crates/api_common/src/site.rs
+++ b/crates/api_common/src/site.rs
@@ -2,6 +2,7 @@ use crate::sensitive::Sensitive;
 use lemmy_db_schema::{
   newtypes::{CommentId, CommunityId, PersonId, PostId},
   ListingType,
+  ModlogActionType,
   SearchType,
   SortType,
 };
@@ -83,6 +84,8 @@ pub struct GetModlog {
   pub page: Option<i64>,
   pub limit: Option<i64>,
   pub auth: Option<Sensitive<String>>,
+  pub type_: Option<ModlogActionType>,
+  pub other_person_id: Option<PersonId>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -122,6 +125,7 @@ pub struct CreateSite {
   pub default_theme: Option<String>,
   pub default_post_listing_type: Option<String>,
   pub auth: Sensitive<String>,
+  pub hide_modlog_mod_names: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -143,6 +147,7 @@ pub struct EditSite {
   pub default_post_listing_type: Option<String>,
   pub legal_information: Option<String>,
   pub auth: Sensitive<String>,
+  pub hide_modlog_mod_names: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]

--- a/crates/api_crud/src/site/create.rs
+++ b/crates/api_crud/src/site/create.rs
@@ -76,6 +76,7 @@ impl PerformCrud for CreateSite {
       public_key: Some(keypair.public_key),
       default_theme: data.default_theme.clone(),
       default_post_listing_type: data.default_post_listing_type.clone(),
+      hide_modlog_mod_names: data.hide_modlog_mod_names,
       ..SiteForm::default()
     };
 

--- a/crates/api_crud/src/site/update.rs
+++ b/crates/api_crud/src/site/update.rs
@@ -86,6 +86,7 @@ impl PerformCrud for EditSite {
       default_theme: data.default_theme.clone(),
       default_post_listing_type: data.default_post_listing_type.clone(),
       legal_information,
+      hide_modlog_mod_names: data.hide_modlog_mod_names,
       ..SiteForm::default()
     };
 

--- a/crates/db_schema/src/lib.rs
+++ b/crates/db_schema/src/lib.rs
@@ -71,3 +71,23 @@ pub enum SubscribedType {
   NotSubscribed,
   Pending,
 }
+
+#[derive(EnumString, Display, Debug, Serialize, Deserialize, Clone, Copy, PartialEq)]
+pub enum ModlogActionType {
+  All,
+  ModRemovePost,
+  ModLockPost,
+  ModStickyPost,
+  ModRemoveComment,
+  ModRemoveCommunity,
+  ModBanFromCommunity,
+  ModAddCommunity,
+  ModTransferCommunity,
+  ModAdd,
+  ModBan,
+  ModHideCommunity,
+  AdminPurgePerson,
+  AdminPurgeCommunity,
+  AdminPurgePost,
+  AdminPurgeComment,
+}

--- a/crates/db_schema/src/schema.rs
+++ b/crates/db_schema/src/schema.rs
@@ -477,6 +477,7 @@ table! {
         default_theme -> Text,
         default_post_listing_type -> Text,
         legal_information -> Nullable<Text>,
+        hide_modlog_mod_names -> Bool,
     }
 }
 

--- a/crates/db_schema/src/source/site.rs
+++ b/crates/db_schema/src/source/site.rs
@@ -32,6 +32,7 @@ pub struct Site {
   pub default_theme: String,
   pub default_post_listing_type: String,
   pub legal_information: Option<String>,
+  pub hide_modlog_mod_names: bool,
 }
 
 #[derive(Default)]
@@ -61,4 +62,5 @@ pub struct SiteForm {
   pub default_theme: Option<String>,
   pub default_post_listing_type: Option<String>,
   pub legal_information: Option<Option<String>>,
+  pub hide_modlog_mod_names: Option<bool>,
 }

--- a/crates/db_views_moderator/src/admin_purge_comment_view.rs
+++ b/crates/db_views_moderator/src/admin_purge_comment_view.rs
@@ -1,4 +1,4 @@
-use crate::structs::AdminPurgeCommentView;
+use crate::structs::{AdminPurgeCommentView, ModlogListParams};
 use diesel::{result::Error, *};
 use lemmy_db_schema::{
   newtypes::PersonId,
@@ -15,15 +15,9 @@ use lemmy_db_schema::{
 type AdminPurgeCommentViewTuple = (AdminPurgeComment, Option<PersonSafe>, Post);
 
 impl AdminPurgeCommentView {
-  pub fn list(
-    conn: &PgConnection,
-    admin_person_id: Option<PersonId>,
-    page: Option<i64>,
-    limit: Option<i64>,
-    hide_mod_names: bool,
-  ) -> Result<Vec<Self>, Error> {
-    let admin_person_id_join = admin_person_id.unwrap_or(PersonId(-1));
-    let show_mod_names = !hide_mod_names;
+  pub fn list(conn: &PgConnection, params: ModlogListParams) -> Result<Vec<Self>, Error> {
+    let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
+    let show_mod_names = !params.hide_modlog_names;
     let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
 
     let admin_names_join = admin_purge_comment::admin_person_id
@@ -40,11 +34,11 @@ impl AdminPurgeCommentView {
       ))
       .into_boxed();
 
-    if let Some(admin_person_id) = admin_person_id {
+    if let Some(admin_person_id) = params.mod_person_id {
       query = query.filter(admin_purge_comment::admin_person_id.eq(admin_person_id));
     };
 
-    let (limit, offset) = limit_and_offset(page, limit)?;
+    let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
     let res = query
       .limit(limit)

--- a/crates/db_views_moderator/src/admin_purge_person_view.rs
+++ b/crates/db_views_moderator/src/admin_purge_person_view.rs
@@ -1,4 +1,4 @@
-use crate::structs::AdminPurgePersonView;
+use crate::structs::{AdminPurgePersonView, ModlogListParams};
 use diesel::{result::Error, *};
 use lemmy_db_schema::{
   newtypes::PersonId,
@@ -14,15 +14,9 @@ use lemmy_db_schema::{
 type AdminPurgePersonViewTuple = (AdminPurgePerson, Option<PersonSafe>);
 
 impl AdminPurgePersonView {
-  pub fn list(
-    conn: &PgConnection,
-    admin_person_id: Option<PersonId>,
-    page: Option<i64>,
-    limit: Option<i64>,
-    hide_mod_names: bool,
-  ) -> Result<Vec<Self>, Error> {
-    let admin_person_id_join = admin_person_id.unwrap_or(PersonId(-1));
-    let show_mod_names = !hide_mod_names;
+  pub fn list(conn: &PgConnection, params: ModlogListParams) -> Result<Vec<Self>, Error> {
+    let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
+    let show_mod_names = !params.hide_modlog_names;
     let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
 
     let admin_names_join = admin_purge_person::admin_person_id
@@ -36,11 +30,11 @@ impl AdminPurgePersonView {
       ))
       .into_boxed();
 
-    if let Some(admin_person_id) = admin_person_id {
+    if let Some(admin_person_id) = params.mod_person_id {
       query = query.filter(admin_purge_person::admin_person_id.eq(admin_person_id));
     };
 
-    let (limit, offset) = limit_and_offset(page, limit)?;
+    let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
     let res = query
       .limit(limit)

--- a/crates/db_views_moderator/src/admin_purge_person_view.rs
+++ b/crates/db_views_moderator/src/admin_purge_person_view.rs
@@ -11,7 +11,7 @@ use lemmy_db_schema::{
   utils::limit_and_offset,
 };
 
-type AdminPurgePersonViewTuple = (AdminPurgePerson, PersonSafe);
+type AdminPurgePersonViewTuple = (AdminPurgePerson, Option<PersonSafe>);
 
 impl AdminPurgePersonView {
   pub fn list(
@@ -19,12 +19,20 @@ impl AdminPurgePersonView {
     admin_person_id: Option<PersonId>,
     page: Option<i64>,
     limit: Option<i64>,
+    hide_mod_names: bool,
   ) -> Result<Vec<Self>, Error> {
+    let admin_person_id_join = admin_person_id.unwrap_or(PersonId(-1));
+    let show_mod_names = !hide_mod_names;
+    let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
+
+    let admin_names_join = admin_purge_person::admin_person_id
+      .eq(person::id)
+      .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
     let mut query = admin_purge_person::table
-      .inner_join(person::table.on(admin_purge_person::admin_person_id.eq(person::id)))
+      .left_join(person::table.on(admin_names_join))
       .select((
         admin_purge_person::all_columns,
-        Person::safe_columns_tuple(),
+        Person::safe_columns_tuple().nullable(),
       ))
       .into_boxed();
 
@@ -40,7 +48,8 @@ impl AdminPurgePersonView {
       .order_by(admin_purge_person::when_.desc())
       .load::<AdminPurgePersonViewTuple>(conn)?;
 
-    Ok(Self::from_tuple_to_vec(res))
+    let results = Self::from_tuple_to_vec(res);
+    Ok(results)
   }
 }
 

--- a/crates/db_views_moderator/src/admin_purge_post_view.rs
+++ b/crates/db_views_moderator/src/admin_purge_post_view.rs
@@ -12,7 +12,7 @@ use lemmy_db_schema::{
   utils::limit_and_offset,
 };
 
-type AdminPurgePostViewTuple = (AdminPurgePost, PersonSafe, CommunitySafe);
+type AdminPurgePostViewTuple = (AdminPurgePost, Option<PersonSafe>, CommunitySafe);
 
 impl AdminPurgePostView {
   pub fn list(
@@ -20,13 +20,21 @@ impl AdminPurgePostView {
     admin_person_id: Option<PersonId>,
     page: Option<i64>,
     limit: Option<i64>,
+    hide_mod_names: bool,
   ) -> Result<Vec<Self>, Error> {
+    let admin_person_id_join = admin_person_id.unwrap_or(PersonId(-1));
+    let show_mod_names = !hide_mod_names;
+    let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
+
+    let admin_names_join = admin_purge_post::admin_person_id
+      .eq(person::id)
+      .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
     let mut query = admin_purge_post::table
-      .inner_join(person::table.on(admin_purge_post::admin_person_id.eq(person::id)))
+      .left_join(person::table.on(admin_names_join))
       .inner_join(community::table)
       .select((
         admin_purge_post::all_columns,
-        Person::safe_columns_tuple(),
+        Person::safe_columns_tuple().nullable(),
         Community::safe_columns_tuple(),
       ))
       .into_boxed();
@@ -43,7 +51,8 @@ impl AdminPurgePostView {
       .order_by(admin_purge_post::when_.desc())
       .load::<AdminPurgePostViewTuple>(conn)?;
 
-    Ok(Self::from_tuple_to_vec(res))
+    let results = Self::from_tuple_to_vec(res);
+    Ok(results)
   }
 }
 

--- a/crates/db_views_moderator/src/admin_purge_post_view.rs
+++ b/crates/db_views_moderator/src/admin_purge_post_view.rs
@@ -1,4 +1,4 @@
-use crate::structs::AdminPurgePostView;
+use crate::structs::{AdminPurgePostView, ModlogListParams};
 use diesel::{result::Error, *};
 use lemmy_db_schema::{
   newtypes::PersonId,
@@ -15,15 +15,9 @@ use lemmy_db_schema::{
 type AdminPurgePostViewTuple = (AdminPurgePost, Option<PersonSafe>, CommunitySafe);
 
 impl AdminPurgePostView {
-  pub fn list(
-    conn: &PgConnection,
-    admin_person_id: Option<PersonId>,
-    page: Option<i64>,
-    limit: Option<i64>,
-    hide_mod_names: bool,
-  ) -> Result<Vec<Self>, Error> {
-    let admin_person_id_join = admin_person_id.unwrap_or(PersonId(-1));
-    let show_mod_names = !hide_mod_names;
+  pub fn list(conn: &PgConnection, params: ModlogListParams) -> Result<Vec<Self>, Error> {
+    let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
+    let show_mod_names = !params.hide_modlog_names;
     let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
 
     let admin_names_join = admin_purge_post::admin_person_id
@@ -39,11 +33,11 @@ impl AdminPurgePostView {
       ))
       .into_boxed();
 
-    if let Some(admin_person_id) = admin_person_id {
+    if let Some(admin_person_id) = params.mod_person_id {
       query = query.filter(admin_purge_post::admin_person_id.eq(admin_person_id));
     };
 
-    let (limit, offset) = limit_and_offset(page, limit)?;
+    let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
     let res = query
       .limit(limit)

--- a/crates/db_views_moderator/src/mod_add_community_view.rs
+++ b/crates/db_views_moderator/src/mod_add_community_view.rs
@@ -12,25 +12,39 @@ use lemmy_db_schema::{
   utils::limit_and_offset,
 };
 
-type ModAddCommunityViewTuple = (ModAddCommunity, PersonSafe, CommunitySafe, PersonSafeAlias1);
+type ModAddCommunityViewTuple = (
+  ModAddCommunity,
+  Option<PersonSafe>,
+  CommunitySafe,
+  PersonSafeAlias1,
+);
 
 impl ModAddCommunityView {
   pub fn list(
     conn: &PgConnection,
     community_id: Option<CommunityId>,
     mod_person_id: Option<PersonId>,
+    other_person_id: Option<PersonId>,
     page: Option<i64>,
     limit: Option<i64>,
+    hide_mod_names: bool,
   ) -> Result<Vec<Self>, Error> {
+    let admin_person_id_join = mod_person_id.unwrap_or(PersonId(-1));
+    let show_mod_names = !hide_mod_names;
+    let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
+
+    let admin_names_join = mod_add_community::mod_person_id
+      .eq(person::id)
+      .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
     let mut query = mod_add_community::table
-      .inner_join(person::table.on(mod_add_community::mod_person_id.eq(person::id)))
+      .left_join(person::table.on(admin_names_join))
       .inner_join(community::table)
       .inner_join(
         person_alias_1::table.on(mod_add_community::other_person_id.eq(person_alias_1::id)),
       )
       .select((
         mod_add_community::all_columns,
-        Person::safe_columns_tuple(),
+        Person::safe_columns_tuple().nullable(),
         Community::safe_columns_tuple(),
         PersonAlias1::safe_columns_tuple(),
       ))
@@ -44,6 +58,10 @@ impl ModAddCommunityView {
       query = query.filter(mod_add_community::community_id.eq(community_id));
     };
 
+    if let Some(other_person_id) = other_person_id {
+      query = query.filter(person_alias_1::id.eq(other_person_id));
+    };
+
     let (limit, offset) = limit_and_offset(page, limit)?;
 
     let res = query
@@ -52,7 +70,8 @@ impl ModAddCommunityView {
       .order_by(mod_add_community::when_.desc())
       .load::<ModAddCommunityViewTuple>(conn)?;
 
-    Ok(Self::from_tuple_to_vec(res))
+    let results = Self::from_tuple_to_vec(res);
+    Ok(results)
   }
 }
 

--- a/crates/db_views_moderator/src/mod_add_community_view.rs
+++ b/crates/db_views_moderator/src/mod_add_community_view.rs
@@ -1,7 +1,7 @@
 use crate::structs::{ModAddCommunityView, ModlogListParams};
 use diesel::{result::Error, *};
 use lemmy_db_schema::{
-  newtypes::{CommunityId, PersonId},
+  newtypes::PersonId,
   schema::{community, mod_add_community, person, person_alias_1},
   source::{
     community::{Community, CommunitySafe},

--- a/crates/db_views_moderator/src/mod_add_community_view.rs
+++ b/crates/db_views_moderator/src/mod_add_community_view.rs
@@ -1,4 +1,4 @@
-use crate::structs::ModAddCommunityView;
+use crate::structs::{ModAddCommunityView, ModlogListParams};
 use diesel::{result::Error, *};
 use lemmy_db_schema::{
   newtypes::{CommunityId, PersonId},
@@ -20,17 +20,9 @@ type ModAddCommunityViewTuple = (
 );
 
 impl ModAddCommunityView {
-  pub fn list(
-    conn: &PgConnection,
-    community_id: Option<CommunityId>,
-    mod_person_id: Option<PersonId>,
-    other_person_id: Option<PersonId>,
-    page: Option<i64>,
-    limit: Option<i64>,
-    hide_mod_names: bool,
-  ) -> Result<Vec<Self>, Error> {
-    let admin_person_id_join = mod_person_id.unwrap_or(PersonId(-1));
-    let show_mod_names = !hide_mod_names;
+  pub fn list(conn: &PgConnection, params: ModlogListParams) -> Result<Vec<Self>, Error> {
+    let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
+    let show_mod_names = !params.hide_modlog_names;
     let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
 
     let admin_names_join = mod_add_community::mod_person_id
@@ -50,19 +42,19 @@ impl ModAddCommunityView {
       ))
       .into_boxed();
 
-    if let Some(mod_person_id) = mod_person_id {
+    if let Some(mod_person_id) = params.mod_person_id {
       query = query.filter(mod_add_community::mod_person_id.eq(mod_person_id));
     };
 
-    if let Some(community_id) = community_id {
+    if let Some(community_id) = params.community_id {
       query = query.filter(mod_add_community::community_id.eq(community_id));
     };
 
-    if let Some(other_person_id) = other_person_id {
+    if let Some(other_person_id) = params.other_person_id {
       query = query.filter(person_alias_1::id.eq(other_person_id));
     };
 
-    let (limit, offset) = limit_and_offset(page, limit)?;
+    let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
     let res = query
       .limit(limit)

--- a/crates/db_views_moderator/src/mod_add_view.rs
+++ b/crates/db_views_moderator/src/mod_add_view.rs
@@ -11,27 +11,40 @@ use lemmy_db_schema::{
   utils::limit_and_offset,
 };
 
-type ModAddViewTuple = (ModAdd, PersonSafe, PersonSafeAlias1);
+type ModAddViewTuple = (ModAdd, Option<PersonSafe>, PersonSafeAlias1);
 
 impl ModAddView {
   pub fn list(
     conn: &PgConnection,
     mod_person_id: Option<PersonId>,
+    other_person_id: Option<PersonId>,
     page: Option<i64>,
     limit: Option<i64>,
+    hide_mod_names: bool,
   ) -> Result<Vec<Self>, Error> {
+    let admin_person_id_join = mod_person_id.unwrap_or(PersonId(-1));
+    let show_mod_names = !hide_mod_names;
+    let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
+
+    let admin_names_join = mod_add::mod_person_id
+      .eq(person::id)
+      .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
     let mut query = mod_add::table
-      .inner_join(person::table.on(mod_add::mod_person_id.eq(person::id)))
+      .left_join(person::table.on(admin_names_join))
       .inner_join(person_alias_1::table.on(mod_add::other_person_id.eq(person_alias_1::id)))
       .select((
         mod_add::all_columns,
-        Person::safe_columns_tuple(),
+        Person::safe_columns_tuple().nullable(),
         PersonAlias1::safe_columns_tuple(),
       ))
       .into_boxed();
 
     if let Some(mod_person_id) = mod_person_id {
       query = query.filter(mod_add::mod_person_id.eq(mod_person_id));
+    };
+
+    if let Some(other_person_id) = other_person_id {
+      query = query.filter(person_alias_1::id.eq(other_person_id));
     };
 
     let (limit, offset) = limit_and_offset(page, limit)?;
@@ -42,7 +55,8 @@ impl ModAddView {
       .order_by(mod_add::when_.desc())
       .load::<ModAddViewTuple>(conn)?;
 
-    Ok(Self::from_tuple_to_vec(res))
+    let results = Self::from_tuple_to_vec(res);
+    Ok(results)
   }
 }
 

--- a/crates/db_views_moderator/src/mod_add_view.rs
+++ b/crates/db_views_moderator/src/mod_add_view.rs
@@ -1,4 +1,4 @@
-use crate::structs::ModAddView;
+use crate::structs::{ModAddView, ModlogListParams};
 use diesel::{result::Error, *};
 use lemmy_db_schema::{
   newtypes::PersonId,
@@ -14,16 +14,9 @@ use lemmy_db_schema::{
 type ModAddViewTuple = (ModAdd, Option<PersonSafe>, PersonSafeAlias1);
 
 impl ModAddView {
-  pub fn list(
-    conn: &PgConnection,
-    mod_person_id: Option<PersonId>,
-    other_person_id: Option<PersonId>,
-    page: Option<i64>,
-    limit: Option<i64>,
-    hide_mod_names: bool,
-  ) -> Result<Vec<Self>, Error> {
-    let admin_person_id_join = mod_person_id.unwrap_or(PersonId(-1));
-    let show_mod_names = !hide_mod_names;
+  pub fn list(conn: &PgConnection, params: ModlogListParams) -> Result<Vec<Self>, Error> {
+    let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
+    let show_mod_names = !params.hide_modlog_names;
     let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
 
     let admin_names_join = mod_add::mod_person_id
@@ -39,15 +32,15 @@ impl ModAddView {
       ))
       .into_boxed();
 
-    if let Some(mod_person_id) = mod_person_id {
+    if let Some(mod_person_id) = params.mod_person_id {
       query = query.filter(mod_add::mod_person_id.eq(mod_person_id));
     };
 
-    if let Some(other_person_id) = other_person_id {
+    if let Some(other_person_id) = params.other_person_id {
       query = query.filter(person_alias_1::id.eq(other_person_id));
     };
 
-    let (limit, offset) = limit_and_offset(page, limit)?;
+    let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
     let res = query
       .limit(limit)

--- a/crates/db_views_moderator/src/mod_ban_from_community_view.rs
+++ b/crates/db_views_moderator/src/mod_ban_from_community_view.rs
@@ -1,4 +1,4 @@
-use crate::structs::ModBanFromCommunityView;
+use crate::structs::{ModBanFromCommunityView, ModlogListParams};
 use diesel::{result::Error, *};
 use lemmy_db_schema::{
   newtypes::{CommunityId, PersonId},
@@ -20,17 +20,9 @@ type ModBanFromCommunityViewTuple = (
 );
 
 impl ModBanFromCommunityView {
-  pub fn list(
-    conn: &PgConnection,
-    community_id: Option<CommunityId>,
-    mod_person_id: Option<PersonId>,
-    other_person_id: Option<PersonId>,
-    page: Option<i64>,
-    limit: Option<i64>,
-    hide_mod_names: bool,
-  ) -> Result<Vec<Self>, Error> {
-    let admin_person_id_join = mod_person_id.unwrap_or(PersonId(-1));
-    let show_mod_names = !hide_mod_names;
+  pub fn list(conn: &PgConnection, params: ModlogListParams) -> Result<Vec<Self>, Error> {
+    let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
+    let show_mod_names = !params.hide_modlog_names;
     let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
 
     let admin_names_join = mod_ban_from_community::mod_person_id
@@ -50,19 +42,19 @@ impl ModBanFromCommunityView {
       ))
       .into_boxed();
 
-    if let Some(mod_person_id) = mod_person_id {
+    if let Some(mod_person_id) = params.mod_person_id {
       query = query.filter(mod_ban_from_community::mod_person_id.eq(mod_person_id));
     };
 
-    if let Some(community_id) = community_id {
+    if let Some(community_id) = params.community_id {
       query = query.filter(mod_ban_from_community::community_id.eq(community_id));
     };
 
-    if let Some(other_person_id) = other_person_id {
+    if let Some(other_person_id) = params.other_person_id {
       query = query.filter(mod_ban_from_community::other_person_id.eq(other_person_id));
     };
 
-    let (limit, offset) = limit_and_offset(page, limit)?;
+    let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
     let res = query
       .limit(limit)

--- a/crates/db_views_moderator/src/mod_ban_from_community_view.rs
+++ b/crates/db_views_moderator/src/mod_ban_from_community_view.rs
@@ -1,7 +1,7 @@
 use crate::structs::{ModBanFromCommunityView, ModlogListParams};
 use diesel::{result::Error, *};
 use lemmy_db_schema::{
-  newtypes::{CommunityId, PersonId},
+  newtypes::PersonId,
   schema::{community, mod_ban_from_community, person, person_alias_1},
   source::{
     community::{Community, CommunitySafe},

--- a/crates/db_views_moderator/src/mod_ban_view.rs
+++ b/crates/db_views_moderator/src/mod_ban_view.rs
@@ -1,4 +1,4 @@
-use crate::structs::ModBanView;
+use crate::structs::{ModBanView, ModlogListParams};
 use diesel::{result::Error, *};
 use lemmy_db_schema::{
   newtypes::PersonId,
@@ -14,16 +14,9 @@ use lemmy_db_schema::{
 type ModBanViewTuple = (ModBan, Option<PersonSafe>, PersonSafeAlias1);
 
 impl ModBanView {
-  pub fn list(
-    conn: &PgConnection,
-    mod_person_id: Option<PersonId>,
-    other_person_id: Option<PersonId>,
-    page: Option<i64>,
-    limit: Option<i64>,
-    hide_mod_names: bool,
-  ) -> Result<Vec<Self>, Error> {
-    let admin_person_id_join = mod_person_id.unwrap_or(PersonId(-1));
-    let show_mod_names = !hide_mod_names;
+  pub fn list(conn: &PgConnection, params: ModlogListParams) -> Result<Vec<Self>, Error> {
+    let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
+    let show_mod_names = !params.hide_modlog_names;
     let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
 
     let admin_names_join = mod_ban::mod_person_id
@@ -39,15 +32,15 @@ impl ModBanView {
       ))
       .into_boxed();
 
-    if let Some(mod_person_id) = mod_person_id {
+    if let Some(mod_person_id) = params.mod_person_id {
       query = query.filter(mod_ban::mod_person_id.eq(mod_person_id));
     };
 
-    if let Some(other_person_id) = other_person_id {
+    if let Some(other_person_id) = params.other_person_id {
       query = query.filter(person_alias_1::id.eq(other_person_id));
     };
 
-    let (limit, offset) = limit_and_offset(page, limit)?;
+    let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
     let res = query
       .limit(limit)

--- a/crates/db_views_moderator/src/mod_ban_view.rs
+++ b/crates/db_views_moderator/src/mod_ban_view.rs
@@ -11,27 +11,40 @@ use lemmy_db_schema::{
   utils::limit_and_offset,
 };
 
-type ModBanViewTuple = (ModBan, PersonSafe, PersonSafeAlias1);
+type ModBanViewTuple = (ModBan, Option<PersonSafe>, PersonSafeAlias1);
 
 impl ModBanView {
   pub fn list(
     conn: &PgConnection,
     mod_person_id: Option<PersonId>,
+    other_person_id: Option<PersonId>,
     page: Option<i64>,
     limit: Option<i64>,
+    hide_mod_names: bool,
   ) -> Result<Vec<Self>, Error> {
+    let admin_person_id_join = mod_person_id.unwrap_or(PersonId(-1));
+    let show_mod_names = !hide_mod_names;
+    let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
+
+    let admin_names_join = mod_ban::mod_person_id
+      .eq(person::id)
+      .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
     let mut query = mod_ban::table
-      .inner_join(person::table.on(mod_ban::mod_person_id.eq(person::id)))
+      .left_join(person::table.on(admin_names_join))
       .inner_join(person_alias_1::table.on(mod_ban::other_person_id.eq(person_alias_1::id)))
       .select((
         mod_ban::all_columns,
-        Person::safe_columns_tuple(),
+        Person::safe_columns_tuple().nullable(),
         PersonAlias1::safe_columns_tuple(),
       ))
       .into_boxed();
 
     if let Some(mod_person_id) = mod_person_id {
       query = query.filter(mod_ban::mod_person_id.eq(mod_person_id));
+    };
+
+    if let Some(other_person_id) = other_person_id {
+      query = query.filter(person_alias_1::id.eq(other_person_id));
     };
 
     let (limit, offset) = limit_and_offset(page, limit)?;
@@ -42,7 +55,8 @@ impl ModBanView {
       .order_by(mod_ban::when_.desc())
       .load::<ModBanViewTuple>(conn)?;
 
-    Ok(Self::from_tuple_to_vec(res))
+    let results = Self::from_tuple_to_vec(res);
+    Ok(results)
   }
 }
 

--- a/crates/db_views_moderator/src/mod_hide_community_view.rs
+++ b/crates/db_views_moderator/src/mod_hide_community_view.rs
@@ -1,7 +1,7 @@
 use crate::structs::{ModHideCommunityView, ModlogListParams};
 use diesel::{result::Error, *};
 use lemmy_db_schema::{
-  newtypes::{CommunityId, PersonId},
+  newtypes::PersonId,
   schema::{community, mod_hide_community, person},
   source::{
     community::{Community, CommunitySafe},

--- a/crates/db_views_moderator/src/mod_lock_post_view.rs
+++ b/crates/db_views_moderator/src/mod_lock_post_view.rs
@@ -1,4 +1,4 @@
-use crate::structs::ModLockPostView;
+use crate::structs::{ModLockPostView, ModlogListParams};
 use diesel::{result::Error, *};
 use lemmy_db_schema::{
   newtypes::{CommunityId, PersonId},
@@ -16,17 +16,9 @@ use lemmy_db_schema::{
 type ModLockPostViewTuple = (ModLockPost, Option<PersonSafe>, Post, CommunitySafe);
 
 impl ModLockPostView {
-  pub fn list(
-    conn: &PgConnection,
-    community_id: Option<CommunityId>,
-    mod_person_id: Option<PersonId>,
-    other_person_id: Option<PersonId>,
-    page: Option<i64>,
-    limit: Option<i64>,
-    hide_mod_names: bool,
-  ) -> Result<Vec<Self>, Error> {
-    let admin_person_id_join = mod_person_id.unwrap_or(PersonId(-1));
-    let show_mod_names = !hide_mod_names;
+  pub fn list(conn: &PgConnection, params: ModlogListParams) -> Result<Vec<Self>, Error> {
+    let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
+    let show_mod_names = !params.hide_modlog_names;
     let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
 
     let admin_names_join = mod_lock_post::mod_person_id
@@ -45,19 +37,19 @@ impl ModLockPostView {
       ))
       .into_boxed();
 
-    if let Some(community_id) = community_id {
+    if let Some(community_id) = params.community_id {
       query = query.filter(post::community_id.eq(community_id));
     };
 
-    if let Some(mod_person_id) = mod_person_id {
+    if let Some(mod_person_id) = params.mod_person_id {
       query = query.filter(mod_lock_post::mod_person_id.eq(mod_person_id));
     };
 
-    if let Some(other_person_id) = other_person_id {
+    if let Some(other_person_id) = params.other_person_id {
       query = query.filter(person_alias_1::id.eq(other_person_id));
     };
 
-    let (limit, offset) = limit_and_offset(page, limit)?;
+    let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
     let res = query
       .limit(limit)

--- a/crates/db_views_moderator/src/mod_lock_post_view.rs
+++ b/crates/db_views_moderator/src/mod_lock_post_view.rs
@@ -1,7 +1,7 @@
 use crate::structs::{ModLockPostView, ModlogListParams};
 use diesel::{result::Error, *};
 use lemmy_db_schema::{
-  newtypes::{CommunityId, PersonId},
+  newtypes::PersonId,
   schema::{community, mod_lock_post, person, person_alias_1, post},
   source::{
     community::{Community, CommunitySafe},

--- a/crates/db_views_moderator/src/mod_remove_comment_view.rs
+++ b/crates/db_views_moderator/src/mod_remove_comment_view.rs
@@ -1,7 +1,7 @@
 use crate::structs::{ModRemoveCommentView, ModlogListParams};
 use diesel::{result::Error, *};
 use lemmy_db_schema::{
-  newtypes::{CommunityId, PersonId},
+  newtypes::PersonId,
   schema::{comment, community, mod_remove_comment, person, person_alias_1, post},
   source::{
     comment::Comment,

--- a/crates/db_views_moderator/src/mod_remove_comment_view.rs
+++ b/crates/db_views_moderator/src/mod_remove_comment_view.rs
@@ -1,4 +1,4 @@
-use crate::structs::ModRemoveCommentView;
+use crate::structs::{ModRemoveCommentView, ModlogListParams};
 use diesel::{result::Error, *};
 use lemmy_db_schema::{
   newtypes::{CommunityId, PersonId},
@@ -24,17 +24,9 @@ type ModRemoveCommentViewTuple = (
 );
 
 impl ModRemoveCommentView {
-  pub fn list(
-    conn: &PgConnection,
-    community_id: Option<CommunityId>,
-    mod_person_id: Option<PersonId>,
-    other_person_id: Option<PersonId>,
-    page: Option<i64>,
-    limit: Option<i64>,
-    hide_mod_names: bool,
-  ) -> Result<Vec<Self>, Error> {
-    let admin_person_id_join = mod_person_id.unwrap_or(PersonId(-1));
-    let show_mod_names = !hide_mod_names;
+  pub fn list(conn: &PgConnection, params: ModlogListParams) -> Result<Vec<Self>, Error> {
+    let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
+    let show_mod_names = !params.hide_modlog_names;
     let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
 
     let admin_names_join = mod_remove_comment::mod_person_id
@@ -56,19 +48,19 @@ impl ModRemoveCommentView {
       ))
       .into_boxed();
 
-    if let Some(community_id) = community_id {
+    if let Some(community_id) = params.community_id {
       query = query.filter(post::community_id.eq(community_id));
     };
 
-    if let Some(mod_person_id) = mod_person_id {
+    if let Some(mod_person_id) = params.mod_person_id {
       query = query.filter(mod_remove_comment::mod_person_id.eq(mod_person_id));
     };
 
-    if let Some(other_person_id) = other_person_id {
+    if let Some(other_person_id) = params.other_person_id {
       query = query.filter(person_alias_1::id.eq(other_person_id));
     };
 
-    let (limit, offset) = limit_and_offset(page, limit)?;
+    let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
     let res = query
       .limit(limit)

--- a/crates/db_views_moderator/src/mod_remove_comment_view.rs
+++ b/crates/db_views_moderator/src/mod_remove_comment_view.rs
@@ -16,7 +16,7 @@ use lemmy_db_schema::{
 
 type ModRemoveCommentViewTuple = (
   ModRemoveComment,
-  PersonSafe,
+  Option<PersonSafe>,
   Comment,
   PersonSafeAlias1,
   Post,
@@ -28,18 +28,27 @@ impl ModRemoveCommentView {
     conn: &PgConnection,
     community_id: Option<CommunityId>,
     mod_person_id: Option<PersonId>,
+    other_person_id: Option<PersonId>,
     page: Option<i64>,
     limit: Option<i64>,
+    hide_mod_names: bool,
   ) -> Result<Vec<Self>, Error> {
+    let admin_person_id_join = mod_person_id.unwrap_or(PersonId(-1));
+    let show_mod_names = !hide_mod_names;
+    let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
+
+    let admin_names_join = mod_remove_comment::mod_person_id
+      .eq(person::id)
+      .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
     let mut query = mod_remove_comment::table
-      .inner_join(person::table)
+      .left_join(person::table.on(admin_names_join))
       .inner_join(comment::table)
       .inner_join(person_alias_1::table.on(comment::creator_id.eq(person_alias_1::id)))
       .inner_join(post::table.on(comment::post_id.eq(post::id)))
       .inner_join(community::table.on(post::community_id.eq(community::id)))
       .select((
         mod_remove_comment::all_columns,
-        Person::safe_columns_tuple(),
+        Person::safe_columns_tuple().nullable(),
         comment::all_columns,
         PersonAlias1::safe_columns_tuple(),
         post::all_columns,
@@ -55,6 +64,10 @@ impl ModRemoveCommentView {
       query = query.filter(mod_remove_comment::mod_person_id.eq(mod_person_id));
     };
 
+    if let Some(other_person_id) = other_person_id {
+      query = query.filter(person_alias_1::id.eq(other_person_id));
+    };
+
     let (limit, offset) = limit_and_offset(page, limit)?;
 
     let res = query
@@ -63,7 +76,8 @@ impl ModRemoveCommentView {
       .order_by(mod_remove_comment::when_.desc())
       .load::<ModRemoveCommentViewTuple>(conn)?;
 
-    Ok(Self::from_tuple_to_vec(res))
+    let results = Self::from_tuple_to_vec(res);
+    Ok(results)
   }
 }
 

--- a/crates/db_views_moderator/src/mod_remove_community_view.rs
+++ b/crates/db_views_moderator/src/mod_remove_community_view.rs
@@ -1,4 +1,4 @@
-use crate::structs::ModRemoveCommunityView;
+use crate::structs::{ModRemoveCommunityView, ModlogListParams};
 use diesel::{result::Error, *};
 use lemmy_db_schema::{
   newtypes::PersonId,
@@ -15,15 +15,9 @@ use lemmy_db_schema::{
 type ModRemoveCommunityTuple = (ModRemoveCommunity, Option<PersonSafe>, CommunitySafe);
 
 impl ModRemoveCommunityView {
-  pub fn list(
-    conn: &PgConnection,
-    mod_person_id: Option<PersonId>,
-    page: Option<i64>,
-    limit: Option<i64>,
-    hide_mod_names: bool,
-  ) -> Result<Vec<Self>, Error> {
-    let admin_person_id_join = mod_person_id.unwrap_or(PersonId(-1));
-    let show_mod_names = !hide_mod_names;
+  pub fn list(conn: &PgConnection, params: ModlogListParams) -> Result<Vec<Self>, Error> {
+    let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
+    let show_mod_names = !params.hide_modlog_names;
     let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
 
     let admin_names_join = mod_remove_community::mod_person_id
@@ -39,11 +33,11 @@ impl ModRemoveCommunityView {
       ))
       .into_boxed();
 
-    if let Some(mod_person_id) = mod_person_id {
+    if let Some(mod_person_id) = params.mod_person_id {
       query = query.filter(mod_remove_community::mod_person_id.eq(mod_person_id));
     };
 
-    let (limit, offset) = limit_and_offset(page, limit)?;
+    let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
     let res = query
       .limit(limit)

--- a/crates/db_views_moderator/src/mod_remove_post_view.rs
+++ b/crates/db_views_moderator/src/mod_remove_post_view.rs
@@ -2,7 +2,7 @@ use crate::structs::ModRemovePostView;
 use diesel::{result::Error, *};
 use lemmy_db_schema::{
   newtypes::{CommunityId, PersonId},
-  schema::{community, mod_remove_post, person, post},
+  schema::{community, mod_remove_post, person, person_alias_1, post},
   source::{
     community::{Community, CommunitySafe},
     moderator::ModRemovePost,
@@ -13,23 +13,33 @@ use lemmy_db_schema::{
   utils::limit_and_offset,
 };
 
-type ModRemovePostViewTuple = (ModRemovePost, PersonSafe, Post, CommunitySafe);
+type ModRemovePostViewTuple = (ModRemovePost, Option<PersonSafe>, Post, CommunitySafe);
 
 impl ModRemovePostView {
   pub fn list(
     conn: &PgConnection,
     community_id: Option<CommunityId>,
     mod_person_id: Option<PersonId>,
+    other_person_id: Option<PersonId>,
     page: Option<i64>,
     limit: Option<i64>,
+    hide_mod_names: bool,
   ) -> Result<Vec<Self>, Error> {
+    let admin_person_id_join = mod_person_id.unwrap_or(PersonId(-1));
+    let show_mod_names = !hide_mod_names;
+    let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
+
+    let admin_names_join = mod_remove_post::mod_person_id
+      .eq(person::id)
+      .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
     let mut query = mod_remove_post::table
-      .inner_join(person::table)
+      .left_join(person::table.on(admin_names_join))
       .inner_join(post::table)
       .inner_join(community::table.on(post::community_id.eq(community::id)))
+      .inner_join(person_alias_1::table.on(post::creator_id.eq(person_alias_1::id)))
       .select((
         mod_remove_post::all_columns,
-        Person::safe_columns_tuple(),
+        Person::safe_columns_tuple().nullable(),
         post::all_columns,
         Community::safe_columns_tuple(),
       ))
@@ -43,6 +53,10 @@ impl ModRemovePostView {
       query = query.filter(mod_remove_post::mod_person_id.eq(mod_person_id));
     };
 
+    if let Some(other_person_id) = other_person_id {
+      query = query.filter(person_alias_1::id.eq(other_person_id));
+    };
+
     let (limit, offset) = limit_and_offset(page, limit)?;
 
     let res = query
@@ -51,7 +65,8 @@ impl ModRemovePostView {
       .order_by(mod_remove_post::when_.desc())
       .load::<ModRemovePostViewTuple>(conn)?;
 
-    Ok(Self::from_tuple_to_vec(res))
+    let results = Self::from_tuple_to_vec(res);
+    Ok(results)
   }
 }
 

--- a/crates/db_views_moderator/src/mod_remove_post_view.rs
+++ b/crates/db_views_moderator/src/mod_remove_post_view.rs
@@ -1,4 +1,4 @@
-use crate::structs::ModRemovePostView;
+use crate::structs::{ModRemovePostView, ModlogListParams};
 use diesel::{result::Error, *};
 use lemmy_db_schema::{
   newtypes::{CommunityId, PersonId},
@@ -16,17 +16,9 @@ use lemmy_db_schema::{
 type ModRemovePostViewTuple = (ModRemovePost, Option<PersonSafe>, Post, CommunitySafe);
 
 impl ModRemovePostView {
-  pub fn list(
-    conn: &PgConnection,
-    community_id: Option<CommunityId>,
-    mod_person_id: Option<PersonId>,
-    other_person_id: Option<PersonId>,
-    page: Option<i64>,
-    limit: Option<i64>,
-    hide_mod_names: bool,
-  ) -> Result<Vec<Self>, Error> {
-    let admin_person_id_join = mod_person_id.unwrap_or(PersonId(-1));
-    let show_mod_names = !hide_mod_names;
+  pub fn list(conn: &PgConnection, params: ModlogListParams) -> Result<Vec<Self>, Error> {
+    let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
+    let show_mod_names = !params.hide_modlog_names;
     let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
 
     let admin_names_join = mod_remove_post::mod_person_id
@@ -45,19 +37,19 @@ impl ModRemovePostView {
       ))
       .into_boxed();
 
-    if let Some(community_id) = community_id {
+    if let Some(community_id) = params.community_id {
       query = query.filter(post::community_id.eq(community_id));
     };
 
-    if let Some(mod_person_id) = mod_person_id {
+    if let Some(mod_person_id) = params.mod_person_id {
       query = query.filter(mod_remove_post::mod_person_id.eq(mod_person_id));
     };
 
-    if let Some(other_person_id) = other_person_id {
+    if let Some(other_person_id) = params.other_person_id {
       query = query.filter(person_alias_1::id.eq(other_person_id));
     };
 
-    let (limit, offset) = limit_and_offset(page, limit)?;
+    let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
     let res = query
       .limit(limit)

--- a/crates/db_views_moderator/src/mod_remove_post_view.rs
+++ b/crates/db_views_moderator/src/mod_remove_post_view.rs
@@ -1,7 +1,7 @@
 use crate::structs::{ModRemovePostView, ModlogListParams};
 use diesel::{result::Error, *};
 use lemmy_db_schema::{
-  newtypes::{CommunityId, PersonId},
+  newtypes::PersonId,
   schema::{community, mod_remove_post, person, person_alias_1, post},
   source::{
     community::{Community, CommunitySafe},

--- a/crates/db_views_moderator/src/mod_sticky_post_view.rs
+++ b/crates/db_views_moderator/src/mod_sticky_post_view.rs
@@ -1,4 +1,4 @@
-use crate::structs::ModStickyPostView;
+use crate::structs::{ModStickyPostView, ModlogListParams};
 use diesel::{result::Error, *};
 use lemmy_db_schema::{
   newtypes::{CommunityId, PersonId},
@@ -16,17 +16,9 @@ use lemmy_db_schema::{
 type ModStickyPostViewTuple = (ModStickyPost, Option<PersonSafe>, Post, CommunitySafe);
 
 impl ModStickyPostView {
-  pub fn list(
-    conn: &PgConnection,
-    community_id: Option<CommunityId>,
-    mod_person_id: Option<PersonId>,
-    other_person_id: Option<PersonId>,
-    page: Option<i64>,
-    limit: Option<i64>,
-    hide_mod_names: bool,
-  ) -> Result<Vec<Self>, Error> {
-    let admin_person_id_join = mod_person_id.unwrap_or(PersonId(-1));
-    let show_mod_names = !hide_mod_names;
+  pub fn list(conn: &PgConnection, params: ModlogListParams) -> Result<Vec<Self>, Error> {
+    let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
+    let show_mod_names = !params.hide_modlog_names;
     let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
 
     let admin_names_join = mod_sticky_post::mod_person_id
@@ -45,19 +37,19 @@ impl ModStickyPostView {
       ))
       .into_boxed();
 
-    if let Some(community_id) = community_id {
+    if let Some(community_id) = params.community_id {
       query = query.filter(post::community_id.eq(community_id));
     };
 
-    if let Some(mod_person_id) = mod_person_id {
+    if let Some(mod_person_id) = params.mod_person_id {
       query = query.filter(mod_sticky_post::mod_person_id.eq(mod_person_id));
     };
 
-    if let Some(other_person_id) = other_person_id {
+    if let Some(other_person_id) = params.other_person_id {
       query = query.filter(person_alias_1::id.eq(other_person_id));
     };
 
-    let (limit, offset) = limit_and_offset(page, limit)?;
+    let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
     let res = query
       .limit(limit)

--- a/crates/db_views_moderator/src/mod_sticky_post_view.rs
+++ b/crates/db_views_moderator/src/mod_sticky_post_view.rs
@@ -1,7 +1,7 @@
 use crate::structs::{ModStickyPostView, ModlogListParams};
 use diesel::{result::Error, *};
 use lemmy_db_schema::{
-  newtypes::{CommunityId, PersonId},
+  newtypes::PersonId,
   schema::{community, mod_sticky_post, person, person_alias_1, post},
   source::{
     community::{Community, CommunitySafe},

--- a/crates/db_views_moderator/src/mod_sticky_post_view.rs
+++ b/crates/db_views_moderator/src/mod_sticky_post_view.rs
@@ -2,7 +2,7 @@ use crate::structs::ModStickyPostView;
 use diesel::{result::Error, *};
 use lemmy_db_schema::{
   newtypes::{CommunityId, PersonId},
-  schema::{community, mod_sticky_post, person, post},
+  schema::{community, mod_sticky_post, person, person_alias_1, post},
   source::{
     community::{Community, CommunitySafe},
     moderator::ModStickyPost,
@@ -13,23 +13,33 @@ use lemmy_db_schema::{
   utils::limit_and_offset,
 };
 
-type ModStickyPostViewTuple = (ModStickyPost, PersonSafe, Post, CommunitySafe);
+type ModStickyPostViewTuple = (ModStickyPost, Option<PersonSafe>, Post, CommunitySafe);
 
 impl ModStickyPostView {
   pub fn list(
     conn: &PgConnection,
     community_id: Option<CommunityId>,
     mod_person_id: Option<PersonId>,
+    other_person_id: Option<PersonId>,
     page: Option<i64>,
     limit: Option<i64>,
+    hide_mod_names: bool,
   ) -> Result<Vec<Self>, Error> {
+    let admin_person_id_join = mod_person_id.unwrap_or(PersonId(-1));
+    let show_mod_names = !hide_mod_names;
+    let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
+
+    let admin_names_join = mod_sticky_post::mod_person_id
+      .eq(person::id)
+      .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
     let mut query = mod_sticky_post::table
-      .inner_join(person::table)
+      .left_join(person::table.on(admin_names_join))
       .inner_join(post::table)
+      .inner_join(person_alias_1::table.on(post::creator_id.eq(person_alias_1::id)))
       .inner_join(community::table.on(post::community_id.eq(community::id)))
       .select((
         mod_sticky_post::all_columns,
-        Person::safe_columns_tuple(),
+        Person::safe_columns_tuple().nullable(),
         post::all_columns,
         Community::safe_columns_tuple(),
       ))
@@ -43,6 +53,10 @@ impl ModStickyPostView {
       query = query.filter(mod_sticky_post::mod_person_id.eq(mod_person_id));
     };
 
+    if let Some(other_person_id) = other_person_id {
+      query = query.filter(person_alias_1::id.eq(other_person_id));
+    };
+
     let (limit, offset) = limit_and_offset(page, limit)?;
 
     let res = query
@@ -51,7 +65,8 @@ impl ModStickyPostView {
       .order_by(mod_sticky_post::when_.desc())
       .load::<ModStickyPostViewTuple>(conn)?;
 
-    Ok(Self::from_tuple_to_vec(res))
+    let results = Self::from_tuple_to_vec(res);
+    Ok(results)
   }
 }
 

--- a/crates/db_views_moderator/src/mod_transfer_community_view.rs
+++ b/crates/db_views_moderator/src/mod_transfer_community_view.rs
@@ -1,4 +1,4 @@
-use crate::structs::ModTransferCommunityView;
+use crate::structs::{ModTransferCommunityView, ModlogListParams};
 use diesel::{result::Error, *};
 use lemmy_db_schema::{
   newtypes::{CommunityId, PersonId},
@@ -20,17 +20,9 @@ type ModTransferCommunityViewTuple = (
 );
 
 impl ModTransferCommunityView {
-  pub fn list(
-    conn: &PgConnection,
-    community_id: Option<CommunityId>,
-    mod_person_id: Option<PersonId>,
-    other_person_id: Option<PersonId>,
-    page: Option<i64>,
-    limit: Option<i64>,
-    hide_mod_names: bool,
-  ) -> Result<Vec<Self>, Error> {
-    let admin_person_id_join = mod_person_id.unwrap_or(PersonId(-1));
-    let show_mod_names = !hide_mod_names;
+  pub fn list(conn: &PgConnection, params: ModlogListParams) -> Result<Vec<Self>, Error> {
+    let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
+    let show_mod_names = !params.hide_modlog_names;
     let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
 
     let admin_names_join = mod_transfer_community::mod_person_id
@@ -50,19 +42,19 @@ impl ModTransferCommunityView {
       ))
       .into_boxed();
 
-    if let Some(mod_person_id) = mod_person_id {
+    if let Some(mod_person_id) = params.mod_person_id {
       query = query.filter(mod_transfer_community::mod_person_id.eq(mod_person_id));
     };
 
-    if let Some(community_id) = community_id {
+    if let Some(community_id) = params.community_id {
       query = query.filter(mod_transfer_community::community_id.eq(community_id));
     };
 
-    if let Some(other_person_id) = other_person_id {
+    if let Some(other_person_id) = params.other_person_id {
       query = query.filter(person_alias_1::id.eq(other_person_id));
     };
 
-    let (limit, offset) = limit_and_offset(page, limit)?;
+    let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
     let res = query
       .limit(limit)

--- a/crates/db_views_moderator/src/mod_transfer_community_view.rs
+++ b/crates/db_views_moderator/src/mod_transfer_community_view.rs
@@ -14,7 +14,7 @@ use lemmy_db_schema::{
 
 type ModTransferCommunityViewTuple = (
   ModTransferCommunity,
-  PersonSafe,
+  Option<PersonSafe>,
   CommunitySafe,
   PersonSafeAlias1,
 );
@@ -24,18 +24,27 @@ impl ModTransferCommunityView {
     conn: &PgConnection,
     community_id: Option<CommunityId>,
     mod_person_id: Option<PersonId>,
+    other_person_id: Option<PersonId>,
     page: Option<i64>,
     limit: Option<i64>,
+    hide_mod_names: bool,
   ) -> Result<Vec<Self>, Error> {
+    let admin_person_id_join = mod_person_id.unwrap_or(PersonId(-1));
+    let show_mod_names = !hide_mod_names;
+    let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
+
+    let admin_names_join = mod_transfer_community::mod_person_id
+      .eq(person::id)
+      .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
     let mut query = mod_transfer_community::table
-      .inner_join(person::table.on(mod_transfer_community::mod_person_id.eq(person::id)))
+      .left_join(person::table.on(admin_names_join))
       .inner_join(community::table)
       .inner_join(
         person_alias_1::table.on(mod_transfer_community::other_person_id.eq(person_alias_1::id)),
       )
       .select((
         mod_transfer_community::all_columns,
-        Person::safe_columns_tuple(),
+        Person::safe_columns_tuple().nullable(),
         Community::safe_columns_tuple(),
         PersonAlias1::safe_columns_tuple(),
       ))
@@ -49,6 +58,10 @@ impl ModTransferCommunityView {
       query = query.filter(mod_transfer_community::community_id.eq(community_id));
     };
 
+    if let Some(other_person_id) = other_person_id {
+      query = query.filter(person_alias_1::id.eq(other_person_id));
+    };
+
     let (limit, offset) = limit_and_offset(page, limit)?;
 
     let res = query
@@ -57,7 +70,8 @@ impl ModTransferCommunityView {
       .order_by(mod_transfer_community::when_.desc())
       .load::<ModTransferCommunityViewTuple>(conn)?;
 
-    Ok(Self::from_tuple_to_vec(res))
+    let results = Self::from_tuple_to_vec(res);
+    Ok(results)
   }
 }
 

--- a/crates/db_views_moderator/src/mod_transfer_community_view.rs
+++ b/crates/db_views_moderator/src/mod_transfer_community_view.rs
@@ -1,7 +1,7 @@
 use crate::structs::{ModTransferCommunityView, ModlogListParams};
 use diesel::{result::Error, *};
 use lemmy_db_schema::{
-  newtypes::{CommunityId, PersonId},
+  newtypes::PersonId,
   schema::{community, mod_transfer_community, person, person_alias_1},
   source::{
     community::{Community, CommunitySafe},

--- a/crates/db_views_moderator/src/structs.rs
+++ b/crates/db_views_moderator/src/structs.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ModAddCommunityView {
   pub mod_add_community: ModAddCommunity,
-  pub moderator: PersonSafe,
+  pub moderator: Option<PersonSafe>,
   pub community: CommunitySafe,
   pub modded_person: PersonSafeAlias1,
 }
@@ -34,14 +34,14 @@ pub struct ModAddCommunityView {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ModAddView {
   pub mod_add: ModAdd,
-  pub moderator: PersonSafe,
+  pub moderator: Option<PersonSafe>,
   pub modded_person: PersonSafeAlias1,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ModBanFromCommunityView {
   pub mod_ban_from_community: ModBanFromCommunity,
-  pub moderator: PersonSafe,
+  pub moderator: Option<PersonSafe>,
   pub community: CommunitySafe,
   pub banned_person: PersonSafeAlias1,
 }
@@ -49,21 +49,21 @@ pub struct ModBanFromCommunityView {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ModBanView {
   pub mod_ban: ModBan,
-  pub moderator: PersonSafe,
+  pub moderator: Option<PersonSafe>,
   pub banned_person: PersonSafeAlias1,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ModHideCommunityView {
   pub mod_hide_community: ModHideCommunity,
-  pub admin: PersonSafe,
+  pub admin: Option<PersonSafe>,
   pub community: CommunitySafe,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ModLockPostView {
   pub mod_lock_post: ModLockPost,
-  pub moderator: PersonSafe,
+  pub moderator: Option<PersonSafe>,
   pub post: Post,
   pub community: CommunitySafe,
 }
@@ -71,7 +71,7 @@ pub struct ModLockPostView {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ModRemoveCommentView {
   pub mod_remove_comment: ModRemoveComment,
-  pub moderator: PersonSafe,
+  pub moderator: Option<PersonSafe>,
   pub comment: Comment,
   pub commenter: PersonSafeAlias1,
   pub post: Post,
@@ -81,14 +81,14 @@ pub struct ModRemoveCommentView {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ModRemoveCommunityView {
   pub mod_remove_community: ModRemoveCommunity,
-  pub moderator: PersonSafe,
+  pub moderator: Option<PersonSafe>,
   pub community: CommunitySafe,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ModRemovePostView {
   pub mod_remove_post: ModRemovePost,
-  pub moderator: PersonSafe,
+  pub moderator: Option<PersonSafe>,
   pub post: Post,
   pub community: CommunitySafe,
 }
@@ -96,7 +96,7 @@ pub struct ModRemovePostView {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ModStickyPostView {
   pub mod_sticky_post: ModStickyPost,
-  pub moderator: PersonSafe,
+  pub moderator: Option<PersonSafe>,
   pub post: Post,
   pub community: CommunitySafe,
 }
@@ -104,7 +104,7 @@ pub struct ModStickyPostView {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ModTransferCommunityView {
   pub mod_transfer_community: ModTransferCommunity,
-  pub moderator: PersonSafe,
+  pub moderator: Option<PersonSafe>,
   pub community: CommunitySafe,
   pub modded_person: PersonSafeAlias1,
 }
@@ -112,25 +112,25 @@ pub struct ModTransferCommunityView {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct AdminPurgeCommentView {
   pub admin_purge_comment: AdminPurgeComment,
-  pub admin: PersonSafe,
+  pub admin: Option<PersonSafe>,
   pub post: Post,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct AdminPurgeCommunityView {
   pub admin_purge_community: AdminPurgeCommunity,
-  pub admin: PersonSafe,
+  pub admin: Option<PersonSafe>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct AdminPurgePersonView {
   pub admin_purge_person: AdminPurgePerson,
-  pub admin: PersonSafe,
+  pub admin: Option<PersonSafe>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct AdminPurgePostView {
   pub admin_purge_post: AdminPurgePost,
-  pub admin: PersonSafe,
+  pub admin: Option<PersonSafe>,
   pub community: CommunitySafe,
 }

--- a/crates/db_views_moderator/src/structs.rs
+++ b/crates/db_views_moderator/src/structs.rs
@@ -1,25 +1,28 @@
-use lemmy_db_schema::source::{
-  comment::Comment,
-  community::CommunitySafe,
-  moderator::{
-    AdminPurgeComment,
-    AdminPurgeCommunity,
-    AdminPurgePerson,
-    AdminPurgePost,
-    ModAdd,
-    ModAddCommunity,
-    ModBan,
-    ModBanFromCommunity,
-    ModHideCommunity,
-    ModLockPost,
-    ModRemoveComment,
-    ModRemoveCommunity,
-    ModRemovePost,
-    ModStickyPost,
-    ModTransferCommunity,
+use lemmy_db_schema::{
+  newtypes::{CommunityId, PersonId},
+  source::{
+    comment::Comment,
+    community::CommunitySafe,
+    moderator::{
+      AdminPurgeComment,
+      AdminPurgeCommunity,
+      AdminPurgePerson,
+      AdminPurgePost,
+      ModAdd,
+      ModAddCommunity,
+      ModBan,
+      ModBanFromCommunity,
+      ModHideCommunity,
+      ModLockPost,
+      ModRemoveComment,
+      ModRemoveCommunity,
+      ModRemovePost,
+      ModStickyPost,
+      ModTransferCommunity,
+    },
+    person::{PersonSafe, PersonSafeAlias1},
+    post::Post,
   },
-  person::{PersonSafe, PersonSafeAlias1},
-  post::Post,
 };
 use serde::{Deserialize, Serialize};
 
@@ -133,4 +136,14 @@ pub struct AdminPurgePostView {
   pub admin_purge_post: AdminPurgePost,
   pub admin: Option<PersonSafe>,
   pub community: CommunitySafe,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
+pub struct ModlogListParams {
+  pub community_id: Option<CommunityId>,
+  pub mod_person_id: Option<PersonId>,
+  pub other_person_id: Option<PersonId>,
+  pub page: Option<i64>,
+  pub limit: Option<i64>,
+  pub hide_modlog_names: bool,
 }

--- a/migrations/2022-06-12-012121_add_site_hide_modlog_names/down.sql
+++ b/migrations/2022-06-12-012121_add_site_hide_modlog_names/down.sql
@@ -1,0 +1,1 @@
+alter table site drop column hide_modlog_mod_names;

--- a/migrations/2022-06-12-012121_add_site_hide_modlog_names/up.sql
+++ b/migrations/2022-06-12-012121_add_site_hide_modlog_names/up.sql
@@ -1,0 +1,1 @@
+alter table site add column hide_modlog_mod_names boolean default true NOT NULL;

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,7 @@ async fn main() -> Result<(), LemmyError> {
   let manager = ConnectionManager::<PgConnection>::new(&db_url);
   let pool = Pool::builder()
     .max_size(settings.database.pool_size)
+    .min_idle(Some(1))
     .build(manager)
     .unwrap_or_else(|_| panic!("Error connecting to {}", db_url));
 


### PR DESCRIPTION
Addresses issue: https://github.com/LemmyNet/lemmy-ui/issues/555

In summary, this PR does the following:
* (minor) fixes running on windows build
* Adds three new filter inputs to the Modlog: Action, Mod, and User
* Adds new setting to Site: Hide modlog mod names (default true). Hides the mod names on the mod log page (front and backend)
* Adds a generic dropdown component for general use (derived from the navbar user dropdown, could eventually be refactored to use new component)


Associated PRs:
* https://github.com/LemmyNet/lemmy-ui/pull/682
* https://github.com/LemmyNet/lemmy-js-client/pull/65
* https://github.com/LemmyNet/lemmy-translations/pull/27


![image](https://user-images.githubusercontent.com/4389156/174458955-eaf92599-81cf-4f07-bab2-10bf1756f526.png)
![image](https://user-images.githubusercontent.com/4389156/174458959-9fc59e13-8860-4eb2-90f4-3d7ab715efed.png)


Site:
![image](https://user-images.githubusercontent.com/4389156/173270477-73edbeb6-6cf5-4eda-b8ac-2f17ac0ad672.png)

