### PR TITLE
replace {{yourdomain}} with lemmyui.com

### DIFF
--- a/docker/prod/nginx.conf
+++ b/docker/prod/nginx.conf
@@ -1,7 +1,7 @@
 # nginx example config
-# replace {{yourdomain}} and review the certbot/letsencrypt config
+# replace lemmyui.com and review the certbot/letsencrypt config
 
-limit_req_zone $binary_remote_addr zone={{yourdomain}}_ratelimit:10m rate=1r/s;
+limit_req_zone $binary_remote_addr zone=lemmyui.com_ratelimit:10m rate=1r/s;
 
 upstream lemmy {
     # this needs to map to the lemmy (server) docker service hostname
@@ -17,7 +17,7 @@ server {
     # redirect everything else to 443
     listen 80;
     listen [::]:80;
-    server_name {{yourdomain}};
+    server_name lemmyui.com;
     location /.well-known/acme-challenge/ {
         root /var/www/certbot;
     }
@@ -29,10 +29,10 @@ server {
 server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
-    server_name {{yourdomain}};
+    server_name lemmyui.com;
 
-    ssl_certificate /etc/letsencrypt/live/{{yourdomain}}/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/{{yourdomain}}/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/lemmyui.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/lemmyui.com/privkey.pem;
 
     # Various TLS hardening settings
     # https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
@@ -100,7 +100,7 @@ server {
         proxy_set_header Connection "upgrade";
 
         # Rate limit
-        limit_req zone={{yourdomain}}_ratelimit burst=30 nodelay;
+        limit_req zone=lemmyui.com_ratelimit burst=30 nodelay;
 
         # Add IP forwarding headers
         proxy_set_header X-Real-IP $remote_addr;
@@ -121,7 +121,7 @@ server {
         proxy_set_header Connection "upgrade";
 
         # Rate limit
-        limit_req zone={{yourdomain}}_ratelimit burst=30 nodelay;
+        limit_req zone=lemmyui.com_ratelimit burst=30 nodelay;
 
         # Add IP forwarding headers
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
the sed command for installing lemmybb uses lemmyui.com not {{yourdomain}} so the install instructions currently do not work. Having lemmyui.com instead of {{yourdomain}} is easier to understand and is more consistent

here are the instructions the with the sed command i mentioned for reference: https://github.com/LemmyNet/lemmyBB