### PR TITLE
Specify dependencies and metadata for entire workspace

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -22,6 +22,11 @@ steps:
     commands:
       - /root/.cargo/bin/cargo fmt -- --check
 
+  - name: lemmy_api_common doesnt depend on diesel
+    image: rust:1.64-buster
+    commands:
+      - ! cargo tree -p lemmy_api_common --no-default-features -i diesel
+
   # latest rust for clippy to get extra checks
   - name: cargo clippy
     image: rust:1.64-buster

--- a/.drone.yml
+++ b/.drone.yml
@@ -22,6 +22,11 @@ steps:
     commands:
       - /root/.cargo/bin/cargo fmt -- --check
 
+  - name: lemmy_api_common doesnt depend on diesel
+    image: rust:1.64-buster
+    commands:
+      - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
+
   # latest rust for clippy to get extra checks
   - name: cargo clippy
     image: rust:1.64-buster

--- a/.drone.yml
+++ b/.drone.yml
@@ -22,11 +22,6 @@ steps:
     commands:
       - /root/.cargo/bin/cargo fmt -- --check
 
-  - name: lemmy_api_common doesnt depend on diesel
-    image: rust:1.64-buster
-    commands:
-      - ! cargo tree -p lemmy_api_common --no-default-features -i diesel
-
   # latest rust for clippy to get extra checks
   - name: cargo clippy
     image: rust:1.64-buster

--- a/.drone.yml
+++ b/.drone.yml
@@ -22,11 +22,6 @@ steps:
     commands:
       - /root/.cargo/bin/cargo fmt -- --check
 
-  - name: lemmy_api_common doesnt depend on diesel
-    image: rust:1.64-buster
-    commands:
-      - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
-
   # latest rust for clippy to get extra checks
   - name: cargo clippy
     image: rust:1.64-buster
@@ -61,6 +56,11 @@ steps:
       - cargo install cargo-workspaces
       - cargo workspaces exec cargo check --no-default-features
       - cargo workspaces exec cargo check --all-features
+
+  - name: lemmy_api_common doesnt depend on diesel
+    image: rust:1.64-buster
+    commands:
+      - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
 
   - name: cargo build
     image: clux/muslrust:1.64.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2269,7 +2269,6 @@ dependencies = [
  "reqwest-retry",
  "reqwest-tracing",
  "serde",
- "tokio",
  "tracing",
  "tracing-actix-web",
  "tracing-error",
@@ -2334,7 +2333,7 @@ dependencies = [
  "lemmy_db_views",
  "lemmy_db_views_actor",
  "lemmy_utils",
- "opentelemetry 0.18.0",
+ "opentelemetry 0.17.0",
  "rand 0.8.5",
  "reqwest-middleware",
  "serde",
@@ -2343,7 +2342,7 @@ dependencies = [
  "strum_macros",
  "tokio",
  "tracing",
- "tracing-opentelemetry 0.18.0",
+ "tracing-opentelemetry 0.17.4",
 ]
 
 [[package]]
@@ -2817,16 +2816,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d6c3d7288a106c0a363e4b0e8d308058d56902adefb16f4936f417ffef086e"
-dependencies = [
- "opentelemetry_api",
- "opentelemetry_sdk",
-]
-
-[[package]]
 name = "opentelemetry-otlp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2842,42 +2831,6 @@ dependencies = [
  "tokio",
  "tonic 0.6.2",
  "tonic-build",
-]
-
-[[package]]
-name = "opentelemetry_api"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c24f96e21e7acc813c7a8394ee94978929db2bcc46cf6b5014fc612bf7760c22"
-dependencies = [
- "fnv",
- "futures-channel",
- "futures-util",
- "indexmap",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca41c4933371b61c2a2f214bf16931499af4ec90543604ec828f7a625c09113"
-dependencies = [
- "async-trait",
- "crossbeam-channel",
- "dashmap",
- "fnv",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "once_cell",
- "opentelemetry_api",
- "percent-encoding",
- "rand 0.8.5",
- "thiserror",
 ]
 
 [[package]]
@@ -4541,20 +4494,6 @@ checksum = "fbbe89715c1dbbb790059e2565353978564924ee85017b5fff365c872ff6721f"
 dependencies = [
  "once_cell",
  "opentelemetry 0.17.0",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "tracing-opentelemetry"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ebb87a95ea13271332df069020513ab70bdb5637ca42d6e492dc3bbbad48de"
-dependencies = [
- "once_cell",
- "opentelemetry 0.18.0",
  "tracing",
  "tracing-core",
  "tracing-log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,19 @@
-[package]
-name = "lemmy_server"
+[workspace.package]
 version = "0.16.5"
 edition = "2021"
 description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
 homepage = "https://join-lemmy.org/"
 documentation = "https://join-lemmy.org/docs/en/index.html"
-rust-version = "1.57"
+
+[package]
+name = "lemmy_server"
+version.workspace = true
+edition.workspace = true
+description.workspace = true
+license.workspace = true
+homepage.workspace = true
+documentation.workspace = true
 
 [lib]
 doctest = false
@@ -40,15 +47,18 @@ members = [
     "crates/routes"
 ]
 
-[dependencies]
+[workspace.dependencies]
 lemmy_api = { version = "=0.16.5", path = "./crates/api" }
 lemmy_api_crud = { version = "=0.16.5", path = "./crates/api_crud" }
 lemmy_apub = { version = "=0.16.5", path = "./crates/apub" }
 lemmy_utils = { version = "=0.16.5", path = "./crates/utils" }
 lemmy_db_schema = { version = "=0.16.5", path = "./crates/db_schema" }
-lemmy_api_common = { version = "=0.16.5", path = "crates/api_common" }
+lemmy_api_common = { version = "=0.16.5", path = "./crates/api_common" }
 lemmy_websocket = { version = "=0.16.5", path = "./crates/websocket" }
 lemmy_routes = { version = "=0.16.5", path = "./crates/routes" }
+lemmy_db_views = { version = "=0.16.5", path = "./crates/db_views" }
+lemmy_db_views_actor = { version = "=0.16.5", path = "./crates/db_views_actor" }
+lemmy_db_views_moderator = { version = "=0.16.5", path = "./crates/db_views_moderator" }
 activitypub_federation = "0.3.2"
 diesel = "2.0.2"
 diesel_migrations = "2.0.0"
@@ -69,8 +79,64 @@ clokwerk = "0.3.5"
 doku = { version = "0.20.0", features = ["url-2"] }
 parking_lot = "0.12.1"
 reqwest-retry = "0.1.5"
-console-subscriber = { version = "0.1.8", optional = true }
-opentelemetry = { version = "0.17.0", features = ["rt-tokio"], optional = true }
-opentelemetry-otlp = { version = "0.10.0", optional = true }
-tracing-opentelemetry = { version = "0.17.2", optional = true }
+bcrypt = "0.13.0"
+chrono = { version = "0.4.22", features = ["serde"], default-features = false }
+serde_json = { version = "1.0.87", features = ["preserve_order"] }
+base64 = "0.13.1"
+uuid = { version = "1.2.1", features = ["serde", "v4"] }
+async-trait = "0.1.58"
+captcha = "0.0.9"
+anyhow = "1.0.66"
+diesel_ltree = "0.3.0"
+typed-builder = "0.10.0"
+serial_test = "0.9.0"
 tokio = "1.21.2"
+sha2 = "0.10.6"
+regex = "1.6.0"
+once_cell = "1.15.0"
+diesel-derive-newtype = "2.0.0-rc.0"
+strum = "0.24.1"
+strum_macros = "0.24.3"
+itertools = "0.10.5"
+futures = "0.3.25"
+http = "0.2.8"
+actix-rt = { version = "2.7.0", default-features = false }
+percent-encoding = "2.2.0"
+rosetta-i18n = "0.1.2"
+rand = "0.8.5"
+opentelemetry = { version = "0.17.0", features = ["rt-tokio"] }
+tracing-opentelemetry = { version = "0.17.2" }
+
+[dependencies]
+lemmy_api = { workspace = true }
+lemmy_api_crud = { workspace = true }
+lemmy_apub = { workspace = true }
+lemmy_utils = { workspace = true }
+lemmy_db_schema = { workspace = true }
+lemmy_api_common = { workspace = true }
+lemmy_websocket = { workspace = true }
+lemmy_routes = { workspace = true }
+activitypub_federation = { workspace = true }
+diesel = { workspace = true }
+diesel_migrations = { workspace = true }
+diesel-async = { workspace = true }
+serde = { workspace = true }
+actix = { workspace = true }
+actix-web = { workspace = true }
+tracing = { workspace = true }
+tracing-actix-web = { workspace = true }
+tracing-error = { workspace = true }
+tracing-log = { workspace = true }
+tracing-subscriber = { workspace = true }
+url = { workspace = true }
+reqwest = { workspace = true }
+reqwest-middleware = { workspace = true }
+reqwest-tracing = { workspace = true }
+clokwerk = { workspace = true }
+doku = { workspace = true }
+parking_lot = { workspace = true }
+reqwest-retry = { workspace = true }
+tracing-opentelemetry = { workspace = true, optional = true }
+opentelemetry = { workspace = true, optional = true }
+console-subscriber = { version = "0.1.8", optional = true }
+opentelemetry-otlp = { version = "0.10.0", optional = true }

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name = "lemmy_api"
-version = "0.16.5"
-edition = "2021"
-description = "A link aggregator for the fediverse"
-license = "AGPL-3.0"
-homepage = "https://join-lemmy.org/"
-documentation = "https://join-lemmy.org/docs/en/index.html"
-rust-version = "1.57"
+version.workspace = true
+edition.workspace = true
+description.workspace = true
+license.workspace = true
+homepage.workspace = true
+documentation.workspace = true
 
 [lib]
 name = "lemmy_api"
@@ -14,28 +13,28 @@ path = "src/lib.rs"
 doctest = false
 
 [dependencies]
-lemmy_apub = { version = "=0.16.5", path = "../apub" }
-lemmy_utils = { version = "=0.16.5", path = "../utils" }
-lemmy_db_schema = { version = "=0.16.5", path = "../db_schema", features = ["full"] }
-lemmy_db_views = { version = "=0.16.5", path = "../db_views", features = ["full"] }
-lemmy_db_views_moderator = { version = "=0.16.5", path = "../db_views_moderator", features = ["full"] }
-lemmy_db_views_actor = { version = "=0.16.5", path = "../db_views_actor", features = ["full"] }
-lemmy_api_common = { version = "=0.16.5", path = "../api_common", features = ["full"] }
-lemmy_websocket = { version = "=0.16.5", path = "../websocket" }
-activitypub_federation = "0.3.2"
-diesel = "2.0.2"
-bcrypt = "0.13.0"
-chrono = { version = "0.4.22", features = ["serde"], default-features = false }
-serde_json = { version = "1.0.87", features = ["preserve_order"] }
-serde = { version = "1.0.147", features = ["derive"] }
-actix-web = { version = "4.2.1", default-features = false }
-base64 = "0.13.1"
-uuid = { version = "1.2.1", features = ["serde", "v4"] }
-async-trait = "0.1.58"
-captcha = "0.0.9"
-anyhow = "1.0.66"
-tracing = "0.1.37"
+lemmy_apub = { workspace = true }
+lemmy_utils = { workspace = true }
+lemmy_db_schema = { workspace = true, features = ["full"] }
+lemmy_db_views = { workspace = true, features = ["full"] }
+lemmy_db_views_moderator = { workspace = true, features = ["full"] }
+lemmy_db_views_actor = { workspace = true, features = ["full"] }
+lemmy_api_common = { workspace = true, features = ["full"] }
+lemmy_websocket = { workspace = true }
+activitypub_federation = { workspace = true }
+diesel = { workspace = true }
+bcrypt = { workspace = true }
+chrono = { workspace = true }
+serde_json = { workspace = true }
+serde = { workspace = true }
+actix-web = { workspace = true }
+base64 = { workspace = true }
+uuid = { workspace = true }
+async-trait = { workspace = true }
+captcha = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
-serial_test = "0.9.0"
-tokio = "1.21.2"
+serial_test = { workspace = true }
+tokio = { workspace = true }

--- a/crates/api_common/Cargo.toml
+++ b/crates/api_common/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name = "lemmy_api_common"
-version = "0.16.5"
-edition = "2021"
-description = "A link aggregator for the fediverse"
-license = "AGPL-3.0"
-homepage = "https://join-lemmy.org/"
-documentation = "https://join-lemmy.org/docs/en/index.html"
-rust-version = "1.57"
+version.workspace = true
+edition.workspace = true
+description.workspace = true
+license.workspace = true
+homepage.workspace = true
+documentation.workspace = true
 
 [lib]
 name = "lemmy_api_common"
@@ -19,24 +18,24 @@ full = ["diesel", "tracing", "rosetta-i18n", "chrono", "actix-web", "lemmy_utils
     "percent-encoding", "encoding", "reqwest-middleware", "webpage"]
 
 [dependencies]
-lemmy_db_views = { version = "=0.16.5", path = "../db_views" }
-lemmy_db_views_moderator = { version = "=0.16.5", path = "../db_views_moderator" }
-lemmy_db_views_actor = { version = "=0.16.5", path = "../db_views_actor" }
-lemmy_db_schema = { version = "=0.16.5", path = "../db_schema", default-features = false }
-lemmy_utils = { version = "=0.16.5", path = "../utils", optional = true }
-serde = { version = "1.0.147", features = ["derive"] }
-url = "2.3.1"
-actix-web = { version = "4.2.1", default-features = false, features = ["cookies"], optional = true }
-chrono = { version = "0.4.22", features = ["serde"], optional = true }
-diesel = { version = "2.0.2", optional = true }
-tracing = { version = "0.1.36", optional = true }
-rosetta-i18n = { version = "0.1.2", optional = true }
-percent-encoding = { version = "2.2.0", optional = true }
-encoding = { version = "0.2.33", optional = true }
-reqwest-middleware = { version = "0.1.6", optional = true }
+lemmy_db_views = { workspace = true }
+lemmy_db_views_moderator = { workspace = true }
+lemmy_db_views_actor = { workspace = true }
+lemmy_db_schema = { workspace = true, default-features = false }
+lemmy_utils = { workspace = true, optional = true }
+serde = { workspace = true }
+url = { workspace = true }
+actix-web = { workspace = true, features = ["cookies"], optional = true }
+chrono = { workspace = true, optional = true }
+diesel = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
+reqwest-middleware = { workspace = true, optional = true }
+regex = { workspace = true }
+rosetta-i18n = { workspace = true, optional = true }
+percent-encoding = { workspace = true, optional = true }
 webpage = { version = "1.4.0", default-features = false, features = ["serde"], optional = true }
-regex = "1.6.0"
+encoding = { version = "0.2.33", optional = true }
 
 [dev-dependencies]
-actix-rt = { version = "2.7.0", default-features = false }
-reqwest = { version = "0.11.12", features = ["json"] }
+actix-rt = { workspace = true }
+reqwest = { workspace = true }

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -274,8 +274,8 @@ pub async fn build_federated_instances(
     let blocked = Instance::blocklist(pool).await?;
 
     // These can return empty vectors, so convert them to options
-    let allowed = (!allowed.is_empty()).then(|| allowed);
-    let blocked = (!blocked.is_empty()).then(|| blocked);
+    let allowed = (!allowed.is_empty()).then_some(allowed);
+    let blocked = (!blocked.is_empty()).then_some(blocked);
 
     Ok(Some(FederatedInstances {
       linked,

--- a/crates/api_crud/Cargo.toml
+++ b/crates/api_crud/Cargo.toml
@@ -1,27 +1,26 @@
 [package]
 name = "lemmy_api_crud"
-version = "0.16.5"
-edition = "2021"
-description = "A link aggregator for the fediverse"
-license = "AGPL-3.0"
-homepage = "https://join-lemmy.org/"
-documentation = "https://join-lemmy.org/docs/en/index.html"
-rust-version = "1.57"
+version.workspace = true
+edition.workspace = true
+description.workspace = true
+license.workspace = true
+homepage.workspace = true
+documentation.workspace = true
 
 [dependencies]
-lemmy_apub = { version = "=0.16.5", path = "../apub" }
-lemmy_utils = { version = "=0.16.5", path = "../utils" }
-lemmy_db_schema = { version = "=0.16.5", path = "../db_schema", features = ["full"] }
-lemmy_db_views = { version = "=0.16.5", path = "../db_views", features = ["full"] }
-lemmy_db_views_actor = { version = "=0.16.5", path = "../db_views_actor", features = ["full"] }
-lemmy_api_common = { version = "=0.16.5", path = "../api_common", features = ["full"] }
-lemmy_websocket = { version = "=0.16.5", path = "../websocket" }
-activitypub_federation = "0.3.2"
-bcrypt = "0.13.0"
-serde_json = { version = "1.0.87", features = ["preserve_order"] }
-serde = { version = "1.0.147", features = ["derive"] }
-actix-web = { version = "4.2.1", default-features = false }
-tracing = "0.1.36"
-url = { version = "2.3.1", features = ["serde"] }
-async-trait = "0.1.58"
+lemmy_apub = { workspace = true }
+lemmy_utils = { workspace = true }
+lemmy_db_schema = { workspace = true, features = ["full"] }
+lemmy_db_views = { workspace = true, features = ["full"] }
+lemmy_db_views_actor = { workspace = true, features = ["full"] }
+lemmy_api_common = { workspace = true, features = ["full"] }
+lemmy_websocket = { workspace = true }
+activitypub_federation = { workspace = true }
+bcrypt = { workspace = true }
+serde_json = { workspace = true }
+serde = { workspace = true }
+actix-web = { workspace = true }
+tracing = { workspace = true }
+url = { workspace = true }
+async-trait = { workspace = true }
 webmention = "0.4.0"

--- a/crates/apub/Cargo.toml
+++ b/crates/apub/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name = "lemmy_apub"
-version = "0.16.5"
-edition = "2021"
-description = "A link aggregator for the fediverse"
-license = "AGPL-3.0"
-homepage = "https://join-lemmy.org/"
-documentation = "https://join-lemmy.org/docs/en/index.html"
-rust-version = "1.57"
+version.workspace = true
+edition.workspace = true
+description.workspace = true
+license.workspace = true
+homepage.workspace = true
+documentation.workspace = true
 
 [lib]
 name = "lemmy_apub"
@@ -14,41 +13,41 @@ path = "src/lib.rs"
 doctest = false
 
 [dependencies]
-lemmy_utils = { version = "=0.16.5", path = "../utils" }
-lemmy_db_schema = { version = "=0.16.5", path = "../db_schema", features = ["full"] }
-lemmy_db_views = { version = "=0.16.5", path = "../db_views", features = ["full"] }
-lemmy_db_views_actor = { version = "=0.16.5", path = "../db_views_actor", features = ["full"] }
-lemmy_api_common = { version = "=0.16.5", path = "../api_common", features = ["full"] }
-lemmy_websocket = { version = "=0.16.5", path = "../websocket" }
-activitypub_federation = "0.3.2"
-diesel = "2.0.2"
-activitystreams-kinds = "0.2.1"
-chrono = { version = "0.4.22", features = ["serde"], default-features = false }
-serde_json = { version = "1.0.87", features = ["preserve_order"] }
-serde = { version = "1.0.147", features = ["derive"] }
-serde_with = "1.14.0"
-actix = "0.13.0"
-actix-web = { version = "4.2.1", default-features = false }
-actix-rt = { version = "2.7.0", default-features = false }
-tracing = "0.1.36"
-strum_macros = "0.24.3"
-url = { version = "2.3.1", features = ["serde"] }
-http = "0.2.8"
-http-signature-normalization-actix = { version = "0.6.1", default-features = false, features = ["server", "sha-2"] }
-futures = "0.3.25"
-itertools = "0.10.5"
-uuid = { version = "1.2.1", features = ["serde", "v4"] }
-sha2 = "0.10.6"
-async-trait = "0.1.58"
-anyhow = "1.0.66"
-reqwest = { version = "0.11.12", features = ["json"] }
+lemmy_utils = { workspace = true }
+lemmy_db_schema = { workspace = true, features = ["full"] }
+lemmy_db_views = { workspace = true, features = ["full"] }
+lemmy_db_views_actor = { workspace = true, features = ["full"] }
+lemmy_api_common = { workspace = true, features = ["full"] }
+lemmy_websocket = { workspace = true }
+activitypub_federation = { workspace = true }
+diesel = { workspace = true }
+chrono = { workspace = true }
+serde_json = { workspace = true }
+serde = { workspace = true }
+actix = { workspace = true }
+actix-web = { workspace = true }
+actix-rt = { workspace = true }
+tracing = { workspace = true }
+strum_macros = { workspace = true }
+url = { workspace = true }
+http = { workspace = true }
+futures = { workspace = true }
+itertools = { workspace = true }
+uuid = { workspace = true }
+sha2 = { workspace = true }
+async-trait = { workspace = true }
+anyhow = { workspace = true }
+reqwest = { workspace = true }
+once_cell = { workspace = true }
+tokio = { workspace = true }
 html2md = "0.2.13"
-once_cell = "1.15.0"
-tokio = "1.21.2"
+serde_with = "1.14.0"
+activitystreams-kinds = "0.2.1"
+http-signature-normalization-actix = { version = "0.6.1", default-features = false, features = ["server", "sha-2"] }
 enum_delegate = "0.2.0"
 
 [dev-dependencies]
-serial_test = "0.9.0"
-assert-json-diff = "2.0.2"
-reqwest-middleware = "0.1.6"
+serial_test = { workspace = true }
+reqwest-middleware = { workspace = true }
 task-local-extensions = "0.1.3"
+assert-json-diff = "2.0.2"

--- a/crates/apub/src/lib.rs
+++ b/crates/apub/src/lib.rs
@@ -151,8 +151,8 @@ pub(crate) async fn fetch_local_site_data(
   let blocked = Instance::blocklist(pool).await?;
 
   // These can return empty vectors, so convert them to options
-  let allowed_instances = (!allowed.is_empty()).then(|| allowed);
-  let blocked_instances = (!blocked.is_empty()).then(|| blocked);
+  let allowed_instances = (!allowed.is_empty()).then_some(allowed);
+  let blocked_instances = (!blocked.is_empty()).then_some(blocked);
 
   Ok(LocalSiteData {
     local_site,

--- a/crates/db_schema/Cargo.toml
+++ b/crates/db_schema/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name = "lemmy_db_schema"
-version = "0.16.5"
-edition = "2021"
-description = "A link aggregator for the fediverse"
-license = "AGPL-3.0"
-homepage = "https://join-lemmy.org/"
-documentation = "https://join-lemmy.org/docs/en/index.html"
-rust-version = "1.57"
+version.workspace = true
+edition.workspace = true
+description.workspace = true
+license.workspace = true
+homepage.workspace = true
+documentation.workspace = true
 
 [lib]
 name = "lemmy_db_schema"
@@ -18,28 +17,28 @@ full = ["diesel", "diesel-derive-newtype", "diesel_migrations", "bcrypt", "lemmy
     "activitypub_federation", "sha2", "regex", "once_cell", "serde_json"]
 
 [dependencies]
-chrono = { version = "0.4.22", features = ["serde"], default-features = false }
-serde = { version = "1.0.147", features = ["derive"] }
-url = { version = "2.3.1", features = ["serde"] }
-strum = "0.24.1"
-strum_macros = "0.24.3"
-serde_json = { version = "1.0.87", features = ["preserve_order"], optional = true }
-activitypub_federation = {version = "0.3.2", optional = true }
-lemmy_utils = { version = "=0.16.5", path = "../utils", optional = true }
-bcrypt = { version = "0.13.0", optional = true }
-diesel = { version = "2.0.2", features = ["postgres","chrono", "serde_json"], optional = true }
-diesel-derive-newtype = { version = "2.0.0-rc.0", optional = true }
-diesel_migrations = { version = "2.0.0", optional = true }
-diesel-async = { version = "0.1.1", features = ["postgres", "bb8"] }
+chrono = { workspace = true }
+serde = { workspace = true }
+url = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
+serde_json = { workspace = true, optional = true }
+activitypub_federation = { workspace = true, optional = true }
+lemmy_utils = { workspace = true, optional = true }
+bcrypt = { workspace = true, optional = true }
+diesel = { workspace = true, features = ["postgres","chrono", "serde_json"], optional = true }
+diesel-derive-newtype = { workspace = true, optional = true }
+diesel_migrations = { workspace = true, optional = true }
+diesel-async = { workspace = true, features = ["postgres", "bb8"] }
+sha2 = { workspace = true, optional = true }
+regex = { workspace = true, optional = true }
+once_cell = { workspace = true, optional = true }
+diesel_ltree = { workspace = true }
+typed-builder = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true }
 bb8 = "0.8.0"
-sha2 = { version = "0.10.6", optional = true }
-regex = { version = "1.6.0", optional = true }
-once_cell = { version = "1.15.0", optional = true }
-diesel_ltree = "0.3.0"
-typed-builder = "0.10.0"
-async-trait = "0.1.58"
-tokio = "1.21.2"
 
 [dev-dependencies]
-serial_test = "0.9.0"
+serial_test = { workspace = true }
 

--- a/crates/db_schema/Cargo.toml
+++ b/crates/db_schema/Cargo.toml
@@ -14,7 +14,8 @@ doctest = false
 
 [features]
 full = ["diesel", "diesel-derive-newtype", "diesel_migrations", "bcrypt", "lemmy_utils",
-    "activitypub_federation", "sha2", "regex", "once_cell", "serde_json"]
+    "activitypub_federation", "sha2", "regex", "once_cell", "serde_json", "diesel_ltree",
+    "diesel-async", "bb8"]
 
 [dependencies]
 chrono = { workspace = true }
@@ -29,15 +30,15 @@ bcrypt = { workspace = true, optional = true }
 diesel = { workspace = true, features = ["postgres","chrono", "serde_json"], optional = true }
 diesel-derive-newtype = { workspace = true, optional = true }
 diesel_migrations = { workspace = true, optional = true }
-diesel-async = { workspace = true, features = ["postgres", "bb8"] }
+diesel-async = { workspace = true, features = ["postgres", "bb8"], optional = true }
 sha2 = { workspace = true, optional = true }
 regex = { workspace = true, optional = true }
 once_cell = { workspace = true, optional = true }
-diesel_ltree = { workspace = true }
+diesel_ltree = { workspace = true, optional = true }
 typed-builder = { workspace = true }
 async-trait = { workspace = true }
 tokio = { workspace = true }
-bb8 = "0.8.0"
+bb8 = { version = "0.8.0", optional = true }
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/crates/db_schema/src/lib.rs
+++ b/crates/db_schema/src/lib.rs
@@ -8,10 +8,10 @@ extern crate diesel;
 extern crate diesel_derive_newtype;
 // this is used in tests
 #[cfg(feature = "full")]
-#[allow(unused_imports)]
 #[macro_use]
 extern crate diesel_migrations;
 
+#[cfg(feature = "full")]
 #[macro_use]
 extern crate async_trait;
 

--- a/crates/db_schema/src/newtypes.rs
+++ b/crates/db_schema/src/newtypes.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "full")]
 use diesel_ltree::Ltree;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -111,6 +112,7 @@ pub struct LocalSiteId(i32);
 #[cfg_attr(feature = "full", diesel(sql_type = diesel::sql_types::Text))]
 pub struct DbUrl(pub(crate) Url);
 
+#[cfg(feature = "full")]
 #[derive(Serialize, Deserialize)]
 #[serde(remote = "Ltree")]
 /// Do remote derivation for the Ltree struct

--- a/crates/db_schema/src/source/comment.rs
+++ b/crates/db_schema/src/source/comment.rs
@@ -1,6 +1,9 @@
-use crate::newtypes::{CommentId, DbUrl, LanguageId, LtreeDef, PersonId, PostId};
+#[cfg(feature = "full")]
+use crate::newtypes::LtreeDef;
+use crate::newtypes::{CommentId, DbUrl, LanguageId, PersonId, PostId};
 #[cfg(feature = "full")]
 use crate::schema::{comment, comment_like, comment_saved};
+#[cfg(feature = "full")]
 use diesel_ltree::Ltree;
 use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
@@ -20,6 +23,7 @@ pub struct Comment {
   pub deleted: bool,
   pub ap_id: DbUrl,
   pub local: bool,
+  #[cfg(feature = "full")]
   #[serde(with = "LtreeDef")]
   pub path: Ltree,
   pub distinguished: bool,

--- a/crates/db_views/Cargo.toml
+++ b/crates/db_views/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name = "lemmy_db_views"
-version = "0.16.5"
-edition = "2021"
-description = "A link aggregator for the fediverse"
-license = "AGPL-3.0"
-homepage = "https://join-lemmy.org/"
-documentation = "https://join-lemmy.org/docs/en/index.html"
-rust-version = "1.57"
+version.workspace = true
+edition.workspace = true
+description.workspace = true
+license.workspace = true
+homepage.workspace = true
+documentation.workspace = true
 
 [lib]
 doctest = false
@@ -15,15 +14,15 @@ doctest = false
 full = ["lemmy_db_schema/full", "diesel", "diesel-async", "diesel_ltree", "tracing"]
 
 [dependencies]
-lemmy_db_schema = { version = "=0.16.5", path = "../db_schema" }
-diesel = { version = "2.0.2", features = ["postgres","chrono","serde_json"], optional = true }
-diesel-async = { version = "0.1.1", features = ["postgres", "bb8"], optional = true}
-diesel_ltree = { version = "0.3.0", optional = true}
-serde = { version = "1.0.147", features = ["derive"] }
-tracing = { version = "0.1.36", optional = true }
-typed-builder = "0.10.0"
-url = { version = "2.3.1", features = ["serde"] }
+lemmy_db_schema = { workspace = true }
+diesel = { workspace = true, optional = true }
+diesel-async = { workspace = true, optional = true}
+diesel_ltree = { workspace = true, optional = true}
+serde = { workspace = true }
+tracing = { workspace = true, optional = true }
+typed-builder = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
-serial_test = "0.9.0"
-tokio = "1.21.2"
+serial_test = { workspace = true }
+tokio = { workspace = true }

--- a/crates/db_views_actor/Cargo.toml
+++ b/crates/db_views_actor/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name = "lemmy_db_views_actor"
-version = "0.16.5"
-edition = "2021"
-description = "A link aggregator for the fediverse"
-license = "AGPL-3.0"
-homepage = "https://join-lemmy.org/"
-documentation = "https://join-lemmy.org/docs/en/index.html"
-rust-version = "1.57"
+version.workspace = true
+edition.workspace = true
+description.workspace = true
+license.workspace = true
+homepage.workspace = true
+documentation.workspace = true
 
 [lib]
 doctest = false
@@ -15,8 +14,8 @@ doctest = false
 full = ["lemmy_db_schema/full", "diesel", "diesel-async"]
 
 [dependencies]
-lemmy_db_schema = { version = "=0.16.5", path = "../db_schema" }
-diesel = { version = "2.0.2", features = ["postgres","chrono","serde_json"], optional = true }
-diesel-async = { version = "0.1.1", features = ["postgres", "bb8"], optional = true }
-serde = { version = "1.0.147", features = ["derive"] }
-typed-builder = "0.10.0"
+lemmy_db_schema = { workspace = true }
+diesel = { workspace = true, features = ["postgres","chrono","serde_json"], optional = true }
+diesel-async = { workspace = true, features = ["postgres", "bb8"], optional = true }
+serde = { workspace = true }
+typed-builder = { workspace = true }

--- a/crates/db_views_moderator/Cargo.toml
+++ b/crates/db_views_moderator/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name = "lemmy_db_views_moderator"
-version = "0.16.5"
-edition = "2021"
-description = "A link aggregator for the fediverse"
-license = "AGPL-3.0"
-homepage = "https://join-lemmy.org/"
-documentation = "https://join-lemmy.org/docs/en/index.html"
-rust-version = "1.57"
+version.workspace = true
+edition.workspace = true
+description.workspace = true
+license.workspace = true
+homepage.workspace = true
+documentation.workspace = true
 
 [lib]
 doctest = false
@@ -15,7 +14,7 @@ doctest = false
 full = ["lemmy_db_schema/full", "diesel", "diesel-async"]
 
 [dependencies]
-lemmy_db_schema = { version = "=0.16.5", path = "../db_schema" }
-diesel = { version = "2.0.2", features = ["postgres","chrono","serde_json"], optional = true }
-diesel-async = { version = "0.1.1", features = ["postgres", "bb8"], optional = true }
-serde = { version = "1.0.147", features = ["derive"] }
+lemmy_db_schema = { workspace = true }
+diesel = { workspace = true, features = ["postgres","chrono","serde_json"], optional = true }
+diesel-async = { workspace = true, features = ["postgres", "bb8"], optional = true }
+serde = { workspace = true }

--- a/crates/routes/Cargo.toml
+++ b/crates/routes/Cargo.toml
@@ -1,35 +1,34 @@
 [package]
 name = "lemmy_routes"
-version = "0.16.5"
-edition = "2021"
-description = "A link aggregator for the fediverse"
-license = "AGPL-3.0"
-homepage = "https://join-lemmy.org/"
-documentation = "https://join-lemmy.org/docs/en/index.html"
-rust-version = "1.57"
+version.workspace = true
+edition.workspace = true
+description.workspace = true
+license.workspace = true
+homepage.workspace = true
+documentation.workspace = true
 
 [lib]
 doctest = false
 
 [dependencies]
-lemmy_utils = { version = "=0.16.5", path = "../utils" }
-lemmy_websocket = { version = "=0.16.5", path = "../websocket" }
-lemmy_db_views = { version = "=0.16.5", path = "../db_views" }
-lemmy_db_views_actor = { version = "=0.16.5", path = "../db_views_actor" }
-lemmy_db_schema = { version = "=0.16.5", path = "../db_schema" }
-lemmy_api_common = { version = "=0.16.5", path = "../api_common" }
-lemmy_apub = { version = "=0.16.5", path = "../apub" }
-diesel = "2.0.2"
-actix-web = { version = "4.2.1", default-features = false, features = ["rustls"] }
-anyhow = "1.0.66"
-chrono = { version = "0.4.22", features = ["serde"], default-features = false }
-futures = "0.3.25"
-reqwest = { version = "0.11.12", features = ["stream"] }
-reqwest-middleware = "0.1.6"
+lemmy_utils = { workspace = true }
+lemmy_websocket = { workspace = true }
+lemmy_db_views = { workspace = true }
+lemmy_db_views_actor = { workspace = true }
+lemmy_db_schema = { workspace = true }
+lemmy_api_common = { workspace = true }
+lemmy_apub = { workspace = true }
+diesel = { workspace = true }
+actix-web = { workspace = true }
+anyhow = { workspace = true }
+chrono = { workspace = true }
+futures = { workspace = true }
+reqwest = { workspace = true, features = ["stream"] }
+reqwest-middleware = { workspace = true }
+serde = { workspace = true }
+url = { workspace = true }
+strum = { workspace = true }
+once_cell = { workspace = true }
+tracing = { workspace = true }
+tokio = { workspace = true }
 rss = "2.0.1"
-serde = { version = "1.0.147", features = ["derive"] }
-url = { version = "2.3.1", features = ["serde"] }
-strum = "0.24.1"
-once_cell = "1.15.0"
-tracing = "0.1.36"
-tokio = { version = "1.21.2", features = ["sync"] }

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name = "lemmy_utils"
-version = "0.16.5"
-edition = "2021"
-description = "A link aggregator for the fediverse"
-license = "AGPL-3.0"
-homepage = "https://join-lemmy.org/"
-documentation = "https://join-lemmy.org/docs/en/index.html"
-rust-version = "1.57"
+version.workspace = true
+edition.workspace = true
+description.workspace = true
+license.workspace = true
+homepage.workspace = true
+documentation.workspace = true
 
 [lib]
 name = "lemmy_utils"
@@ -14,38 +13,38 @@ path = "src/lib.rs"
 doctest = false
 
 [dependencies]
-regex = "1.6.0"
-chrono = { version = "0.4.22", features = ["serde", "clock"], default-features = false }
-lettre = "0.10.1"
-tracing = "0.1.37"
-tracing-error = "0.2.0"
-itertools = "0.10.5"
-rand = "0.8.5"
-serde = { version = "1.0.147", features = ["derive"] }
-serde_json = { version = "1.0.87", features = ["preserve_order"] }
-comrak = { version = "0.14.0", default-features = false }
-once_cell = "1.15.0"
+regex = { workspace = true }
+chrono = { workspace = true }
+tracing = { workspace = true }
+tracing-error = { workspace = true }
+itertools = { workspace = true }
+rand = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+once_cell = { workspace = true }
+url = { workspace = true }
+actix-web = { workspace = true }
+anyhow = { workspace = true }
+reqwest-middleware = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
+futures = { workspace = true }
+diesel = { workspace = true, features = ["chrono"] }
+http = { workspace = true }
+doku = { workspace = true, features = ["url-2"] }
+uuid = { workspace = true, features = ["serde", "v4"] }
+rosetta-i18n = { workspace = true }
+parking_lot = { workspace = true }
+typed-builder = { workspace = true }
+percent-encoding = { workspace = true }
+tokio = { workspace = true }
 openssl = "0.10.42"
-url = { version = "2.3.1", features = ["serde"] }
-actix-web = { version = "4.2.1", default-features = false, features = ["rustls"] }
-anyhow = "1.0.66"
-reqwest-middleware = "0.1.6"
-strum = "0.24.1"
-strum_macros = "0.24.3"
-futures = "0.3.25"
-diesel = { version = "2.0.2", features = ["chrono"] }
-http = "0.2.8"
+html2text = "0.4.3"
 deser-hjson = "1.0.2"
 smart-default = "0.6.0"
 jsonwebtoken = "8.1.1"
-doku = { version = "0.20.0", features = ["url-2"] }
-uuid = { version = "1.2.1", features = ["serde", "v4"] }
-html2text = "0.4.3"
-rosetta-i18n = "0.1.2"
-parking_lot = "0.12.1"
-typed-builder = "0.10.0"
-percent-encoding = "2.2.0"
-tokio = "1.21.2"
+lettre = "0.10.1"
+comrak = { version = "0.14.0", default-features = false }
 
 [build-dependencies]
 rosetta-build = "0.1.2"

--- a/crates/websocket/Cargo.toml
+++ b/crates/websocket/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name = "lemmy_websocket"
-version = "0.16.5"
-edition = "2021"
-description = "A link aggregator for the fediverse"
-license = "AGPL-3.0"
-homepage = "https://join-lemmy.org/"
-documentation = "https://join-lemmy.org/docs/en/index.html"
-rust-version = "1.57"
+version.workspace = true
+edition.workspace = true
+description.workspace = true
+license.workspace = true
+homepage.workspace = true
+documentation.workspace = true
 
 [lib]
 name = "lemmy_websocket"
@@ -14,25 +13,25 @@ path = "src/lib.rs"
 doctest = false
 
 [dependencies]
-lemmy_utils = { version = "=0.16.5", path = "../utils" }
-lemmy_api_common = { version = "=0.16.5", path = "../api_common", features = ["full"] }
-lemmy_db_schema = { version = "=0.16.5", path = "../db_schema", features = ["full"] }
-lemmy_db_views = { version = "=0.16.5", path = "../db_views", features = ["full"] }
-lemmy_db_views_actor = { version = "=0.16.5", path = "../db_views_actor", features = ["full"] }
-reqwest-middleware = "0.1.6"
-tracing = "0.1.36"
-rand = "0.8.5"
-serde = { version = "1.0.147", features = ["derive"] }
-serde_json = { version = "1.0.87", features = ["preserve_order"] }
-actix = "0.13.0"
-anyhow = "1.0.66"
-diesel = "2.0.2"
-background-jobs = "0.13.0"
-tokio = "1.21.2"
-strum = "0.24.1"
-strum_macros = "0.24.3"
-chrono = { version = "0.4.22", features = ["serde"], default-features = false }
-actix-web = { version = "4.2.1", default-features = false, features = ["rustls"] }
+lemmy_utils = { workspace = true }
+lemmy_api_common = { workspace = true, features = ["full"] }
+lemmy_db_schema = { workspace = true, features = ["full"] }
+lemmy_db_views = { workspace = true, features = ["full"] }
+lemmy_db_views_actor = { workspace = true, features = ["full"] }
+reqwest-middleware = { workspace = true }
+tracing = { workspace = true }
+rand = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+actix = { workspace = true }
+anyhow = { workspace = true }
+diesel = { workspace = true }
+tokio = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
+chrono = { workspace = true }
+actix-web = { workspace = true }
+opentelemetry = { workspace = true }
+tracing-opentelemetry = { workspace = true }
 actix-web-actors = { version = "4.1.0", default-features = false }
-opentelemetry = "0.18.0"
-tracing-opentelemetry = "0.18.0"
+background-jobs = "0.13.0"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -32,16 +32,6 @@ fi
 # Update crate versions for crates.io
 pushd ../../
 old_tag=$(head -3 Cargo.toml | tail -1 | cut -d'"' -f 2)
-for crate in crates/*; do
-  pushd $crate
-  # update version of the crate itself (only first occurence)
-  # https://stackoverflow.com/a/9453461
-  sed -i "0,/version = \"$old_tag\"/s//version = \"$new_tag\"/g" Cargo.toml
-  # update version of lemmy dependencies
-  sed -i "s/{ version = \"=$old_tag\", path/{ version = \"=$new_tag\", path/g" Cargo.toml
-  git add Cargo.toml
-  popd
-done
 # same as above, for the main cargo.toml
 sed -i "s/{ version = \"=$old_tag\", path/{ version = \"=$new_tag\", path/g" Cargo.toml
 sed -i "s/version = \"$old_tag\"/version = \"$new_tag\"/g" Cargo.toml


### PR DESCRIPTION
We are now using Rust 1.64 in CI, so we can use this feature.