### PR TITLE
Federate votes as private

### DIFF
--- a/crates/apub/assets/lemmy/activities/voting/dislike_page.json
+++ b/crates/apub/assets/lemmy/activities/voting/dislike_page.json
@@ -1,9 +1,6 @@
 {
   "actor": "http://enterprise.lemmy.ml/u/lemmy_beta",
   "object": "http://ds9.lemmy.ml/post/1",
-  "cc": [
-    "https://www.w3.org/ns/activitystreams#Public"
-  ],
   "type": "Dislike",
   "id": "http://enterprise.lemmy.ml/activities/dislike/64d40d40-a829-43a5-8247-1fb595b3ca1c"
 }

--- a/crates/apub/assets/lemmy/activities/voting/like_note.json
+++ b/crates/apub/assets/lemmy/activities/voting/like_note.json
@@ -1,9 +1,6 @@
 {
   "actor": "http://ds9.lemmy.ml/u/lemmy_alpha",
   "object": "http://ds9.lemmy.ml/comment/1",
-  "cc": [
-    "https://www.w3.org/ns/activitystreams#Public"
-  ],
   "type": "Like",
   "id": "http://ds9.lemmy.ml/activities/like/fd61d070-7382-46a9-b2b7-6bb253732877"
 }

--- a/crates/apub/assets/lemmy/activities/voting/undo_dislike_page.json
+++ b/crates/apub/assets/lemmy/activities/voting/undo_dislike_page.json
@@ -3,15 +3,9 @@
   "object": {
     "actor": "http://enterprise.lemmy.ml/u/lemmy_beta",
     "object": "http://ds9.lemmy.ml/post/1",
-    "cc": [
-      "https://www.w3.org/ns/activitystreams#Public"
-    ],
     "type": "Like",
     "id": "http://enterprise.lemmy.ml/activities/like/2227ab2c-79e2-4fca-a1d2-1d67dacf2457"
   },
-  "cc": [
-    "https://www.w3.org/ns/activitystreams#Public"
-  ],
   "type": "Undo",
   "id": "http://enterprise.lemmy.ml/activities/undo/6cc6fb71-39fe-49ea-9506-f0423b101e98"
 }

--- a/crates/apub/assets/lemmy/activities/voting/undo_like_note.json
+++ b/crates/apub/assets/lemmy/activities/voting/undo_like_note.json
@@ -3,15 +3,9 @@
   "object": {
     "actor": "http://ds9.lemmy.ml/u/lemmy_alpha",
     "object": "http://ds9.lemmy.ml/comment/1",
-    "cc": [
-      "https://www.w3.org/ns/activitystreams#Public"
-    ],
     "type": "Like",
     "id": "http://ds9.lemmy.ml/activities/like/efcf7ae2-dfcc-4ff4-9ce4-6adf251ff004"
   },
-  "cc": [
-    "https://www.w3.org/ns/activitystreams#Public"
-  ],
   "type": "Undo",
   "id": "http://ds9.lemmy.ml/activities/undo/3518565c-24a7-4d9e-8e0a-f7a2f45ac618"
 }

--- a/crates/apub/src/activities/voting/undo_vote.rs
+++ b/crates/apub/src/activities/voting/undo_vote.rs
@@ -21,7 +21,7 @@ use activitypub_federation::{
   traits::ActivityHandler,
   utils::verify_urls_match,
 };
-use activitystreams_kinds::{activity::UndoType, public};
+use activitystreams_kinds::activity::UndoType;
 use lemmy_api_common::utils::blocking;
 use lemmy_db_schema::{newtypes::CommunityId, source::community::Community, traits::Crud};
 use lemmy_utils::error::LemmyError;
@@ -54,7 +54,6 @@ impl UndoVote {
     let undo_vote = UndoVote {
       actor: ObjectId::new(actor.actor_id()),
       object,
-      cc: vec![public()],
       kind: UndoType::Undo,
       id: id.clone(),
       unparsed: Default::default(),

--- a/crates/apub/src/activities/voting/vote.rs
+++ b/crates/apub/src/activities/voting/vote.rs
@@ -13,7 +13,6 @@ use crate::{
   PostOrComment,
 };
 use activitypub_federation::{core::object_id::ObjectId, data::Data, traits::ActivityHandler};
-use activitystreams_kinds::public;
 use anyhow::anyhow;
 use lemmy_api_common::utils::blocking;
 use lemmy_db_schema::{
@@ -37,7 +36,6 @@ impl Vote {
     Ok(Vote {
       actor: ObjectId::new(actor.actor_id()),
       object: ObjectId::new(object.ap_id()),
-      cc: vec![public()],
       kind: kind.clone(),
       id: generate_activity_id(kind, &context.settings().get_protocol_and_hostname())?,
       unparsed: Default::default(),

--- a/crates/apub/src/protocol/activities/voting/undo_vote.rs
+++ b/crates/apub/src/protocol/activities/voting/undo_vote.rs
@@ -2,7 +2,7 @@ use crate::{
   objects::person::ApubPerson,
   protocol::{activities::voting::vote::Vote, Unparsed},
 };
-use activitypub_federation::{core::object_id::ObjectId, deser::helpers::deserialize_one_or_many};
+use activitypub_federation::core::object_id::ObjectId;
 use activitystreams_kinds::activity::UndoType;
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -12,8 +12,6 @@ use url::Url;
 pub struct UndoVote {
   pub(crate) actor: ObjectId<ApubPerson>,
   pub(crate) object: Vote,
-  #[serde(deserialize_with = "deserialize_one_or_many", default)]
-  pub(crate) cc: Vec<Url>,
   #[serde(rename = "type")]
   pub(crate) kind: UndoType,
   pub(crate) id: Url,

--- a/crates/apub/src/protocol/activities/voting/vote.rs
+++ b/crates/apub/src/protocol/activities/voting/vote.rs
@@ -3,7 +3,7 @@ use crate::{
   objects::person::ApubPerson,
   protocol::Unparsed,
 };
-use activitypub_federation::{core::object_id::ObjectId, deser::helpers::deserialize_one_or_many};
+use activitypub_federation::core::object_id::ObjectId;
 use lemmy_utils::error::LemmyError;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
@@ -15,8 +15,6 @@ use url::Url;
 pub struct Vote {
   pub(crate) actor: ObjectId<ApubPerson>,
   pub(crate) object: ObjectId<PostOrComment>,
-  #[serde(deserialize_with = "deserialize_one_or_many", default)]
-  pub(crate) cc: Vec<Url>,
   #[serde(rename = "type")]
   pub(crate) kind: VoteType,
   pub(crate) id: Url,


### PR DESCRIPTION
I looked into it and this change is actually backwards compatible with Lemmy 0.16.6 which was relesed in July. I think it makes sense to include this in 0.17, so that other software doesnt leak the names of users who voted (iirc this happens with hubzilla). Older Lemmy versions would be unable to federate votes then, but other things would work fine.