### PR TITLE
Fix follow being stuck as pending after accept

### DIFF
--- a/api_tests/src/follow.spec.ts
+++ b/api_tests/src/follow.spec.ts
@@ -26,13 +26,10 @@ test('Follow federated community', async () => {
     betaCommunity.community.id
   );
 
-  // Wait for it to accept on the alpha side ( follows are async )
-  await delay();
-
   // Make sure the follow response went through
   expect(follow.community_view.community.local).toBe(false);
   expect(follow.community_view.community.name).toBe('main');
-  expect(follow.community_view.subscribed).toBe(SubscribedType.Pending);
+  expect(follow.community_view.subscribed).toBe(SubscribedType.Subscribed);
 
   // Check it from local
   let site = await getSite(alpha);

--- a/crates/db_schema/src/impls/community.rs
+++ b/crates/db_schema/src/impls/community.rs
@@ -294,7 +294,7 @@ impl Followable for CommunityFollower {
         .filter(community_id.eq(community_id_))
         .filter(person_id.eq(person_id_)),
     )
-    .set(pending.eq(true))
+    .set(pending.eq(false))
     .get_result::<Self>(conn)
   }
   fn unfollow(


### PR DESCRIPTION
This should fix it, though i couldnt test properly because lemmy-ui 0.16.5 cant handle the new subscribed values.