### PR TITLE
Update message_id to comply with RFC 2822

### DIFF
--- a/crates/utils/src/email.rs
+++ b/crates/utils/src/email.rs
@@ -58,7 +58,7 @@ pub fn send_email(
       Some(to_username.to_string()),
       Address::from_str(to_email).expect("email to address isn't valid"),
     ))
-    .message_id(Some(format!("{}@{}", Uuid::new_v4(), settings.hostname)))
+    .message_id(Some(format!("<{}@{}>", Uuid::new_v4(), settings.hostname)))
     .subject(subject)
     .multipart(MultiPart::alternative_plain_html(
       plain_text,


### PR DESCRIPTION
The RFC 2822 format standard requires the message ID to be enclosed within angle brackets. If the standard is not followed, SpamAssassin deducts points from the e-mail.

Solves Issue #2667