### PR TITLE
Use join_all instead of try_join_all. Fixes #2673

### DIFF
--- a/crates/api_common/src/websocket/chat_server.rs
+++ b/crates/api_common/src/websocket/chat_server.rs
@@ -231,6 +231,7 @@ impl ChatServer {
   {
     let msg = &serialize_websocket_message(&op, response)?;
     let sessions = self.inner()?.sessions.clone();
+    // Note, this will ignore any errors, such as closed connections
     join_all(
       sessions
         .into_iter()
@@ -368,6 +369,7 @@ impl ChatServer {
   ) -> Result<(), LemmyError> {
     let mut session = self.inner()?.sessions.clone();
     if let Some(room) = room {
+      // Note, this will ignore any errors, such as closed connections
       join_all(
         room
           .into_iter()

--- a/crates/api_common/src/websocket/chat_server.rs
+++ b/crates/api_common/src/websocket/chat_server.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use actix_ws::Session;
 use anyhow::Context as acontext;
-use futures::future::try_join_all;
+use futures::future::join_all;
 use lemmy_db_schema::newtypes::{CommunityId, LocalUserId, PostId};
 use lemmy_utils::{error::LemmyError, location_info, ConnectionId};
 use rand::{rngs::StdRng, SeedableRng};
@@ -231,13 +231,13 @@ impl ChatServer {
   {
     let msg = &serialize_websocket_message(&op, response)?;
     let sessions = self.inner()?.sessions.clone();
-    try_join_all(
+    join_all(
       sessions
         .into_iter()
         .filter(|(id, _)| Some(id) != exclude_connection.as_ref())
         .map(|(_, mut s): (_, Session)| async move { s.text(msg).await }),
     )
-    .await?;
+    .await;
     Ok(())
   }
 
@@ -368,14 +368,14 @@ impl ChatServer {
   ) -> Result<(), LemmyError> {
     let mut session = self.inner()?.sessions.clone();
     if let Some(room) = room {
-      try_join_all(
+      join_all(
         room
           .into_iter()
           .filter(|c| Some(c) != exclude_connection.as_ref())
           .filter_map(|c| session.remove(&c))
           .map(|mut s: Session| async move { s.text(message).await }),
       )
-      .await?;
+      .await;
     }
     Ok(())
   }


### PR DESCRIPTION
Okay this was an easy fix. There was conflicting documentation on whether `join_all` would fail if one of the futures had an error, like `try_join_all` . It seems that after `futures: 0.3`, [join_all won't fail.](https://stackoverflow.com/questions/61481079/how-can-i-join-all-the-futures-in-a-vector-without-cancelling-on-failure-like-jo)