### PR TITLE
Fix ports used by docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,5 +33,4 @@ RUN apk add libpq
 # Copy resources
 COPY --from=builder /app/lemmy_server /app/lemmy
 
-EXPOSE 8536
 CMD ["/app/lemmy"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,8 +16,9 @@ services:
       - lemmyexternalproxy
     ports:
       # actual and only port facing any connection from outside
-      # Note, change the left number if port 80 is already in use on your system (or you want to run a reverse proxy outside this config)
-      - "80:80"
+      # Note, change the left number if port 1236 is already in use on your system
+      # You could use port 80 if you won't use a reverse proxy
+      - "1236:1236"
       - "8536:8536"
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro,Z


### PR DESCRIPTION
- Update host docker port to `1236` as described in [the documentation](https://join-lemmy.org/docs/en/contributors/03-docker-development.html)  
- Update container docker port to `1236` as used in the [nginx.conf file](https://github.com/LemmyNet/lemmy/blob/main/docker/nginx.conf#L17)  
- Removed exposed port `8536` from dockerfile as it's already handled by nginx.  