### PR TITLE
Mark objects as not deleted when received via apub (fixes #2507)

### DIFF
--- a/crates/apub/src/objects/comment.rs
+++ b/crates/apub/src/objects/comment.rs
@@ -202,7 +202,7 @@ impl ApubObject for ApubComment {
       removed: None,
       published: note.published.map(|u| u.naive_local()),
       updated: note.updated.map(|u| u.naive_local()),
-      deleted: None,
+      deleted: Some(false),
       ap_id: Some(note.id.into()),
       distinguished: note.distinguished,
       local: Some(false),

--- a/crates/apub/src/objects/person.rs
+++ b/crates/apub/src/objects/person.rs
@@ -160,7 +160,7 @@ impl ApubObject for ApubPerson {
       display_name: person.name,
       banned: None,
       ban_expires: None,
-      deleted: None,
+      deleted: Some(false),
       avatar: person.icon.map(|i| i.url.into()),
       banner: person.image.map(|i| i.url.into()),
       published: person.published.map(|u| u.naive_local()),

--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -217,7 +217,7 @@ impl ApubObject for ApubPost {
         locked: page.comments_enabled.map(|e| !e),
         published: page.published.map(|u| u.naive_local()),
         updated: page.updated.map(|u| u.naive_local()),
-        deleted: None,
+        deleted: Some(false),
         nsfw: page.sensitive,
         stickied: page.stickied,
         embed_title,

--- a/crates/apub/src/objects/private_message.rs
+++ b/crates/apub/src/objects/private_message.rs
@@ -149,7 +149,7 @@ impl ApubObject for ApubPrivateMessage {
       content: read_from_string_or_source(&note.content, &None, &note.source),
       published: note.published.map(|u| u.naive_local()),
       updated: note.updated.map(|u| u.naive_local()),
-      deleted: None,
+      deleted: Some(false),
       read: None,
       ap_id: Some(note.id.into()),
       local: Some(false),

--- a/crates/apub/src/protocol/objects/group.rs
+++ b/crates/apub/src/protocol/objects/group.rs
@@ -102,7 +102,7 @@ impl Group {
       removed: None,
       published: self.published.map(|u| u.naive_local()),
       updated: self.updated.map(|u| u.naive_local()),
-      deleted: None,
+      deleted: Some(false),
       nsfw: Some(self.sensitive.unwrap_or(false)),
       actor_id: Some(self.id.into()),
       local: Some(false),


### PR DESCRIPTION
To be honest this feels a bit like a hack, but should work fine.