### PR TITLE
Handling disconnect in heartbeat timeout causing memory overflow. #2778

### DIFF
--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -39,7 +39,6 @@ fn html_to_site_metadata(html_bytes: &[u8]) -> Result<SiteMetadata, LemmyError> 
   let first_line = html
     .trim_start()
     .lines()
-    .into_iter()
     .next()
     .ok_or_else(|| LemmyError::from_message("No lines in html"))?
     .to_lowercase();

--- a/crates/api_common/src/websocket/handlers.rs
+++ b/crates/api_common/src/websocket/handlers.rs
@@ -36,6 +36,10 @@ impl ChatServer {
       for sessions in inner.community_rooms.values_mut() {
         sessions.remove(connection_id);
       }
+
+      for sessions in inner.mod_rooms.values_mut() {
+        sessions.remove(connection_id);
+      }
     }
     Ok(())
   }

--- a/src/api_routes_websocket.rs
+++ b/src/api_routes_websocket.rs
@@ -242,10 +242,7 @@ fn heartbeat(
         let _ = session.close(None).await;
         chat_server
           .handle_disconnect(&connection_id)
-          .expect(&format!(
-            "could not disconnect connection_id: {} from chat_server",
-            connection_id
-          ));
+          .expect("Could not disconnect due to heartbeat timeout");
         break;
       }
       if session.ping(b"").await.is_err() {


### PR DESCRIPTION
@asonix Lemmy's memory has been overflowing after running for a few days, and I think I found the culprit: it came when nutomic converted our code to your actorless websocket example here: 

https://git.asonix.dog/asonix/actix-actorless-websockets/src/branch/main/examples/chat/src/main.rs

There's a memory issue where it doesn't properly handle a heartbeat disconnect, to remove the session from the server's sessions hashmap, that is correct in actix's official example:

https://github.com/actix/examples/blob/master/websockets/chat/src/session.rs#L16


Without removing heartbeat disconnected sessions from the server's session map, it will cause the memory to consistently increase.

I wanted to let you know, because this will affect anyone who uses your actorless code as a template. 
