### PR TITLE
Fix panics in search_by_apub_id() (fixes #2371)

### DIFF
--- a/crates/apub/src/fetcher/search.rs
+++ b/crates/apub/src/fetcher/search.rs
@@ -32,9 +32,11 @@ pub async fn search_by_apub_id(
         .await
     }
     Err(_) => {
-      let (kind, identifier) = query.split_at(1);
+      let mut chars = query.chars();
+      let kind = chars.next();
+      let identifier = chars.as_str();
       match kind {
-        "@" => {
+        Some('@') => {
           let id =
             webfinger_resolve_actor::<ApubPerson>(identifier, context, request_counter).await?;
           Ok(SearchableObjects::Person(
@@ -43,7 +45,7 @@ pub async fn search_by_apub_id(
               .await?,
           ))
         }
-        "!" => {
+        Some('!') => {
           let id =
             webfinger_resolve_actor::<ApubCommunity>(identifier, context, request_counter).await?;
           Ok(SearchableObjects::Community(

--- a/crates/apub/src/fetcher/webfinger.rs
+++ b/crates/apub/src/fetcher/webfinger.rs
@@ -39,7 +39,7 @@ where
   let (_, domain) = identifier
     .splitn(2, '@')
     .collect_tuple()
-    .expect("invalid query");
+    .ok_or_else(|| LemmyError::from_message("Invalid webfinger query, missing domain"))?;
   let fetch_url = format!(
     "{}://{}/.well-known/webfinger?resource=acct:{}",
     protocol, domain, identifier


### PR DESCRIPTION
Turns out that String::split_at() panics if the position is not the boundary of a UTF8 codepoint. This panic could happen in our code when passing eg a chinese character in the first position. Chars::next() instead returns the first unicode codepoint, which works fine for us. 

Also replaced an expect() call (which can panic) with a Result.