### PR TITLE
Set attribute `deny_unknown_fields` for Lemmy config

### DIFF
--- a/crates/api_common/src/sensitive.rs
+++ b/crates/api_common/src/sensitive.rs
@@ -3,7 +3,6 @@ use std::{
   borrow::Borrow,
   ops::{Deref, DerefMut},
 };
-
 #[cfg(feature = "full")]
 use ts_rs::TS;
 

--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -80,7 +80,7 @@ impl Debug for LemmyError {
     f.debug_struct("LemmyError")
       .field("message", &self.message)
       .field("inner", &self.inner)
-      .field("context", &"SpanTrace")
+      .field("context", &self.context)
       .finish()
   }
 }

--- a/crates/utils/src/settings/mod.rs
+++ b/crates/utils/src/settings/mod.rs
@@ -14,8 +14,9 @@ pub mod structs;
 
 static DEFAULT_CONFIG_FILE: &str = "config/config.hjson";
 
-pub static SETTINGS: Lazy<Settings> =
-  Lazy::new(|| Settings::init().expect("Failed to load settings file"));
+pub static SETTINGS: Lazy<Settings> = Lazy::new(|| {
+  Settings::init().expect("Failed to load settings file, see documentation (https://join-lemmy.org/docs/en/administration/configuration.html)")
+});
 static WEBFINGER_REGEX: Lazy<Regex> = Lazy::new(|| {
   Regex::new(&format!(
     "^acct:([a-zA-Z0-9_]{{3,}})@{}$",
@@ -53,11 +54,11 @@ impl Settings {
     )
   }
 
-  pub fn get_config_location() -> String {
+  fn get_config_location() -> String {
     env::var("LEMMY_CONFIG_LOCATION").unwrap_or_else(|_| DEFAULT_CONFIG_FILE.to_string())
   }
 
-  pub fn read_config_file() -> Result<String, Error> {
+  fn read_config_file() -> Result<String, Error> {
     fs::read_to_string(Self::get_config_location())
   }
 

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -42,7 +42,7 @@ pub struct Settings {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, SmartDefault, Document)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct PictrsConfig {
   /// Address where pictrs is available (for image hosting)
   #[default(Url::parse("http://localhost:8080").expect("parse pictrs url"))]
@@ -55,7 +55,7 @@ pub struct PictrsConfig {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, SmartDefault, Document)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct DatabaseConfig {
   /// Username to connect to postgres
   #[default("lemmy")]
@@ -78,6 +78,7 @@ pub struct DatabaseConfig {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Document, SmartDefault)]
+#[serde(deny_unknown_fields)]
 pub struct EmailConfig {
   /// Hostname and port of the smtp server
   #[doku(example = "localhost:25")]
@@ -96,6 +97,7 @@ pub struct EmailConfig {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, SmartDefault, Document)]
+#[serde(deny_unknown_fields)]
 pub struct SetupConfig {
   /// Username for the admin user
   #[doku(example = "admin")]


### PR DESCRIPTION
With this attribute, Lemmy will throw an error and exit if any invalid entry is found in the config file. I think can be useful to notice typos or keys that were removed or renamed in an upgrade. Currently you wouldnt notice these at all unless you manually compare the config file with settings that are listed in documentation.

This should be considered a breaking change.