### PR TITLE
Fix translation build error (fixes #2967)

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -20,7 +20,7 @@ pipeline:
       - apk add git
         #- git fetch --tags
       - git submodule init
-      - git submodule update --recursive --remote
+      - git submodule update
 
   prettier_check:
     image: tmknom/prettier


### PR DESCRIPTION
Someone had translated the string `new_application_subject` and replaced the variable name `{hostname}` with `{instance}`. This broke compilation because the correct variable is missing, and the other one is not known. Because our CI is automatically pulling the latest translations with each build, this broke all builds. 

I fixed the translation and also changed CI to use a consistent translation version, without pulling new ones automatically. Translators should also take care not to change variable names.