### PR TITLE
Federate group moderators using attributedTo field

### DIFF
--- a/crates/apub/assets/lemmy/objects/group.json
+++ b/crates/apub/assets/lemmy/objects/group.json
@@ -20,6 +20,7 @@
   "inbox": "https://enterprise.lemmy.ml/c/tenforward/inbox",
   "followers": "https://enterprise.lemmy.ml/c/tenforward/followers",
   "moderators": "https://enterprise.lemmy.ml/c/tenforward/moderators",
+  "attributedTo": "https://enterprise.lemmy.ml/c/tenforward/moderators",
   "postingRestrictedToMods": false,
   "endpoints": {
     "sharedInbox": "https://enterprise.lemmy.ml/inbox"

--- a/crates/apub/src/objects/community.rs
+++ b/crates/apub/src/objects/community.rs
@@ -242,6 +242,7 @@ pub(crate) mod tests {
     let mut json: Group = file_to_json_object("assets/lemmy/objects/group.json").unwrap();
     // change these links so they dont fetch over the network
     json.moderators = None;
+    json.attributed_to = None;
     json.outbox =
       ObjectId::new(Url::parse("https://enterprise.lemmy.ml/c/tenforward/not_outbox").unwrap());
 

--- a/crates/apub/src/protocol/objects/group.rs
+++ b/crates/apub/src/protocol/objects/group.rs
@@ -57,8 +57,9 @@ pub struct Group {
   pub(crate) image: Option<ImageObject>,
   // lemmy extension
   pub(crate) sensitive: Option<bool>,
-  // lemmy extension
+  // deprecated, use attributed_to instead
   pub(crate) moderators: Option<ObjectId<ApubCommunityModerators>>,
+  pub(crate) attributed_to: Option<ObjectId<ApubCommunityModerators>>,
   // lemmy extension
   pub(crate) posting_restricted_to_mods: Option<bool>,
   pub(crate) outbox: ObjectId<ApubCommunityOutbox>,

--- a/crates/apub/src/protocol/objects/group.rs
+++ b/crates/apub/src/protocol/objects/group.rs
@@ -59,6 +59,7 @@ pub struct Group {
   pub(crate) sensitive: Option<bool>,
   // deprecated, use attributed_to instead
   pub(crate) moderators: Option<ObjectId<ApubCommunityModerators>>,
+  #[serde(deserialize_with = "deserialize_skip_error", default)]
   pub(crate) attributed_to: Option<ObjectId<ApubCommunityModerators>>,
   // lemmy extension
   pub(crate) posting_restricted_to_mods: Option<bool>,


### PR DESCRIPTION
The field `moderators` is nonstandard, we should use `attributedTo` instead.