### PR TITLE
Add CORS support for debug mode.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-cors"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b340e9cfa5b08690aae90fb61beb44e9b06f44fe3d0f93781aaa58cfba86245e"
+dependencies = [
+ "actix-utils",
+ "actix-web",
+ "derive_more",
+ "futures-util",
+ "log",
+ "once_cell",
+ "smallvec",
+]
+
+[[package]]
 name = "actix-form-data"
 version = "0.7.0-beta.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2732,6 +2747,7 @@ version = "0.17.1"
 dependencies = [
  "activitypub_federation",
  "actix",
+ "actix-cors",
  "actix-web",
  "clokwerk",
  "console-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,3 +141,4 @@ console-subscriber = { version = "0.1.8", optional = true }
 opentelemetry-otlp = { version = "0.10.0", optional = true }
 pict-rs = { version = "0.4.0-beta.9", optional = true }
 tokio.workspace = true
+actix-cors = "0.6.4"


### PR DESCRIPTION
This adds a permissive CORS when running lemmy in debug mode. This helps for doing front end development, so that you can use a different port / origin using the http client, without having to install a browser plugin.