### PR TITLE
Dont allow blocking admin

### DIFF
--- a/crates/api/src/local_user/block.rs
+++ b/crates/api/src/local_user/block.rs
@@ -39,6 +39,15 @@ impl Perform for BlockPerson {
       target_id,
     };
 
+    let target_person_view = blocking(context.pool(), move |conn| {
+      PersonViewSafe::read(conn, target_id)
+    })
+    .await??;
+
+    if target_person_view.person.admin {
+      return Err(LemmyError::from_message("cant_block_admin"));
+    }
+
     if data.block {
       let block = move |conn: &'_ _| PersonBlock::block(conn, &person_block_form);
       blocking(context.pool(), block)
@@ -51,13 +60,8 @@ impl Perform for BlockPerson {
         .map_err(|e| LemmyError::from_error_message(e, "person_block_already_exists"))?;
     }
 
-    let person_view = blocking(context.pool(), move |conn| {
-      PersonViewSafe::read(conn, target_id)
-    })
-    .await??;
-
     let res = BlockPersonResponse {
-      person_view,
+      person_view: target_person_view,
       blocked: data.block,
     };
 


### PR DESCRIPTION
As mentioned by ex_06 in admin chat, it doesnt really make sense that users can block admins, because it completely interferes with moderation.