### PR TITLE
Remove explicit panic from db connection code (fixes #2533)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -78,8 +78,7 @@ async fn main() -> Result<(), LemmyError> {
   let pool = Pool::builder()
     .max_size(settings.database.pool_size)
     .min_idle(Some(1))
-    .build(manager)
-    .unwrap_or_else(|_| panic!("Error connecting to {}", db_url));
+    .build(manager)?;
 
   // Run the migrations from code
   let settings_cloned = settings.to_owned();


### PR DESCRIPTION
This is the error message mentioned in #2533. Tbh i dont know why this panics explicitly, instead of normal error handling.