### PR TITLE
Fixing empty req issue.

### DIFF
--- a/crates/api_common/src/person.rs
+++ b/crates/api_common/src/person.rs
@@ -48,7 +48,9 @@ pub struct Register {
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 #[cfg_attr(feature = "full", derive(TS))]
 #[cfg_attr(feature = "full", ts(export))]
-pub struct GetCaptcha {}
+pub struct GetCaptcha {
+  pub auth: Option<Sensitive<String>>,
+}
 
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/crates/api_common/src/person.rs
+++ b/crates/api_common/src/person.rs
@@ -45,6 +45,7 @@ pub struct Register {
   pub answer: Option<String>,
 }
 
+#[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 #[cfg_attr(feature = "full", derive(TS))]
 #[cfg_attr(feature = "full", ts(export))]

--- a/crates/api_common/src/sensitive.rs
+++ b/crates/api_common/src/sensitive.rs
@@ -3,7 +3,6 @@ use std::{
   borrow::Borrow,
   ops::{Deref, DerefMut},
 };
-
 #[cfg(feature = "full")]
 use ts_rs::TS;
 

--- a/crates/api_common/src/site.rs
+++ b/crates/api_common/src/site.rs
@@ -260,7 +260,9 @@ pub struct GetSiteResponse {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "full", derive(TS))]
 #[cfg_attr(feature = "full", ts(export))]
-pub struct GetFederatedInstances {}
+pub struct GetFederatedInstances {
+  pub auth: Option<Sensitive<String>>,
+}
 
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/crates/api_common/src/site.rs
+++ b/crates/api_common/src/site.rs
@@ -257,6 +257,7 @@ pub struct GetSiteResponse {
   pub custom_emojis: Vec<CustomEmojiView>,
 }
 
+#[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "full", derive(TS))]
 #[cfg_attr(feature = "full", ts(export))]


### PR DESCRIPTION
I ran into this issue when adding lemmy-ui support for `GetFederatedInstances`.

Unfortunately, due to some peculiarities with our http and websocket code, request objects can not be empty / null / empty null unit structs. We have only two, and adding an optional auth fixes it.