### PR TITLE
Fix typo that caused error

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -136,7 +136,7 @@ services:
     ports:
       - "4317:4317"
     volumes:
-      - ./otel.yaml:/otel-local-config.yaml:Z
+      - ./otel.yml:/otel-local-config.yaml:Z
     restart: unless-stopped
     depends_on:
       - jaeger


### PR DESCRIPTION
I made a typo in the SELinux docker-compose PR that caused a bad gateway error. This fixes that.