### PR TITLE
make shebangs posix compliant

### DIFF
--- a/api_tests/prepare-drone-federation-test.sh
+++ b/api_tests/prepare-drone-federation-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 export RUST_BACKTRACE=1

--- a/api_tests/run-federation-test.sh
+++ b/api_tests/run-federation-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 export LEMMY_DATABASE_URL=postgres://lemmy:password@localhost:5432

--- a/docker/docker_db_backup.sh
+++ b/docker/docker_db_backup.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 docker-compose exec postgres pg_dumpall -c -U lemmy > dump_`date +%Y-%m-%d"_"%H_%M_%S`.sql

--- a/docker/test_deploy.sh
+++ b/docker/test_deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 export COMPOSE_DOCKER_CLI_BUILD=1

--- a/scripts/clear_db.sh
+++ b/scripts/clear_db.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 psql -U lemmy -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public; DROP SCHEMA utils CASCADE;"

--- a/scripts/compilation_benchmark.sh
+++ b/scripts/compilation_benchmark.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 times=3

--- a/scripts/db-init.sh
+++ b/scripts/db-init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Default configurations

--- a/scripts/fix-clippy.sh
+++ b/scripts/fix-clippy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Set the database variable to the default first.

--- a/scripts/query_testing/apache_bench_report.sh
+++ b/scripts/query_testing/apache_bench_report.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 declare -a arr=(

--- a/scripts/query_testing/api_benchmark.sh
+++ b/scripts/query_testing/api_benchmark.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # By default, this script runs against `http://127.0.0.1:8536`, but you can pass a different Lemmy instance,

--- a/scripts/query_testing/views_old/generate_reports.sh
+++ b/scripts/query_testing/views_old/generate_reports.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # You can import these to http://tatiyants.com/pev/#/plans/new

--- a/scripts/query_testing/views_to_diesel_migration/generate_reports.sh
+++ b/scripts/query_testing/views_to_diesel_migration/generate_reports.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # You can import these to http://tatiyants.com/pev/#/plans/new

--- a/scripts/restore_db.sh
+++ b/scripts/restore_db.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 psql -U lemmy -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
 cat docker/lemmy_dump_2021-01-29_16_13_40.sqldump | psql -U lemmy

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 PACKAGE="$1"

--- a/scripts/update_config_defaults.sh
+++ b/scripts/update_config_defaults.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 dest=${1-config/defaults.hjson}

--- a/scripts/update_translations.sh
+++ b/scripts/update_translations.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 pushd ../../lemmy-translations

--- a/scripts/upgrade_deps.sh
+++ b/scripts/upgrade_deps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 pushd ../
 


### PR DESCRIPTION
Previously, these scripts wouldn't work on exotic systems such as NixOS.

```
fd '\.sh$' -t f --exec sed -i 's@#!/bin/bash@#!/usr/bin/env bash@'
```