### PR TITLE
Group imports with rustfmt

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -2,4 +2,4 @@ tab_spaces = 2
 edition="2021"
 imports_layout="HorizontalVertical"
 imports_granularity="Crate"
-reorder_imports=true
+group_imports="One"

--- a/crates/api_crud/src/comment/update.rs
+++ b/crates/api_crud/src/comment/update.rs
@@ -1,3 +1,4 @@
+use crate::PerformCrud;
 use actix_web::web::Data;
 use lemmy_api_common::{
   comment::{CommentResponse, EditComment},
@@ -34,8 +35,6 @@ use lemmy_websocket::{
   LemmyContext,
   UserOperationCrud,
 };
-
-use crate::PerformCrud;
 
 #[async_trait::async_trait(?Send)]
 impl PerformCrud for EditComment {

--- a/crates/apub/src/activities/voting/mod.rs
+++ b/crates/apub/src/activities/voting/mod.rs
@@ -1,3 +1,7 @@
+use crate::{
+  objects::{comment::ApubComment, person::ApubPerson, post::ApubPost},
+  protocol::activities::voting::vote::VoteType,
+};
 use lemmy_api_common::utils::blocking;
 use lemmy_db_schema::{
   source::{
@@ -11,11 +15,6 @@ use lemmy_websocket::{
   send::{send_comment_ws_message_simple, send_post_ws_message},
   LemmyContext,
   UserOperation,
-};
-
-use crate::{
-  objects::{comment::ApubComment, person::ApubPerson, post::ApubPost},
-  protocol::activities::voting::vote::VoteType,
 };
 
 pub mod undo_vote;

--- a/crates/apub/src/collections/mod.rs
+++ b/crates/apub/src/collections/mod.rs
@@ -1,6 +1,5 @@
-use lemmy_websocket::LemmyContext;
-
 use crate::objects::community::ApubCommunity;
+use lemmy_websocket::LemmyContext;
 
 pub(crate) mod community_moderators;
 pub(crate) mod community_outbox;

--- a/crates/db_schema/src/aggregates/structs.rs
+++ b/crates/db_schema/src/aggregates/structs.rs
@@ -1,6 +1,4 @@
 use crate::newtypes::{CommentId, CommunityId, PersonId, PostId};
-use serde::{Deserialize, Serialize};
-
 #[cfg(feature = "full")]
 use crate::schema::{
   comment_aggregates,
@@ -10,6 +8,7 @@ use crate::schema::{
   post_aggregates,
   site_aggregates,
 };
+use serde::{Deserialize, Serialize};
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "full", derive(Queryable, Associations, Identifiable))]

--- a/crates/db_schema/src/source/actor_language.rs
+++ b/crates/db_schema/src/source/actor_language.rs
@@ -7,10 +7,9 @@ use crate::newtypes::{
   SiteId,
   SiteLanguageId,
 };
-use serde::{Deserialize, Serialize};
-
 #[cfg(feature = "full")]
 use crate::schema::local_user_language;
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(Queryable, Identifiable))]

--- a/crates/db_schema/src/source/comment.rs
+++ b/crates/db_schema/src/source/comment.rs
@@ -1,10 +1,9 @@
 use crate::newtypes::{CommentId, DbUrl, LanguageId, LtreeDef, PersonId, PostId};
+#[cfg(feature = "full")]
+use crate::schema::{comment, comment_like, comment_saved};
 use diesel_ltree::Ltree;
 use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
-
-#[cfg(feature = "full")]
-use crate::schema::{comment, comment_like, comment_saved};
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(Queryable, Associations, Identifiable))]

--- a/crates/db_schema/src/source/comment_reply.rs
+++ b/crates/db_schema/src/source/comment_reply.rs
@@ -1,8 +1,7 @@
 use crate::newtypes::{CommentId, CommentReplyId, PersonId};
-use serde::{Deserialize, Serialize};
-
 #[cfg(feature = "full")]
 use crate::schema::comment_reply;
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(Queryable, Associations, Identifiable))]

--- a/crates/db_schema/src/source/comment_report.rs
+++ b/crates/db_schema/src/source/comment_report.rs
@@ -1,8 +1,7 @@
 use crate::newtypes::{CommentId, CommentReportId, PersonId};
-use serde::{Deserialize, Serialize};
-
 #[cfg(feature = "full")]
 use crate::schema::comment_report;
+use serde::{Deserialize, Serialize};
 
 #[derive(PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
 #[cfg_attr(feature = "full", derive(Queryable, Associations, Identifiable))]

--- a/crates/db_schema/src/source/community.rs
+++ b/crates/db_schema/src/source/community.rs
@@ -1,9 +1,8 @@
 use crate::newtypes::{CommunityId, DbUrl, InstanceId, PersonId};
-use serde::{Deserialize, Serialize};
-use typed_builder::TypedBuilder;
-
 #[cfg(feature = "full")]
 use crate::schema::{community, community_follower, community_moderator, community_person_ban};
+use serde::{Deserialize, Serialize};
+use typed_builder::TypedBuilder;
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(Queryable, Identifiable))]

--- a/crates/db_schema/src/source/community_block.rs
+++ b/crates/db_schema/src/source/community_block.rs
@@ -1,8 +1,7 @@
 use crate::newtypes::{CommunityBlockId, CommunityId, PersonId};
-use serde::{Deserialize, Serialize};
-
 #[cfg(feature = "full")]
 use crate::schema::community_block;
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(Queryable, Associations, Identifiable))]

--- a/crates/db_schema/src/source/email_verification.rs
+++ b/crates/db_schema/src/source/email_verification.rs
@@ -1,5 +1,4 @@
 use crate::newtypes::LocalUserId;
-
 #[cfg(feature = "full")]
 use crate::schema::email_verification;
 

--- a/crates/db_schema/src/source/federation_allowlist.rs
+++ b/crates/db_schema/src/source/federation_allowlist.rs
@@ -1,9 +1,8 @@
 use crate::newtypes::InstanceId;
-use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
-
 #[cfg(feature = "full")]
 use crate::schema::federation_allowlist;
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(Queryable, Associations, Identifiable))]

--- a/crates/db_schema/src/source/federation_blocklist.rs
+++ b/crates/db_schema/src/source/federation_blocklist.rs
@@ -1,9 +1,8 @@
 use crate::newtypes::InstanceId;
-use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
-
 #[cfg(feature = "full")]
 use crate::schema::federation_blocklist;
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(Queryable, Associations, Identifiable))]

--- a/crates/db_schema/src/source/instance.rs
+++ b/crates/db_schema/src/source/instance.rs
@@ -1,8 +1,7 @@
 use crate::newtypes::InstanceId;
-use std::fmt::Debug;
-
 #[cfg(feature = "full")]
 use crate::schema::instance;
+use std::fmt::Debug;
 
 #[derive(PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "full", derive(Queryable, Identifiable))]

--- a/crates/db_schema/src/source/language.rs
+++ b/crates/db_schema/src/source/language.rs
@@ -1,8 +1,7 @@
 use crate::newtypes::LanguageId;
-use serde::{Deserialize, Serialize};
-
 #[cfg(feature = "full")]
 use crate::schema::language;
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(Queryable, Identifiable))]

--- a/crates/db_schema/src/source/local_site.rs
+++ b/crates/db_schema/src/source/local_site.rs
@@ -1,9 +1,8 @@
 use crate::newtypes::{LocalSiteId, SiteId};
-use serde::{Deserialize, Serialize};
-use typed_builder::TypedBuilder;
-
 #[cfg(feature = "full")]
 use crate::schema::local_site;
+use serde::{Deserialize, Serialize};
+use typed_builder::TypedBuilder;
 
 #[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(Queryable, Identifiable))]

--- a/crates/db_schema/src/source/local_site_rate_limit.rs
+++ b/crates/db_schema/src/source/local_site_rate_limit.rs
@@ -1,9 +1,8 @@
 use crate::newtypes::LocalSiteId;
-use serde::{Deserialize, Serialize};
-use typed_builder::TypedBuilder;
-
 #[cfg(feature = "full")]
 use crate::schema::local_site_rate_limit;
+use serde::{Deserialize, Serialize};
+use typed_builder::TypedBuilder;
 
 #[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(Queryable, Identifiable))]

--- a/crates/db_schema/src/source/local_user.rs
+++ b/crates/db_schema/src/source/local_user.rs
@@ -1,9 +1,8 @@
 use crate::newtypes::{LocalUserId, PersonId};
-use serde::{Deserialize, Serialize};
-use typed_builder::TypedBuilder;
-
 #[cfg(feature = "full")]
 use crate::schema::local_user;
+use serde::{Deserialize, Serialize};
+use typed_builder::TypedBuilder;
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(Queryable, Identifiable))]

--- a/crates/db_schema/src/source/moderator.rs
+++ b/crates/db_schema/src/source/moderator.rs
@@ -1,6 +1,4 @@
 use crate::newtypes::{CommentId, CommunityId, PersonId, PostId};
-use serde::{Deserialize, Serialize};
-
 #[cfg(feature = "full")]
 use crate::schema::{
   admin_purge_comment,
@@ -19,6 +17,7 @@ use crate::schema::{
   mod_sticky_post,
   mod_transfer_community,
 };
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(Queryable, Identifiable))]

--- a/crates/db_schema/src/source/password_reset_request.rs
+++ b/crates/db_schema/src/source/password_reset_request.rs
@@ -1,5 +1,4 @@
 use crate::newtypes::LocalUserId;
-
 #[cfg(feature = "full")]
 use crate::schema::password_reset_request;
 

--- a/crates/db_schema/src/source/person.rs
+++ b/crates/db_schema/src/source/person.rs
@@ -1,9 +1,8 @@
 use crate::newtypes::{DbUrl, InstanceId, PersonId};
-use serde::{Deserialize, Serialize};
-use typed_builder::TypedBuilder;
-
 #[cfg(feature = "full")]
 use crate::schema::person;
+use serde::{Deserialize, Serialize};
+use typed_builder::TypedBuilder;
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(Queryable, Identifiable))]

--- a/crates/db_schema/src/source/person_block.rs
+++ b/crates/db_schema/src/source/person_block.rs
@@ -1,8 +1,7 @@
 use crate::newtypes::{PersonBlockId, PersonId};
-use serde::{Deserialize, Serialize};
-
 #[cfg(feature = "full")]
 use crate::schema::person_block;
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(Queryable, Associations, Identifiable))]

--- a/crates/db_schema/src/source/person_mention.rs
+++ b/crates/db_schema/src/source/person_mention.rs
@@ -1,8 +1,7 @@
 use crate::newtypes::{CommentId, PersonId, PersonMentionId};
-use serde::{Deserialize, Serialize};
-
 #[cfg(feature = "full")]
 use crate::schema::person_mention;
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(Queryable, Associations, Identifiable))]

--- a/crates/db_schema/src/source/post.rs
+++ b/crates/db_schema/src/source/post.rs
@@ -1,9 +1,8 @@
 use crate::newtypes::{CommunityId, DbUrl, LanguageId, PersonId, PostId};
-use serde::{Deserialize, Serialize};
-use typed_builder::TypedBuilder;
-
 #[cfg(feature = "full")]
 use crate::schema::{post, post_like, post_read, post_saved};
+use serde::{Deserialize, Serialize};
+use typed_builder::TypedBuilder;
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(Queryable, Identifiable))]

--- a/crates/db_schema/src/source/post_report.rs
+++ b/crates/db_schema/src/source/post_report.rs
@@ -1,8 +1,7 @@
 use crate::newtypes::{DbUrl, PersonId, PostId, PostReportId};
-use serde::{Deserialize, Serialize};
-
 #[cfg(feature = "full")]
 use crate::schema::post_report;
+use serde::{Deserialize, Serialize};
 
 #[derive(PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
 #[cfg_attr(feature = "full", derive(Identifiable, Queryable, Associations))]

--- a/crates/db_schema/src/source/private_message.rs
+++ b/crates/db_schema/src/source/private_message.rs
@@ -1,9 +1,8 @@
 use crate::newtypes::{DbUrl, PersonId, PrivateMessageId};
-use serde::{Deserialize, Serialize};
-use typed_builder::TypedBuilder;
-
 #[cfg(feature = "full")]
 use crate::schema::private_message;
+use serde::{Deserialize, Serialize};
+use typed_builder::TypedBuilder;
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(Queryable, Associations, Identifiable))]

--- a/crates/db_schema/src/source/private_message_report.rs
+++ b/crates/db_schema/src/source/private_message_report.rs
@@ -1,8 +1,7 @@
 use crate::newtypes::{PersonId, PrivateMessageId, PrivateMessageReportId};
-use serde::{Deserialize, Serialize};
-
 #[cfg(feature = "full")]
 use crate::schema::private_message_report;
+use serde::{Deserialize, Serialize};
 
 #[derive(PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
 #[cfg_attr(feature = "full", derive(Queryable, Associations, Identifiable))]

--- a/crates/db_schema/src/source/registration_application.rs
+++ b/crates/db_schema/src/source/registration_application.rs
@@ -1,8 +1,7 @@
 use crate::newtypes::{LocalUserId, PersonId};
-use serde::{Deserialize, Serialize};
-
 #[cfg(feature = "full")]
 use crate::schema::registration_application;
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(Queryable, Identifiable))]

--- a/crates/db_schema/src/source/site.rs
+++ b/crates/db_schema/src/source/site.rs
@@ -1,9 +1,8 @@
 use crate::newtypes::{DbUrl, InstanceId, SiteId};
-use serde::{Deserialize, Serialize};
-use typed_builder::TypedBuilder;
-
 #[cfg(feature = "full")]
 use crate::schema::site;
+use serde::{Deserialize, Serialize};
+use typed_builder::TypedBuilder;
 
 #[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(Queryable, Identifiable))]

--- a/crates/utils/src/test.rs
+++ b/crates/utils/src/test.rs
@@ -1,5 +1,3 @@
-use regex::RegexBuilder;
-
 use crate::utils::{
   is_valid_actor_name,
   is_valid_display_name,
@@ -10,6 +8,7 @@ use crate::utils::{
   slur_check,
   slurs_vec_to_str,
 };
+use regex::RegexBuilder;
 
 #[test]
 fn test_mentions_regex() {


### PR DESCRIPTION
There was some inconsistency in imports because sometimes an empty line sneaked between import lines, and cargo fmt didnt remove it. This setting guarantees that all imports are merged into a single block. Value StdExternalCrate could also work but doesnt make much sense to me.

https://rust-lang.github.io/rustfmt/?version=v1.5.1&search=import#group_imports