### PR TITLE
Add limit and pagination to feeds

### DIFF
--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -208,6 +208,7 @@ pub struct PostQuery<'a> {
   is_mod_or_admin: Option<bool>,
   page: Option<i64>,
   limit: Option<i64>,
+  offset: Option<i64>,
 }
 
 impl<'a> PostQuery<'a> {
@@ -416,7 +417,9 @@ impl<'a> PostQuery<'a> {
         .then_order_by(post_aggregates::published.desc()),
     };
 
-    let (limit, offset) = limit_and_offset(self.page, self.limit)?;
+    let (limit, mut offset) = limit_and_offset(self.page, self.limit)?;
+
+    offset += self.offset.unwrap_or(0);
 
     query = query.limit(limit).offset(offset);
 

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -208,7 +208,6 @@ pub struct PostQuery<'a> {
   is_mod_or_admin: Option<bool>,
   page: Option<i64>,
   limit: Option<i64>,
-  offset: Option<i64>,
 }
 
 impl<'a> PostQuery<'a> {
@@ -417,9 +416,7 @@ impl<'a> PostQuery<'a> {
         .then_order_by(post_aggregates::published.desc()),
     };
 
-    let (limit, mut offset) = limit_and_offset(self.page, self.limit)?;
-
-    offset += self.offset.unwrap_or(0);
+    let (limit, offset) = limit_and_offset(self.page, self.limit)?;
 
     query = query.limit(limit).offset(offset);
 

--- a/crates/routes/src/feeds.rs
+++ b/crates/routes/src/feeds.rs
@@ -31,7 +31,6 @@ use rss::{
 };
 use serde::Deserialize;
 use std::{collections::BTreeMap, str::FromStr};
-use strum::ParseError;
 
 const RSS_FETCH_LIMIT: i64 = 20;
 

--- a/crates/routes/src/feeds.rs
+++ b/crates/routes/src/feeds.rs
@@ -244,9 +244,9 @@ async fn get_feed_user(
     .pool(pool)
     .listing_type(Some(ListingType::All))
     .sort(Some(*sort_type))
-    .page(Some(*page))
     .creator_id(Some(person.id))
     .limit(Some(*limit))
+    .page(Some(*page))
     .build()
     .list()
     .await?;


### PR DESCRIPTION
Addresses Issue https://github.com/LemmyNet/lemmy/issues/2906 

## Summary
Adds limit and pagination to the RSS feeds. The original issue requests an `after` param, but I couldn't actually figure out the intent behind that nor did it seem to work with reddits rss feed. I'd be happy to address it if it's something we do want and someone can explain what it is, but for now substituting in `page` as that seems more common and useful.

## Testing
Example query:
`http://localhost:8536/feeds/c/test.xml?limit=1&page=2`

If there's 20 posts and you set the `limit` to 10 and `page` to 1, it will return the first 10 results. Set `page` to 1 and it will return the next 10.