### PR TITLE
Fix handling of follows addressed to single value

### DIFF
--- a/crates/apub/assets/lotide/activities/follow.json
+++ b/crates/apub/assets/lotide/activities/follow.json
@@ -1,0 +1,8 @@
+{
+  "actor": "https://dev.narwhal.city/users/1",
+  "object": "https://beehaw.org/c/foss",
+  "to": "https://beehaw.org/c/foss",
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "id": "https://dev.narwhal.city/communities/90/followers/1",
+  "type": "Follow"
+}

--- a/crates/apub/src/lib.rs
+++ b/crates/apub/src/lib.rs
@@ -13,7 +13,7 @@ use lemmy_db_schema::{
 };
 use lemmy_utils::{error::LemmyError, settings::structs::Settings};
 use once_cell::sync::Lazy;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::Serialize;
 use url::Url;
 
 pub mod activities;
@@ -88,25 +88,6 @@ fn check_apub_id_valid(apub_id: &Url, local_site_data: &LocalSiteData) -> Result
   }
 
   Ok(())
-}
-
-fn deserialize_opt_one<'de, T, D>(deserializer: D) -> Result<Option<[T; 1]>, D::Error>
-where
-  T: Deserialize<'de>,
-  D: Deserializer<'de>,
-{
-  #[derive(Deserialize)]
-  #[serde(untagged)]
-  enum MaybeArray<T> {
-    Simple(T),
-    Array([T; 1]),
-  }
-
-  let result: Option<MaybeArray<T>> = Deserialize::deserialize(deserializer)?;
-  Ok(result.map(|result| match result {
-    MaybeArray::Simple(value) => [value],
-    MaybeArray::Array(value) => value,
-  }))
 }
 
 #[derive(Clone)]

--- a/crates/apub/src/lib.rs
+++ b/crates/apub/src/lib.rs
@@ -13,7 +13,7 @@ use lemmy_db_schema::{
 };
 use lemmy_utils::{error::LemmyError, settings::structs::Settings};
 use once_cell::sync::Lazy;
-use serde::Serialize;
+use serde::{Deserialize, Deserializer, Serialize};
 use url::Url;
 
 pub mod activities;
@@ -88,6 +88,25 @@ fn check_apub_id_valid(apub_id: &Url, local_site_data: &LocalSiteData) -> Result
   }
 
   Ok(())
+}
+
+fn deserialize_opt_one<'de, T, D>(deserializer: D) -> Result<Option<[T; 1]>, D::Error>
+where
+  T: Deserialize<'de>,
+  D: Deserializer<'de>,
+{
+  #[derive(Deserialize)]
+  #[serde(untagged)]
+  enum MaybeArray<T> {
+    Simple(T),
+    Array([T; 1]),
+  }
+
+  let result: Option<MaybeArray<T>> = Deserialize::deserialize(deserializer)?;
+  Ok(result.map(|result| match result {
+    MaybeArray::Simple(value) => [value],
+    MaybeArray::Array(value) => value,
+  }))
 }
 
 #[derive(Clone)]

--- a/crates/apub/src/protocol/activities/following/accept.rs
+++ b/crates/apub/src/protocol/activities/following/accept.rs
@@ -2,7 +2,11 @@ use crate::{
   objects::{community::ApubCommunity, person::ApubPerson},
   protocol::activities::following::follow::Follow,
 };
-use activitypub_federation::{fetch::object_id::ObjectId, kinds::activity::AcceptType};
+use activitypub_federation::{
+  fetch::object_id::ObjectId,
+  kinds::activity::AcceptType,
+  protocol::helpers::deserialize_skip_error,
+};
 use serde::{Deserialize, Serialize};
 use url::Url;
 

--- a/crates/apub/src/protocol/activities/following/accept.rs
+++ b/crates/apub/src/protocol/activities/following/accept.rs
@@ -11,6 +11,7 @@ use url::Url;
 pub struct AcceptFollow {
   pub(crate) actor: ObjectId<ApubCommunity>,
   /// Optional, for compatibility with platforms that always expect recipient field
+  #[serde(deserialize_with = "deserialize_skip_error", default)]
   pub(crate) to: Option<[ObjectId<ApubPerson>; 1]>,
   pub(crate) object: Follow,
   #[serde(rename = "type")]

--- a/crates/apub/src/protocol/activities/following/follow.rs
+++ b/crates/apub/src/protocol/activities/following/follow.rs
@@ -1,4 +1,8 @@
-use crate::{fetcher::user_or_community::UserOrCommunity, objects::person::ApubPerson};
+use crate::{
+  deserialize_opt_one,
+  fetcher::user_or_community::UserOrCommunity,
+  objects::person::ApubPerson,
+};
 use activitypub_federation::{fetch::object_id::ObjectId, kinds::activity::FollowType};
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -8,6 +12,8 @@ use url::Url;
 pub struct Follow {
   pub(crate) actor: ObjectId<ApubPerson>,
   /// Optional, for compatibility with platforms that always expect recipient field
+  #[serde(deserialize_with = "deserialize_opt_one")]
+  #[serde(default)]
   pub(crate) to: Option<[ObjectId<UserOrCommunity>; 1]>,
   pub(crate) object: ObjectId<UserOrCommunity>,
   #[serde(rename = "type")]

--- a/crates/apub/src/protocol/activities/following/follow.rs
+++ b/crates/apub/src/protocol/activities/following/follow.rs
@@ -1,9 +1,9 @@
-use crate::{
-  deserialize_opt_one,
-  fetcher::user_or_community::UserOrCommunity,
-  objects::person::ApubPerson,
+use crate::{fetcher::user_or_community::UserOrCommunity, objects::person::ApubPerson};
+use activitypub_federation::{
+  fetch::object_id::ObjectId,
+  kinds::activity::FollowType,
+  protocol::helpers::deserialize_skip_error,
 };
-use activitypub_federation::{fetch::object_id::ObjectId, kinds::activity::FollowType};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -12,8 +12,7 @@ use url::Url;
 pub struct Follow {
   pub(crate) actor: ObjectId<ApubPerson>,
   /// Optional, for compatibility with platforms that always expect recipient field
-  #[serde(deserialize_with = "deserialize_opt_one")]
-  #[serde(default)]
+  #[serde(deserialize_with = "deserialize_skip_error", default)]
   pub(crate) to: Option<[ObjectId<UserOrCommunity>; 1]>,
   pub(crate) object: ObjectId<UserOrCommunity>,
   #[serde(rename = "type")]

--- a/crates/apub/src/protocol/activities/following/undo_follow.rs
+++ b/crates/apub/src/protocol/activities/following/undo_follow.rs
@@ -1,5 +1,9 @@
 use crate::{objects::person::ApubPerson, protocol::activities::following::follow::Follow};
-use activitypub_federation::{fetch::object_id::ObjectId, kinds::activity::UndoType};
+use activitypub_federation::{
+  fetch::object_id::ObjectId,
+  kinds::activity::UndoType,
+  protocol::helpers::deserialize_skip_error,
+};
 use serde::{Deserialize, Serialize};
 use url::Url;
 

--- a/crates/apub/src/protocol/activities/following/undo_follow.rs
+++ b/crates/apub/src/protocol/activities/following/undo_follow.rs
@@ -8,6 +8,7 @@ use url::Url;
 pub struct UndoFollow {
   pub(crate) actor: ObjectId<ApubPerson>,
   /// Optional, for compatibility with platforms that always expect recipient field
+  #[serde(deserialize_with = "deserialize_skip_error", default)]
   pub(crate) to: Option<[ObjectId<ApubPerson>; 1]>,
   pub(crate) object: Follow,
   #[serde(rename = "type")]

--- a/crates/apub/src/protocol/activities/mod.rs
+++ b/crates/apub/src/protocol/activities/mod.rs
@@ -51,6 +51,7 @@ mod tests {
 
   #[test]
   fn test_parse_lotide_activities() {
+    test_json::<Follow>("assets/lotide/activities/follow.json").unwrap();
     test_json::<CreateOrUpdatePage>("assets/lotide/activities/create_page.json").unwrap();
     test_json::<CreateOrUpdatePage>("assets/lotide/activities/create_page_image.json").unwrap();
     test_json::<CreateOrUpdateNote>("assets/lotide/activities/create_note_reply.json").unwrap();


### PR DESCRIPTION
Should fix follows from lotide, which seem to have been broken by #2829 

Includes a `deserialize_opt_one` function in lemmy_apub, though maybe you want to move that to activitypub-federation with the others?