### PR TITLE
Fix post titles being cut off (fixes #2718)

### DIFF
--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -47,7 +47,7 @@ use lemmy_utils::{
 use std::ops::Deref;
 use url::Url;
 
-const MAX_TITLE_LENGTH: usize = 100;
+const MAX_TITLE_LENGTH: usize = 200;
 
 #[derive(Clone, Debug)]
 pub struct ApubPost(pub(crate) Post);


### PR DESCRIPTION
I didnt notice that this limit would also apply to Lemmy and other software which has the title field. So gonna change it to be identical to db limit