### PR TITLE
Specify minimum Rust version 1.57 (fixes #2333)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -23,9 +23,8 @@ steps:
       - /root/.cargo/bin/cargo fmt -- --check
 
   - name: cargo clippy
-    image: clux/muslrust:1.60.0
+    image: clux/muslrust:1.61.0
     commands:
-      - rustup component add clippy
       - cargo clippy --workspace --tests --all-targets --all-features -- -D warnings -D deprecated -D clippy::perf -D clippy::complexity -D clippy::dbg_macro
       - cargo clippy --workspace -- -D clippy::unwrap_used
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -23,8 +23,9 @@ steps:
       - /root/.cargo/bin/cargo fmt -- --check
 
   - name: cargo clippy
-    image: clux/muslrust:1.61.0
+    image: rust:1.61-buster
     commands:
+      - rustup component add clippy
       - cargo clippy --workspace --tests --all-targets --all-features -- -D warnings -D deprecated -D clippy::perf -D clippy::complexity -D clippy::dbg_macro
       - cargo clippy --workspace -- -D clippy::unwrap_used
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -23,7 +23,7 @@ steps:
       - /root/.cargo/bin/cargo fmt -- --check
 
   - name: cargo clippy
-    image: clux/muslrust:1.61.0
+    image: clux/muslrust:1.60.0
     commands:
       - rustup component add clippy
       - cargo clippy --workspace --tests --all-targets --all-features -- -D warnings -D deprecated -D clippy::perf -D clippy::complexity -D clippy::dbg_macro

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,7 @@ platform:
 
 steps:
 
+  # use minimum supported rust version for most steps
   - name: prepare repo
     image: clux/muslrust:1.57.0
     user: root
@@ -22,6 +23,7 @@ steps:
     commands:
       - /root/.cargo/bin/cargo fmt -- --check
 
+  # latest rust for clippy to get extra checks
   - name: cargo clippy
     image: rust:1.61-buster
     commands:

--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ platform:
 steps:
 
   - name: prepare repo
-    image: clux/muslrust:1.59.0
+    image: clux/muslrust:1.57.0
     user: root
     commands:
       - git fetch --tags
@@ -23,14 +23,14 @@ steps:
       - /root/.cargo/bin/cargo fmt -- --check
 
   - name: cargo clippy
-    image: clux/muslrust:1.59.0
+    image: clux/muslrust:1.57.0
     commands:
       - rustup component add clippy
       - cargo clippy --workspace --tests --all-targets --all-features -- -D warnings -D deprecated -D clippy::perf -D clippy::complexity -D clippy::dbg_macro
       - cargo clippy --workspace -- -D clippy::unwrap_used
 
   - name: cargo test
-    image: clux/muslrust:1.59.0
+    image: clux/muslrust:1.57.0
     environment:
       LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
       LEMMY_CONFIG_LOCATION: ../../config/config.hjson
@@ -42,20 +42,20 @@ steps:
       - cargo test --workspace --no-fail-fast
 
   - name: check defaults.hjson updated
-    image: clux/muslrust:1.59.0
+    image: clux/muslrust:1.57.0
     commands:
       - ./scripts/update_config_defaults.sh config/defaults_current.hjson
       - diff config/defaults.hjson config/defaults_current.hjson
 
   - name: check with different features
-    image: clux/muslrust:1.59.0
+    image: clux/muslrust:1.57.0
     commands:
       - cargo install cargo-workspaces
       - cargo workspaces exec cargo check --no-default-features
       - cargo workspaces exec cargo check --all-features
 
   - name: cargo build
-    image: clux/muslrust:1.59.0
+    image: clux/muslrust:1.57.0
     commands:
       - cargo build
       - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server
@@ -169,7 +169,7 @@ platform:
 steps:
 
   - name: prepare repo
-    image: rust:1.60-slim
+    image: rust:1.57-slim
     user: root
     commands:
       - chown 1000:1000 . -R
@@ -181,7 +181,7 @@ steps:
 
   # TODO temporarily disable arm tests
   # - name: cargo test
-  #   image: rust:1.60-slim
+  #   image: rust:1.57-slim
   #   environment:
   #     LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
   #     LEMMY_CONFIG_LOCATION: ../../config/config.hjson
@@ -196,7 +196,7 @@ steps:
   # TODO temporarily disable arm tests
   # Using Debian here because there seems to be no official Alpine-based Rust docker image for ARM.
   # - name: cargo build
-  #   image: rust:1.60-slim
+  #   image: rust:1.57-slim
   #   commands:
   #     - apt-get update
   #     - apt-get -y install --no-install-recommends libssl-dev pkg-config libpq-dev

--- a/.drone.yml
+++ b/.drone.yml
@@ -23,7 +23,7 @@ steps:
       - /root/.cargo/bin/cargo fmt -- --check
 
   - name: cargo clippy
-    image: clux/muslrust:1.57.0
+    image: clux/muslrust:1.61.0
     commands:
       - rustup component add clippy
       - cargo clippy --workspace --tests --all-targets --all-features -- -D warnings -D deprecated -D clippy::perf -D clippy::complexity -D clippy::dbg_macro

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
 homepage = "https://join-lemmy.org/"
 documentation = "https://join-lemmy.org/docs/en/index.html"
+rust-version = "1.57"
 
 [lib]
 doctest = false

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -6,6 +6,7 @@ description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
 homepage = "https://join-lemmy.org/"
 documentation = "https://join-lemmy.org/docs/en/index.html"
+rust-version = "1.57"
 
 [lib]
 name = "lemmy_api"

--- a/crates/api_common/Cargo.toml
+++ b/crates/api_common/Cargo.toml
@@ -6,6 +6,7 @@ description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
 homepage = "https://join-lemmy.org/"
 documentation = "https://join-lemmy.org/docs/en/index.html"
+rust-version = "1.57"
 
 [lib]
 name = "lemmy_api_common"

--- a/crates/api_crud/Cargo.toml
+++ b/crates/api_crud/Cargo.toml
@@ -6,6 +6,7 @@ description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
 homepage = "https://join-lemmy.org/"
 documentation = "https://join-lemmy.org/docs/en/index.html"
+rust-version = "1.57"
 
 [dependencies]
 lemmy_apub = { version = "=0.16.5", path = "../apub" }

--- a/crates/apub/Cargo.toml
+++ b/crates/apub/Cargo.toml
@@ -6,6 +6,7 @@ description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
 homepage = "https://join-lemmy.org/"
 documentation = "https://join-lemmy.org/docs/en/index.html"
+rust-version = "1.57"
 
 [lib]
 name = "lemmy_apub"

--- a/crates/db_schema/Cargo.toml
+++ b/crates/db_schema/Cargo.toml
@@ -6,6 +6,7 @@ description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
 homepage = "https://join-lemmy.org/"
 documentation = "https://join-lemmy.org/docs/en/index.html"
+rust-version = "1.57"
 
 [lib]
 name = "lemmy_db_schema"

--- a/crates/db_views/Cargo.toml
+++ b/crates/db_views/Cargo.toml
@@ -6,6 +6,7 @@ description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
 homepage = "https://join-lemmy.org/"
 documentation = "https://join-lemmy.org/docs/en/index.html"
+rust-version = "1.57"
 
 [lib]
 doctest = false

--- a/crates/db_views_actor/Cargo.toml
+++ b/crates/db_views_actor/Cargo.toml
@@ -6,6 +6,7 @@ description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
 homepage = "https://join-lemmy.org/"
 documentation = "https://join-lemmy.org/docs/en/index.html"
+rust-version = "1.57"
 
 [lib]
 doctest = false

--- a/crates/db_views_moderator/Cargo.toml
+++ b/crates/db_views_moderator/Cargo.toml
@@ -6,6 +6,7 @@ description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
 homepage = "https://join-lemmy.org/"
 documentation = "https://join-lemmy.org/docs/en/index.html"
+rust-version = "1.57"
 
 [lib]
 doctest = false

--- a/crates/routes/Cargo.toml
+++ b/crates/routes/Cargo.toml
@@ -6,6 +6,7 @@ description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
 homepage = "https://join-lemmy.org/"
 documentation = "https://join-lemmy.org/docs/en/index.html"
+rust-version = "1.57"
 
 [lib]
 doctest = false

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -6,6 +6,7 @@ description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
 homepage = "https://join-lemmy.org/"
 documentation = "https://join-lemmy.org/docs/en/index.html"
+rust-version = "1.57"
 
 [lib]
 name = "lemmy_utils"

--- a/crates/websocket/Cargo.toml
+++ b/crates/websocket/Cargo.toml
@@ -6,6 +6,7 @@ description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
 homepage = "https://join-lemmy.org/"
 documentation = "https://join-lemmy.org/docs/en/index.html"
+rust-version = "1.57"
 
 [lib]
 name = "lemmy_websocket"


### PR DESCRIPTION
Tested this, with 1.56 it doesnt compile, but 1.57 works. Only disadvantage is that the older compiler might give worse error outputs, and might have less clippy lints.