### PR TITLE
Ignore undetermined language when calculating post default language

### DIFF
--- a/crates/apub/src/protocol/objects/mod.rs
+++ b/crates/apub/src/protocol/objects/mod.rs
@@ -1,4 +1,9 @@
-use lemmy_db_schema::{newtypes::LanguageId, source::language::Language, utils::DbPool};
+use lemmy_db_schema::{
+  impls::actor_language::UNDETERMINED_ID,
+  newtypes::LanguageId,
+  source::language::Language,
+  utils::DbPool,
+};
 use lemmy_utils::error::LemmyError;
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -33,7 +38,7 @@ impl LanguageTag {
     let lang = Language::read_from_id(pool, lang).await?;
 
     // undetermined
-    if lang.code == "und" {
+    if lang.id == UNDETERMINED_ID {
       Ok(None)
     } else {
       Ok(Some(LanguageTag {

--- a/crates/db_schema/src/impls/actor_language.rs
+++ b/crates/db_schema/src/impls/actor_language.rs
@@ -29,6 +29,8 @@ use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use lemmy_utils::error::LemmyError;
 use tokio::sync::OnceCell;
 
+pub const UNDETERMINED_ID: LanguageId = LanguageId(0);
+
 impl LocalUserLanguage {
   pub async fn read(
     pool: &DbPool,
@@ -280,7 +282,7 @@ pub async fn default_post_language(
 ) -> Result<Option<LanguageId>, Error> {
   use crate::schema::{community_language::dsl as cl, local_user_language::dsl as ul};
   let conn = &mut get_conn(pool).await?;
-  let intersection = ul::local_user_language
+  let mut intersection = ul::local_user_language
     .inner_join(cl::community_language.on(ul::language_id.eq(cl::language_id)))
     .filter(ul::local_user_id.eq(local_user_id))
     .filter(cl::community_id.eq(community_id))
@@ -290,6 +292,9 @@ pub async fn default_post_language(
 
   if intersection.len() == 1 {
     Ok(Some(intersection[0]))
+  } else if intersection.len() == 2 && intersection.contains(&UNDETERMINED_ID) {
+    intersection.retain(|i| i != &UNDETERMINED_ID);
+    Ok(intersection.pop())
   } else {
     Ok(None)
   }
@@ -340,6 +345,7 @@ async fn convert_read_languages(
 
 #[cfg(test)]
 mod tests {
+  use super::*;
   use crate::{
     impls::actor_language::{
       convert_read_languages,
@@ -583,7 +589,8 @@ mod tests {
   async fn test_default_post_language() {
     let pool = &build_db_pool_for_tests().await;
     let (site, instance) = create_test_site(pool).await;
-    let test_langs = test_langs1(pool).await;
+    let mut test_langs = test_langs1(pool).await;
+    test_langs.push(UNDETERMINED_ID);
     let test_langs2 = test_langs2(pool).await;
 
     let community_form = CommunityInsertForm::builder()
@@ -632,6 +639,7 @@ mod tests {
         .await
         .unwrap()
         .unwrap(),
+      UNDETERMINED_ID,
     ];
     LocalUserLanguage::update(pool, test_langs3, local_user.id)
       .await

--- a/crates/db_views/src/comment_view.rs
+++ b/crates/db_views/src/comment_view.rs
@@ -418,6 +418,7 @@ mod tests {
   };
   use lemmy_db_schema::{
     aggregates::structs::CommentAggregates,
+    impls::actor_language::UNDETERMINED_ID,
     newtypes::LanguageId,
     source::{
       actor_language::LocalUserLanguage,
@@ -775,11 +776,7 @@ mod tests {
     assert_eq!(finnish_id, finnish_comment[0].comment.language_id);
 
     // now show all comments with undetermined language (which is the default value)
-    let undetermined_id = Language::read_id_from_code(pool, Some("und"))
-      .await
-      .unwrap()
-      .unwrap();
-    LocalUserLanguage::update(pool, vec![undetermined_id], data.inserted_local_user.id)
+    LocalUserLanguage::update(pool, vec![UNDETERMINED_ID], data.inserted_local_user.id)
       .await
       .unwrap();
     let undetermined_comment = CommentQuery::builder()

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -467,6 +467,7 @@ mod tests {
   use crate::post_view::{PostQuery, PostView};
   use lemmy_db_schema::{
     aggregates::structs::PostAggregates,
+    impls::actor_language::UNDETERMINED_ID,
     newtypes::LanguageId,
     source::{
       actor_language::LocalUserLanguage,
@@ -800,13 +801,9 @@ mod tests {
     assert_eq!(1, post_listing_french.len());
     assert_eq!(french_id, post_listing_french[0].post.language_id);
 
-    let undetermined_id = Language::read_id_from_code(pool, Some("und"))
-      .await
-      .unwrap()
-      .unwrap();
     LocalUserLanguage::update(
       pool,
-      vec![french_id, undetermined_id],
+      vec![french_id, UNDETERMINED_ID],
       data.inserted_local_user.id,
     )
     .await
@@ -823,7 +820,7 @@ mod tests {
     // french post and undetermined language post should be returned
     assert_eq!(2, post_listings_french_und.len());
     assert_eq!(
-      undetermined_id,
+      UNDETERMINED_ID,
       post_listings_french_und[0].post.language_id
     );
     assert_eq!(french_id, post_listings_french_und[1].post.language_id);


### PR DESCRIPTION
This will make it much more likely to successfully get a default, as most users and communities have undetermined selected.