### PR TITLE
Convert emails to lowercase (fixes #2462)

### DIFF
--- a/crates/api/src/local_user/reset_password.rs
+++ b/crates/api/src/local_user/reset_password.rs
@@ -21,7 +21,7 @@ impl Perform for PasswordReset {
     let data: &PasswordReset = self;
 
     // Fetch that email
-    let email = data.email.clone();
+    let email = data.email.to_lowercase();
     let local_user_view = blocking(context.pool(), move |conn| {
       LocalUserView::find_by_email(conn, &email)
     })

--- a/crates/api/src/local_user/save_settings.rs
+++ b/crates/api/src/local_user/save_settings.rs
@@ -42,7 +42,7 @@ impl Perform for SaveUserSettings {
     let display_name = diesel_option_overwrite(&data.display_name);
     let matrix_user_id = diesel_option_overwrite(&data.matrix_user_id);
     let bot_account = data.bot_account;
-    let email_deref = data.email.as_deref().map(|e| e.to_owned());
+    let email_deref = data.email.as_deref().map(|e| e.to_lowercase());
     let email = diesel_option_overwrite(&email_deref);
 
     if let Some(Some(email)) = &email {

--- a/crates/api_crud/src/user/create.rs
+++ b/crates/api_crud/src/user/create.rs
@@ -137,7 +137,7 @@ impl PerformCrud for Register {
     // Create the local user
     let local_user_form = LocalUserForm {
       person_id: Some(inserted_person.id),
-      email: Some(data.email.as_deref().map(|s| s.to_owned())),
+      email: Some(data.email.as_deref().map(|s| s.to_lowercase())),
       password_encrypted: Some(data.password.to_string()),
       show_nsfw: Some(data.show_nsfw),
       email_verified: Some(false),


### PR DESCRIPTION
It would also make sense to convert to lowercase in Login API call, but there we dont know if its an email or a username (which can have uppercase afaik).