### PR TITLE
Point to !lemmy_support for support questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -11,6 +11,8 @@ Found a bug? Please fill out the sections below. 👍
 
 For front end issues, use [lemmy-ui](https://github.com/LemmyNet/lemmy-ui)
 
+If you have problems installing Lemmy, you should post in [!lemmy_support](https://lemmy.ml/c/lemmy_support).
+
 ### Issue Summary
 
 A summary of the bug.

--- a/.github/ISSUE_TEMPLATE/QUESTION.md
+++ b/.github/ISSUE_TEMPLATE/QUESTION.md
@@ -8,3 +8,5 @@ assignees: ''
 ---
 
 What's the question you have about lemmy?
+
+If you have problems installing Lemmy, you should post in [!lemmy_support](https://lemmy.ml/c/lemmy_support).


### PR DESCRIPTION
Github issues are the wrong place to ask for support, so im emphasizing this. We could also link to the Matrix chat (or possibly create a separate Matrix chat for support).

Btw is the hexbear issue template still needed?