### PR TITLE
allow specifying db uri in config file

### DIFF
--- a/config/defaults.hjson
+++ b/config/defaults.hjson
@@ -22,16 +22,18 @@
       # Note that specifying the `uri` field should be preferred since it provides
       # greater control over how the connection is made. This merely exists for
       # backwards-compatibility.
-      # Username to connect to postgres
-      user: "string"
-      # Password to connect to postgres
-      password: "string"
-      # Host where postgres is running
-      host: "string"
-      # Port where postgres can be accessed
-      port: 123
-      # Name of the postgres database for lemmy
-      database: "string"
+      {
+        # Username to connect to postgres
+        user: "string"
+        # Password to connect to postgres
+        password: "string"
+        # Host where postgres is running
+        host: "string"
+        # Port where postgres can be accessed
+        port: 123
+        # Name of the postgres database for lemmy
+        database: "string"
+      }
     # Maximum number of active sql connections
     pool_size: 5
   }

--- a/config/defaults.hjson
+++ b/config/defaults.hjson
@@ -1,16 +1,37 @@
 {
   # settings related to the postgresql database
   database: {
-    # Username to connect to postgres
-    user: "lemmy"
-    # Password to connect to postgres
-    password: "password"
-    # Host where postgres is running
-    host: "localhost"
-    # Port where postgres can be accessed
-    port: 5432
-    # Name of the postgres database for lemmy
-    database: "lemmy"
+
+      # Configure the database by specifying a URI
+      # 
+      # This is the preferred method to specify database connection details since
+      # it is the most flexible.
+      # Connection URI pointing to a postgres instance
+      # 
+      # This example uses peer authentication to obviate the need for creating,
+      # configuring, and managing passwords.
+      # 
+      # For an explanation of how to use connection URIs, see [here][0] in
+      # PostgreSQL's documentation.
+      # 
+      # [0]: https://www.postgresql.org/docs/current/libpq-connect.html#id-1.7.3.8.3.6
+      uri: "postgresql:///lemmy?user=lemmy&host=/var/run/postgresql"
+      // or
+      # Configure the database by specifying parts of a URI
+      # 
+      # Note that specifying the `uri` field should be preferred since it provides
+      # greater control over how the connection is made. This merely exists for
+      # backwards-compatibility.
+      # Username to connect to postgres
+      user: "string"
+      # Password to connect to postgres
+      password: "string"
+      # Host where postgres is running
+      host: "string"
+      # Port where postgres can be accessed
+      port: 123
+      # Name of the postgres database for lemmy
+      database: "string"
     # Maximum number of active sql connections
     pool_size: 5
   }

--- a/crates/utils/src/settings/mod.rs
+++ b/crates/utils/src/settings/mod.rs
@@ -12,6 +12,8 @@ use std::{env, fs, io::Error};
 
 pub mod structs;
 
+use structs::DatabaseConnection;
+
 static DEFAULT_CONFIG_FILE: &str = "config/config.hjson";
 
 pub static SETTINGS: Lazy<Settings> = Lazy::new(|| {
@@ -43,15 +45,19 @@ impl Settings {
   }
 
   pub fn get_database_url(&self) -> String {
-    let conf = &self.database;
-    format!(
-      "postgres://{}:{}@{}:{}/{}",
-      utf8_percent_encode(&conf.user, NON_ALPHANUMERIC),
-      utf8_percent_encode(&conf.password, NON_ALPHANUMERIC),
-      conf.host,
-      conf.port,
-      utf8_percent_encode(&conf.database, NON_ALPHANUMERIC),
-    )
+    match &self.database.connection {
+      DatabaseConnection::Uri { uri } => uri.clone(),
+      DatabaseConnection::Parts(parts) => {
+        format!(
+          "postgres://{}:{}@{}:{}/{}",
+          utf8_percent_encode(&parts.user, NON_ALPHANUMERIC),
+          utf8_percent_encode(&parts.password, NON_ALPHANUMERIC),
+          parts.host,
+          parts.port,
+          utf8_percent_encode(&parts.database, NON_ALPHANUMERIC),
+        )
+      }
+    }
   }
 
   fn get_config_location() -> String {

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -55,8 +55,49 @@ pub struct PictrsConfig {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, SmartDefault, Document)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct DatabaseConfig {
+  #[serde(flatten, default)]
+  pub connection: DatabaseConnection,
+
+  /// Maximum number of active sql connections
+  #[default(5)]
+  pub pool_size: usize,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, SmartDefault, Document)]
+#[serde(untagged)]
+pub enum DatabaseConnection {
+  /// Configure the database by specifying a URI
+  ///
+  /// This is the preferred method to specify database connection details since
+  /// it is the most flexible.
+  Uri {
+    /// Connection URI pointing to a postgres instance
+    ///
+    /// This example uses peer authentication to obviate the need for creating,
+    /// configuring, and managing passwords.
+    ///
+    /// For an explanation of how to use connection URIs, see [here][0] in
+    /// PostgreSQL's documentation.
+    ///
+    /// [0]: https://www.postgresql.org/docs/current/libpq-connect.html#id-1.7.3.8.3.6
+    #[doku(example = "postgresql:///lemmy?user=lemmy&host=/var/run/postgresql")]
+    uri: String,
+  },
+
+  /// Configure the database by specifying parts of a URI
+  ///
+  /// Note that specifying the `uri` field should be preferred since it provides
+  /// greater control over how the connection is made. This merely exists for
+  /// backwards-compatibility.
+  #[default]
+  Parts(DatabaseConnectionParts),
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, SmartDefault, Document)]
+#[serde(default)]
+pub struct DatabaseConnectionParts {
   /// Username to connect to postgres
   #[default("lemmy")]
   pub(super) user: String,
@@ -72,9 +113,6 @@ pub struct DatabaseConfig {
   /// Name of the postgres database for lemmy
   #[default("lemmy")]
   pub(super) database: String,
-  /// Maximum number of active sql connections
-  #[default(5)]
-  pub pool_size: usize,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Document, SmartDefault)]


### PR DESCRIPTION
Fixes https://github.com/LemmyNet/lemmy/issues/2945.

Currently doesn't work because

```
error[E0277]: the trait bound `either::Either<std::string::String, DatabaseConfig>: doku::Document` is not satisfied
 --> crates/utils/src/settings/structs.rs:7:62
  |
7 | #[derive(Debug, Deserialize, Serialize, Clone, SmartDefault, Document)]
  |                                                              ^^^^^^^^ the trait `doku::Document` is not implemented for `either::Either<std::string::String, DatabaseConfig>`
```

Options for fixing this:

1. Defining our own `Either` type and implementing `Document` for it
2. Submitting a patch upstream to support the `either` crate

I like the second option more.