### PR TITLE
Parse HTML from mastdon and friendica posts for creating titles

### DIFF
--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -23,6 +23,7 @@ use activitypub_federation::{
 use activitystreams_kinds::public;
 use anyhow::anyhow;
 use chrono::NaiveDateTime;
+use html2md::parse_html;
 use lemmy_api_common::{
   context::LemmyContext,
   request::fetch_site_data,
@@ -183,7 +184,8 @@ impl ApubObject for ApubPost {
         page
           .content
           .clone()
-          .and_then(|c| c.lines().next().map(ToString::to_string))
+          .as_ref()
+          .and_then(|c| parse_html(c).lines().next().map(ToString::to_string))
       })
       .ok_or_else(|| anyhow!("Object must have name or content"))?;
     if name.chars().count() > MAX_TITLE_LENGTH {


### PR DESCRIPTION
The contents from mastodon and friendica posts are delivered in HTML format. The title is generated by taking the first sentence, but the HTML tags remain visible and prevent the lines from being split. Converting the HTML into markdown allows the title to be generated correctly.

Fixes #2686
Previous related PR with a different strategy that was closed by error is #2690

Known issues:
- The markdown is rendered in the title, and the invisible markdown characters will count towards the MAX_TITLE_LENGTH.
