### PR TITLE
Adding email admins for new applications. Fixes #2271

### DIFF
--- a/crates/api_common/src/site.rs
+++ b/crates/api_common/src/site.rs
@@ -121,6 +121,7 @@ pub struct CreateSite {
   pub private_instance: Option<bool>,
   pub default_theme: Option<String>,
   pub default_post_listing_type: Option<String>,
+  pub application_email_admins: Option<bool>,
   pub auth: Sensitive<String>,
 }
 
@@ -142,6 +143,7 @@ pub struct EditSite {
   pub default_theme: Option<String>,
   pub default_post_listing_type: Option<String>,
   pub legal_information: Option<String>,
+  pub application_email_admins: Option<bool>,
   pub auth: Sensitive<String>,
 }
 

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -407,7 +407,7 @@ pub async fn send_password_reset_email(
   .await??;
 
   let email = &user.local_user.email.to_owned().expect("email");
-  let lang = get_user_lang(user);
+  let lang = get_local_user_lang(user);
   let subject = &lang.password_reset_subject(&user.person.name);
   let protocol_and_hostname = settings.get_protocol_and_hostname();
   let reset_link = format!("{}/password_change/{}", protocol_and_hostname, &token);
@@ -434,7 +434,7 @@ pub async fn send_verification_email(
   );
   blocking(pool, move |conn| EmailVerification::create(conn, &form)).await??;
 
-  let lang = get_user_lang(user);
+  let lang = get_local_user_lang(user);
   let subject = lang.verify_email_subject(&settings.hostname);
   let body = lang.verify_email_body(&settings.hostname, &user.person.name, verify_link);
   send_email(&subject, new_email, &user.person.name, &body, settings)?;
@@ -447,14 +447,22 @@ pub fn send_email_verification_success(
   settings: &Settings,
 ) -> Result<(), LemmyError> {
   let email = &user.local_user.email.to_owned().expect("email");
-  let lang = get_user_lang(user);
+  let lang = get_local_user_lang(user);
   let subject = &lang.email_verified_subject(&user.person.actor_id);
   let body = &lang.email_verified_body();
   send_email(subject, email, &user.person.name, body, settings)
 }
 
-pub fn get_user_lang(user: &LocalUserView) -> Lang {
-  let user_lang = LanguageId::new(user.local_user.lang.clone());
+pub fn get_local_user_lang(user: &LocalUserView) -> Lang {
+  user_lang_to_lang_type(&user.local_user.lang)
+}
+
+pub fn get_local_user_settings_lang(user: &LocalUserSettingsView) -> Lang {
+  user_lang_to_lang_type(&user.local_user.lang)
+}
+
+fn user_lang_to_lang_type(lang: &str) -> Lang {
+  let user_lang = LanguageId::new(lang);
   Lang::from_language_id(&user_lang).unwrap_or_else(|| {
     let en = LanguageId::new("en");
     Lang::from_language_id(&en).expect("default language")
@@ -466,10 +474,37 @@ pub fn send_application_approved_email(
   settings: &Settings,
 ) -> Result<(), LemmyError> {
   let email = &user.local_user.email.to_owned().expect("email");
-  let lang = get_user_lang(user);
+  let lang = get_local_user_lang(user);
   let subject = lang.registration_approved_subject(&user.person.actor_id);
   let body = lang.registration_approved_body(&settings.hostname);
   send_email(&subject, email, &user.person.name, &body, settings)
+}
+
+/// Send a new applicant email notification to all admins
+pub async fn send_new_applicant_email_to_admins(
+  applicant_username: &str,
+  pool: &DbPool,
+  settings: &Settings,
+) -> Result<(), LemmyError> {
+  // Collect the admins with emails
+  let admins = blocking(pool, move |conn| {
+    LocalUserSettingsView::list_admins_with_emails(conn)
+  })
+  .await??;
+
+  let applications_link = &format!(
+    "{}/registration_applications",
+    settings.get_protocol_and_hostname(),
+  );
+
+  for admin in &admins {
+    let email = &admin.local_user.email.to_owned().expect("email");
+    let lang = get_local_user_settings_lang(admin);
+    let subject = lang.new_application_subject(applicant_username, &settings.hostname);
+    let body = lang.new_application_body(applications_link);
+    send_email(&subject, email, &admin.person.name, &body, settings)?;
+  }
+  Ok(())
 }
 
 pub async fn check_registration_application(
@@ -488,7 +523,7 @@ pub async fn check_registration_application(
     })
     .await??;
     if let Some(deny_reason) = registration.deny_reason {
-      let lang = get_user_lang(local_user_view);
+      let lang = get_local_user_lang(local_user_view);
       let registration_denied_message = format!("{}: {}", lang.registration_denied(), &deny_reason);
       return Err(LemmyError::from_message(&registration_denied_message));
     } else {

--- a/crates/api_crud/src/private_message/create.rs
+++ b/crates/api_crud/src/private_message/create.rs
@@ -5,8 +5,8 @@ use lemmy_api_common::{
   utils::{
     blocking,
     check_person_block,
+    get_local_user_lang,
     get_local_user_view_from_jwt,
-    get_user_lang,
     send_email_to_user,
   },
 };
@@ -109,7 +109,7 @@ impl PerformCrud for CreatePrivateMessage {
         LocalUserView::read_person(conn, recipient_id)
       })
       .await??;
-      let lang = get_user_lang(&local_recipient);
+      let lang = get_local_user_lang(&local_recipient);
       let inbox_link = format!("{}/inbox", context.settings().get_protocol_and_hostname());
       send_email_to_user(
         &local_recipient,

--- a/crates/api_crud/src/site/create.rs
+++ b/crates/api_crud/src/site/create.rs
@@ -76,6 +76,7 @@ impl PerformCrud for CreateSite {
       public_key: Some(keypair.public_key),
       default_theme: data.default_theme.clone(),
       default_post_listing_type: data.default_post_listing_type.clone(),
+      application_email_admins: data.application_email_admins,
       ..SiteForm::default()
     };
 

--- a/crates/api_crud/src/site/update.rs
+++ b/crates/api_crud/src/site/update.rs
@@ -86,6 +86,7 @@ impl PerformCrud for EditSite {
       default_theme: data.default_theme.clone(),
       default_post_listing_type: data.default_post_listing_type.clone(),
       legal_information,
+      application_email_admins: data.application_email_admins,
       ..SiteForm::default()
     };
 

--- a/crates/db_schema/src/schema.rs
+++ b/crates/db_schema/src/schema.rs
@@ -477,6 +477,7 @@ table! {
         default_theme -> Text,
         default_post_listing_type -> Text,
         legal_information -> Nullable<Text>,
+        application_email_admins -> Bool,
     }
 }
 

--- a/crates/db_schema/src/source/site.rs
+++ b/crates/db_schema/src/source/site.rs
@@ -32,6 +32,7 @@ pub struct Site {
   pub default_theme: String,
   pub default_post_listing_type: String,
   pub legal_information: Option<String>,
+  pub application_email_admins: bool,
 }
 
 #[derive(Default)]
@@ -61,4 +62,5 @@ pub struct SiteForm {
   pub default_theme: Option<String>,
   pub default_post_listing_type: Option<String>,
   pub legal_information: Option<Option<String>>,
+  pub application_email_admins: Option<bool>,
 }

--- a/crates/db_views/src/local_user_view.rs
+++ b/crates/db_views/src/local_user_view.rs
@@ -8,7 +8,7 @@ use lemmy_db_schema::{
     local_user::{LocalUser, LocalUserSettings},
     person::{Person, PersonSafe},
   },
-  traits::{ToSafe, ToSafeSettings},
+  traits::{ToSafe, ToSafeSettings, ViewToVec},
   utils::functions::lower,
 };
 
@@ -130,5 +130,35 @@ impl LocalUserSettingsView {
       person,
       counts,
     })
+  }
+
+  pub fn list_admins_with_emails(conn: &PgConnection) -> Result<Vec<Self>, Error> {
+    let res = local_user::table
+      .filter(person::admin.eq(true))
+      .filter(local_user::email.is_not_null())
+      .inner_join(person::table)
+      .inner_join(person_aggregates::table.on(person::id.eq(person_aggregates::person_id)))
+      .select((
+        LocalUser::safe_settings_columns_tuple(),
+        Person::safe_columns_tuple(),
+        person_aggregates::all_columns,
+      ))
+      .load::<LocalUserSettingsViewTuple>(conn)?;
+
+    Ok(LocalUserSettingsView::from_tuple_to_vec(res))
+  }
+}
+
+impl ViewToVec for LocalUserSettingsView {
+  type DbTuple = LocalUserSettingsViewTuple;
+  fn from_tuple_to_vec(items: Vec<Self::DbTuple>) -> Vec<Self> {
+    items
+      .into_iter()
+      .map(|a| Self {
+        local_user: a.0,
+        person: a.1,
+        counts: a.2,
+      })
+      .collect::<Vec<Self>>()
   }
 }

--- a/crates/websocket/src/send.rs
+++ b/crates/websocket/src/send.rs
@@ -8,7 +8,7 @@ use lemmy_api_common::{
   community::CommunityResponse,
   person::PrivateMessageResponse,
   post::PostResponse,
-  utils::{blocking, check_person_block, get_user_lang, send_email_to_user},
+  utils::{blocking, check_person_block, get_local_user_lang, send_email_to_user},
 };
 use lemmy_db_schema::{
   newtypes::{CommentId, CommunityId, LocalUserId, PersonId, PostId, PrivateMessageId},
@@ -213,7 +213,7 @@ pub async fn send_local_notifs(
 
       // Send an email to those local users that have notifications on
       if do_send_email {
-        let lang = get_user_lang(&mention_user_view);
+        let lang = get_local_user_lang(&mention_user_view);
         send_email_to_user(
           &mention_user_view,
           &lang.notification_mentioned_by_subject(&person.name),
@@ -263,7 +263,7 @@ pub async fn send_local_notifs(
         .ok();
 
         if do_send_email {
-          let lang = get_user_lang(&parent_user_view);
+          let lang = get_local_user_lang(&parent_user_view);
           send_email_to_user(
             &parent_user_view,
             &lang.notification_comment_reply_subject(&person.name),
@@ -304,7 +304,7 @@ pub async fn send_local_notifs(
         .ok();
 
         if do_send_email {
-          let lang = get_user_lang(&parent_user_view);
+          let lang = get_local_user_lang(&parent_user_view);
           send_email_to_user(
             &parent_user_view,
             &lang.notification_post_reply_subject(&person.name),

--- a/migrations/2022-08-04-150644_add_application_email_admins/down.sql
+++ b/migrations/2022-08-04-150644_add_application_email_admins/down.sql
@@ -1,0 +1,1 @@
+alter table site drop column application_email_admins;

--- a/migrations/2022-08-04-150644_add_application_email_admins/up.sql
+++ b/migrations/2022-08-04-150644_add_application_email_admins/up.sql
@@ -1,0 +1,2 @@
+-- Adding a field to email admins for new applications
+alter table site add column application_email_admins boolean not null default false;


### PR DESCRIPTION
- Adds a new boolean column to the site table, `application_email_admins` . Should this be default false, or true?
- Added a view to get admins with emails.
- Added API fields to CreateSite and EditSite. 
