### PR TITLE
Fix contributing link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing
 
-See [here](https://join-lemmy.org/docs/en/contributing/contributing.html) for contributing Instructions.
+See [here](https://join-lemmy.org/docs/en/contributors/01-overview.html) for contributing Instructions.


### PR DESCRIPTION
The link in CONTRIBUTING.md was dead, this updates it to point to the right location.