### PR TITLE
Mark own private messages as read in api (fixes #2484)

### DIFF
--- a/crates/api_crud/src/private_message/read.rs
+++ b/crates/api_crud/src/private_message/read.rs
@@ -39,6 +39,14 @@ impl PerformCrud for GetPrivateMessages {
     })
     .await??;
 
+    // Messages sent by ourselves should be marked as read. The `read` column in database is only
+    // for the recipient, and shouldnt be exposed to sender.
+    messages.iter_mut().for_each(|pmv| {
+      if pmv.creator.id == person_id {
+        pmv.private_message.read = true
+      }
+    });
+
     // Blank out deleted or removed info
     for pmv in messages
       .iter_mut()


### PR DESCRIPTION
I noticed that this is also a privacy issue, because currently it allows the pm sender to see if the recipient has read the message. So it should be overwritten, because the sender has read his own message by definition.