### PR TITLE
Enable lto, strip symbols via cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,13 @@ rust-version = "1.57"
 [lib]
 doctest = false
 
+[profile.release]
+strip = "symbols"
+debug = 0
+lto = "thin"
+
 [profile.dev]
+strip = "symbols"
 debug = 0
 
 [features]

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -29,9 +29,6 @@ COPY . .
 RUN echo "pub const VERSION: &str = \"$(git describe --tag)\";" > "crates/utils/src/version.rs"
 RUN cargo build --target ${CARGO_BUILD_TARGET}
 
-# reduce binary size
-RUN strip ./target/$CARGO_BUILD_TARGET/$RUSTRELEASEDIR/lemmy_server
-
 RUN cp ./target/$CARGO_BUILD_TARGET/$RUSTRELEASEDIR/lemmy_server /app/lemmy_server
 
 # The alpine runner

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -11,9 +11,6 @@ COPY ./ ./
 RUN echo "pub const VERSION: &str = \"$(git describe --tag)\";" > "crates/utils/src/version.rs"
 RUN cargo build --release
 
-# reduce binary size
-RUN strip ./target/$CARGO_BUILD_TARGET/$RUSTRELEASEDIR/lemmy_server
-
 RUN cp ./target/$CARGO_BUILD_TARGET/$RUSTRELEASEDIR/lemmy_server /app/lemmy_server
 
 # The alpine runner

--- a/docker/prod/Dockerfile.arm
+++ b/docker/prod/Dockerfile.arm
@@ -15,9 +15,6 @@ RUN echo "pub const VERSION: &str = \"$(git describe --tag)\";" > "crates/utils/
 
 RUN cargo build --release
 
-# reduce binary size
-RUN strip ./target/release/lemmy_server
-
 RUN cp ./target/release/lemmy_server /app/lemmy_server
 
 # The Debian runner


### PR DESCRIPTION
Thin lto doesnt have any effect on compile time in my tests, and should improve performance. So no reason to leave it disabled. Stripping symbols via cargo.toml might be slightly faster, and means one step less in docker builds.

We could also try full lto, but it doubles build time and i fear that ci might time out then.