### PR TITLE
Only allow authenticated users to fetch remote objects

### DIFF
--- a/api_tests/src/comment.spec.ts
+++ b/api_tests/src/comment.spec.ts
@@ -30,6 +30,7 @@ import {
   unfollows,
   getComments,
   getCommentParentId,
+  resolveCommunity,
 } from './shared';
 
 let postRes: PostResponse;
@@ -293,8 +294,8 @@ test('Comment Search', async () => {
 
 test('A and G subscribe to B (center) A posts, G mentions B, it gets announced to A', async () => {
   // Create a local post
-  let alphaCommunity = await createCommunity(alpha, "main");
-  let alphaPost = await createPost(alpha, alphaCommunity.community_view.community.id);
+  let alphaCommunity = (await resolveCommunity(alpha, "!main@lemmy-alpha:8541")).community.unwrap();
+  let alphaPost = await createPost(alpha, alphaCommunity.community.id);
   expect(alphaPost.post_view.community.local).toBe(true);
 
   // Make sure gamma sees it

--- a/api_tests/src/follow.spec.ts
+++ b/api_tests/src/follow.spec.ts
@@ -37,7 +37,7 @@ test('Follow federated community', async () => {
     c => c.community.local == false
   ).community.id;
   expect(remoteCommunityId).toBeDefined();
-  expect(site.my_user.unwrap().follows.length).toBe(1);
+  expect(site.my_user.unwrap().follows.length).toBe(2);
 
   // Test an unfollow
   let unfollow = await followCommunity(alpha, false, remoteCommunityId);
@@ -45,5 +45,5 @@ test('Follow federated community', async () => {
 
   // Make sure you are unsubbed locally
   let siteUnfollowCheck = await getSite(alpha);
-  expect(siteUnfollowCheck.my_user.unwrap().follows.length).toBe(0);
+  expect(siteUnfollowCheck.my_user.unwrap().follows.length).toBe(1);
 });

--- a/api_tests/src/post.spec.ts
+++ b/api_tests/src/post.spec.ts
@@ -32,7 +32,8 @@ import {
   registerUser,
   API,
   getSite,
-  unfollows
+  unfollows,
+  resolveCommunity
 } from './shared';
 
 let betaCommunity: CommunityView;
@@ -226,7 +227,8 @@ test('Delete a post', async () => {
 });
 
 test('Remove a post from admin and community on different instance', async () => {
-  let postRes = await createPost(gamma, betaCommunity.community.id);
+  let gammaCommunity = await resolveCommunity(gamma, betaCommunity.community.actor_id);
+  let postRes = await createPost(gamma, gammaCommunity.community.unwrap().community.id);
 
   let alphaPost = (await resolvePost(alpha, postRes.post_view.post)).post.unwrap();
   let removedPost = await removePost(alpha, true, alphaPost.post);

--- a/api_tests/src/shared.ts
+++ b/api_tests/src/shared.ts
@@ -174,9 +174,9 @@ export async function setupLogins() {
   editSiteForm.auth = epsilon.auth.unwrap();
   await epsilon.client.editSite(editSiteForm);
 
-  // Create the main beta community, follow it
+  // Create the main alpha/beta communities
+  await createCommunity(alpha, "main");
   await createCommunity(beta, "main");
-  await followBeta(beta);
 }
 
 export async function createPost(

--- a/api_tests/src/user.spec.ts
+++ b/api_tests/src/user.spec.ts
@@ -19,7 +19,12 @@ import {
   API,
   resolveComment,
   saveUserSettingsFederated,
+  setupLogins,
 } from './shared';
+
+beforeAll(async () => {
+  await setupLogins();
+});
 
 let apShortname: string;
 

--- a/crates/api/src/site/resolve_object.rs
+++ b/crates/api/src/site/resolve_object.rs
@@ -5,7 +5,7 @@ use lemmy_api_common::{
   site::{ResolveObject, ResolveObjectResponse},
   utils::{blocking, check_private_instance, get_local_user_view_from_jwt_opt},
 };
-use lemmy_apub::fetcher::search::{search_by_apub_id, SearchableObjects};
+use lemmy_apub::fetcher::search::{search_query_to_object_id, SearchableObjects};
 use lemmy_db_schema::{newtypes::PersonId, utils::DbPool};
 use lemmy_db_views::structs::{CommentView, PostView};
 use lemmy_db_views_actor::structs::{CommunityView, PersonViewSafe};
@@ -27,7 +27,7 @@ impl Perform for ResolveObject {
         .await?;
     check_private_instance(&local_user_view, context.pool()).await?;
 
-    let res = search_by_apub_id(&self.q, context)
+    let res = search_query_to_object_id(&self.q, local_user_view.is_none(), context)
       .await
       .map_err(|e| e.with_message("couldnt_find_object"))?;
     convert_response(res, local_user_view.map(|l| l.person.id), context.pool())

--- a/crates/apub/src/fetcher/mod.rs
+++ b/crates/apub/src/fetcher/mod.rs
@@ -45,7 +45,7 @@ where
       Ok(actor?)
     } else {
       // Fetch the actor from its home instance using webfinger
-      let id = webfinger_resolve_actor::<Actor>(identifier, context, &mut 0).await?;
+      let id = webfinger_resolve_actor::<Actor>(identifier, true, context, &mut 0).await?;
       let actor: DbActor = blocking(context.pool(), move |conn| {
         DbActor::read_from_apub_id(conn, &id)
       })

--- a/crates/apub/src/fetcher/webfinger.rs
+++ b/crates/apub/src/fetcher/webfinger.rs
@@ -28,6 +28,7 @@ pub struct WebfingerResponse {
 #[tracing::instrument(skip_all)]
 pub(crate) async fn webfinger_resolve_actor<Kind>(
   identifier: &str,
+  local_only: bool,
   context: &LemmyContext,
   request_counter: &mut i32,
 ) -> Result<DbUrl, LemmyError>
@@ -68,9 +69,14 @@ where
     .filter_map(|l| l.href.clone())
     .collect();
   for l in links {
-    let object = ObjectId::<Kind>::new(l)
-      .dereference(context, local_instance(context), request_counter)
-      .await;
+    let object_id = ObjectId::<Kind>::new(l);
+    let object = if local_only {
+      object_id.dereference_local(context).await
+    } else {
+      object_id
+        .dereference(context, local_instance(context), request_counter)
+        .await
+    };
     if object.is_ok() {
       return object.map(|o| o.actor_id().into());
     }

--- a/crates/apub/src/mentions.rs
+++ b/crates/apub/src/mentions.rs
@@ -73,10 +73,9 @@ pub async fn collect_non_local_mentions(
     .collect::<Vec<MentionData>>();
 
   for mention in &mentions {
-    // TODO should it be fetching it every time?
     let identifier = format!("{}@{}", mention.name, mention.domain);
     let actor_id =
-      webfinger_resolve_actor::<ApubPerson>(&identifier, context, request_counter).await;
+      webfinger_resolve_actor::<ApubPerson>(&identifier, true, context, request_counter).await;
     if let Ok(actor_id) = actor_id {
       let actor_id: ObjectId<ApubPerson> = ObjectId::new(actor_id);
       addressed_ccs.push(actor_id.to_string().parse()?);


### PR DESCRIPTION
Only logged in users can use resolve object endpoint to fetch remote activitypub objects. In case of an unauthenticated user, only objects which are already stored in the instance database will be returned.