### PR TITLE
Remove GetCommunityResponse.default_post_language

### DIFF
--- a/crates/api/src/community/transfer.rs
+++ b/crates/api/src/community/transfer.rs
@@ -98,7 +98,6 @@ impl Perform for TransferCommunity {
       moderators,
       online: 0,
       discussion_languages: vec![],
-      default_post_language: None,
     })
   }
 }

--- a/crates/api_common/src/community.rs
+++ b/crates/api_common/src/community.rs
@@ -34,9 +34,6 @@ pub struct GetCommunityResponse {
   pub moderators: Vec<CommunityModeratorView>,
   pub online: usize,
   pub discussion_languages: Vec<LanguageId>,
-  /// Default language used for new posts if none is specified, generated based on community and
-  /// user languages.
-  pub default_post_language: Option<LanguageId>,
 }
 
 #[skip_serializing_none]

--- a/crates/apub/src/api/read_community.rs
+++ b/crates/apub/src/api/read_community.rs
@@ -10,14 +10,11 @@ use lemmy_api_common::{
   utils::{check_private_instance, get_local_user_view_from_jwt_opt, is_mod_or_admin_opt},
   websocket::handlers::online_users::GetCommunityUsersOnline,
 };
-use lemmy_db_schema::{
-  impls::actor_language::default_post_language,
-  source::{
-    actor_language::CommunityLanguage,
-    community::Community,
-    local_site::LocalSite,
-    site::Site,
-  },
+use lemmy_db_schema::source::{
+  actor_language::CommunityLanguage,
+  community::Community,
+  local_site::LocalSite,
+  site::Site,
 };
 use lemmy_db_views_actor::structs::{CommunityModeratorView, CommunityView};
 use lemmy_utils::{error::LemmyError, ConnectionId};
@@ -93,11 +90,6 @@ impl PerformApub for GetCommunity {
 
     let community_id = community_view.community.id;
     let discussion_languages = CommunityLanguage::read(context.pool(), community_id).await?;
-    let default_post_language = if let Some(user) = local_user_view {
-      default_post_language(context.pool(), community_id, user.local_user.id).await?
-    } else {
-      None
-    };
 
     let res = GetCommunityResponse {
       community_view,
@@ -105,7 +97,6 @@ impl PerformApub for GetCommunity {
       moderators,
       online,
       discussion_languages,
-      default_post_language,
     };
 
     // Return the jwt


### PR DESCRIPTION
This field is unnecessary because we already set a default language with the same logic if none is passed in CreatePost. So if the user doesnt set a post language, it should simply be passed as None. This also has the advantage that it works with clients that dont support language tags.

Technically not a breaking change because its optional, but better be safe.