### PR TITLE
Move setting http_fetch_retry_limit into federation block

### DIFF
--- a/config/defaults.hjson
+++ b/config/defaults.hjson
@@ -62,6 +62,8 @@
     # use allowlist only for remote communities, and posts/comments in local communities
     # (meaning remote communities will show content from arbitrary instances).
     strict_allowlist: true
+    # Maximum number of HTTP requests allowed to handle a single incoming activity (or a single object fetch through the search).
+    http_fetch_retry_limit: 25
     # Number of workers for sending outgoing activities. Search logs for Activity queue stats to
     # see information. If running number is consistently close to the worker_count, you should
     # increase it.
@@ -119,6 +121,4 @@
   slur_filter: "(\bThis\b)|(\bis\b)|(\bsample\b)"
   # Maximum length of local community and user names
   actor_name_max_length: 20
-  # Maximum number of HTTP requests allowed to handle a single incoming activity (or a single object fetch through the search).
-  http_fetch_retry_limit: 25
 }

--- a/crates/apub/src/fetcher/webfinger.rs
+++ b/crates/apub/src/fetcher/webfinger.rs
@@ -47,7 +47,7 @@ where
   debug!("Fetching webfinger url: {}", &fetch_url);
 
   *request_counter += 1;
-  if *request_counter > context.settings().http_fetch_retry_limit {
+  if *request_counter > context.settings().federation.http_fetch_retry_limit {
     return Err(LemmyError::from_message("Request retry limit reached"));
   }
 

--- a/crates/apub/src/lib.rs
+++ b/crates/apub/src/lib.rs
@@ -31,7 +31,7 @@ fn local_instance(context: &LemmyContext) -> &'static LocalInstance {
   static LOCAL_INSTANCE: OnceCell<LocalInstance> = OnceCell::new();
   LOCAL_INSTANCE.get_or_init(|| {
     let settings = InstanceSettingsBuilder::default()
-      .http_fetch_retry_limit(context.settings().http_fetch_retry_limit)
+      .http_fetch_retry_limit(context.settings().federation.http_fetch_retry_limit)
       .worker_count(context.settings().federation.worker_count)
       .debug(context.settings().federation.debug)
       .verify_url_function(|url| check_apub_id_valid(url, &Settings::get()))

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -46,9 +46,6 @@ pub struct Settings {
   /// Maximum length of local community and user names
   #[default(20)]
   pub actor_name_max_length: usize,
-  /// Maximum number of HTTP requests allowed to handle a single incoming activity (or a single object fetch through the search).
-  #[default(25)]
-  pub http_fetch_retry_limit: i32,
 
   /// Set the URL for opentelemetry exports. If you do not have an opentelemetry collector, do not set this option
   #[default(None)]
@@ -142,6 +139,9 @@ pub struct FederationConfig {
   /// (meaning remote communities will show content from arbitrary instances).
   #[default(true)]
   pub strict_allowlist: bool,
+  /// Maximum number of HTTP requests allowed to handle a single incoming activity (or a single object fetch through the search).
+  #[default(25)]
+  pub http_fetch_retry_limit: i32,
   /// Number of workers for sending outgoing activities. Search logs for "Activity queue stats" to
   /// see information. If "running" number is consistently close to the worker_count, you should
   /// increase it.


### PR DESCRIPTION
This is used only for federation, and shouldnt be in the general config block.