### PR TITLE
Dont purge posts/comments when user deletes account (ref #2426)

### DIFF
--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -763,21 +763,6 @@ pub async fn delete_user_account(
   }
   // No need to update avatar and banner, those are handled in Person::delete_account
 
-  // Comments
-  let permadelete = move |conn: &mut _| Comment::permadelete_for_creator(conn, person_id);
-  blocking(pool, permadelete)
-    .await?
-    .map_err(|e| LemmyError::from_error_message(e, "couldnt_update_comment"))?;
-
-  // Posts
-  let permadelete = move |conn: &mut _| Post::permadelete_for_creator(conn, person_id);
-  blocking(pool, permadelete)
-    .await?
-    .map_err(|e| LemmyError::from_error_message(e, "couldnt_update_post"))?;
-
-  // Purge image posts
-  purge_image_posts_for_person(person_id, pool, settings, client).await?;
-
   blocking(pool, move |conn| Person::delete_account(conn, person_id)).await??;
 
   Ok(())

--- a/crates/db_schema/src/impls/comment.rs
+++ b/crates/db_schema/src/impls/comment.rs
@@ -17,20 +17,6 @@ use diesel_ltree::Ltree;
 use url::Url;
 
 impl Comment {
-  pub fn permadelete_for_creator(
-    conn: &mut PgConnection,
-    for_creator_id: PersonId,
-  ) -> Result<Vec<Self>, Error> {
-    use crate::schema::comment::dsl::*;
-    diesel::update(comment.filter(creator_id.eq(for_creator_id)))
-      .set((
-        content.eq("*Permananently Deleted*"),
-        deleted.eq(true),
-        updated.eq(naive_now()),
-      ))
-      .get_results::<Self>(conn)
-  }
-
   pub fn update_removed_for_creator(
     conn: &mut PgConnection,
     for_creator_id: PersonId,

--- a/crates/db_schema/src/impls/post.rs
+++ b/crates/db_schema/src/impls/post.rs
@@ -69,26 +69,6 @@ impl Post {
       .load::<Self>(conn)
   }
 
-  pub fn permadelete_for_creator(
-    conn: &mut PgConnection,
-    for_creator_id: PersonId,
-  ) -> Result<Vec<Self>, Error> {
-    use crate::schema::post::dsl::*;
-
-    let perma_deleted = "*Permananently Deleted*";
-    let perma_deleted_url = "https://deleted.com";
-
-    diesel::update(post.filter(creator_id.eq(for_creator_id)))
-      .set((
-        name.eq(perma_deleted),
-        url.eq(perma_deleted_url),
-        body.eq(perma_deleted),
-        deleted.eq(true),
-        updated.eq(naive_now()),
-      ))
-      .get_results::<Self>(conn)
-  }
-
   pub fn update_removed_for_creator(
     conn: &mut PgConnection,
     for_creator_id: PersonId,


### PR DESCRIPTION
Based on the comment below by kromonos in Matrix, GDPR only requires operators to delete the following personally identifying information: 

- Name (nickname is part of it) and address
- E-mail address / Internet address
- Identity card number
- IP address
- Other individual data, such as (gender, title, height, hair color, telephone number, account data, record of working hours, location data, vehicle license plate number, audio recordings of voice, photo, answers of an examinee and comments of the examiner on this, opinions and assessments on the part of the data subject and about the data subject e.g., about his creditworthiness, his sexual orientation, work performance).

Posted content is not part of it, so there is no legal problem if we leave it. Deleting such content is also bad for the ecosystem, because valuable information disappears.

We should update the account deletion message to account for this, and tell the user to delete individual posts/comments before deleting the account, if desired.