### PR TITLE
don't require `SUPERUSER` to run migrations

### DIFF
--- a/migrations/2022-07-07-182650_comment_ltrees/up.sql
+++ b/migrations/2022-07-07-182650_comment_ltrees/up.sql
@@ -60,7 +60,7 @@ ORDER BY
 	breadcrumb;
 
 -- Remove indexes and foreign key constraints, and disable triggers for faster updates
-alter table comment disable trigger all;
+alter table comment disable trigger user;
 
 alter table comment drop constraint if exists comment_creator_id_fkey;
 alter table comment drop constraint if exists comment_parent_id_fkey;
@@ -115,4 +115,4 @@ create index idx_path_gist on comment using gist (path);
 -- Drop the parent_id column
 alter table comment drop column parent_id cascade;
 
-alter table comment enable trigger all;
+alter table comment enable trigger user;


### PR DESCRIPTION
Fixes https://github.com/LemmyNet/lemmy/issues/2863.

The first commit fixes the problem, the second one prevents it from happening again.

The second commit is there to convey the idea but obviously it shouldn't be implemented this way since there's an existing `docker-compose.yml` in the repository. If you can point me to the relevant places this sort of change needs to *actually* happen, I'll amend that second commit.

Would probably also be wise to test this with more data, I used a completely different hack to work around this for my instance.