### PR TITLE
Update apub examples to remove `to` field (ref #2380)

### DIFF
--- a/crates/apub/assets/lemmy/activities/voting/dislike_page.json
+++ b/crates/apub/assets/lemmy/activities/voting/dislike_page.json
@@ -1,8 +1,5 @@
 {
   "actor": "http://enterprise.lemmy.ml/u/lemmy_beta",
-  "to": [
-    "http://enterprise.lemmy.ml/c/main"
-  ],
   "object": "http://ds9.lemmy.ml/post/1",
   "cc": [
     "https://www.w3.org/ns/activitystreams#Public"

--- a/crates/apub/assets/lemmy/activities/voting/like_note.json
+++ b/crates/apub/assets/lemmy/activities/voting/like_note.json
@@ -1,8 +1,5 @@
 {
   "actor": "http://ds9.lemmy.ml/u/lemmy_alpha",
-  "to": [
-    "http://enterprise.lemmy.ml/c/main"
-  ],
   "object": "http://ds9.lemmy.ml/comment/1",
   "cc": [
     "https://www.w3.org/ns/activitystreams#Public"

--- a/crates/apub/assets/lemmy/activities/voting/undo_dislike_page.json
+++ b/crates/apub/assets/lemmy/activities/voting/undo_dislike_page.json
@@ -1,13 +1,7 @@
 {
   "actor": "http://enterprise.lemmy.ml/u/lemmy_beta",
-  "to": [
-    "http://enterprise.lemmy.ml/c/main"
-  ],
   "object": {
     "actor": "http://enterprise.lemmy.ml/u/lemmy_beta",
-    "to": [
-      "http://enterprise.lemmy.ml/c/main"
-    ],
     "object": "http://ds9.lemmy.ml/post/1",
     "cc": [
       "https://www.w3.org/ns/activitystreams#Public"

--- a/crates/apub/assets/lemmy/activities/voting/undo_like_note.json
+++ b/crates/apub/assets/lemmy/activities/voting/undo_like_note.json
@@ -1,13 +1,7 @@
 {
   "actor": "http://ds9.lemmy.ml/u/lemmy_alpha",
-  "to": [
-    "http://enterprise.lemmy.ml/c/main"
-  ],
   "object": {
     "actor": "http://ds9.lemmy.ml/u/lemmy_alpha",
-    "to": [
-      "http://enterprise.lemmy.ml/c/main"
-    ],
     "object": "http://ds9.lemmy.ml/comment/1",
     "cc": [
       "https://www.w3.org/ns/activitystreams#Public"


### PR DESCRIPTION
Forgot to do this in the previous commit.