### PR TITLE
Fix data fetching from Peertube (fixes #2689)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "activitypub_federation"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f61d7a9a1207e70140b47869fd05222e30052ddc9ccfcc43098e48396c4e176"
+checksum = "59fbd2b7fb0aea9bdd738fc1441d34d3e7b585d60b42ed63deeac289c872f119"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ lemmy_routes = { version = "=0.17.1", path = "./crates/routes" }
 lemmy_db_views = { version = "=0.17.1", path = "./crates/db_views" }
 lemmy_db_views_actor = { version = "=0.17.1", path = "./crates/db_views_actor" }
 lemmy_db_views_moderator = { version = "=0.17.1", path = "./crates/db_views_moderator" }
-activitypub_federation = "0.3.4"
+activitypub_federation = "0.3.5"
 diesel = "2.0.2"
 diesel_migrations = "2.0.0"
 diesel-async = "0.1.1"

--- a/crates/apub/src/api/resolve_object.rs
+++ b/crates/apub/src/api/resolve_object.rs
@@ -30,7 +30,9 @@ impl PerformApub for ResolveObject {
     let local_site = LocalSite::read(context.pool()).await?;
     check_private_instance(&local_user_view, &local_site)?;
 
-    let res = search_query_to_object_id(&self.q, local_user_view.is_none(), context)
+    // In release builds only allow for authenticated users to fetch remote objects
+    let local_only = local_user_view.is_none() && cfg!(not(debug_assertions));
+    let res = search_query_to_object_id(&self.q, local_only, context)
       .await
       .map_err(|e| e.with_message("couldnt_find_object"))?;
     convert_response(res, local_user_view.map(|l| l.person.id), context.pool())

--- a/crates/apub/src/protocol/objects/group.rs
+++ b/crates/apub/src/protocol/objects/group.rs
@@ -31,6 +31,7 @@ use lemmy_utils::{
 };
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
+use std::fmt::Debug;
 use url::Url;
 
 #[skip_serializing_none]

--- a/crates/apub/src/protocol/objects/mod.rs
+++ b/crates/apub/src/protocol/objects/mod.rs
@@ -68,7 +68,7 @@ impl LanguageTag {
     pool: &DbPool,
   ) -> Result<Option<LanguageId>, LemmyError> {
     let identifier = lang.map(|l| l.identifier);
-    let language = Language::read_id_from_code_opt(pool, identifier.as_deref()).await?;
+    let language = Language::read_id_from_code(pool, identifier.as_deref()).await?;
 
     Ok(language)
   }
@@ -81,10 +81,10 @@ impl LanguageTag {
 
     for l in langs {
       let id = l.identifier;
-      language_ids.push(Language::read_id_from_code(pool, &id).await?);
+      language_ids.push(Language::read_id_from_code(pool, Some(&id)).await?);
     }
 
-    Ok(language_ids)
+    Ok(language_ids.into_iter().flatten().collect())
   }
 }
 

--- a/crates/db_schema/src/impls/actor_language.rs
+++ b/crates/db_schema/src/impls/actor_language.rs
@@ -370,15 +370,30 @@ mod tests {
 
   async fn test_langs1(pool: &DbPool) -> Vec<LanguageId> {
     vec![
-      Language::read_id_from_code(pool, "en").await.unwrap(),
-      Language::read_id_from_code(pool, "fr").await.unwrap(),
-      Language::read_id_from_code(pool, "ru").await.unwrap(),
+      Language::read_id_from_code(pool, Some("en"))
+        .await
+        .unwrap()
+        .unwrap(),
+      Language::read_id_from_code(pool, Some("fr"))
+        .await
+        .unwrap()
+        .unwrap(),
+      Language::read_id_from_code(pool, Some("ru"))
+        .await
+        .unwrap()
+        .unwrap(),
     ]
   }
   async fn test_langs2(pool: &DbPool) -> Vec<LanguageId> {
     vec![
-      Language::read_id_from_code(pool, "fi").await.unwrap(),
-      Language::read_id_from_code(pool, "se").await.unwrap(),
+      Language::read_id_from_code(pool, Some("fi"))
+        .await
+        .unwrap()
+        .unwrap(),
+      Language::read_id_from_code(pool, Some("se"))
+        .await
+        .unwrap()
+        .unwrap(),
     ]
   }
 
@@ -603,11 +618,20 @@ mod tests {
       .unwrap();
     assert_eq!(None, def1);
 
-    let ru = Language::read_id_from_code(pool, "ru").await.unwrap();
+    let ru = Language::read_id_from_code(pool, Some("ru"))
+      .await
+      .unwrap()
+      .unwrap();
     let test_langs3 = vec![
       ru,
-      Language::read_id_from_code(pool, "fi").await.unwrap(),
-      Language::read_id_from_code(pool, "se").await.unwrap(),
+      Language::read_id_from_code(pool, Some("fi"))
+        .await
+        .unwrap()
+        .unwrap(),
+      Language::read_id_from_code(pool, Some("se"))
+        .await
+        .unwrap()
+        .unwrap(),
     ];
     LocalUserLanguage::update(pool, test_langs3, local_user.id)
       .await

--- a/crates/db_schema/src/impls/language.rs
+++ b/crates/db_schema/src/impls/language.rs
@@ -23,23 +23,21 @@ impl Language {
     language.filter(id.eq(id_)).first::<Self>(conn).await
   }
 
-  pub async fn read_id_from_code(pool: &DbPool, code_: &str) -> Result<LanguageId, Error> {
-    let conn = &mut get_conn(pool).await?;
-    Ok(
-      language
-        .filter(code.eq(code_))
-        .first::<Self>(conn)
-        .await?
-        .id,
-    )
-  }
-
-  pub async fn read_id_from_code_opt(
+  /// Attempts to find the given language code and return its ID. If not found, returns none.
+  pub async fn read_id_from_code(
     pool: &DbPool,
     code_: Option<&str>,
   ) -> Result<Option<LanguageId>, Error> {
     if let Some(code_) = code_ {
-      Ok(Some(Language::read_id_from_code(pool, code_).await?))
+      let conn = &mut get_conn(pool).await?;
+      Ok(
+        language
+          .filter(code.eq(code_))
+          .first::<Self>(conn)
+          .await
+          .map(|l| l.id)
+          .ok(),
+      )
     } else {
       Ok(None)
     }

--- a/crates/db_views/src/comment_view.rs
+++ b/crates/db_views/src/comment_view.rs
@@ -513,7 +513,10 @@ mod tests {
       .await
       .unwrap();
 
-    let finnish_id = Language::read_id_from_code(pool, "fi").await.unwrap();
+    let finnish_id = Language::read_id_from_code(pool, Some("fi"))
+      .await
+      .unwrap()
+      .unwrap();
     let comment_form_2 = CommentInsertForm::builder()
       .content("Comment 2".into())
       .creator_id(inserted_person.id)
@@ -536,7 +539,10 @@ mod tests {
         .await
         .unwrap();
 
-    let polish_id = Language::read_id_from_code(pool, "pl").await.unwrap();
+    let polish_id = Language::read_id_from_code(pool, Some("pl"))
+      .await
+      .unwrap()
+      .unwrap();
     let comment_form_4 = CommentInsertForm::builder()
       .content("Comment 4".into())
       .creator_id(inserted_person.id)
@@ -747,7 +753,10 @@ mod tests {
     assert_eq!(5, all_languages.len());
 
     // change user lang to finnish, should only show single finnish comment
-    let finnish_id = Language::read_id_from_code(pool, "fi").await.unwrap();
+    let finnish_id = Language::read_id_from_code(pool, Some("fi"))
+      .await
+      .unwrap()
+      .unwrap();
     LocalUserLanguage::update(pool, vec![finnish_id], data.inserted_local_user.id)
       .await
       .unwrap();
@@ -766,7 +775,10 @@ mod tests {
     assert_eq!(finnish_id, finnish_comment[0].comment.language_id);
 
     // now show all comments with undetermined language (which is the default value)
-    let undetermined_id = Language::read_id_from_code(pool, "und").await.unwrap();
+    let undetermined_id = Language::read_id_from_code(pool, Some("und"))
+      .await
+      .unwrap()
+      .unwrap();
     LocalUserLanguage::update(pool, vec![undetermined_id], data.inserted_local_user.id)
       .await
       .unwrap();

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -754,7 +754,10 @@ mod tests {
     let pool = &build_db_pool_for_tests().await;
     let data = init_data(pool).await;
 
-    let spanish_id = Language::read_id_from_code(pool, "es").await.unwrap();
+    let spanish_id = Language::read_id_from_code(pool, Some("es"))
+      .await
+      .unwrap()
+      .unwrap();
     let post_spanish = PostInsertForm::builder()
       .name("asffgdsc".to_string())
       .creator_id(data.inserted_person.id)
@@ -776,7 +779,10 @@ mod tests {
     // no language filters specified, all posts should be returned
     assert_eq!(3, post_listings_all.len());
 
-    let french_id = Language::read_id_from_code(pool, "fr").await.unwrap();
+    let french_id = Language::read_id_from_code(pool, Some("fr"))
+      .await
+      .unwrap()
+      .unwrap();
     LocalUserLanguage::update(pool, vec![french_id], data.inserted_local_user.id)
       .await
       .unwrap();
@@ -794,7 +800,10 @@ mod tests {
     assert_eq!(1, post_listing_french.len());
     assert_eq!(french_id, post_listing_french[0].post.language_id);
 
-    let undetermined_id = Language::read_id_from_code(pool, "und").await.unwrap();
+    let undetermined_id = Language::read_id_from_code(pool, Some("und"))
+      .await
+      .unwrap()
+      .unwrap();
     LocalUserLanguage::update(
       pool,
       vec![french_id, undetermined_id],


### PR DESCRIPTION
- Other platforms can support additional language tags. Treat those as None instead of throwing error
- deserialize_skip_error was implemented incorrectly and failed on array values (https://github.com/LemmyNet/activitypub-federation-rust/commit/6d9682f4e6e5d47afaa05f8a35a230bf5e07a334)