### PR TITLE
Remove federation_debug site setting

### DIFF
--- a/crates/api_common/src/site.rs
+++ b/crates/api_common/src/site.rs
@@ -176,7 +176,6 @@ pub struct CreateSite {
   pub rate_limit_search: Option<i32>,
   pub rate_limit_search_per_second: Option<i32>,
   pub federation_enabled: Option<bool>,
-  pub federation_debug: Option<bool>,
   pub federation_worker_count: Option<i32>,
   pub captcha_enabled: Option<bool>,
   pub captcha_difficulty: Option<String>,
@@ -248,8 +247,6 @@ pub struct EditSite {
   pub rate_limit_search_per_second: Option<i32>,
   /// Whether to enable federation.
   pub federation_enabled: Option<bool>,
-  /// Enables federation debugging.
-  pub federation_debug: Option<bool>,
   /// The number of federation workers.
   pub federation_worker_count: Option<i32>,
   /// Whether to enable captchas for signups.

--- a/crates/api_crud/src/site/create.rs
+++ b/crates/api_crud/src/site/create.rs
@@ -115,7 +115,6 @@ impl PerformCrud for CreateSite {
       .slur_filter_regex(diesel_option_overwrite(&data.slur_filter_regex))
       .actor_name_max_length(data.actor_name_max_length)
       .federation_enabled(data.federation_enabled)
-      .federation_debug(data.federation_debug)
       .federation_worker_count(data.federation_worker_count)
       .captcha_enabled(data.captcha_enabled)
       .captcha_difficulty(data.captcha_difficulty.clone())

--- a/crates/api_crud/src/site/update.rs
+++ b/crates/api_crud/src/site/update.rs
@@ -113,7 +113,6 @@ impl PerformCrud for EditSite {
       .slur_filter_regex(diesel_option_overwrite(&data.slur_filter_regex))
       .actor_name_max_length(data.actor_name_max_length)
       .federation_enabled(data.federation_enabled)
-      .federation_debug(data.federation_debug)
       .federation_worker_count(data.federation_worker_count)
       .captcha_enabled(data.captcha_enabled)
       .captcha_difficulty(data.captcha_difficulty.clone())

--- a/crates/db_schema/src/schema.rs
+++ b/crates/db_schema/src/schema.rs
@@ -337,7 +337,6 @@ diesel::table! {
         slur_filter_regex -> Nullable<Text>,
         actor_name_max_length -> Int4,
         federation_enabled -> Bool,
-        federation_debug -> Bool,
         federation_worker_count -> Int4,
         captcha_enabled -> Bool,
         #[max_length = 255]

--- a/crates/db_schema/src/source/local_site.rs
+++ b/crates/db_schema/src/source/local_site.rs
@@ -50,7 +50,6 @@ pub struct LocalSite {
   pub actor_name_max_length: i32,
   /// Whether federation is enabled.
   pub federation_enabled: bool,
-  pub federation_debug: bool,
   /// The number of concurrent federation http workers.
   pub federation_worker_count: i32,
   /// Whether captcha is enabled.
@@ -86,7 +85,6 @@ pub struct LocalSiteInsertForm {
   pub slur_filter_regex: Option<String>,
   pub actor_name_max_length: Option<i32>,
   pub federation_enabled: Option<bool>,
-  pub federation_debug: Option<bool>,
   pub federation_worker_count: Option<i32>,
   pub captcha_enabled: Option<bool>,
   pub captcha_difficulty: Option<String>,
@@ -114,7 +112,6 @@ pub struct LocalSiteUpdateForm {
   pub slur_filter_regex: Option<Option<String>>,
   pub actor_name_max_length: Option<i32>,
   pub federation_enabled: Option<bool>,
-  pub federation_debug: Option<bool>,
   pub federation_worker_count: Option<i32>,
   pub captcha_enabled: Option<bool>,
   pub captcha_difficulty: Option<String>,

--- a/migrations/2023-06-07-105106_remove_local_site_federation_debug/down.sql
+++ b/migrations/2023-06-07-105106_remove_local_site_federation_debug/down.sql
@@ -1,0 +1,1 @@
+alter table local_site add column federation_debug boolean default false not null;

--- a/migrations/2023-06-07-105106_remove_local_site_federation_debug/up.sql
+++ b/migrations/2023-06-07-105106_remove_local_site_federation_debug/up.sql
@@ -1,0 +1,1 @@
+alter table local_site drop column federation_debug;


### PR DESCRIPTION
This setting is actually not used since a while already. Federation debugging is now enabled automatically when Lemmy is compiled in debug mode.