### PR TITLE
Make path to local lemmy-ui use correct relative path

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -54,7 +54,7 @@ services:
     # run docker compose up --build
     # assuming lemmy-ui is cloned besides lemmy directory
     # build: 
-    #  context: ../../../lemmy-ui
+    #  context: ../../lemmy-ui
     #  dockerfile: dev.dockerfile
     networks:
       - lemmyinternal


### PR DESCRIPTION
This throws me off sometimes when I'm trying to test the UI locally. The current comment was made back when the Dockerfile was in `./docker/dev` instead of `./docker`.