### PR TITLE
Update clippy to use Rust 1.64

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,7 @@ steps:
 
   # latest rust for clippy to get extra checks
   - name: cargo clippy
-    image: rust:1.61-buster
+    image: rust:1.64-buster
     commands:
       - apt-get update
       - apt-get -y install protobuf-compiler libprotobuf-dev


### PR DESCRIPTION
This might catch some more problems. Was previously blocked because of some clippy failures in diesel macros.