### PR TITLE
Use correct url for activitystreams protocol context

### DIFF
--- a/crates/apub/assets/lemmy/context.json
+++ b/crates/apub/assets/lemmy/context.json
@@ -1,5 +1,5 @@
 [
-  "https://www.w3.org/ns/activitystreams",
+  "https://www.w3.org/ns/activitystreams#",
   "https://w3id.org/security/v1",
   {
     "lemmy": "https://join-lemmy.org/ns#",


### PR DESCRIPTION
Apparently the trailing `#` is mandatory.

https://socialhub.activitypub.rocks/t/we-have-created-documentation-on-how-exactly-lemmy-federation-works/1085/39