### PR TITLE
Allow filtering out of deleted and removed comments when getting person details

### DIFF
--- a/crates/api_common/src/person.rs
+++ b/crates/api_common/src/person.rs
@@ -99,6 +99,7 @@ pub struct GetPersonDetails {
   pub limit: Option<i64>,
   pub community_id: Option<CommunityId>,
   pub saved_only: Option<bool>,
+  pub show_deleted_and_removed: Option<bool>,
   pub auth: Option<Sensitive<String>>,
 }
 

--- a/crates/api_crud/src/user/read.rs
+++ b/crates/api_crud/src/user/read.rs
@@ -60,6 +60,7 @@ impl PerformCrud for GetPersonDetails {
     let page = data.page;
     let limit = data.limit;
     let saved_only = data.saved_only;
+    let show_deleted_and_removed = data.show_deleted_and_removed;
     let community_id = data.community_id;
 
     let (posts, comments) = blocking(context.pool(), move |conn| {
@@ -77,6 +78,7 @@ impl PerformCrud for GetPersonDetails {
         .local_user(local_user.as_ref())
         .sort(sort.map(post_to_comment_sort_type))
         .saved_only(saved_only)
+        .show_deleted_and_removed(show_deleted_and_removed)
         .community_id(community_id)
         .page(page)
         .limit(limit);

--- a/crates/db_views/src/comment_view.rs
+++ b/crates/db_views/src/comment_view.rs
@@ -165,6 +165,7 @@ pub struct CommentQuery<'a> {
   local_user: Option<&'a LocalUser>,
   search_term: Option<String>,
   saved_only: Option<bool>,
+  show_deleted_and_removed: Option<bool>,
   page: Option<i64>,
   limit: Option<i64>,
   max_depth: Option<i32>,
@@ -300,6 +301,11 @@ impl<'a> CommentQuery<'a> {
 
     if self.saved_only.unwrap_or(false) {
       query = query.filter(comment_saved::id.is_not_null());
+    }
+
+    if !self.show_deleted_and_removed.unwrap_or(true) {
+      query = query.filter(comment::deleted.eq(false));
+      query = query.filter(comment::removed.eq(false));
     }
 
     if !self.local_user.map(|l| l.show_bot_accounts).unwrap_or(true) {


### PR DESCRIPTION
For https://github.com/LemmyNet/lemmy/issues/1053

While showing deleted/removed comments for a post might be useful because these comments might have children that are not removed. On the other hand, while is user is viewing the profile of another user, it might be helpful to not show deleted/removed comments to avoid clutter. When a user is viewing their own profile, they may or may not want to see deleted/removed comments depending on whether they want to restore a deleted comment.

In the PR I add basic provision of filtering out deleted and removed comments from the user view as well a parameter in the `CommentQuery::builder` for the same. This filtering is disabled by default so it won't break any frontend behaviour.