### PR TITLE
Publish without verify

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -190,7 +190,7 @@ steps:
       - cargo install cargo-workspaces
       - cp -r migrations crates/db_schema/
       - cargo login "$CARGO_TOKEN"
-      - cargo workspaces publish --from-git --allow-dirty --allow-branch "${DRONE_TAG}" --yes custom "${DRONE_TAG}"
+      - cargo workspaces publish --from-git --allow-dirty --no-verify --allow-branch "${DRONE_TAG}" --yes custom "${DRONE_TAG}"
     when:
       ref:
         - refs/tags/*


### PR DESCRIPTION
This is just running cargo check on each crate before publishing. Takes a lot of time and isnt necessary because we already do that in previous ci step.