### PR TITLE
Send error message when rate limit is reached

### DIFF
--- a/crates/utils/src/rate_limit/mod.rs
+++ b/crates/utils/src/rate_limit/mod.rs
@@ -1,7 +1,6 @@
-use crate::{utils::get_ip, IpAddr};
+use crate::{error::LemmyError, utils::get_ip, IpAddr};
 use actix_web::{
   dev::{Service, ServiceRequest, ServiceResponse, Transform},
-  HttpResponse,
 };
 use futures::future::{ok, Ready};
 use rate_limiter::{RateLimitType, RateLimiter};
@@ -177,10 +176,9 @@ where
         service.call(req).await
       } else {
         let (http_req, _) = req.into_parts();
-        // if rate limit was hit, respond with http 400
-        Ok(ServiceResponse::new(
+        Ok(ServiceResponse::from_err(
+          LemmyError::from_message("error_rate_limited"),
           http_req,
-          HttpResponse::BadRequest().finish(),
         ))
       }
     })

--- a/crates/utils/src/rate_limit/mod.rs
+++ b/crates/utils/src/rate_limit/mod.rs
@@ -1,7 +1,5 @@
 use crate::{error::LemmyError, utils::get_ip, IpAddr};
-use actix_web::{
-  dev::{Service, ServiceRequest, ServiceResponse, Transform},
-};
+use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform};
 use futures::future::{ok, Ready};
 use rate_limiter::{RateLimitType, RateLimiter};
 use serde::{Deserialize, Serialize};
@@ -177,7 +175,7 @@ where
       } else {
         let (http_req, _) = req.into_parts();
         Ok(ServiceResponse::from_err(
-          LemmyError::from_message("error_rate_limited"),
+          LemmyError::from_message("rate_limit_error"),
           http_req,
         ))
       }


### PR DESCRIPTION
Sending an empty response is security by obscurity, and very confusing for users. Better to give an actual error message.

https://github.com/LemmyNet/lemmyBB/issues/38#issuecomment-1301394380