### PR TITLE
Force enable undetermined language

### DIFF
--- a/crates/db_schema/src/impls/actor_language.rs
+++ b/crates/db_schema/src/impls/actor_language.rs
@@ -80,7 +80,7 @@ impl LocalUserLanguage {
       return Ok(());
     }
 
-    // HACK: Force enable undetermined language for all users. This is necessary because many posts
+    // TODO: Force enable undetermined language for all users. This is necessary because many posts
     //       don't have a language tag (e.g. those from other federated platforms), so Lemmy users
     //       won't see them if undetermined language is disabled.
     //       This hack can be removed once a majority of posts have language tags, or when it is

--- a/crates/db_schema/src/impls/actor_language.rs
+++ b/crates/db_schema/src/impls/actor_language.rs
@@ -533,7 +533,7 @@ mod tests {
     let pool = &build_db_pool_for_tests().await;
 
     let (site, instance) = create_test_site(pool).await;
-    let test_langs = test_langs1(pool).await;
+    let mut test_langs = test_langs1(pool).await;
     SiteLanguage::update(pool, test_langs.clone(), &site)
       .await
       .unwrap();
@@ -552,7 +552,10 @@ mod tests {
     let local_user = LocalUser::create(pool, &local_user_form).await.unwrap();
     let local_user_langs1 = LocalUserLanguage::read(pool, local_user.id).await.unwrap();
 
-    // new user should be initialized with site languages
+    // new user should be initialized with site languages and undetermined
+    //test_langs.push(UNDETERMINED_ID);
+    //test_langs.sort();
+    test_langs.insert(0, UNDETERMINED_ID);
     assert_eq!(test_langs, local_user_langs1);
 
     // update user languages
@@ -561,7 +564,7 @@ mod tests {
       .await
       .unwrap();
     let local_user_langs2 = LocalUserLanguage::read(pool, local_user.id).await.unwrap();
-    assert_eq!(2, local_user_langs2.len());
+    assert_eq!(3, local_user_langs2.len());
 
     Person::delete(pool, person.id).await.unwrap();
     LocalUser::delete(pool, local_user.id).await.unwrap();
@@ -636,8 +639,7 @@ mod tests {
   async fn test_default_post_language() {
     let pool = &build_db_pool_for_tests().await;
     let (site, instance) = create_test_site(pool).await;
-    let mut test_langs = test_langs1(pool).await;
-    test_langs.push(UNDETERMINED_ID);
+    let test_langs = test_langs1(pool).await;
     let test_langs2 = test_langs2(pool).await;
 
     let community_form = CommunityInsertForm::builder()
@@ -666,7 +668,7 @@ mod tests {
       .await
       .unwrap();
 
-    // no overlap in user/community languages, so no default language for post
+    // no overlap in user/community languages, so defaults to undetermined
     let def1 = default_post_language(pool, community.id, local_user.id)
       .await
       .unwrap();

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -799,9 +799,11 @@ mod tests {
       .await
       .unwrap();
 
-    // only one french language post should be returned
-    assert_eq!(1, post_listing_french.len());
-    assert_eq!(french_id, post_listing_french[0].post.language_id);
+    // only one post in french and one undetermined should be returned
+    assert_eq!(2, post_listing_french.len());
+    assert!(post_listing_french
+      .iter()
+      .any(|p| p.post.language_id == french_id));
 
     LocalUserLanguage::update(
       pool,

--- a/migrations/2023-05-10-095739_force_enable_undetermined_language/up.sql
+++ b/migrations/2023-05-10-095739_force_enable_undetermined_language/up.sql
@@ -1,7 +1,4 @@
 -- force enable undetermined language for all users
 insert into local_user_language (local_user_id, language_id)
-    select id, 0 from (
-        select id from local_user where id not in (
-            select local_user_id fromlocal_user_language where language_id = 0
-        )
-    ) as foo;
+    select id, 0 from local_user
+    on conflict (local_user_id, language_id) do nothing;

--- a/migrations/2023-05-10-095739_force_enable_undetermined_language/up.sql
+++ b/migrations/2023-05-10-095739_force_enable_undetermined_language/up.sql
@@ -1,0 +1,7 @@
+-- force enable undetermined language for all users
+insert into local_user_language (local_user_id, language_id)
+    select id, 0 from (
+        select id from local_user where id not in (
+            select local_user_id fromlocal_user_language where language_id = 0
+        )
+    ) as foo;


### PR DESCRIPTION
This enables undetermined language for all existing users, and also enables it whenever the user language is updated. This is necessary because many posts don't have a language tag (e.g. those from other federated platforms), so Lemmy users won't see them if undetermined language is disabled. This hack can be removed once a majority of posts have language tags, or when it is clearer for new users that they need to enable undetermined language.

I think we should include this in 0.17.3

By the way I noticed that the user language selection in lemmy-ui at /settings seems to be broken in latest dev version (Firefox). The `x` button does nothing so its not possible to clear the selection and select other languages. Also "undetermined" is not shown in enabled languages even when it is returned by Lemmy API.
