### PR TITLE
Fixing `.drone.yml`

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -18,60 +18,60 @@ steps:
       - git submodule update --recursive --remote
       - chown 1000:1000 . -R
 
-  # - name: Cargo tasks
-  #   image: clux/muslrust:1.67.0
-  #   environment:
-  #     LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
-  #     RUST_BACKTRACE: 1
-  #     RUST_TEST_THREADS: 1
-  #   commands:
-      # - apk add --no-cache musl-dev pkgconfig openssl-dev make protobuf-dev libpq-dev
-      # - echo "Check Formatting"
-      # - rustup toolchain install nightly
-      # - rustup component add rustfmt --toolchain nightly
-      # - cargo +nightly fmt -- --check
+  - name: Cargo tasks
+    image: clux/muslrust:1.67.0
+    environment:
+      LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
+      RUST_BACKTRACE: 1
+      RUST_TEST_THREADS: 1
+    commands:
+      - apk add --no-cache musl-dev pkgconfig openssl-dev make protobuf-dev libpq-dev
+      - echo "Check Formatting"
+      - rustup toolchain install nightly
+      - rustup component add rustfmt --toolchain nightly
+      - cargo +nightly fmt -- --check
         # latest rust for clippy to get extra checks
         # when adding new clippy lints, make sure to also add them in scripts/fix-clippy.sh
-      # - echo "Check clippy"
-      # - rustup component add clippy
-      # - cargo clippy --workspace --tests --all-targets --all-features -- 
-      #     -D warnings -D deprecated -D clippy::perf -D clippy::complexity 
-      #     -D clippy::style -D clippy::correctness -D clippy::suspicious
-      #     -D clippy::dbg_macro -D clippy::inefficient_to_string 
-      #     -D clippy::items-after-statements -D clippy::implicit_clone 
-      #     -D clippy::wildcard_imports -D clippy::cast_lossless 
-      #     -D clippy::manual_string_new -D clippy::redundant_closure_for_method_calls 
-      #     -D clippy::unused_self
-      #     -A clippy::uninlined_format_args
-      # - cargo clippy --workspace --all-features -- -D clippy::unwrap_used
-      # - echo "check with different features"
-      # - cargo check --workspace --no-default-features
-      # - cargo check --workspace --all-features
-      # - echo "lemmy_api_common doesnt depend on diesel"
-      # - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
-      # - echo "check defaults.hjson updated"
-      # - export LEMMY_CONFIG_LOCATION=./config/config.hjson
-      # - ./scripts/update_config_defaults.sh config/defaults_current.hjson
-      # - diff config/defaults.hjson config/defaults_current.hjson
-      # - echo "cargo test"
-      # - export LEMMY_CONFIG_LOCATION=../../config/config.hjson
-      # - cargo test --workspace --no-fail-fast --all-features
-      # - echo "cargo build"
-      # - cargo build
+      - echo "Check clippy"
+      - rustup component add clippy
+      - cargo clippy --workspace --tests --all-targets --all-features -- 
+          -D warnings -D deprecated -D clippy::perf -D clippy::complexity 
+          -D clippy::style -D clippy::correctness -D clippy::suspicious
+          -D clippy::dbg_macro -D clippy::inefficient_to_string 
+          -D clippy::items-after-statements -D clippy::implicit_clone 
+          -D clippy::wildcard_imports -D clippy::cast_lossless 
+          -D clippy::manual_string_new -D clippy::redundant_closure_for_method_calls 
+          -D clippy::unused_self
+          -A clippy::uninlined_format_args
+      - cargo clippy --workspace --all-features -- -D clippy::unwrap_used
+      - echo "check with different features"
+      - cargo check --workspace --no-default-features
+      - cargo check --workspace --all-features
+      - echo "lemmy_api_common doesnt depend on diesel"
+      - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
+      - echo "check defaults.hjson updated"
+      - export LEMMY_CONFIG_LOCATION=./config/config.hjson
+      - ./scripts/update_config_defaults.sh config/defaults_current.hjson
+      - diff config/defaults.hjson config/defaults_current.hjson
+      - echo "cargo test"
+      - export LEMMY_CONFIG_LOCATION=../../config/config.hjson
+      - cargo test --workspace --no-fail-fast --all-features
+      - echo "cargo build"
+      - cargo build
       # When using alpine, this is at target/debug/lemmy_server
-      # - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server
+      - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server
 
-  # - name: run federation tests
-  #   image: node:alpine
-  #   environment:
-  #     LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432
-  #     DO_WRITE_HOSTS_FILE: 1
-  #   commands:
-  #     - apk add bash curl postgresql-client
-  #     - bash api_tests/prepare-drone-federation-test.sh
-  #     - cd api_tests/
-  #     - yarn
-  #     - yarn api-test
+  - name: run federation tests
+    image: node:alpine
+    environment:
+      LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432
+      DO_WRITE_HOSTS_FILE: 1
+    commands:
+      - apk add bash curl postgresql-client
+      - bash api_tests/prepare-drone-federation-test.sh
+      - cd api_tests/
+      - yarn
+      - yarn api-test
 
   - name: nightly build
     image: plugins/docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,7 @@ steps:
       RUST_BACKTRACE: 1
       RUST_TEST_THREADS: 1
     commands:
-      - apk add --no-cache musl-dev openssl
+      - apk add --no-cache musl-dev openssl openssl-dev
       # - echo "Check Formatting"
       # - rustup toolchain install nightly
       # - rustup component add rustfmt --toolchain nightly

--- a/.drone.yml
+++ b/.drone.yml
@@ -17,18 +17,24 @@ steps:
       - git submodule init
       - git submodule update --recursive --remote
 
-  - name: Cargo tasks
+  - name: cargo fmt
     image: clux/muslrust:1.67.0
     environment:
-      LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
-      RUST_BACKTRACE: 1
-      RUST_TEST_THREADS: 1
+      # store cargo data in repo folder so that it gets cached between steps
+      CARGO_HOME: .cargo
     commands:
-      - echo "Check Formatting"
+      # need make existing toolchain available
+      - cp ~/.cargo . -r
       - rustup toolchain install nightly
       - rustup component add rustfmt --toolchain nightly
       - cargo +nightly fmt -- --check
-      - echo "Check clippy"
+
+
+  - name: cargo clippy
+    image: clux/muslrust:1.67.0
+    environment:
+      CARGO_HOME: .cargo
+    commands:
         # latest rust for clippy to get extra checks
         # when adding new clippy lints, make sure to also add them in scripts/fix-clippy.sh
       - rustup component add clippy
@@ -42,9 +48,12 @@ steps:
           -D clippy::unused_self
           -A clippy::uninlined_format_args
       - cargo clippy --workspace --all-features -- -D clippy::unwrap_used
-      - echo "check with different features"
-      - cargo check --workspace --no-default-features
-      - cargo check --workspace --all-features
+
+  - name: cargo check
+    image: clux/muslrust:1.67.0
+    environment:
+      CARGO_HOME: .cargo
+    commands:
       - cargo check --package lemmy_utils
       - cargo check --package lemmy_db_schema
       - cargo check --package lemmy_db_views
@@ -55,16 +64,41 @@ steps:
       - cargo check --package lemmy_api_crud
       - cargo check --package lemmy_apub
       - cargo check --package lemmy_routes
-      - echo "lemmy_api_common doesnt depend on diesel"
+      - cargo check --workspace --no-default-features
+      - cargo check --workspace --all-features
+
+  - name: lemmy_api_common doesnt depend on diesel
+    image: clux/muslrust:1.67.0
+    environment:
+      CARGO_HOME: .cargo
+    commands:
       - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
-      - echo "check defaults.hjson updated"
+
+  - name: check defaults.hjson updated
+    image: clux/muslrust:1.67.0
+    environment:
+      CARGO_HOME: .cargo
+    commands:
       - export LEMMY_CONFIG_LOCATION=./config/config.hjson
       - ./scripts/update_config_defaults.sh config/defaults_current.hjson
       - diff config/defaults.hjson config/defaults_current.hjson
-      - echo "cargo test"
+
+  - name: cargo test
+    image: clux/muslrust:1.67.0
+    environment:
+      LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
+      RUST_BACKTRACE: 1
+      RUST_TEST_THREADS: 1
+      CARGO_HOME: .cargo
+    commands:
       - export LEMMY_CONFIG_LOCATION=../../config/config.hjson
-      - cargo test --workspace --no-fail-fast --all-features
-      - echo "cargo build"
+      - cargo test --workspace --no-fail-fast
+
+  - name: cargo build
+    image: clux/muslrust:1.67.0
+    environment:
+      CARGO_HOME: .cargo
+    commands:
       - cargo build
       - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -82,7 +82,7 @@ steps:
       password:
         from_secret: docker_password
       repo: dessalines/lemmy
-      add_host: github.com:140.82.112.3,static.crates.io:18.154.227.73,crates.io:108.138.64.68
+      add_host: github.com:140.82.112.3,static.crates.io:18.154.227.73,crates.io:108.138.64.68,dl-cdn.alpinelinux.org:146.75.30.133
       platform: linux/amd64
       tags:
         - dev
@@ -99,7 +99,7 @@ steps:
       password:
         from_secret: docker_password
       repo: dessalines/lemmy
-      custom_dns: 8.8.8.8
+      add_host: github.com:140.82.112.3,static.crates.io:18.154.227.73,crates.io:108.138.64.68,dl-cdn.alpinelinux.org:146.75.30.133
       auto_tag: true
       auto_tag_suffix: linux-amd64
     when:
@@ -241,7 +241,7 @@ steps:
       password:
         from_secret: docker_password
       repo: dessalines/lemmy
-      custom_dns: 8.8.8.8
+      add_host: github.com:140.82.112.3,static.crates.io:18.154.227.73,crates.io:108.138.64.68,dl-cdn.alpinelinux.org:146.75.30.133
       auto_tag: true
       auto_tag_suffix: linux-arm64
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -22,7 +22,6 @@ steps:
     image: clux/muslrust:1.67.0
     environment:
       LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
-      LEMMY_CONFIG_LOCATION: ../../config/config.hjson
       RUST_BACKTRACE: 1
       RUST_TEST_THREADS: 1
     commands:
@@ -44,8 +43,8 @@ steps:
       #     -D clippy::unused_self
       #     -A clippy::uninlined_format_args
       # - cargo clippy --workspace --all-features -- -D clippy::unwrap_used
-      - echo "cargo test"
-      - cargo test --workspace --no-fail-fast --all-features
+      # - echo "cargo test"
+      # - cargo test --workspace --no-fail-fast --all-features
       - echo "check defaults.hjson updated"
       - ./scripts/update_config_defaults.sh config/defaults_current.hjson
       - diff config/defaults.hjson config/defaults_current.hjson

--- a/.drone.yml
+++ b/.drone.yml
@@ -24,6 +24,7 @@ steps:
       LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
       RUST_BACKTRACE: 1
       RUST_TEST_THREADS: 1
+      LEMMY_CONFIG_LOCATION: ./config/config.hjson
     commands:
       # - apk add --no-cache musl-dev pkgconfig openssl-dev make protobuf-dev libpq-dev
       - echo "Check Formatting"

--- a/.drone.yml
+++ b/.drone.yml
@@ -26,13 +26,6 @@ steps:
       RUST_TEST_THREADS: 1
     commands:
       # - apk add --no-cache musl-dev pkgconfig openssl-dev make protobuf-dev libpq-dev
-      - echo "cargo test"
-      - export LEMMY_CONFIG_LOCATION=../../config/config.hjson
-      - cargo test --workspace --no-fail-fast --all-features
-      - echo "check defaults.hjson updated"
-      - export LEMMY_CONFIG_LOCATION=./config/config.hjson
-      - ./scripts/update_config_defaults.sh config/defaults_current.hjson
-      - diff config/defaults.hjson config/defaults_current.hjson
       - echo "Check Formatting"
       - rustup toolchain install nightly
       - rustup component add rustfmt --toolchain nightly
@@ -56,6 +49,13 @@ steps:
       - cargo check --workspace --all-features
       - echo "lemmy_api_common doesnt depend on diesel"
       - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
+      - echo "check defaults.hjson updated"
+      - export LEMMY_CONFIG_LOCATION=./config/config.hjson
+      - ./scripts/update_config_defaults.sh config/defaults_current.hjson
+      - diff config/defaults.hjson config/defaults_current.hjson
+      - echo "cargo test"
+      - export LEMMY_CONFIG_LOCATION=../../config/config.hjson
+      - cargo test --workspace --no-fail-fast --all-features
       - echo "cargo build"
       - cargo build
       # When using alpine, this is at target/debug/lemmy_server
@@ -86,9 +86,9 @@ steps:
       platform: linux/amd64
       tags:
         - dev
-    when:
-      event:
-        - cron
+    # when:
+    #   event:
+    #     - cron
 
   - name: publish release docker image
     image: plugins/docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -57,7 +57,9 @@ steps:
       # - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
       - echo "cargo build"
       - cargo build
-      - mv target/debug/lemmy_server target/lemmy_server
+      # This one is for alpine
+      # - mv target/debug/lemmy_server target/lemmy_server
+      - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server
 
   - name: run federation tests
     image: node:alpine
@@ -65,9 +67,9 @@ steps:
       LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432
       DO_WRITE_HOSTS_FILE: 1
     commands:
-      - apk add bash curl postgresql-client ca-certificates
+      - apk add bash curl postgresql-client
+      - bash api_tests/prepare-drone-federation-test.sh
       - cd api_tests/
-      - bash prepare-drone-federation-test.sh
       - yarn
       - yarn api-test
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,7 @@ steps:
       RUST_BACKTRACE: 1
       RUST_TEST_THREADS: 1
     commands:
-      - apk add --no-cache musl-dev openssl openssl-dev
+      - apk add --no-cache musl-dev pkgconfig openssl-dev make protobuf-dev
       # - echo "Check Formatting"
       # - rustup toolchain install nightly
       # - rustup component add rustfmt --toolchain nightly

--- a/.drone.yml
+++ b/.drone.yml
@@ -11,6 +11,8 @@ steps:
   # use minimum supported rust version for most steps
   - name: prepare repo
     image: clux/muslrust:1.64.0
+    environment:
+      CARGO_HOME: .cargo
     commands:
       - git fetch --tags
       - git submodule init
@@ -19,6 +21,8 @@ steps:
 
   - name: check formatting
     image: clux/muslrust:1.64.0
+    environment:
+      CARGO_HOME: .cargo
     commands:
       - rustup toolchain install nightly
       - rustup default nightly
@@ -54,8 +58,8 @@ steps:
       RUST_TEST_THREADS: 1
       CARGO_HOME: .cargo
     commands:
-      - apt-get update
-      - apt-get -y install --no-install-recommends postgresql-client protobuf-compiler libprotobuf-dev
+      # - apt-get update
+      # - apt-get -y install --no-install-recommends postgresql-client protobuf-compiler libprotobuf-dev
       - cargo test --workspace --no-fail-fast --all-features
 
   - name: check defaults.hjson updated
@@ -180,6 +184,15 @@ steps:
     when:
       ref:
         - refs/tags/*
+
+  - name: Notify on failure
+    image: alpine:3
+    commands: 
+      - apk add curl
+      - curl -d"Drone build failed" ntfy.sh/dessalines
+    when:
+      status:
+        - failure
 
 services:
   - name: database

--- a/.drone.yml
+++ b/.drone.yml
@@ -57,9 +57,9 @@ steps:
       # - export LEMMY_CONFIG_LOCATION=../../config/config.hjson
       # - cargo test --workspace --no-fail-fast --all-features
       # - echo "cargo build"
-      - cargo build
+      # - cargo build
       # When using alpine, this is at target/debug/lemmy_server
-      - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server
+      # - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server
 
   # - name: run federation tests
   #   image: node:alpine

--- a/.drone.yml
+++ b/.drone.yml
@@ -82,7 +82,7 @@ steps:
       password:
         from_secret: docker_password
       repo: dessalines/lemmy
-      add_host: github.com:140.82.112.3
+      add_host: github.com:140.82.112.3,static.crates.io:18.154.227.73,crates.io:108.138.64.68
       ## TODO not sure if this custom_dns works
       # custom_dns: 8.8.8.8
       # custom_dns_search: 8.8.8.8

--- a/.drone.yml
+++ b/.drone.yml
@@ -18,14 +18,14 @@ steps:
       - chown 1000:1000 . -R
 
   - name: check formatting
-    image: rustdocker/rust:nightly
+    image: clux/muslrust:1.64.0
     commands:
       - /root/.cargo/bin/cargo fmt -- --check
 
   # latest rust for clippy to get extra checks
   # when adding new clippy lints, make sure to also add them in scripts/fix-clippy.sh
   - name: cargo clippy
-    image: rust:1.65-buster
+    image: clux/muslrust:1.64.0
     environment:
       CARGO_HOME: .cargo
     commands:
@@ -73,7 +73,7 @@ steps:
       - cargo workspaces exec cargo check --all-features
 
   - name: lemmy_api_common doesnt depend on diesel
-    image: rust:1.64-buster
+    image: clux/muslrust:1.64.0
     commands:
       - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
 
@@ -165,7 +165,7 @@ steps:
 
   # using https://github.com/pksunkara/cargo-workspaces
   - name: publish to crates.io
-    image: rustlang/rust:nightly
+    image: clux/muslrust:1.64.0
     environment:
       CARGO_TOKEN:
         from_secret: cargo_api_token
@@ -180,7 +180,7 @@ steps:
 
 services:
   - name: database
-    image: postgres:14-alpine
+    image: postgres:15-alpine
     environment:
       POSTGRES_USER: lemmy
       POSTGRES_PASSWORD: password

--- a/.drone.yml
+++ b/.drone.yml
@@ -11,8 +11,6 @@ steps:
   # use minimum supported rust version for most steps
   - name: prepare repo
     image: clux/muslrust:1.64.0
-    environment:
-      CARGO_HOME: .cargo
     commands:
       - git fetch --tags
       - git submodule init
@@ -21,8 +19,6 @@ steps:
 
   - name: check formatting
     image: clux/muslrust:1.64.0
-    environment:
-      CARGO_HOME: .cargo
     commands:
       - rustup toolchain install nightly
       - rustup default nightly
@@ -33,8 +29,6 @@ steps:
   # when adding new clippy lints, make sure to also add them in scripts/fix-clippy.sh
   - name: cargo clippy
     image: clux/muslrust:1.64.0
-    environment:
-      CARGO_HOME: .cargo
     commands:
       # - apt-get update
       # - apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev
@@ -56,7 +50,6 @@ steps:
       LEMMY_CONFIG_LOCATION: ../../config/config.hjson
       RUST_BACKTRACE: 1
       RUST_TEST_THREADS: 1
-      CARGO_HOME: .cargo
     commands:
       # - apt-get update
       # - apt-get -y install --no-install-recommends postgresql-client protobuf-compiler libprotobuf-dev
@@ -64,16 +57,12 @@ steps:
 
   - name: check defaults.hjson updated
     image: clux/muslrust:1.64.0
-    environment:
-      CARGO_HOME: .cargo
     commands:
       - ./scripts/update_config_defaults.sh config/defaults_current.hjson
       - diff config/defaults.hjson config/defaults_current.hjson
 
   - name: check with different features
     image: clux/muslrust:1.64.0
-    environment:
-      CARGO_HOME: .cargo
     commands:
       - cargo install cargo-workspaces
       - cargo workspaces exec cargo check --no-default-features
@@ -86,8 +75,6 @@ steps:
 
   - name: cargo build
     image: clux/muslrust:1.64.0
-    environment:
-      CARGO_HOME: .cargo
     commands:
       - cargo build
       - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server

--- a/.drone.yml
+++ b/.drone.yml
@@ -16,7 +16,6 @@ steps:
       - git fetch --tags
       - git submodule init
       - git submodule update --recursive --remote
-      - chown 1000:1000 . -R
 
   - name: Cargo tasks
     image: clux/muslrust:1.67.0
@@ -25,7 +24,7 @@ steps:
       RUST_BACKTRACE: 1
       RUST_TEST_THREADS: 1
     commands:
-      - apk add --no-cache musl-dev pkgconfig openssl-dev make protobuf-dev libpq-dev
+      # - apk add --no-cache musl-dev pkgconfig openssl-dev make protobuf-dev libpq-dev
       - echo "Check Formatting"
       - rustup toolchain install nightly
       - rustup component add rustfmt --toolchain nightly
@@ -186,7 +185,6 @@ steps:
     image: rust:1.57-slim
     user: root
     commands:
-      - chown 1000:1000 . -R
       - apt update
       - apt install --no-install-recommends --yes git
       - git fetch --tags

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,7 @@ steps:
       RUST_BACKTRACE: 1
       RUST_TEST_THREADS: 1
     commands:
-      - apk add --no-cache musl-dev pkgconfig openssl-dev make protobuf-dev
+      - apk add --no-cache musl-dev pkgconfig openssl-dev make protobuf-dev libpq-dev
       # - echo "Check Formatting"
       # - rustup toolchain install nightly
       # - rustup component add rustfmt --toolchain nightly
@@ -49,11 +49,11 @@ steps:
       # - echo "check defaults.hjson updated"
       # - ./scripts/update_config_defaults.sh config/defaults_current.hjson
       # - diff config/defaults.hjson config/defaults_current.hjson
-      - echo "check with different features"
-      - cargo check --workspace --no-default-features
-      - cargo check --workspace --all-features
-      - echo "lemmy_api_common doesnt depend on diesel"
-      - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
+      # - echo "check with different features"
+      # - cargo check --workspace --no-default-features
+      # - cargo check --workspace --all-features
+      # - echo "lemmy_api_common doesnt depend on diesel"
+      # - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
       - echo "cargo build"
       - cargo build
       - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server

--- a/.drone.yml
+++ b/.drone.yml
@@ -18,63 +18,59 @@ steps:
       - git submodule update --recursive --remote
       - chown 1000:1000 . -R
 
-  # - name: Cargo tasks
-  #   # image: rust:1.67.0-alpine
-  #   image: clux/muslrust:1.67.0
-  #   environment:
-  #     LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
-  #     RUST_BACKTRACE: 1
-  #     RUST_TEST_THREADS: 1
-  #   commands:
-      # - apk add --no-cache musl-dev pkgconfig openssl-dev make protobuf-dev libpq-dev
-      # - echo "Check Formatting"
-      # - rustup toolchain install nightly
-      # - rustup component add rustfmt --toolchain nightly
-      # - cargo +nightly fmt -- --check
-        # latest rust for clippy to get extra checks
-        # when adding new clippy lints, make sure to also add them in scripts/fix-clippy.sh
-      # - echo "Check clippy"
-      # - rustup component add clippy
-      # - cargo clippy --workspace --tests --all-targets --all-features -- 
-      #     -D warnings -D deprecated -D clippy::perf -D clippy::complexity 
-      #     -D clippy::style -D clippy::correctness -D clippy::suspicious
-      #     -D clippy::dbg_macro -D clippy::inefficient_to_string 
-      #     -D clippy::items-after-statements -D clippy::implicit_clone 
-      #     -D clippy::wildcard_imports -D clippy::cast_lossless 
-      #     -D clippy::manual_string_new -D clippy::redundant_closure_for_method_calls 
-      #     -D clippy::unused_self
-      #     -A clippy::uninlined_format_args
-      # - cargo clippy --workspace --all-features -- -D clippy::unwrap_used
-      # - echo "cargo test"
-      # - cargo test --workspace --no-fail-fast --all-features
-      # - echo "check defaults.hjson updated"
-      # - ./scripts/update_config_defaults.sh config/defaults_current.hjson
-      # - diff config/defaults.hjson config/defaults_current.hjson
-      # - echo "check with different features"
-      # - cargo check --workspace --no-default-features
-      # - cargo check --workspace --all-features
-      # - echo "lemmy_api_common doesnt depend on diesel"
-      # - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
-      # - echo "cargo build"
-      # - cargo build
-      # - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server
+  - name: Cargo tasks
+    image: clux/muslrust:1.67.0
+    environment:
+      LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
+      RUST_BACKTRACE: 1
+      RUST_TEST_THREADS: 1
+    commands:
+      - echo "Check Formatting"
+      - rustup toolchain install nightly
+      - rustup component add rustfmt --toolchain nightly
+      - cargo +nightly fmt -- --check
+        latest rust for clippy to get extra checks
+        when adding new clippy lints, make sure to also add them in scripts/fix-clippy.sh
+      - echo "Check clippy"
+      - rustup component add clippy
+      - cargo clippy --workspace --tests --all-targets --all-features -- 
+          -D warnings -D deprecated -D clippy::perf -D clippy::complexity 
+          -D clippy::style -D clippy::correctness -D clippy::suspicious
+          -D clippy::dbg_macro -D clippy::inefficient_to_string 
+          -D clippy::items-after-statements -D clippy::implicit_clone 
+          -D clippy::wildcard_imports -D clippy::cast_lossless 
+          -D clippy::manual_string_new -D clippy::redundant_closure_for_method_calls 
+          -D clippy::unused_self
+          -A clippy::uninlined_format_args
+      - cargo clippy --workspace --all-features -- -D clippy::unwrap_used
+      - echo "cargo test"
+      - cargo test --workspace --no-fail-fast --all-features
+      - echo "check defaults.hjson updated"
+      - ./scripts/update_config_defaults.sh config/defaults_current.hjson
+      - diff config/defaults.hjson config/defaults_current.hjson
+      - echo "check with different features"
+      - cargo check --workspace --no-default-features
+      - cargo check --workspace --all-features
+      - echo "lemmy_api_common doesnt depend on diesel"
+      - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
+      - echo "cargo build"
+      - cargo build
+      - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server
 
-  # - name: run federation tests
-  #   image: node:alpine
-  #   environment:
-  #     LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432
-  #     DO_WRITE_HOSTS_FILE: 1
-  #   commands:
-  #     - apk add bash curl postgresql-client
-  #     - bash api_tests/prepare-drone-federation-test.sh
-  #     - cd api_tests/
-  #     - yarn
-  #     - yarn api-test
+  - name: run federation tests
+    image: node:alpine
+    environment:
+      LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432
+      DO_WRITE_HOSTS_FILE: 1
+    commands:
+      - apk add bash curl postgresql-client
+      - bash api_tests/prepare-drone-federation-test.sh
+      - cd api_tests/
+      - yarn
+      - yarn api-test
 
   - name: nightly build
     image: plugins/docker
-    # environment:
-    #   CARGO_NET_GIT_FETCH_WITH_CLI: true 
     settings:
       dockerfile: docker/prod/Dockerfile
       username:
@@ -83,16 +79,11 @@ steps:
         from_secret: docker_password
       repo: dessalines/lemmy
       add_host: github.com:140.82.112.3,static.crates.io:18.154.227.73,crates.io:108.138.64.68
-      ## TODO not sure if this custom_dns works
-      # custom_dns: 8.8.8.8
-      # custom_dns_search: 8.8.8.8
-      # experimental: true
-      platform: linux/amd64
       tags:
         - dev
-    # when:
-    #   event:
-    #     - cron
+    when:
+      event:
+        - cron
 
   - name: publish release docker image
     image: plugins/docker
@@ -103,7 +94,7 @@ steps:
       password:
         from_secret: docker_password
       repo: dessalines/lemmy
-      custom_dns: 8.8.8.8
+      add_host: github.com:140.82.112.3,static.crates.io:18.154.227.73,crates.io:108.138.64.68
       auto_tag: true
       auto_tag_suffix: linux-amd64
     when:
@@ -167,6 +158,7 @@ steps:
     when:
       status:
         - failure
+        - success
 
 services:
   - name: database
@@ -244,7 +236,6 @@ steps:
       password:
         from_secret: docker_password
       repo: dessalines/lemmy
-      custom_dns: 8.8.8.8
       auto_tag: true
       auto_tag_suffix: linux-arm64
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -106,6 +106,7 @@ steps:
       password:
         from_secret: docker_password
       repo: dessalines/lemmy
+      custom_dns: 8.8.8.8
       tags:
         - dev
     when:
@@ -121,6 +122,7 @@ steps:
       password:
         from_secret: docker_password
       repo: dessalines/lemmy
+      custom_dns: 8.8.8.8
       auto_tag: true
       auto_tag_suffix: linux-amd64
     when:
@@ -252,6 +254,7 @@ steps:
       password:
         from_secret: docker_password
       repo: dessalines/lemmy
+      custom_dns: 8.8.8.8
       auto_tag: true
       auto_tag_suffix: linux-arm64
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -18,13 +18,13 @@ steps:
       - git submodule update --recursive --remote
       - chown 1000:1000 . -R
 
-  - name: Cargo tasks
-    image: clux/muslrust:1.67.0
-    environment:
-      LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
-      RUST_BACKTRACE: 1
-      RUST_TEST_THREADS: 1
-    commands:
+  # - name: Cargo tasks
+  #   image: clux/muslrust:1.67.0
+  #   environment:
+  #     LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
+  #     RUST_BACKTRACE: 1
+  #     RUST_TEST_THREADS: 1
+  #   commands:
       # - apk add --no-cache musl-dev pkgconfig openssl-dev make protobuf-dev libpq-dev
       # - echo "Check Formatting"
       # - rustup toolchain install nightly
@@ -61,17 +61,17 @@ steps:
       # When using alpine, this is at target/debug/lemmy_server
       - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server
 
-  - name: run federation tests
-    image: node:alpine
-    environment:
-      LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432
-      DO_WRITE_HOSTS_FILE: 1
-    commands:
-      - apk add bash curl postgresql-client
-      - bash api_tests/prepare-drone-federation-test.sh
-      - cd api_tests/
-      - yarn
-      - yarn api-test
+  # - name: run federation tests
+  #   image: node:alpine
+  #   environment:
+  #     LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432
+  #     DO_WRITE_HOSTS_FILE: 1
+  #   commands:
+  #     - apk add bash curl postgresql-client
+  #     - bash api_tests/prepare-drone-federation-test.sh
+  #     - cd api_tests/
+  #     - yarn
+  #     - yarn api-test
 
   - name: nightly build
     image: plugins/docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,37 +25,37 @@ steps:
       RUST_TEST_THREADS: 1
     commands:
       # - apk add --no-cache musl-dev pkgconfig openssl-dev make protobuf-dev libpq-dev
-      - echo "Check Formatting"
-      - rustup toolchain install nightly
-      - rustup component add rustfmt --toolchain nightly
-      - cargo +nightly fmt -- --check
-        # latest rust for clippy to get extra checks
-        # when adding new clippy lints, make sure to also add them in scripts/fix-clippy.sh
-      - echo "Check clippy"
-      - rustup component add clippy
-      - cargo clippy --workspace --tests --all-targets --all-features -- 
-          -D warnings -D deprecated -D clippy::perf -D clippy::complexity 
-          -D clippy::style -D clippy::correctness -D clippy::suspicious
-          -D clippy::dbg_macro -D clippy::inefficient_to_string 
-          -D clippy::items-after-statements -D clippy::implicit_clone 
-          -D clippy::wildcard_imports -D clippy::cast_lossless 
-          -D clippy::manual_string_new -D clippy::redundant_closure_for_method_calls 
-          -D clippy::unused_self
-          -A clippy::uninlined_format_args
-      - cargo clippy --workspace --all-features -- -D clippy::unwrap_used
-      - echo "check with different features"
-      - cargo check --workspace --no-default-features
-      - cargo check --workspace --all-features
-      - echo "lemmy_api_common doesnt depend on diesel"
-      - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
-      - echo "check defaults.hjson updated"
-      - export LEMMY_CONFIG_LOCATION=./config/config.hjson
-      - ./scripts/update_config_defaults.sh config/defaults_current.hjson
-      - diff config/defaults.hjson config/defaults_current.hjson
-      - echo "cargo test"
-      - export LEMMY_CONFIG_LOCATION=../../config/config.hjson
-      - cargo test --workspace --no-fail-fast --all-features
-      - echo "cargo build"
+      # - echo "Check Formatting"
+      # - rustup toolchain install nightly
+      # - rustup component add rustfmt --toolchain nightly
+      # - cargo +nightly fmt -- --check
+      #   # latest rust for clippy to get extra checks
+      #   # when adding new clippy lints, make sure to also add them in scripts/fix-clippy.sh
+      # - echo "Check clippy"
+      # - rustup component add clippy
+      # - cargo clippy --workspace --tests --all-targets --all-features -- 
+      #     -D warnings -D deprecated -D clippy::perf -D clippy::complexity 
+      #     -D clippy::style -D clippy::correctness -D clippy::suspicious
+      #     -D clippy::dbg_macro -D clippy::inefficient_to_string 
+      #     -D clippy::items-after-statements -D clippy::implicit_clone 
+      #     -D clippy::wildcard_imports -D clippy::cast_lossless 
+      #     -D clippy::manual_string_new -D clippy::redundant_closure_for_method_calls 
+      #     -D clippy::unused_self
+      #     -A clippy::uninlined_format_args
+      # - cargo clippy --workspace --all-features -- -D clippy::unwrap_used
+      # - echo "check with different features"
+      # - cargo check --workspace --no-default-features
+      # - cargo check --workspace --all-features
+      # - echo "lemmy_api_common doesnt depend on diesel"
+      # - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
+      # - echo "check defaults.hjson updated"
+      # - export LEMMY_CONFIG_LOCATION=./config/config.hjson
+      # - ./scripts/update_config_defaults.sh config/defaults_current.hjson
+      # - diff config/defaults.hjson config/defaults_current.hjson
+      # - echo "cargo test"
+      # - export LEMMY_CONFIG_LOCATION=../../config/config.hjson
+      # - cargo test --workspace --no-fail-fast --all-features
+      # - echo "cargo build"
       - cargo build
       # When using alpine, this is at target/debug/lemmy_server
       - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server
@@ -85,9 +85,9 @@ steps:
       platform: linux/amd64
       tags:
         - dev
-    # when:
-    #   event:
-    #     - cron
+    when:
+      event:
+        - cron
 
   - name: publish release docker image
     image: plugins/docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,6 +25,7 @@ steps:
       RUST_BACKTRACE: 1
       RUST_TEST_THREADS: 1
     commands:
+      - apk add --no-cache musl-dev
       # - echo "Check Formatting"
       # - rustup toolchain install nightly
       # - rustup component add rustfmt --toolchain nightly

--- a/.drone.yml
+++ b/.drone.yml
@@ -20,7 +20,10 @@ steps:
   - name: check formatting
     image: clux/muslrust:1.64.0
     commands:
-      - /root/.cargo/bin/cargo fmt -- --check
+      - rustup toolchain install nightly
+      - rustup default nightly
+      - rustup component add clippy
+      - cargo +nightly fmt -- --check
 
   # latest rust for clippy to get extra checks
   # when adding new clippy lints, make sure to also add them in scripts/fix-clippy.sh
@@ -29,8 +32,8 @@ steps:
     environment:
       CARGO_HOME: .cargo
     commands:
-      - apt-get update
-      - apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev
+      # - apt-get update
+      # - apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev
       - rustup component add clippy
       - cargo clippy --workspace --tests --all-targets --all-features -- 
           -D warnings -D deprecated -D clippy::perf -D clippy::complexity 

--- a/.drone.yml
+++ b/.drone.yml
@@ -17,21 +17,22 @@ steps:
       - git submodule update --recursive --remote
       - chown 1000:1000 . -R
 
-  - name: check formatting
+  - name: Cargo tasks
     image: clux/muslrust:1.67.0
+    environment:
+      LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
+      LEMMY_CONFIG_LOCATION: ../../config/config.hjson
+      RUST_BACKTRACE: 1
+      RUST_TEST_THREADS: 1
     commands:
+      - echo "Check Formatting"
       - rustup toolchain install nightly
       - rustup default nightly
       - rustup component add rustfmt --toolchain nightly
       - cargo +nightly fmt -- --check
-
-  # latest rust for clippy to get extra checks
-  # when adding new clippy lints, make sure to also add them in scripts/fix-clippy.sh
-  - name: cargo clippy
-    image: clux/muslrust:1.67.0
-    commands:
-      # - apt-get update
-      # - apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev
+        # latest rust for clippy to get extra checks
+        # when adding new clippy lints, make sure to also add them in scripts/fix-clippy.sh
+      - echo "Check clippy"
       - rustup component add clippy
       - cargo clippy --workspace --tests --all-targets --all-features -- 
           -D warnings -D deprecated -D clippy::perf -D clippy::complexity 
@@ -43,40 +44,18 @@ steps:
           -D clippy::unused_self
           -A clippy::uninlined_format_args
       - cargo clippy --workspace --all-features -- -D clippy::unwrap_used
-
-  - name: cargo test
-    image: clux/muslrust:1.67.0
-    environment:
-      LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
-      LEMMY_CONFIG_LOCATION: ../../config/config.hjson
-      RUST_BACKTRACE: 1
-      RUST_TEST_THREADS: 1
-    commands:
-      # - apt-get update
-      # - apt-get -y install --no-install-recommends postgresql-client protobuf-compiler libprotobuf-dev
+      - echo "cargo test"
       - cargo test --workspace --no-fail-fast --all-features
-
-  - name: check defaults.hjson updated
-    image: clux/muslrust:1.67.0
-    commands:
+      - echo "check defaults.hjson updated"
       - ./scripts/update_config_defaults.sh config/defaults_current.hjson
       - diff config/defaults.hjson config/defaults_current.hjson
-
-  - name: check with different features
-    image: clux/muslrust:1.67.0
-    commands:
+      - echo "check with different features"
       - cargo install cargo-workspaces
       - cargo workspaces exec cargo check --no-default-features
       - cargo workspaces exec cargo check --all-features
-
-  - name: lemmy_api_common doesnt depend on diesel
-    image: clux/muslrust:1.67.0
-    commands:
+      - echo "lemmy_api_common doesnt depend on diesel"
       - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
-
-  - name: cargo build
-    image: clux/muslrust:1.67.0
-    commands:
+      - echo "cargo build"
       - cargo build
       - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server
 
@@ -101,6 +80,7 @@ steps:
       password:
         from_secret: docker_password
       repo: dessalines/lemmy
+      ## TODO not sure if this custom_dns works
       custom_dns: 8.8.8.8
       tags:
         - dev

--- a/.drone.yml
+++ b/.drone.yml
@@ -81,7 +81,7 @@ steps:
         from_secret: docker_password
       repo: dessalines/lemmy
       ## TODO not sure if this custom_dns works
-      custom_dns: 8.8.8.8
+      # custom_dns: 8.8.8.8
       tags:
         - dev
     # when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,12 +25,13 @@ steps:
       RUST_BACKTRACE: 1
       RUST_TEST_THREADS: 1
     commands:
+      # - apk add --no-cache musl-dev pkgconfig openssl-dev make protobuf-dev libpq-dev
       - echo "Check Formatting"
       - rustup toolchain install nightly
       - rustup component add rustfmt --toolchain nightly
       - cargo +nightly fmt -- --check
-        latest rust for clippy to get extra checks
-        when adding new clippy lints, make sure to also add them in scripts/fix-clippy.sh
+        # latest rust for clippy to get extra checks
+        # when adding new clippy lints, make sure to also add them in scripts/fix-clippy.sh
       - echo "Check clippy"
       - rustup component add clippy
       - cargo clippy --workspace --tests --all-targets --all-features -- 
@@ -79,6 +80,7 @@ steps:
         from_secret: docker_password
       repo: dessalines/lemmy
       add_host: github.com:140.82.112.3,static.crates.io:18.154.227.73,crates.io:108.138.64.68
+      platform: linux/amd64
       tags:
         - dev
     when:
@@ -94,7 +96,7 @@ steps:
       password:
         from_secret: docker_password
       repo: dessalines/lemmy
-      add_host: github.com:140.82.112.3,static.crates.io:18.154.227.73,crates.io:108.138.64.68
+      custom_dns: 8.8.8.8
       auto_tag: true
       auto_tag_suffix: linux-amd64
     when:
@@ -236,6 +238,7 @@ steps:
       password:
         from_secret: docker_password
       repo: dessalines/lemmy
+      custom_dns: 8.8.8.8
       auto_tag: true
       auto_tag_suffix: linux-arm64
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -64,9 +64,9 @@ steps:
       LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432
       DO_WRITE_HOSTS_FILE: 1
     commands:
-      - apk add bash curl postgresql-client
-      - bash api_tests/prepare-drone-federation-test.sh
+      - apk add bash curl postgresql-client ca-certificates
       - cd api_tests/
+      - bash prepare-drone-federation-test.sh
       - yarn
       - yarn api-test
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -22,7 +22,7 @@ steps:
     commands:
       - rustup toolchain install nightly
       - rustup default nightly
-      - rustup component add clippy
+      - rustup component add rustfmt --toolchain nightly
       - cargo +nightly fmt -- --check
 
   # latest rust for clippy to get extra checks

--- a/.drone.yml
+++ b/.drone.yml
@@ -24,14 +24,13 @@ steps:
       RUST_BACKTRACE: 1
       RUST_TEST_THREADS: 1
     commands:
-      # - apk add --no-cache musl-dev pkgconfig openssl-dev make protobuf-dev libpq-dev
       - echo "Check Formatting"
       - rustup toolchain install nightly
       - rustup component add rustfmt --toolchain nightly
       - cargo +nightly fmt -- --check
+      - echo "Check clippy"
         # latest rust for clippy to get extra checks
         # when adding new clippy lints, make sure to also add them in scripts/fix-clippy.sh
-      - echo "Check clippy"
       - rustup component add clippy
       - cargo clippy --workspace --tests --all-targets --all-features -- 
           -D warnings -D deprecated -D clippy::perf -D clippy::complexity 
@@ -57,7 +56,6 @@ steps:
       - cargo test --workspace --no-fail-fast --all-features
       - echo "cargo build"
       - cargo build
-      # When using alpine, this is at target/debug/lemmy_server
       - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server
 
   - name: run federation tests
@@ -82,7 +80,6 @@ steps:
         from_secret: docker_password
       repo: dessalines/lemmy
       add_host: github.com:140.82.112.3,static.crates.io:18.154.227.73,crates.io:108.138.64.68,dl-cdn.alpinelinux.org:146.75.30.133
-      platform: linux/amd64
       tags:
         - dev
     when:
@@ -162,7 +159,6 @@ steps:
     when:
       status:
         - failure
-        - success
 
 services:
   - name: database
@@ -239,7 +235,6 @@ steps:
       password:
         from_secret: docker_password
       repo: dessalines/lemmy
-      add_host: github.com:140.82.112.3,static.crates.io:18.154.227.73,crates.io:108.138.64.68,dl-cdn.alpinelinux.org:146.75.30.133
       auto_tag: true
       auto_tag_suffix: linux-arm64
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,37 +25,37 @@ steps:
       RUST_TEST_THREADS: 1
     commands:
       # - apk add --no-cache musl-dev pkgconfig openssl-dev make protobuf-dev libpq-dev
-      # - echo "Check Formatting"
-      # - rustup toolchain install nightly
-      # - rustup component add rustfmt --toolchain nightly
-      # - cargo +nightly fmt -- --check
-      #   # latest rust for clippy to get extra checks
-      #   # when adding new clippy lints, make sure to also add them in scripts/fix-clippy.sh
-      # - echo "Check clippy"
-      # - rustup component add clippy
-      # - cargo clippy --workspace --tests --all-targets --all-features -- 
-      #     -D warnings -D deprecated -D clippy::perf -D clippy::complexity 
-      #     -D clippy::style -D clippy::correctness -D clippy::suspicious
-      #     -D clippy::dbg_macro -D clippy::inefficient_to_string 
-      #     -D clippy::items-after-statements -D clippy::implicit_clone 
-      #     -D clippy::wildcard_imports -D clippy::cast_lossless 
-      #     -D clippy::manual_string_new -D clippy::redundant_closure_for_method_calls 
-      #     -D clippy::unused_self
-      #     -A clippy::uninlined_format_args
-      # - cargo clippy --workspace --all-features -- -D clippy::unwrap_used
-      # - echo "check with different features"
-      # - cargo check --workspace --no-default-features
-      # - cargo check --workspace --all-features
-      # - echo "lemmy_api_common doesnt depend on diesel"
-      # - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
-      # - echo "check defaults.hjson updated"
-      # - export LEMMY_CONFIG_LOCATION=./config/config.hjson
-      # - ./scripts/update_config_defaults.sh config/defaults_current.hjson
-      # - diff config/defaults.hjson config/defaults_current.hjson
-      # - echo "cargo test"
-      # - export LEMMY_CONFIG_LOCATION=../../config/config.hjson
-      # - cargo test --workspace --no-fail-fast --all-features
-      # - echo "cargo build"
+      - echo "Check Formatting"
+      - rustup toolchain install nightly
+      - rustup component add rustfmt --toolchain nightly
+      - cargo +nightly fmt -- --check
+        # latest rust for clippy to get extra checks
+        # when adding new clippy lints, make sure to also add them in scripts/fix-clippy.sh
+      - echo "Check clippy"
+      - rustup component add clippy
+      - cargo clippy --workspace --tests --all-targets --all-features -- 
+          -D warnings -D deprecated -D clippy::perf -D clippy::complexity 
+          -D clippy::style -D clippy::correctness -D clippy::suspicious
+          -D clippy::dbg_macro -D clippy::inefficient_to_string 
+          -D clippy::items-after-statements -D clippy::implicit_clone 
+          -D clippy::wildcard_imports -D clippy::cast_lossless 
+          -D clippy::manual_string_new -D clippy::redundant_closure_for_method_calls 
+          -D clippy::unused_self
+          -A clippy::uninlined_format_args
+      - cargo clippy --workspace --all-features -- -D clippy::unwrap_used
+      - echo "check with different features"
+      - cargo check --workspace --no-default-features
+      - cargo check --workspace --all-features
+      - echo "lemmy_api_common doesnt depend on diesel"
+      - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
+      - echo "check defaults.hjson updated"
+      - export LEMMY_CONFIG_LOCATION=./config/config.hjson
+      - ./scripts/update_config_defaults.sh config/defaults_current.hjson
+      - diff config/defaults.hjson config/defaults_current.hjson
+      - echo "cargo test"
+      - export LEMMY_CONFIG_LOCATION=../../config/config.hjson
+      - cargo test --workspace --no-fail-fast --all-features
+      - echo "cargo build"
       - cargo build
       # When using alpine, this is at target/debug/lemmy_server
       - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server

--- a/.drone.yml
+++ b/.drone.yml
@@ -26,37 +26,37 @@ steps:
       RUST_TEST_THREADS: 1
     commands:
       # - apk add --no-cache musl-dev pkgconfig openssl-dev make protobuf-dev libpq-dev
-      - echo "Check Formatting"
-      - rustup toolchain install nightly
-      - rustup component add rustfmt --toolchain nightly
-      - cargo +nightly fmt -- --check
+      # - echo "Check Formatting"
+      # - rustup toolchain install nightly
+      # - rustup component add rustfmt --toolchain nightly
+      # - cargo +nightly fmt -- --check
         # latest rust for clippy to get extra checks
         # when adding new clippy lints, make sure to also add them in scripts/fix-clippy.sh
-      - echo "Check clippy"
-      - rustup component add clippy
-      - cargo clippy --workspace --tests --all-targets --all-features -- 
-          -D warnings -D deprecated -D clippy::perf -D clippy::complexity 
-          -D clippy::style -D clippy::correctness -D clippy::suspicious
-          -D clippy::dbg_macro -D clippy::inefficient_to_string 
-          -D clippy::items-after-statements -D clippy::implicit_clone 
-          -D clippy::wildcard_imports -D clippy::cast_lossless 
-          -D clippy::manual_string_new -D clippy::redundant_closure_for_method_calls 
-          -D clippy::unused_self
-          -A clippy::uninlined_format_args
-      - cargo clippy --workspace --all-features -- -D clippy::unwrap_used
-      - echo "check with different features"
-      - cargo check --workspace --no-default-features
-      - cargo check --workspace --all-features
-      - echo "lemmy_api_common doesnt depend on diesel"
-      - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
-      - echo "check defaults.hjson updated"
-      - export LEMMY_CONFIG_LOCATION=./config/config.hjson
-      - ./scripts/update_config_defaults.sh config/defaults_current.hjson
-      - diff config/defaults.hjson config/defaults_current.hjson
-      - echo "cargo test"
-      - export LEMMY_CONFIG_LOCATION=../../config/config.hjson
-      - cargo test --workspace --no-fail-fast --all-features
-      - echo "cargo build"
+      # - echo "Check clippy"
+      # - rustup component add clippy
+      # - cargo clippy --workspace --tests --all-targets --all-features -- 
+      #     -D warnings -D deprecated -D clippy::perf -D clippy::complexity 
+      #     -D clippy::style -D clippy::correctness -D clippy::suspicious
+      #     -D clippy::dbg_macro -D clippy::inefficient_to_string 
+      #     -D clippy::items-after-statements -D clippy::implicit_clone 
+      #     -D clippy::wildcard_imports -D clippy::cast_lossless 
+      #     -D clippy::manual_string_new -D clippy::redundant_closure_for_method_calls 
+      #     -D clippy::unused_self
+      #     -A clippy::uninlined_format_args
+      # - cargo clippy --workspace --all-features -- -D clippy::unwrap_used
+      # - echo "check with different features"
+      # - cargo check --workspace --no-default-features
+      # - cargo check --workspace --all-features
+      # - echo "lemmy_api_common doesnt depend on diesel"
+      # - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
+      # - echo "check defaults.hjson updated"
+      # - export LEMMY_CONFIG_LOCATION=./config/config.hjson
+      # - ./scripts/update_config_defaults.sh config/defaults_current.hjson
+      # - diff config/defaults.hjson config/defaults_current.hjson
+      # - echo "cargo test"
+      # - export LEMMY_CONFIG_LOCATION=../../config/config.hjson
+      # - cargo test --workspace --no-fail-fast --all-features
+      # - echo "cargo build"
       - cargo build
       # When using alpine, this is at target/debug/lemmy_server
       - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server

--- a/.drone.yml
+++ b/.drone.yml
@@ -45,6 +45,16 @@ steps:
       - echo "check with different features"
       - cargo check --workspace --no-default-features
       - cargo check --workspace --all-features
+      - cargo check --package lemmy_utils
+      - cargo check --package lemmy_db_schema
+      - cargo check --package lemmy_db_views
+      - cargo check --package lemmy_db_views_actor
+      - cargo check --package lemmy_db_views_moderator
+      - cargo check --package lemmy_api_common
+      - cargo check --package lemmy_api
+      - cargo check --package lemmy_api_crud
+      - cargo check --package lemmy_apub
+      - cargo check --package lemmy_routes
       - echo "lemmy_api_common doesnt depend on diesel"
       - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
       - echo "check defaults.hjson updated"

--- a/.drone.yml
+++ b/.drone.yml
@@ -56,7 +56,6 @@ steps:
       # - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
       - echo "cargo build"
       - cargo build
-      - find target
       - mv target/debug/lemmy_server target/lemmy_server
 
   - name: run federation tests

--- a/.drone.yml
+++ b/.drone.yml
@@ -41,6 +41,7 @@ steps:
           -D clippy::wildcard_imports -D clippy::cast_lossless 
           -D clippy::manual_string_new -D clippy::redundant_closure_for_method_calls 
           -D clippy::unused_self
+          -A clippy::uninlined_format_args
       - cargo clippy --workspace --all-features -- -D clippy::unwrap_used
 
   - name: cargo test

--- a/.drone.yml
+++ b/.drone.yml
@@ -24,9 +24,15 @@ steps:
       LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
       RUST_BACKTRACE: 1
       RUST_TEST_THREADS: 1
-      LEMMY_CONFIG_LOCATION: ../../config/config.hjson
     commands:
       # - apk add --no-cache musl-dev pkgconfig openssl-dev make protobuf-dev libpq-dev
+      - echo "cargo test"
+      - export LEMMY_CONFIG_LOCATION=../../config/config.hjson
+      - cargo test --workspace --no-fail-fast --all-features
+      - echo "check defaults.hjson updated"
+      - export LEMMY_CONFIG_LOCATION=./config/config.hjson
+      - ./scripts/update_config_defaults.sh config/defaults_current.hjson
+      - diff config/defaults.hjson config/defaults_current.hjson
       - echo "Check Formatting"
       - rustup toolchain install nightly
       - rustup component add rustfmt --toolchain nightly
@@ -45,11 +51,6 @@ steps:
           -D clippy::unused_self
           -A clippy::uninlined_format_args
       - cargo clippy --workspace --all-features -- -D clippy::unwrap_used
-      - echo "cargo test"
-      - cargo test --workspace --no-fail-fast --all-features
-      - echo "check defaults.hjson updated"
-      - ./scripts/update_config_defaults.sh config/defaults_current.hjson
-      - diff config/defaults.hjson config/defaults_current.hjson
       - echo "check with different features"
       - cargo check --workspace --no-default-features
       - cargo check --workspace --all-features
@@ -57,6 +58,7 @@ steps:
       - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
       - echo "cargo build"
       - cargo build
+      # When using alpine, this is at target/debug/lemmy_server
       - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server
 
   - name: run federation tests

--- a/.drone.yml
+++ b/.drone.yml
@@ -84,7 +84,7 @@ steps:
       repo: dessalines/lemmy
       ## TODO not sure if this custom_dns works
       custom_dns: 8.8.8.8
-      custom_dns_search: 8.8.8.8
+      # custom_dns_search: 8.8.8.8
       experimental: true
       platform: linux/amd64
       tags:

--- a/.drone.yml
+++ b/.drone.yml
@@ -19,13 +19,14 @@ steps:
       - chown 1000:1000 . -R
 
   - name: Cargo tasks
-    image: rust:1.67.0-alpine
+    # image: rust:1.67.0-alpine
+    image: clux/muslrust:1.67.0
     environment:
       LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
       RUST_BACKTRACE: 1
       RUST_TEST_THREADS: 1
     commands:
-      - apk add --no-cache musl-dev pkgconfig openssl-dev make protobuf-dev libpq-dev
+      # - apk add --no-cache musl-dev pkgconfig openssl-dev make protobuf-dev libpq-dev
       # - echo "Check Formatting"
       # - rustup toolchain install nightly
       # - rustup component add rustfmt --toolchain nightly

--- a/.drone.yml
+++ b/.drone.yml
@@ -73,8 +73,8 @@ steps:
 
   - name: nightly build
     image: plugins/docker
-    environment:
-      CARGO_NET_GIT_FETCH_WITH_CLI: true 
+    # environment:
+    #   CARGO_NET_GIT_FETCH_WITH_CLI: true 
     settings:
       dockerfile: docker/prod/Dockerfile
       username:
@@ -83,7 +83,10 @@ steps:
         from_secret: docker_password
       repo: dessalines/lemmy
       ## TODO not sure if this custom_dns works
-      # custom_dns: 8.8.8.8
+      custom_dns: 8.8.8.8
+      custom_dns_search: 8.8.8.8
+      experimental: true
+      platform: linux/amd64
       tags:
         - dev
     # when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -24,7 +24,7 @@ steps:
       LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
       RUST_BACKTRACE: 1
       RUST_TEST_THREADS: 1
-      LEMMY_CONFIG_LOCATION: ./config/config.hjson
+      LEMMY_CONFIG_LOCATION: config/config.hjson
     commands:
       # - apk add --no-cache musl-dev pkgconfig openssl-dev make protobuf-dev libpq-dev
       - echo "Check Formatting"

--- a/.drone.yml
+++ b/.drone.yml
@@ -24,7 +24,7 @@ steps:
       LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
       RUST_BACKTRACE: 1
       RUST_TEST_THREADS: 1
-      LEMMY_CONFIG_LOCATION: config/config.hjson
+      LEMMY_CONFIG_LOCATION: ../../config/config.hjson
     commands:
       # - apk add --no-cache musl-dev pkgconfig openssl-dev make protobuf-dev libpq-dev
       - echo "Check Formatting"

--- a/.drone.yml
+++ b/.drone.yml
@@ -73,6 +73,8 @@ steps:
 
   - name: nightly build
     image: plugins/docker
+    environment:
+      CARGO_NET_GIT_FETCH_WITH_CLI: true 
     settings:
       dockerfile: docker/prod/Dockerfile
       username:

--- a/.drone.yml
+++ b/.drone.yml
@@ -82,10 +82,11 @@ steps:
       password:
         from_secret: docker_password
       repo: dessalines/lemmy
+      add_host: github.com:140.82.112.3
       ## TODO not sure if this custom_dns works
-      custom_dns: 8.8.8.8
+      # custom_dns: 8.8.8.8
       # custom_dns_search: 8.8.8.8
-      experimental: true
+      # experimental: true
       platform: linux/amd64
       tags:
         - dev

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,8 +10,9 @@ steps:
 
   # use minimum supported rust version for most steps
   - name: prepare repo
-    image: clux/muslrust:1.67.0
+    image: alpine:3
     commands:
+      - apk add git
       - git fetch --tags
       - git submodule init
       - git submodule update --recursive --remote
@@ -25,24 +26,24 @@ steps:
       RUST_BACKTRACE: 1
       RUST_TEST_THREADS: 1
     commands:
-      - echo "Check Formatting"
-      - rustup toolchain install nightly
-      - rustup component add rustfmt --toolchain nightly
-      - cargo +nightly fmt -- --check
+      # - echo "Check Formatting"
+      # - rustup toolchain install nightly
+      # - rustup component add rustfmt --toolchain nightly
+      # - cargo +nightly fmt -- --check
         # latest rust for clippy to get extra checks
         # when adding new clippy lints, make sure to also add them in scripts/fix-clippy.sh
-      - echo "Check clippy"
-      - rustup component add clippy
-      - cargo clippy --workspace --tests --all-targets --all-features -- 
-          -D warnings -D deprecated -D clippy::perf -D clippy::complexity 
-          -D clippy::style -D clippy::correctness -D clippy::suspicious
-          -D clippy::dbg_macro -D clippy::inefficient_to_string 
-          -D clippy::items-after-statements -D clippy::implicit_clone 
-          -D clippy::wildcard_imports -D clippy::cast_lossless 
-          -D clippy::manual_string_new -D clippy::redundant_closure_for_method_calls 
-          -D clippy::unused_self
-          -A clippy::uninlined_format_args
-      - cargo clippy --workspace --all-features -- -D clippy::unwrap_used
+      # - echo "Check clippy"
+      # - rustup component add clippy
+      # - cargo clippy --workspace --tests --all-targets --all-features -- 
+      #     -D warnings -D deprecated -D clippy::perf -D clippy::complexity 
+      #     -D clippy::style -D clippy::correctness -D clippy::suspicious
+      #     -D clippy::dbg_macro -D clippy::inefficient_to_string 
+      #     -D clippy::items-after-statements -D clippy::implicit_clone 
+      #     -D clippy::wildcard_imports -D clippy::cast_lossless 
+      #     -D clippy::manual_string_new -D clippy::redundant_closure_for_method_calls 
+      #     -D clippy::unused_self
+      #     -A clippy::uninlined_format_args
+      # - cargo clippy --workspace --all-features -- -D clippy::unwrap_used
       - echo "cargo test"
       - cargo test --workspace --no-fail-fast --all-features
       - echo "check defaults.hjson updated"
@@ -156,7 +157,7 @@ steps:
     image: alpine:3
     commands: 
       - apk add curl
-      - curl -d"Drone build failed" ntfy.sh/dessalines
+      - curl -d"Drone build failed" ntfy.sh/lemmy_drone_ci
     when:
       status:
         - failure

--- a/.drone.yml
+++ b/.drone.yml
@@ -56,7 +56,8 @@ steps:
       # - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
       - echo "cargo build"
       - cargo build
-      - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server
+      - find target
+      - mv target/debug/lemmy_server target/lemmy_server
 
   - name: run federation tests
     image: node:alpine

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ steps:
 
   # use minimum supported rust version for most steps
   - name: prepare repo
-    image: clux/muslrust:1.64.0
+    image: clux/muslrust:1.67.0
     commands:
       - git fetch --tags
       - git submodule init
@@ -18,7 +18,7 @@ steps:
       - chown 1000:1000 . -R
 
   - name: check formatting
-    image: clux/muslrust:1.64.0
+    image: clux/muslrust:1.67.0
     commands:
       - rustup toolchain install nightly
       - rustup default nightly
@@ -28,7 +28,7 @@ steps:
   # latest rust for clippy to get extra checks
   # when adding new clippy lints, make sure to also add them in scripts/fix-clippy.sh
   - name: cargo clippy
-    image: clux/muslrust:1.64.0
+    image: clux/muslrust:1.67.0
     commands:
       # - apt-get update
       # - apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev
@@ -44,7 +44,7 @@ steps:
       - cargo clippy --workspace --all-features -- -D clippy::unwrap_used
 
   - name: cargo test
-    image: clux/muslrust:1.64.0
+    image: clux/muslrust:1.67.0
     environment:
       LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
       LEMMY_CONFIG_LOCATION: ../../config/config.hjson
@@ -56,25 +56,25 @@ steps:
       - cargo test --workspace --no-fail-fast --all-features
 
   - name: check defaults.hjson updated
-    image: clux/muslrust:1.64.0
+    image: clux/muslrust:1.67.0
     commands:
       - ./scripts/update_config_defaults.sh config/defaults_current.hjson
       - diff config/defaults.hjson config/defaults_current.hjson
 
   - name: check with different features
-    image: clux/muslrust:1.64.0
+    image: clux/muslrust:1.67.0
     commands:
       - cargo install cargo-workspaces
       - cargo workspaces exec cargo check --no-default-features
       - cargo workspaces exec cargo check --all-features
 
   - name: lemmy_api_common doesnt depend on diesel
-    image: clux/muslrust:1.64.0
+    image: clux/muslrust:1.67.0
     commands:
       - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
 
   - name: cargo build
-    image: clux/muslrust:1.64.0
+    image: clux/muslrust:1.67.0
     commands:
       - cargo build
       - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server
@@ -159,7 +159,7 @@ steps:
 
   # using https://github.com/pksunkara/cargo-workspaces
   - name: publish to crates.io
-    image: clux/muslrust:1.64.0
+    image: clux/muslrust:1.67.0
     environment:
       CARGO_TOKEN:
         from_secret: cargo_api_token

--- a/.drone.yml
+++ b/.drone.yml
@@ -18,14 +18,14 @@ steps:
       - git submodule update --recursive --remote
       - chown 1000:1000 . -R
 
-  - name: Cargo tasks
-    # image: rust:1.67.0-alpine
-    image: clux/muslrust:1.67.0
-    environment:
-      LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
-      RUST_BACKTRACE: 1
-      RUST_TEST_THREADS: 1
-    commands:
+  # - name: Cargo tasks
+  #   # image: rust:1.67.0-alpine
+  #   image: clux/muslrust:1.67.0
+  #   environment:
+  #     LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
+  #     RUST_BACKTRACE: 1
+  #     RUST_TEST_THREADS: 1
+  #   commands:
       # - apk add --no-cache musl-dev pkgconfig openssl-dev make protobuf-dev libpq-dev
       # - echo "Check Formatting"
       # - rustup toolchain install nightly
@@ -55,23 +55,21 @@ steps:
       # - cargo check --workspace --all-features
       # - echo "lemmy_api_common doesnt depend on diesel"
       # - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
-      - echo "cargo build"
-      - cargo build
-      # This one is for alpine
-      # - mv target/debug/lemmy_server target/lemmy_server
-      - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server
+      # - echo "cargo build"
+      # - cargo build
+      # - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server
 
-  - name: run federation tests
-    image: node:alpine
-    environment:
-      LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432
-      DO_WRITE_HOSTS_FILE: 1
-    commands:
-      - apk add bash curl postgresql-client
-      - bash api_tests/prepare-drone-federation-test.sh
-      - cd api_tests/
-      - yarn
-      - yarn api-test
+  # - name: run federation tests
+  #   image: node:alpine
+  #   environment:
+  #     LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432
+  #     DO_WRITE_HOSTS_FILE: 1
+  #   commands:
+  #     - apk add bash curl postgresql-client
+  #     - bash api_tests/prepare-drone-federation-test.sh
+  #     - cd api_tests/
+  #     - yarn
+  #     - yarn api-test
 
   - name: nightly build
     image: plugins/docker
@@ -86,9 +84,9 @@ steps:
       custom_dns: 8.8.8.8
       tags:
         - dev
-    when:
-      event:
-        - cron
+    # when:
+    #   event:
+    #     - cron
 
   - name: publish release docker image
     image: plugins/docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,7 @@ steps:
       RUST_BACKTRACE: 1
       RUST_TEST_THREADS: 1
     commands:
-      - apk add --no-cache musl-dev
+      - apk add --no-cache musl-dev openssl
       # - echo "Check Formatting"
       # - rustup toolchain install nightly
       # - rustup component add rustfmt --toolchain nightly

--- a/.drone.yml
+++ b/.drone.yml
@@ -19,7 +19,7 @@ steps:
       - chown 1000:1000 . -R
 
   - name: Cargo tasks
-    image: clux/muslrust:1.67.0
+    image: rust:1.67.0-alpine
     environment:
       LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
       RUST_BACKTRACE: 1
@@ -45,13 +45,12 @@ steps:
       # - cargo clippy --workspace --all-features -- -D clippy::unwrap_used
       # - echo "cargo test"
       # - cargo test --workspace --no-fail-fast --all-features
-      - echo "check defaults.hjson updated"
-      - ./scripts/update_config_defaults.sh config/defaults_current.hjson
-      - diff config/defaults.hjson config/defaults_current.hjson
+      # - echo "check defaults.hjson updated"
+      # - ./scripts/update_config_defaults.sh config/defaults_current.hjson
+      # - diff config/defaults.hjson config/defaults_current.hjson
       - echo "check with different features"
-      - cargo install cargo-workspaces
-      - cargo workspaces exec cargo check --no-default-features
-      - cargo workspaces exec cargo check --all-features
+      - cargo check --workspace --no-default-features
+      - cargo check --workspace --all-features
       - echo "lemmy_api_common doesnt depend on diesel"
       - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
       - echo "cargo build"
@@ -156,7 +155,7 @@ steps:
     image: alpine:3
     commands: 
       - apk add curl
-      - curl -d"Drone build failed" ntfy.sh/lemmy_drone_ci
+      - "curl -d'Drone build failed: ${DRONE_BUILD_LINK}' ntfy.sh/lemmy_drone_ci"
     when:
       status:
         - failure

--- a/.drone.yml
+++ b/.drone.yml
@@ -27,7 +27,6 @@ steps:
     commands:
       - echo "Check Formatting"
       - rustup toolchain install nightly
-      - rustup default nightly
       - rustup component add rustfmt --toolchain nightly
       - cargo +nightly fmt -- --check
         # latest rust for clippy to get extra checks

--- a/api_tests/prepare-drone-federation-test.sh
+++ b/api_tests/prepare-drone-federation-test.sh
@@ -57,8 +57,6 @@ LEMMY_CONFIG_LOCATION=./docker/federation/lemmy_epsilon.hjson \
 LEMMY_DATABASE_URL="${LEMMY_DATABASE_URL}/lemmy_epsilon" \
 target/lemmy_server >/tmp/lemmy_epsilon.out 2>&1 &
 
-sleep 60s
-
 echo "wait for all instances to start"
 while [[ "$(curl -s -o /dev/null -w '%{http_code}' 'lemmy-alpha:8541/api/v3/site')" != "200" ]]; do sleep 1; done
 while [[ "$(curl -s -o /dev/null -w '%{http_code}' 'lemmy-beta:8551/api/v3/site')" != "200" ]]; do sleep 1; done

--- a/api_tests/prepare-drone-federation-test.sh
+++ b/api_tests/prepare-drone-federation-test.sh
@@ -57,6 +57,8 @@ LEMMY_CONFIG_LOCATION=./docker/federation/lemmy_epsilon.hjson \
 LEMMY_DATABASE_URL="${LEMMY_DATABASE_URL}/lemmy_epsilon" \
 target/lemmy_server >/tmp/lemmy_epsilon.out 2>&1 &
 
+sleep 60s
+
 echo "wait for all instances to start"
 while [[ "$(curl -s -o /dev/null -w '%{http_code}' 'lemmy-alpha:8541/api/v3/site')" != "200" ]]; do sleep 1; done
 while [[ "$(curl -s -o /dev/null -w '%{http_code}' 'lemmy-beta:8551/api/v3/site')" != "200" ]]; do sleep 1; done

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -769,15 +769,15 @@ pub fn generate_local_apub_endpoint(
     EndpointType::PrivateMessage => "private_message",
   };
 
-  Ok(Url::parse(&format!("{}/{}/{}", domain, point, name))?.into())
+  Ok(Url::parse(&format!("{domain}/{point}/{name}"))?.into())
 }
 
 pub fn generate_followers_url(actor_id: &DbUrl) -> Result<DbUrl, ParseError> {
-  Ok(Url::parse(&format!("{}/followers", actor_id))?.into())
+  Ok(Url::parse(&format!("{actor_id}/followers"))?.into())
 }
 
 pub fn generate_inbox_url(actor_id: &DbUrl) -> Result<DbUrl, ParseError> {
-  Ok(Url::parse(&format!("{}/inbox", actor_id))?.into())
+  Ok(Url::parse(&format!("{actor_id}/inbox"))?.into())
 }
 
 pub fn generate_site_inbox_url(actor_id: &DbUrl) -> Result<DbUrl, ParseError> {
@@ -793,7 +793,7 @@ pub fn generate_shared_inbox_url(actor_id: &DbUrl) -> Result<DbUrl, LemmyError> 
     &actor_id.scheme(),
     &actor_id.host_str().context(location_info!())?,
     if let Some(port) = actor_id.port() {
-      format!(":{}", port)
+      format!(":{port}")
     } else {
       String::new()
     },
@@ -802,9 +802,9 @@ pub fn generate_shared_inbox_url(actor_id: &DbUrl) -> Result<DbUrl, LemmyError> 
 }
 
 pub fn generate_outbox_url(actor_id: &DbUrl) -> Result<DbUrl, ParseError> {
-  Ok(Url::parse(&format!("{}/outbox", actor_id))?.into())
+  Ok(Url::parse(&format!("{actor_id}/outbox"))?.into())
 }
 
 pub fn generate_moderators_url(community_id: &DbUrl) -> Result<DbUrl, LemmyError> {
-  Ok(Url::parse(&format!("{}/moderators", community_id))?.into())
+  Ok(Url::parse(&format!("{community_id}/moderators"))?.into())
 }

--- a/crates/apub/src/fetcher/webfinger.rs
+++ b/crates/apub/src/fetcher/webfinger.rs
@@ -25,10 +25,7 @@ where
     .splitn(2, '@')
     .collect_tuple()
     .ok_or_else(|| LemmyError::from_message("Invalid webfinger query, missing domain"))?;
-  let fetch_url = format!(
-    "{}://{}/.well-known/webfinger?resource=acct:{}",
-    protocol, domain, identifier
-  );
+  let fetch_url = format!("{protocol}://{domain}/.well-known/webfinger?resource=acct:{identifier}");
   debug!("Fetching webfinger url: {}", &fetch_url);
 
   *request_counter += 1;

--- a/crates/db_schema/src/impls/comment.rs
+++ b/crates/db_schema/src/impls/comment.rs
@@ -105,11 +105,10 @@ update comment_aggregates ca set child_count = c.child_count
 from (
   select c.id, c.path, count(c2.id) as child_count from comment c
   join comment c2 on c2.path <@ c.path and c2.path != c.path
-  and c.path <@ '{}'
+  and c.path <@ '{top_parent}'
   group by c.id
 ) as c
-where ca.comment_id = c.id",
-          top_parent
+where ca.comment_id = c.id"
         );
 
         sql_query(update_child_count_stmt).execute(conn).await?;

--- a/crates/db_schema/src/impls/community.rs
+++ b/crates/db_schema/src/impls/community.rs
@@ -357,7 +357,7 @@ impl ApubActor for Community {
     let conn = &mut get_conn(pool).await?;
     community
       .filter(lower(name).eq(lower(community_name)))
-      .filter(actor_id.like(format!("{}%", protocol_domain)))
+      .filter(actor_id.like(format!("{protocol_domain}%")))
       .first::<Self>(conn)
       .await
   }

--- a/crates/db_schema/src/impls/password_reset_request.rs
+++ b/crates/db_schema/src/impls/password_reset_request.rs
@@ -79,7 +79,7 @@ impl PasswordResetRequest {
 fn bytes_to_hex(bytes: Vec<u8>) -> String {
   let mut str = String::new();
   for byte in bytes {
-    str = format!("{}{:02x}", str, byte);
+    str = format!("{str}{byte:02x}");
   }
   str
 }

--- a/crates/db_schema/src/impls/person.rs
+++ b/crates/db_schema/src/impls/person.rs
@@ -219,7 +219,7 @@ impl ApubActor for Person {
     let conn = &mut get_conn(pool).await?;
     person
       .filter(lower(name).eq(lower(person_name)))
-      .filter(actor_id.like(format!("{}%", protocol_domain)))
+      .filter(actor_id.like(format!("{protocol_domain}%")))
       .first::<Self>(conn)
       .await
   }

--- a/crates/db_schema/src/utils.rs
+++ b/crates/db_schema/src/utils.rs
@@ -46,7 +46,7 @@ pub fn get_database_url_from_env() -> Result<String, VarError> {
 
 pub fn fuzzy_search(q: &str) -> String {
   let replaced = q.replace('%', "\\%").replace('_', "\\_").replace(' ', "%");
-  format!("%{}%", replaced)
+  format!("%{replaced}%")
 }
 
 pub fn limit_and_offset(
@@ -67,7 +67,7 @@ pub fn limit_and_offset(
     Some(limit) => {
       if !(1..=FETCH_LIMIT_MAX).contains(&limit) {
         return Err(QueryBuilderError(
-          format!("Fetch limit is > {}", FETCH_LIMIT_MAX).into(),
+          format!("Fetch limit is > {FETCH_LIMIT_MAX}").into(),
         ));
       } else {
         limit
@@ -154,7 +154,7 @@ pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
 pub fn run_migrations(db_url: &str) {
   // Needs to be a sync connection
   let mut conn =
-    PgConnection::establish(db_url).unwrap_or_else(|_| panic!("Error connecting to {}", db_url));
+    PgConnection::establish(db_url).unwrap_or_else(|_| panic!("Error connecting to {db_url}"));
   info!("Running Database migrations (This may take a long time)...");
   let _ = &mut conn
     .run_pending_migrations(MIGRATIONS)
@@ -178,10 +178,7 @@ pub fn get_database_url(settings: Option<&Settings>) -> String {
     Ok(url) => url,
     Err(e) => match settings {
       Some(settings) => settings.get_database_url(),
-      None => panic!(
-        "Failed to read database URL from env var LEMMY_DATABASE_URL: {}",
-        e
-      ),
+      None => panic!("Failed to read database URL from env var LEMMY_DATABASE_URL: {e}"),
     },
   }
 }

--- a/crates/routes/src/feeds.rs
+++ b/crates/routes/src/feeds.rs
@@ -329,7 +329,7 @@ async fn get_feed_inbox(
   channel_builder
     .namespaces(RSS_NAMESPACE.clone())
     .title(&format!("{} - Inbox", site_view.site.name))
-    .link(format!("{}/inbox", protocol_and_hostname,))
+    .link(format!("{protocol_and_hostname}/inbox",))
     .items(items);
 
   if let Some(site_desc) = site_view.site.description {
@@ -392,11 +392,10 @@ fn build_item(
   protocol_and_hostname: &str,
 ) -> Result<Item, LemmyError> {
   let mut i = ItemBuilder::default();
-  i.title(format!("Reply from {}", creator_name));
-  let author_url = format!("{}/u/{}", protocol_and_hostname, creator_name);
+  i.title(format!("Reply from {creator_name}"));
+  let author_url = format!("{protocol_and_hostname}/u/{creator_name}");
   i.author(format!(
-    "/u/{} <a href=\"{}\">(link)</a>",
-    creator_name, author_url
+    "/u/{creator_name} <a href=\"{author_url}\">(link)</a>"
   ));
   let dt = DateTime::<Utc>::from_utc(*published, Utc);
   i.pub_date(dt.to_rfc2822());
@@ -451,7 +450,7 @@ fn create_post_items(
 
     // If its a url post, add it to the description
     if let Some(url) = p.post.url {
-      let link_html = format!("<br><a href=\"{url}\">{url}</a>", url = url);
+      let link_html = format!("<br><a href=\"{url}\">{url}</a>");
       description.push_str(&link_html);
     }
 

--- a/crates/routes/src/images.rs
+++ b/crates/routes/src/images.rs
@@ -158,7 +158,7 @@ async fn full_res(
     let mut url = format!("{}image/process.{}?src={}", pictrs_config.url, format, name,);
 
     if let Some(size) = params.thumbnail {
-      url = format!("{}&thumbnail={}", url, size,);
+      url = format!("{url}&thumbnail={size}",);
     }
     url
   };

--- a/crates/utils/src/apub.rs
+++ b/crates/utils/src/apub.rs
@@ -16,7 +16,7 @@ pub fn generate_actor_keypair() -> Result<Keypair, Error> {
     Ok(s) => Ok(s),
     Err(e) => Err(Error::new(
       ErrorKind::Other,
-      format!("Failed converting key to string: {}", e),
+      format!("Failed converting key to string: {e}"),
     )),
   };
   Ok(Keypair {

--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -86,7 +86,7 @@ impl Debug for LemmyError {
 impl Display for LemmyError {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     if let Some(message) = &self.message {
-      write!(f, "{}: ", message)?;
+      write!(f, "{message}: ")?;
     }
     writeln!(f, "{}", self.inner)?;
     fmt::Display::fmt(&self.context, f)

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUST_BUILDER_IMAGE=clux/muslrust:1.64.0
+ARG RUST_BUILDER_IMAGE=clux/muslrust:1.67.0
 
 FROM $RUST_BUILDER_IMAGE as chef
 USER root

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 COPY ./ ./
 
 RUN echo "pub const VERSION: &str = \"$(git describe --tag)\";" > "crates/utils/src/version.rs"
-RUN CARGO_NET_GIT_FETCH_WITH_CLI=true CARGO_HTTP_MULTIPLEXING=false cargo build --release
+RUN cargo build --release
 
 RUN cp ./target/$CARGO_BUILD_TARGET/$RUSTRELEASEDIR/lemmy_server /app/lemmy_server
 

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 COPY ./ ./
 
 RUN echo "pub const VERSION: &str = \"$(git describe --tag)\";" > "crates/utils/src/version.rs"
-RUN cargo build --release
+RUN CARGO_NET_GIT_FETCH_WITH_CLI=true CARGO_HTTP_MULTIPLEXING=false cargo build --release
 
 RUN cp ./target/$CARGO_BUILD_TARGET/$RUSTRELEASEDIR/lemmy_server /app/lemmy_server
 

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -1,5 +1,5 @@
 # Build the project
-FROM clux/muslrust:1.64.0 as builder
+FROM clux/muslrust:1.67.0 as builder
 
 ARG CARGO_BUILD_TARGET=x86_64-unknown-linux-musl
 ARG RUSTRELEASEDIR="release"

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -17,7 +17,7 @@ RUN cp ./target/$CARGO_BUILD_TARGET/$RUSTRELEASEDIR/lemmy_server /app/lemmy_serv
 FROM alpine:3 as lemmy
 
 # Install libpq for postgres
-RUN apk add libpq
+RUN apk update && apk add libpq
 
 # Copy resources
 COPY --from=builder /app/lemmy_server /app/lemmy

--- a/scripts/fix-clippy.sh
+++ b/scripts/fix-clippy.sh
@@ -8,4 +8,5 @@ cargo clippy --workspace --fix --allow-staged --allow-dirty --tests --all-target
     -D clippy::items-after-statements -D clippy::implicit_clone \
     -D clippy::wildcard_imports -D clippy::cast_lossless \
     -D clippy::manual_string_new -D clippy::redundant_closure_for_method_calls \
-    -D clippy::unused_self
+    -D clippy::unused_self \
+    -A clippy::uninlined_format_args

--- a/scripts/fix-clippy.sh
+++ b/scripts/fix-clippy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-cargo clippy --workspace --fix --allow-staged --tests --all-targets --all-features -- \
+cargo clippy --workspace --fix --allow-staged --allow-dirty --tests --all-targets --all-features -- \
     -D warnings -D deprecated -D clippy::perf -D clippy::complexity \
     -D clippy::style -D clippy::correctness -D clippy::suspicious \
     -D clippy::dbg_macro -D clippy::inefficient_to_string \

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -17,7 +17,7 @@ if [ -n "$PACKAGE" ];
 then
   cargo test -p $PACKAGE --all-features --no-fail-fast
 else
-  cargo test --workspace --all-features --no-fail-fast
+  cargo test --workspace --no-fail-fast
 fi
 
 # Add this to do printlns: -- --nocapture

--- a/src/code_migrations.rs
+++ b/src/code_migrations.rs
@@ -248,7 +248,7 @@ async fn post_thumbnail_url_updates_2020_07_27(
 
   info!("Running post_thumbnail_url_updates_2020_07_27");
 
-  let domain_prefix = format!("{}/pictrs/image/", protocol_and_hostname,);
+  let domain_prefix = format!("{protocol_and_hostname}/pictrs/image/",);
 
   let incorrect_thumbnails = post.filter(thumbnail_url.not_like("http%"));
 

--- a/src/root_span_builder.rs
+++ b/src/root_span_builder.rs
@@ -65,8 +65,8 @@ fn handle_error(span: Span, status_code: StatusCode, response_error: &dyn Respon
   }
 
   // pre-formatting errors is a workaround for https://github.com/tokio-rs/tracing/issues/1565
-  let display_error = format!("{}", response_error);
-  let debug_error = format!("{:?}", response_error);
+  let display_error = format!("{response_error}");
+  let debug_error = format!("{response_error:?}");
 
   tracing::info_span!(
     parent: None,

--- a/src/scheduled_tasks.rs
+++ b/src/scheduled_tasks.rs
@@ -21,7 +21,7 @@ pub fn setup(db_url: String) -> Result<(), LemmyError> {
   reindex_aggregates_tables(&mut conn, true);
   scheduler.every(1.hour()).run(move || {
     let conn = &mut PgConnection::establish(&db_url)
-      .unwrap_or_else(|_| panic!("Error connecting to {}", db_url));
+      .unwrap_or_else(|_| panic!("Error connecting to {db_url}"));
     active_counts(conn);
     update_banned_when_expired(conn);
     reindex_aggregates_tables(conn, true);
@@ -56,7 +56,7 @@ fn reindex_aggregates_tables(conn: &mut PgConnection, concurrently: bool) {
 fn reindex_table(conn: &mut PgConnection, table_name: &str, concurrently: bool) {
   let concurrently_str = if concurrently { "concurrently" } else { "" };
   info!("Reindexing table {} {} ...", concurrently_str, table_name);
-  let query = format!("reindex table {} {}", concurrently_str, table_name);
+  let query = format!("reindex table {concurrently_str} {table_name}");
   sql_query(query).execute(conn).expect("reindex table");
   info!("Done.");
 }


### PR DESCRIPTION
This took so many tries, but its ready to go. This includes:

- Combining all the cargo tasks into one step. This seems to be the [recommended way](https://docs.drone.io/pipeline/kubernetes/examples/language/rust/) to handle rust pipelines in drone, and it gets around the cache issue. Maybe not ideal, but also not a big deal, since the most important information is what line / where the build failed, which the log still tells us.
- Ran clippy, and added another lint for builds to pass.
- Fixed the drone docker publish plugin by adding explicit `add_host` IP addresses for several crates.io related domains, since DNS resolution breaks in the drone container, probably because they use an old docker build inside.
- Removed the `cargo install workspaces ... cargo exec` steps, changed them to just do `cargo check --workspace --no-default-features`
- Added a notify on failure block at `ntfy.sh/lemmy_drone_ci`, so I get live notifiations for when a build fails, and a link to the build. You can also add this if you have android, or through the ntfy web client.
- Use simple `alpine:3` image for image prep
- 1.67.0 upgrade
- Postgres 15 upgrade.

Note: I tried many times switching from `clux/muslrust`, to `rust:1.67.0-alpine` (which also is a musl image, but maintained by rust), but unfortunately the binary it built kept segfaulting when running on alpine, with no clear indication of what was wrong.
