### PR TITLE
Include type information with webfinger responses (fixes #2037)

### DIFF
--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -15,7 +15,7 @@ pub mod utils;
 pub mod version;
 
 use serde::{Deserialize, Serialize};
-use std::{fmt, time::Duration};
+use std::{collections::HashMap, fmt, time::Duration};
 use url::Url;
 
 pub type ConnectionId = usize;
@@ -37,6 +37,7 @@ pub struct WebfingerLink {
   #[serde(rename = "type")]
   pub kind: Option<String>,
   pub href: Option<Url>,
+  pub properties: HashMap<String, String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
So that it is easier to parse for other software