### PR TITLE
Make volumes used in docker compose work when running on machines with SELinux enabled

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -49,13 +49,13 @@ services:
       - pictrs
 
   lemmy-ui:
-    # image: dessalines/lemmy-ui:0.17.1
+    image: dessalines/lemmy-ui:0.17.1
     # use this to build your local lemmy ui image for development
     # run docker compose up --build
     # assuming lemmy-ui is cloned besides lemmy directory
-    build:
-      context: ../../lemmy-ui
-      dockerfile: dev.dockerfile
+    # build:
+    #   context: ../../lemmy-ui
+    #   dockerfile: dev.dockerfile
     networks:
       - lemmyinternal
     environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,11 +15,11 @@ services:
       - lemmyinternal
       - lemmyexternalproxy
     ports:
-    # actual and only port facing any connection from outside 
+      # actual and only port facing any connection from outside
       - "1236:1236"
       - "8536:8536"
     volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro,Z
     restart: always
     depends_on:
       - pictrs
@@ -29,10 +29,10 @@ services:
     # image: dessalines/lemmy:dev
     # use this to build your local lemmy server image for development
     # run docker compose up --build
-    build: 
+    build:
       context: ../
       dockerfile: docker/Dockerfile
-      # args: 
+      # args:
       #   RUST_RELEASE_MODE: release
     # this hostname is used in nginx reverse proxy and also for lemmy ui to connect to the backend, do not change
     hostname: lemmy
@@ -43,19 +43,19 @@ services:
       - RUST_LOG="warn,lemmy_server=debug,lemmy_api=debug,lemmy_api_common=debug,lemmy_api_crud=debug,lemmy_apub=debug,lemmy_db_schema=debug,lemmy_db_views=debug,lemmy_db_views_actor=debug,lemmy_db_views_moderator=debug,lemmy_routes=debug,lemmy_utils=debug,lemmy_websocket=debug"
       - RUST_BACKTRACE=full
     volumes:
-      - ./lemmy.hjson:/config/config.hjson
+      - ./lemmy.hjson:/config/config.hjson:Z
     depends_on:
       - postgres
       - pictrs
 
   lemmy-ui:
-    image: dessalines/lemmy-ui:0.17.1
+    # image: dessalines/lemmy-ui:0.17.1
     # use this to build your local lemmy ui image for development
     # run docker compose up --build
     # assuming lemmy-ui is cloned besides lemmy directory
-    # build: 
-    #  context: ../../lemmy-ui
-    #  dockerfile: dev.dockerfile
+    build:
+      context: ../../lemmy-ui
+      dockerfile: dev.dockerfile
     networks:
       - lemmyinternal
     environment:
@@ -89,7 +89,7 @@ services:
       - PICTRS__MEDIA__GIF__MAX_FRAME_COUNT=400
     user: 991:991
     volumes:
-      - ./volumes/pictrs:/mnt
+      - ./volumes/pictrs:/mnt:Z
     restart: always
 
   postgres:
@@ -100,26 +100,31 @@ services:
     # You can use this technique to add them here
     # https://stackoverflow.com/a/30850095/1655478
     hostname: postgres
-    command: [
-      "postgres",
-      "-c", "session_preload_libraries=auto_explain",
-      "-c", "auto_explain.log_min_duration=5ms",
-      "-c", "auto_explain.log_analyze=true",
-      "-c", "track_activity_query_size=1048576"
-    ]
+    command:
+      [
+        "postgres",
+        "-c",
+        "session_preload_libraries=auto_explain",
+        "-c",
+        "auto_explain.log_min_duration=5ms",
+        "-c",
+        "auto_explain.log_analyze=true",
+        "-c",
+        "track_activity_query_size=1048576",
+      ]
     networks:
       - lemmyinternal
-    # adding the external facing network to allow direct db access for devs
+      # adding the external facing network to allow direct db access for devs
       - lemmyexternalproxy
     ports:
-    # use a different port so it doesnt conflict with potential postgres db running on the host
+      # use a different port so it doesnt conflict with potential postgres db running on the host
       - "5433:5432"
     environment:
       - POSTGRES_USER=lemmy
       - POSTGRES_PASSWORD=password
       - POSTGRES_DB=lemmy
     volumes:
-      - ./volumes/postgres:/var/lib/postgresql/data
+      - ./volumes/postgres:/var/lib/postgresql/data:Z
     restart: always
 
   otel:
@@ -131,13 +136,11 @@ services:
     ports:
       - "4317:4317"
     volumes:
-      - type: bind
-        source: ./otel.yml
-        target: /otel-local-config.yaml
+      - ./otel.yaml:/otel-local-config.yaml:Z
     restart: unless-stopped
     depends_on:
       - jaeger
-  
+
   jaeger:
     image: jaegertracing/all-in-one:1
     networks:

--- a/docker/federation/docker-compose.yml
+++ b/docker/federation/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: "3.3"
 
 services:
   nginx:
@@ -10,7 +10,7 @@ services:
       - "8570:8570"
       - "8580:8580"
     volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx.conf:/etc/nginx/nginx.conf:Z
     restart: always
     depends_on:
       - pictrs
@@ -25,7 +25,7 @@ services:
     image: asonix/pictrs:0.4.0-beta.19
     user: 991:991
     volumes:
-      - ./volumes/pictrs_alpha:/mnt
+      - ./volumes/pictrs_alpha:/mnt:Z
 
   lemmy-alpha-ui:
     image: dessalines/lemmy-ui:0.17.1
@@ -38,14 +38,14 @@ services:
   lemmy-alpha:
     image: lemmy-federation:latest
     volumes:
-      - ./lemmy_alpha.hjson:/config/config.hjson
+      - ./lemmy_alpha.hjson:/config/config.hjson:Z
     environment:
       - RUST_BACKTRACE=1
       - RUST_LOG="warn,lemmy_server=debug,lemmy_api=debug,lemmy_api_common=debug,lemmy_api_crud=debug,lemmy_apub=debug,lemmy_db_schema=debug,lemmy_db_views=debug,lemmy_db_views_actor=debug,lemmy_db_views_moderator=debug,lemmy_routes=debug,lemmy_utils=debug,lemmy_websocket=debug"
     depends_on:
       - postgres_alpha
     restart: always
-    ports: 
+    ports:
       - "8541:8541"
   postgres_alpha:
     image: postgres:15-alpine
@@ -55,7 +55,7 @@ services:
       - POSTGRES_DB=lemmy
     restart: always
     volumes:
-      - ./volumes/postgres_alpha:/var/lib/postgresql/data
+      - ./volumes/postgres_alpha:/var/lib/postgresql/data:Z
 
   lemmy-beta-ui:
     image: dessalines/lemmy-ui:0.17.1
@@ -68,14 +68,14 @@ services:
   lemmy-beta:
     image: lemmy-federation:latest
     volumes:
-      - ./lemmy_beta.hjson:/config/config.hjson
+      - ./lemmy_beta.hjson:/config/config.hjson:Z
     environment:
       - RUST_BACKTRACE=1
       - RUST_LOG="warn,lemmy_server=debug,lemmy_api=debug,lemmy_api_common=debug,lemmy_api_crud=debug,lemmy_apub=debug,lemmy_db_schema=debug,lemmy_db_views=debug,lemmy_db_views_actor=debug,lemmy_db_views_moderator=debug,lemmy_routes=debug,lemmy_utils=debug,lemmy_websocket=debug"
     depends_on:
       - postgres_beta
     restart: always
-    ports: 
+    ports:
       - "8551:8551"
   postgres_beta:
     image: postgres:15-alpine
@@ -85,7 +85,7 @@ services:
       - POSTGRES_DB=lemmy
     restart: always
     volumes:
-      - ./volumes/postgres_beta:/var/lib/postgresql/data
+      - ./volumes/postgres_beta:/var/lib/postgresql/data:Z
 
   lemmy-gamma-ui:
     image: dessalines/lemmy-ui:0.17.1
@@ -98,14 +98,14 @@ services:
   lemmy-gamma:
     image: lemmy-federation:latest
     volumes:
-      - ./lemmy_gamma.hjson:/config/config.hjson
+      - ./lemmy_gamma.hjson:/config/config.hjson:Z
     environment:
       - RUST_BACKTRACE=1
       - RUST_LOG="warn,lemmy_server=debug,lemmy_api=debug,lemmy_api_common=debug,lemmy_api_crud=debug,lemmy_apub=debug,lemmy_db_schema=debug,lemmy_db_views=debug,lemmy_db_views_actor=debug,lemmy_db_views_moderator=debug,lemmy_routes=debug,lemmy_utils=debug,lemmy_websocket=debug"
     depends_on:
       - postgres_gamma
     restart: always
-    ports: 
+    ports:
       - "8561:8561"
   postgres_gamma:
     image: postgres:15-alpine
@@ -115,7 +115,7 @@ services:
       - POSTGRES_DB=lemmy
     restart: always
     volumes:
-      - ./volumes/postgres_gamma:/var/lib/postgresql/data
+      - ./volumes/postgres_gamma:/var/lib/postgresql/data:Z
 
   # An instance with only an allowlist for beta
   lemmy-delta-ui:
@@ -129,14 +129,14 @@ services:
   lemmy-delta:
     image: lemmy-federation:latest
     volumes:
-      - ./lemmy_delta.hjson:/config/config.hjson
+      - ./lemmy_delta.hjson:/config/config.hjson:Z
     environment:
       - RUST_BACKTRACE=1
       - RUST_LOG="warn,lemmy_server=debug,lemmy_api=debug,lemmy_api_common=debug,lemmy_api_crud=debug,lemmy_apub=debug,lemmy_db_schema=debug,lemmy_db_views=debug,lemmy_db_views_actor=debug,lemmy_db_views_moderator=debug,lemmy_routes=debug,lemmy_utils=debug,lemmy_websocket=debug"
     depends_on:
       - postgres_delta
     restart: always
-    ports: 
+    ports:
       - "8571:8571"
   postgres_delta:
     image: postgres:15-alpine
@@ -146,7 +146,7 @@ services:
       - POSTGRES_DB=lemmy
     restart: always
     volumes:
-      - ./volumes/postgres_delta:/var/lib/postgresql/data
+      - ./volumes/postgres_delta:/var/lib/postgresql/data:Z
 
   # An instance who has a blocklist, with lemmy-alpha blocked
   lemmy-epsilon-ui:
@@ -160,14 +160,14 @@ services:
   lemmy-epsilon:
     image: lemmy-federation:latest
     volumes:
-      - ./lemmy_epsilon.hjson:/config/config.hjson
+      - ./lemmy_epsilon.hjson:/config/config.hjson:Z
     environment:
       - RUST_BACKTRACE=1
       - RUST_LOG="warn,lemmy_server=debug,lemmy_api=debug,lemmy_api_common=debug,lemmy_api_crud=debug,lemmy_apub=debug,lemmy_db_schema=debug,lemmy_db_views=debug,lemmy_db_views_actor=debug,lemmy_db_views_moderator=debug,lemmy_routes=debug,lemmy_utils=debug,lemmy_websocket=debug"
     depends_on:
       - postgres_epsilon
     restart: always
-    ports: 
+    ports:
       - "8581:8581"
   postgres_epsilon:
     image: postgres:15-alpine
@@ -177,4 +177,4 @@ services:
       - POSTGRES_DB=lemmy
     restart: always
     volumes:
-      - ./volumes/postgres_epsilon:/var/lib/postgresql/data
+      - ./volumes/postgres_epsilon:/var/lib/postgresql/data:Z


### PR DESCRIPTION
Back when I used a machine with SELinux to run `docker compose` to start up a local lemmy instance, the containers would be denied access to the bind mounts. I would either have to disable SELinux or add [SELinux labels](https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label) to the volumes in the `docker-compos` file. The latter is the preferable of the two, as it doesn't require instance admins/devs to need to remember to switch SELinux on/off to use lemmy in docker containers.

I'm not sure where the `docker-compose.yml` files used for instances in production is, but that should also get these SELinux labels.