### PR TITLE
Fix private message e-mail notification subject and body

### DIFF
--- a/crates/api_crud/src/private_message/create.rs
+++ b/crates/api_crud/src/private_message/create.rs
@@ -89,14 +89,11 @@ impl PerformCrud for CreatePrivateMessage {
       let local_recipient = LocalUserView::read_person(context.pool(), recipient_id).await?;
       let lang = get_interface_language(&local_recipient);
       let inbox_link = format!("{}/inbox", context.settings().get_protocol_and_hostname());
+      let sender_name = &local_user_view.person.name;
       send_email_to_user(
         &local_recipient,
-        &lang.notification_private_message_subject(&local_recipient.person.name),
-        &lang.notification_private_message_body(
-          inbox_link,
-          &content_slurs_removed,
-          &local_recipient.person.name,
-        ),
+        &lang.notification_private_message_subject(sender_name),
+        &lang.notification_private_message_body(inbox_link, &content_slurs_removed, sender_name),
         context.settings(),
       );
     }


### PR DESCRIPTION
This is just something I happened to notice the other day. ~I can also revert the changes to lines 7-13 if needed, or maybe rustfmt changed how it formats things? i'm not sure.~ oops, i maybe should have read the instructions first!

this is also something super minor so no huge rush to get this in, i know you have more pressing things to do!

It used to say:

Subject: Private message from [your username]
Body: [your username] - [private message]

It now display the correct username that it's from.