### PR TITLE
Change config pictrs key name

### DIFF
--- a/config/defaults.hjson
+++ b/config/defaults.hjson
@@ -73,7 +73,7 @@
     debug: false
   }
   # Pictrs image server configuration.
-  pictrs_config: {
+  pictrs: {
     # Address where pictrs is available (for image hosting)
     url: "http://pictrs:8080/"
     # Set a custom pictrs API key. ( Required for deleting images )

--- a/crates/utils/src/settings/mod.rs
+++ b/crates/utils/src/settings/mod.rs
@@ -101,7 +101,7 @@ impl Settings {
 
   pub fn pictrs_config(&self) -> Result<PictrsConfig, LemmyError> {
     self
-      .pictrs_config
+      .pictrs
       .to_owned()
       .ok_or_else(|| anyhow!("images_disabled").into())
   }

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -17,7 +17,7 @@ pub struct Settings {
   pub federation: FederationConfig,
   /// Pictrs image server configuration.
   #[default(Some(Default::default()))]
-  pub(crate) pictrs_config: Option<PictrsConfig>,
+  pub(crate) pictrs: Option<PictrsConfig>,
   #[default(Default::default())]
   pub captcha: CaptchaConfig,
   /// Email sending configuration. All options except login/password are mandatory
@@ -61,7 +61,7 @@ pub struct Settings {
 pub struct PictrsConfig {
   /// Address where pictrs is available (for image hosting)
   #[default(Url::parse("http://pictrs:8080").expect("parse pictrs url"))]
-  #[doku(example = "Url::parse(\"http://pictrs:8080\").unwrap()")]
+  #[doku(example = "http://pictrs:8080")]
   pub url: Url,
 
   /// Set a custom pictrs API key. ( Required for deleting images )


### PR DESCRIPTION
No need to call the key `pictrs_config` when its clear that its part of the config, and no other key is named in that way.