### PR TITLE
Accept Mastodon private messages

### DIFF
--- a/crates/apub/assets/mastodon/activities/create_private_message.json
+++ b/crates/apub/assets/mastodon/activities/create_private_message.json
@@ -1,0 +1,61 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    {
+      "ostatus": "http://ostatus.org#",
+      "atomUri": "ostatus:atomUri",
+      "inReplyToAtomUri": "ostatus:inReplyToAtomUri",
+      "conversation": "ostatus:conversation",
+      "sensitive": "as:sensitive",
+      "toot": "http://joinmastodon.org/ns#",
+      "votersCount": "toot:votersCount"
+    }
+  ],
+  "id": "https://mastodon.world/users/nutomic/statuses/109689904592699013/activity",
+  "type": "Create",
+  "actor": "https://mastodon.world/users/nutomic",
+  "published": "2023-01-14T22:25:16Z",
+  "to": [
+    "https://ds9.lemmy.ml/u/banme"
+  ],
+  "cc": [],
+  "object": {
+    "id": "https://mastodon.world/users/nutomic/statuses/109689904592699013",
+    "type": "Note",
+    "summary": null,
+    "inReplyTo": "https://ds9.lemmy.ml/post/11000",
+    "published": "2023-01-14T22:25:16Z",
+    "url": "https://mastodon.world/@nutomic/109689904592699013",
+    "attributedTo": "https://mastodon.world/users/nutomic",
+    "to": [
+      "https://ds9.lemmy.ml/u/banme"
+    ],
+    "cc": [],
+    "sensitive": false,
+    "atomUri": "https://mastodon.world/users/nutomic/statuses/109689904592699013",
+    "inReplyToAtomUri": "https://ds9.lemmy.ml/post/11000",
+    "conversation": "tag:mastodon.world,2023-01-03:objectId=26461306:objectType=Conversation",
+    "content": "<p><span class=\"h-card\"><a href=\"https://ds9.lemmy.ml/u/banme\" class=\"u-url mention\">@<span>banme</span></a></span> osefioespjdfksasdwasdkflasewasdsdfsdfsdfsd</p>",
+    "contentMap": {
+      "es": "<p><span class=\"h-card\"><a href=\"https://ds9.lemmy.ml/u/banme\" class=\"u-url mention\">@<span>banme</span></a></span> osefioespjdfksasdwasdkflasewasdsdfsdfsdfsd</p>"
+    },
+    "attachment": [],
+    "tag": [
+      {
+        "type": "Mention",
+        "href": "https://ds9.lemmy.ml/u/banme",
+        "name": "@banme@ds9.lemmy.ml"
+      }
+    ],
+    "replies": {
+      "id": "https://mastodon.world/users/nutomic/statuses/109689904592699013/replies",
+      "type": "Collection",
+      "first": {
+        "type": "CollectionPage",
+        "next": "https://mastodon.world/users/nutomic/statuses/109689904592699013/replies?only_other_accounts=true&page=true",
+        "partOf": "https://mastodon.world/users/nutomic/statuses/109689904592699013/replies",
+        "items": []
+      }
+    }
+  }
+}

--- a/crates/apub/assets/mastodon/objects/private_message.json
+++ b/crates/apub/assets/mastodon/objects/private_message.json
@@ -1,0 +1,51 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    {
+      "ostatus": "http://ostatus.org#",
+      "atomUri": "ostatus:atomUri",
+      "inReplyToAtomUri": "ostatus:inReplyToAtomUri",
+      "conversation": "ostatus:conversation",
+      "sensitive": "as:sensitive",
+      "toot": "http://joinmastodon.org/ns#",
+      "votersCount": "toot:votersCount"
+    }
+  ],
+  "id": "https://mastodon.world/users/nutomic/statuses/109689904592699013",
+  "type": "Note",
+  "summary": null,
+  "inReplyTo": "https://ds9.lemmy.ml/post/11000",
+  "published": "2023-01-14T22:25:16Z",
+  "url": "https://mastodon.world/@nutomic/109689904592699013",
+  "attributedTo": "https://mastodon.world/users/nutomic",
+  "to": [
+    "https://ds9.lemmy.ml/u/banme"
+  ],
+  "cc": [],
+  "sensitive": false,
+  "atomUri": "https://mastodon.world/users/nutomic/statuses/109689904592699013",
+  "inReplyToAtomUri": "https://ds9.lemmy.ml/post/11000",
+  "conversation": "tag:mastodon.world,2023-01-03:objectId=26461306:objectType=Conversation",
+  "content": "<p><span class=\"h-card\"><a href=\"https://ds9.lemmy.ml/u/banme\" class=\"u-url mention\">@<span>banme</span></a></span> osefioespjdfksasdwasdkflasewasdsdfsdfsdfsd</p>",
+  "contentMap": {
+    "es": "<p><span class=\"h-card\"><a href=\"https://ds9.lemmy.ml/u/banme\" class=\"u-url mention\">@<span>banme</span></a></span> osefioespjdfksasdwasdkflasewasdsdfsdfsdfsd</p>"
+  },
+  "attachment": [],
+  "tag": [
+    {
+      "type": "Mention",
+      "href": "https://ds9.lemmy.ml/u/banme",
+      "name": "@banme@ds9.lemmy.ml"
+    }
+  ],
+  "replies": {
+    "id": "https://mastodon.world/users/nutomic/statuses/109689904592699013/replies",
+    "type": "Collection",
+    "first": {
+      "type": "CollectionPage",
+      "next": "https://mastodon.world/users/nutomic/statuses/109689904592699013/replies?only_other_accounts=true&page=true",
+      "partOf": "https://mastodon.world/users/nutomic/statuses/109689904592699013/replies",
+      "items": []
+    }
+  }
+}

--- a/crates/apub/src/protocol/activities/mod.rs
+++ b/crates/apub/src/protocol/activities/mod.rs
@@ -19,7 +19,11 @@ mod tests {
   use crate::protocol::{
     activities::{
       community::announce::AnnounceActivity,
-      create_or_update::{note::CreateOrUpdateNote, page::CreateOrUpdatePage},
+      create_or_update::{
+        chat_message::CreateOrUpdateChatMessage,
+        note::CreateOrUpdateNote,
+        page::CreateOrUpdatePage,
+      },
       deletion::delete::Delete,
       following::{follow::Follow, undo_follow::UndoFollow},
       voting::{undo_vote::UndoVote, vote::Vote},
@@ -47,6 +51,10 @@ mod tests {
     test_json::<UndoFollow>("assets/mastodon/activities/undo_follow.json").unwrap();
     test_json::<Vote>("assets/mastodon/activities/like_page.json").unwrap();
     test_json::<UndoVote>("assets/mastodon/activities/undo_like_page.json").unwrap();
+    test_json::<CreateOrUpdateChatMessage>(
+      "assets/mastodon/activities/create_private_message.json",
+    )
+    .unwrap();
   }
 
   #[test]

--- a/crates/apub/src/protocol/objects/chat_message.rs
+++ b/crates/apub/src/protocol/objects/chat_message.rs
@@ -35,4 +35,5 @@ pub struct ChatMessage {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum ChatMessageType {
   ChatMessage,
+  Note,
 }

--- a/crates/apub/src/protocol/objects/mod.rs
+++ b/crates/apub/src/protocol/objects/mod.rs
@@ -131,6 +131,7 @@ mod tests {
   fn test_parse_objects_mastodon() {
     test_json::<Person>("assets/mastodon/objects/person.json").unwrap();
     test_json::<Note>("assets/mastodon/objects/note.json").unwrap();
+    test_json::<ChatMessage>("assets/mastodon/objects/private_message.json").unwrap();
   }
 
   #[test]


### PR DESCRIPTION
If we want better Mastodon compatibility then we should also accept their private messages. Unfortunately it breaks the activity routing because the json format is indistinguishable from public comments.