### PR TITLE
Add `lemmyexternalproxy` to `lemmy` in docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -39,6 +39,7 @@ services:
     hostname: lemmy
     networks:
       - lemmyinternal
+      - lemmyexternalproxy
     restart: always
     environment:
       - RUST_LOG="warn,lemmy_server=debug,lemmy_api=debug,lemmy_api_common=debug,lemmy_api_crud=debug,lemmy_apub=debug,lemmy_db_schema=debug,lemmy_db_views=debug,lemmy_db_views_actor=debug,lemmy_db_views_moderator=debug,lemmy_routes=debug,lemmy_utils=debug,lemmy_websocket=debug"


### PR DESCRIPTION
Consensus on the matrix channel is that this is necessary to let the `lemmy` container talk to the internet directly, which is in turn necessary for federation.