### PR TITLE
Fixes #1884 - Support Spoiler Tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "background-jobs",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "chrono",
  "derive_builder 0.12.0",
@@ -121,7 +121,7 @@ dependencies = [
  "actix-tls",
  "actix-utils",
  "ahash",
- "base64",
+ "base64 0.13.1",
  "bitflags 1.3.2",
  "bytes",
  "bytestring",
@@ -359,6 +359,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
+name = "argparse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f8ebf5827e4ac4fd5946560e6a99776ea73b596d80898f357007317a7141e47"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,7 +467,7 @@ dependencies = [
  "actix-tls",
  "actix-utils",
  "ahash",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "cfg-if",
  "derive_more",
@@ -605,12 +611,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+
+[[package]]
 name = "bcrypt"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7e7c93a3fb23b2fdde989b2c9ec4dd153063ec81f408507f84c090cd91c6641"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "blowfish",
  "getrandom 0.2.8",
  "zeroize",
@@ -623,6 +635,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73e8ecdec39e98aa3b19e8cd0b8ed8f77ccb86a6b0b2dc7cd86d105438a2123"
 dependencies = [
  "scoped-tls",
+]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -722,7 +743,7 @@ version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db21780337b425f968a2c3efa842eeaa4fe53d2bcb1eb27d2877460a862fb0ab"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "hound",
  "image",
  "lodepng",
@@ -874,24 +895,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "comrak"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15bf1e432b302dc6236dd0db580d182ce520bb24af82d6462e2d7a5e0a31c50d"
-dependencies = [
- "entities",
- "lazy_static",
- "memchr",
- "pest",
- "pest_derive",
- "regex",
- "shell-words",
- "typed-arena 1.7.0",
- "unicode_categories",
- "xdg",
-]
-
-[[package]]
 name = "config"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,6 +947,26 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "const_format"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c990efc7a285731f9a4378d81aff2f0e85a2c8781a05ef0f8baa8dac54d0ff48"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e026b6ce194a874cb9cf32cd5772d1ef9767cc8fcb5765948d74f37a9d8b2bf6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1254,6 +1277,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.103",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1453,26 +1487,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1512,6 +1526,12 @@ dependencies = [
  "quote",
  "syn 1.0.103",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dprint-core"
@@ -1573,7 +1593,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34dd14c63662e0206599796cd5e1ad0268ab2b9d19b868d6050d688eba2bbf98"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "memchr",
 ]
 
@@ -1748,6 +1768,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c195cf4b2285d3c993eb887b4dc56b0d5728bbe1d0f9a99c0ac6bec2da3e4d85"
 dependencies = [
  "hashbrown",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6b8560a05112eb52f04b00e5d3790c0dd75d9d980eb8a122fb23b92a623ccf"
+dependencies = [
+ "bit-set",
+ "regex",
 ]
 
 [[package]]
@@ -2019,7 +2049,7 @@ version = "7.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f19b9f54f7c7f55e31401bb647626ce0cf0f67b0004982ce815b3ee72a02aa8"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "flate2",
  "nom 7.1.1",
@@ -2090,6 +2120,15 @@ name = "hound"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d13cdbd5dbb29f9c88095bbdc2590c9cba0d0a1269b983fef6b2cdd7e9f4db1"
+
+[[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
+]
 
 [[package]]
 name = "html2md"
@@ -2192,7 +2231,7 @@ dependencies = [
  "actix-http",
  "actix-rt",
  "actix-web",
- "base64",
+ "base64 0.13.1",
  "futures-util",
  "http-signature-normalization",
  "sha2",
@@ -2209,7 +2248,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e309145e63e70307ab1f521fb6e354158f0255e572da21c9fd56940c5bd5d854"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "http-signature-normalization",
  "httpdate",
  "reqwest",
@@ -2488,7 +2527,7 @@ version = "8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa4b4af834c6cfd35d8763d359661b90f2e45d8f750a0849156c7f4671af09c"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "pem",
  "ring",
  "serde",
@@ -2515,7 +2554,7 @@ dependencies = [
  "actix-web",
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.13.1",
  "bcrypt",
  "captcha",
  "lemmy_api_common",
@@ -2760,7 +2799,6 @@ dependencies = [
  "actix-web",
  "anyhow",
  "chrono",
- "comrak",
  "deser-hjson",
  "diesel",
  "doku",
@@ -2770,6 +2808,7 @@ dependencies = [
  "itertools",
  "jsonwebtoken",
  "lettre",
+ "markdown-it",
  "once_cell",
  "openssl",
  "percent-encoding",
@@ -2798,7 +2837,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eabca5e0b4d0e98e7f2243fb5b7520b6af2b65d8f87bcc86f2c75185a6ff243"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "email-encoding",
  "email_address",
  "fastrand",
@@ -2907,6 +2946,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
+name = "line-wrap"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9"
+dependencies = [
+ "safemem",
+]
+
+[[package]]
 name = "link-cplusplus"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2920,6 +2968,15 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linkify"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96dd5884008358112bc66093362197c7248ece00d46624e2cf71e50029f8cff5"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -2982,6 +3039,29 @@ name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "markdown-it"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53107ab22a09ae3b2eaedccf1d1c6aa58c1aa77e15689a799e0d8eda2b1a7d54"
+dependencies = [
+ "argparse",
+ "const_format",
+ "derivative",
+ "derive_more",
+ "downcast-rs",
+ "entities",
+ "html-escape",
+ "linkify",
+ "mdurl",
+ "once_cell",
+ "readonly",
+ "regex",
+ "stacker",
+ "syntect",
+ "unicode-general-category",
+]
 
 [[package]]
 name = "markup5ever"
@@ -3057,6 +3137,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "mdurl"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5736ba45bbac8f7ccc99a897f88ce85e508a18baec973a040f2514e6cdbff0d2"
+dependencies = [
+ "idna 0.3.0",
+ "once_cell",
+ "regex",
 ]
 
 [[package]]
@@ -3567,7 +3658,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c64931a1a212348ec4f3b4362585eca7159d0d09cbdf4a7f74f02173596fd4"
 dependencies = [
- "base64",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -3737,7 +3828,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "awc",
- "base64",
+ "base64 0.13.1",
  "clap",
  "color-eyre",
  "config",
@@ -3817,6 +3908,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
+name = "plist"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd9647b268a3d3e14ff09c23201133a62589c658db02bb7388c7246aafe0590"
+dependencies = [
+ "base64 0.21.2",
+ "indexmap",
+ "line-wrap",
+ "quick-xml 0.28.2",
+ "serde",
+ "time 0.3.15",
+]
+
+[[package]]
 name = "pmutil"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3845,7 +3950,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "878c6cbf956e03af9aa8204b407b9cbf47c072164800aa918c516cd4b056c50c"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -4041,6 +4146,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4068,6 +4182,15 @@ checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5e73202a820a31f8a0ee32ada5e21029c81fd9e3ebf668a40832e4219d9d1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -4173,23 +4296,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "readonly"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb656d27c22b5c47154452686cae5e096f12e124daacb36a0bfcb32dbebb39e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-dependencies = [
- "getrandom 0.2.8",
- "redox_syscall",
- "thiserror",
 ]
 
 [[package]]
@@ -4233,7 +4356,7 @@ version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -4332,7 +4455,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitflags 1.3.2",
  "serde",
 ]
@@ -4438,7 +4561,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13332fd1e9538328a80183b9c0bde0cd7065ad2c4405f56b855a51a0a37fffd4"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "hmac",
  "md-5",
  "percent-encoding",
@@ -4456,6 +4579,12 @@ name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "same-file"
@@ -4697,12 +4826,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shell-words"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4792,6 +4915,19 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "winapi",
+]
 
 [[package]]
 name = "static_assertions"
@@ -4959,7 +5095,7 @@ dependencies = [
  "swc_common",
  "swc_ecma_ast",
  "tracing",
- "typed-arena 2.0.2",
+ "typed-arena",
 ]
 
 [[package]]
@@ -5037,6 +5173,29 @@ name = "sync_wrapper"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+
+[[package]]
+name = "syntect"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6c454c27d9d7d9a84c7803aaa3c50cd088d2906fe3c6e42da3209aa623576a8"
+dependencies = [
+ "bincode",
+ "bitflags 1.3.2",
+ "fancy-regex",
+ "flate2",
+ "fnv",
+ "lazy_static",
+ "once_cell",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror",
+ "walkdir",
+ "yaml-rust",
+]
 
 [[package]]
 name = "tap"
@@ -5353,7 +5512,7 @@ checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
 dependencies = [
  "async-stream",
  "async-trait",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -5385,7 +5544,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -5733,12 +5892,6 @@ dependencies = [
 
 [[package]]
 name = "typed-arena"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b2228007eba4120145f785df0f6c92ea538f5a3635a612ecf4e334c8c1446d"
-
-[[package]]
-name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
@@ -5788,6 +5941,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
+name = "unicode-general-category"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2281c8c1d221438e373249e065ca4989c4c36952c211ff21a0ee91c44a3869e7"
+
+[[package]]
 name = "unicode-id"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5821,10 +5980,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
-name = "unicode_categories"
-version = "0.1.1"
+name = "unicode-xid"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "unreachable"
@@ -5864,6 +6023,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-width"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
 
 [[package]]
 name = "uuid"
@@ -6249,15 +6414,6 @@ name = "wyz"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
-
-[[package]]
-name = "xdg"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4583db5cbd4c4c0303df2d15af80f0539db703fa1c68802d4cbbd2dd0f88f6"
-dependencies = [
- "dirs",
-]
 
 [[package]]
 name = "xml5ever"

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -43,7 +43,7 @@ deser-hjson = "1.0.2"
 smart-default = "0.6.0"
 jsonwebtoken = "8.1.1"
 lettre = "0.10.1"
-comrak = { version = "0.14.0", default-features = false }
+markdown-it = "0.5.0"
 totp-rs = { version = "4.2.0", features = ["gen_secret", "otpauth"] }
 
 [dev-dependencies]

--- a/crates/utils/src/utils/markdown.rs
+++ b/crates/utils/src/utils/markdown.rs
@@ -1,3 +1,121 @@
+use markdown_it::MarkdownIt;
+
+pub mod spoiler_rule;
+
 pub fn markdown_to_html(text: &str) -> String {
-  comrak::markdown_to_html(text, &comrak::ComrakOptions::default())
+  let md = &mut MarkdownIt::new();
+  markdown_it::plugins::cmark::add(md);
+  markdown_it::plugins::extra::add(md);
+  spoiler_rule::add(md);
+
+  md.parse(text).render()
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::utils::markdown::markdown_to_html;
+
+  #[test]
+  fn test_markdown() {
+    let tests: Vec<_> = vec![
+      (
+        "headings",
+        "# h1\n## h2\n### h3\n#### h4\n##### h5\n###### h6",
+        "<h1>h1</h1>\n<h2>h2</h2>\n<h3>h3</h3>\n<h4>h4</h4>\n<h5>h5</h5>\n<h6>h6</h6>\n"
+      ),
+      (
+        "line breaks",
+        "First\rSecond",
+        "<p>First\nSecond</p>\n"),
+      (
+        "emphasis",
+        "__bold__ **bold** *italic* ***bold+italic***",
+        "<p><strong>bold</strong> <strong>bold</strong> <em>italic</em> <em><strong>bold+italic</strong></em></p>\n"
+      ),
+      (
+        "basic blockquotes",
+        ">Nice quote",
+        "<blockquote>\n<p>Nice quote</p>\n</blockquote>\n"),
+      (
+        "blockquotes with multiple paragraphs",
+        "> Hello\n > \n > Goodbye",
+        "<blockquote>\n<p>Hello</p>\n<p>Goodbye</p>\n</blockquote>\n"
+      ),
+      (
+        "nested blockquotes",
+        "> Hello\n > \n >> Goodbye",
+        "<blockquote>\n<p>Hello</p>\n<blockquote>\n<p>Goodbye</p>\n</blockquote>\n</blockquote>\n"
+      ),
+      (
+        "blockquotes with other elements",
+        "> #### Hello\n > \n > - Hola\n > - 안영\n",
+        "<blockquote>\n<h4>Hello</h4>\n<ul>\n<li>Hola</li>\n<li>안영</li>\n</ul>\n</blockquote>\n"
+      ),
+      (
+        "ordered lists",
+        "1. pen\n2. apple\n3. apple pen",
+        "<ol>\n<li>pen</li>\n<li>apple</li>\n<li>apple pen</li>\n</ol>\n"
+      ),
+      (
+        "unordered lists",
+        "- pen\n- apple\n- apple pen",
+        "<ul>\n<li>pen</li>\n<li>apple</li>\n<li>apple pen</li>\n</ul>\n"
+      ),
+      (
+        "code",
+        "this is my amazing `code snippet`",
+        "<p>this is my amazing <code>code snippet</code></p>\n"
+      ),
+      (
+        "code block",
+        "this is my amazing ```code block```",
+        "<p>this is my amazing <code>code block</code></p>\n"
+      ),
+      (
+        "links",
+        "[Lemmy](https://join-lemmy.org/ \"Join Lemmy!\")",
+        "<p><a href=\"https://join-lemmy.org/\" title=\"Join Lemmy!\">Lemmy</a></p>\n"
+      ),
+      (
+        "images",
+        "![My linked image](https://image.com \"image alt text\")",
+        "<p><img src=\"https://image.com\" alt=\"My linked image\" title=\"image alt text\"></p>\n"
+      ),
+      (
+        "basic spoiler content, but no newline at the end",
+        "::: spoiler click to see more\nhow spicy!\n:::",
+        "<details><summary>click to see more</summary><p>how spicy!\n</p></details>\n"
+      ),
+      (
+        "basic spoiler content with a newline at the end.",
+        "::: spoiler click to see more\nhow spicy!\n:::\n",
+        "<details><summary>click to see more</summary><p>how spicy!\n</p></details>\n"
+      ),
+      (
+        "spoiler with extra markdown on the call to action. No special parsing will be done.",
+        "::: spoiler _click to see more_\nhow spicy!\n:::\n",
+        "<details><summary>_click to see more_</summary><p>how spicy!\n</p></details>\n"
+      ),
+      (
+        "spoiler with extra markdown in the fenced spoiler block.",
+        "::: spoiler click to see more\n**how spicy!**\n*i have many lines*\n:::\n",
+        "<details><summary>click to see more</summary><p><strong>how spicy!</strong>\n<em>i have many lines</em>\n</p></details>\n"
+      ),
+      (
+        "spoiler mixed with other content.",
+        "hey you\npsst, wanna hear a secret?\n::: spoiler lean in and i'll tell you\n**you are breathtaking!**\n:::\nwhatcha think about that?",
+        "<p>hey you\npsst, wanna hear a secret?</p>\n<details><summary>lean in and i'll tell you</summary><p><strong>you are breathtaking!</strong>\n</p></details>\n<p>whatcha think about that?</p>\n"
+      ),
+    ];
+
+    tests.iter().for_each(|&(msg, input, expected)| {
+      let result = markdown_to_html(input);
+
+      assert_eq!(
+        result, expected,
+        "Testing {}, with original input '{}'",
+        msg, input
+      );
+    });
+  }
 }

--- a/crates/utils/src/utils/markdown.rs
+++ b/crates/utils/src/utils/markdown.rs
@@ -82,12 +82,22 @@ mod tests {
         "<p><img src=\"https://image.com\" alt=\"My linked image\" title=\"image alt text\"></p>\n"
       ),
       (
-        "basic spoiler content, but no newline at the end",
+        "invalid spoiler",
+        "::: spoiler click to see more\nbut I never finished",
+        "<p>::: spoiler click to see more\nbut I never finished</p>\n",
+      ),
+      (
+        "another invalid spoiler",
+        "::: spoiler\nnever added the lead in\n:::",
+        "<p>::: spoiler\nnever added the lead in\n:::</p>\n",
+      ),
+      (
+        "basic spoiler, but no newline at the end",
         "::: spoiler click to see more\nhow spicy!\n:::",
         "<details><summary>click to see more</summary><p>how spicy!\n</p></details>\n"
       ),
       (
-        "basic spoiler content with a newline at the end.",
+        "basic spoiler with a newline at the end.",
         "::: spoiler click to see more\nhow spicy!\n:::\n",
         "<details><summary>click to see more</summary><p>how spicy!\n</p></details>\n"
       ),

--- a/crates/utils/src/utils/markdown.rs
+++ b/crates/utils/src/utils/markdown.rs
@@ -1,6 +1,6 @@
 use markdown_it::MarkdownIt;
 
-pub mod spoiler_rule;
+mod spoiler_rule;
 
 pub fn markdown_to_html(text: &str) -> String {
   let md = &mut MarkdownIt::new();
@@ -8,7 +8,7 @@ pub fn markdown_to_html(text: &str) -> String {
   markdown_it::plugins::extra::add(md);
   spoiler_rule::add(md);
 
-  md.parse(text).render()
+  md.parse(text).xrender()
 }
 
 #[cfg(test)]
@@ -16,7 +16,7 @@ mod tests {
   use crate::utils::markdown::markdown_to_html;
 
   #[test]
-  fn test_markdown() {
+  fn test_basic_markdown() {
     let tests: Vec<_> = vec![
       (
         "headings",
@@ -33,43 +33,19 @@ mod tests {
         "<p><strong>bold</strong> <strong>bold</strong> <em>italic</em> <em><strong>bold+italic</strong></em></p>\n"
       ),
       (
-        "basic blockquotes",
-        ">Nice quote",
-        "<blockquote>\n<p>Nice quote</p>\n</blockquote>\n"),
-      (
-        "blockquotes with multiple paragraphs",
-        "> Hello\n > \n > Goodbye",
-        "<blockquote>\n<p>Hello</p>\n<p>Goodbye</p>\n</blockquote>\n"
+        "blockquotes",
+        "> #### Hello\n > \n > - Hola\n > - 안영 \n>> Goodbye\n",
+        "<blockquote>\n<h4>Hello</h4>\n<ul>\n<li>Hola</li>\n<li>안영</li>\n</ul>\n<blockquote>\n<p>Goodbye</p>\n</blockquote>\n</blockquote>\n"
       ),
       (
-        "nested blockquotes",
-        "> Hello\n > \n >> Goodbye",
-        "<blockquote>\n<p>Hello</p>\n<blockquote>\n<p>Goodbye</p>\n</blockquote>\n</blockquote>\n"
+        "lists (ordered, unordered)",
+        "1. pen\n2. apple\n3. apple pen\n- pen\n- pineapple\n- pineapple pen",
+        "<ol>\n<li>pen</li>\n<li>apple</li>\n<li>apple pen</li>\n</ol>\n<ul>\n<li>pen</li>\n<li>pineapple</li>\n<li>pineapple pen</li>\n</ul>\n"
       ),
       (
-        "blockquotes with other elements",
-        "> #### Hello\n > \n > - Hola\n > - 안영\n",
-        "<blockquote>\n<h4>Hello</h4>\n<ul>\n<li>Hola</li>\n<li>안영</li>\n</ul>\n</blockquote>\n"
-      ),
-      (
-        "ordered lists",
-        "1. pen\n2. apple\n3. apple pen",
-        "<ol>\n<li>pen</li>\n<li>apple</li>\n<li>apple pen</li>\n</ol>\n"
-      ),
-      (
-        "unordered lists",
-        "- pen\n- apple\n- apple pen",
-        "<ul>\n<li>pen</li>\n<li>apple</li>\n<li>apple pen</li>\n</ul>\n"
-      ),
-      (
-        "code",
-        "this is my amazing `code snippet`",
-        "<p>this is my amazing <code>code snippet</code></p>\n"
-      ),
-      (
-        "code block",
-        "this is my amazing ```code block```",
-        "<p>this is my amazing <code>code block</code></p>\n"
+        "code and code blocks",
+        "this is my amazing `code snippet` and my amazing ```code block```",
+        "<p>this is my amazing <code>code snippet</code> and my amazing <code>code block</code></p>\n"
       ),
       (
         "links",
@@ -79,42 +55,7 @@ mod tests {
       (
         "images",
         "![My linked image](https://image.com \"image alt text\")",
-        "<p><img src=\"https://image.com\" alt=\"My linked image\" title=\"image alt text\"></p>\n"
-      ),
-      (
-        "invalid spoiler",
-        "::: spoiler click to see more\nbut I never finished",
-        "<p>::: spoiler click to see more\nbut I never finished</p>\n",
-      ),
-      (
-        "another invalid spoiler",
-        "::: spoiler\nnever added the lead in\n:::",
-        "<p>::: spoiler\nnever added the lead in\n:::</p>\n",
-      ),
-      (
-        "basic spoiler, but no newline at the end",
-        "::: spoiler click to see more\nhow spicy!\n:::",
-        "<details><summary>click to see more</summary><p>how spicy!\n</p></details>\n"
-      ),
-      (
-        "basic spoiler with a newline at the end.",
-        "::: spoiler click to see more\nhow spicy!\n:::\n",
-        "<details><summary>click to see more</summary><p>how spicy!\n</p></details>\n"
-      ),
-      (
-        "spoiler with extra markdown on the call to action. No special parsing will be done.",
-        "::: spoiler _click to see more_\nhow spicy!\n:::\n",
-        "<details><summary>_click to see more_</summary><p>how spicy!\n</p></details>\n"
-      ),
-      (
-        "spoiler with extra markdown in the fenced spoiler block.",
-        "::: spoiler click to see more\n**how spicy!**\n*i have many lines*\n:::\n",
-        "<details><summary>click to see more</summary><p><strong>how spicy!</strong>\n<em>i have many lines</em>\n</p></details>\n"
-      ),
-      (
-        "spoiler mixed with other content.",
-        "hey you\npsst, wanna hear a secret?\n::: spoiler lean in and i'll tell you\n**you are breathtaking!**\n:::\nwhatcha think about that?",
-        "<p>hey you\npsst, wanna hear a secret?</p>\n<details><summary>lean in and i'll tell you</summary><p><strong>you are breathtaking!</strong>\n</p></details>\n<p>whatcha think about that?</p>\n"
+        "<p><img src=\"https://image.com\" alt=\"My linked image\" title=\"image alt text\" /></p>\n"
       ),
     ];
 

--- a/crates/utils/src/utils/markdown/spoiler_rule.rs
+++ b/crates/utils/src/utils/markdown/spoiler_rule.rs
@@ -1,0 +1,109 @@
+// Custom Markdown plugin to manage spoilers.
+//
+// Matches the capability described in Lemmy UI:
+// https://github.com/LemmyNet/lemmy-ui/blob/main/src/shared/utils.ts#L159
+// that is based off of:
+// https://github.com/markdown-it/markdown-it-container/tree/master#example
+//
+// FORMAT:
+// Input Markdown: ::: spoiler THE_LEAD_IN\nTHE_HIDDEN_SPOILER\n:::\n
+// Output HTML: <details><summary>THE_LEAD_IN</summary><p>THE_HIDDEN_SPOILER</p></details>
+
+use markdown_it::{
+  parser::{
+    block::{BlockRule, BlockState},
+    inline::InlineRoot,
+  },
+  MarkdownIt,
+  Node,
+  NodeValue,
+  Renderer,
+};
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+#[derive(Debug)]
+struct SpoilerBlock {
+  call_to_action: String,
+}
+
+const SPOILER_PREFIX: &str = "::: spoiler ";
+const SPOILER_SUFFIX: &str = ":::";
+const SPOILER_SUFFIX_NEWLINE: &str = ":::\n";
+
+static SPOILER_REGEX: Lazy<Regex> =
+  Lazy::new(|| Regex::new(r"^::: spoiler .*$").expect("compile spoiler markdown regex."));
+
+impl NodeValue for SpoilerBlock {
+  fn render(&self, node: &Node, fmt: &mut dyn Renderer) {
+    fmt.cr();
+    fmt.open("details", &node.attrs);
+    fmt.open("summary", &[]);
+    fmt.text(&self.call_to_action); // Not allowing special styling here to keep it simple.
+    fmt.close("summary");
+    fmt.open("p", &[]);
+    fmt.contents(&node.children);
+    fmt.close("p");
+    fmt.close("details");
+    fmt.cr();
+  }
+}
+
+struct SpoilerBlockScanner;
+
+impl BlockRule for SpoilerBlockScanner {
+  fn run(state: &mut BlockState) -> Option<(Node, usize)> {
+    let first_line: &str = state.get_line(state.line).trim();
+
+    // Check if the first line contains the spoiler syntax...
+    if !SPOILER_REGEX.is_match(first_line) {
+      return None;
+    }
+
+    let begin_fence_line_idx: usize = state.line + 1;
+    let mut end_fence_line_idx: usize = begin_fence_line_idx;
+    let mut has_end_marker: bool = false;
+
+    // Search for the end of the spoiler; there could potentially be multiple lines between
+    // the beginning and end of the block.
+    //
+    // Block ends with a line with ':::' or ':::\n'; it must be isolated from other markdown.
+    while end_fence_line_idx < state.line_max && !has_end_marker {
+      let next_line: &str = state.get_line(end_fence_line_idx).trim();
+
+      if next_line.eq(SPOILER_SUFFIX) || next_line.eq(SPOILER_SUFFIX_NEWLINE) {
+        has_end_marker = true;
+        break;
+      }
+
+      end_fence_line_idx += 1;
+    }
+
+    if has_end_marker {
+      let (spoiler_content, mapping) = state.get_lines(
+        begin_fence_line_idx,
+        end_fence_line_idx,
+        state.blk_indent,
+        true,
+      );
+
+      let mut node = Node::new(SpoilerBlock {
+        call_to_action: String::from(first_line.replace(SPOILER_PREFIX, "").trim()),
+      });
+
+      node
+        .children
+        .push(Node::new(InlineRoot::new(spoiler_content, mapping)));
+
+      // NOTE: Not using begin_fence_line_idx here because of incorrect results when state.line == 0
+      //       (subtract an idx) vs the expected correct result (add an idx).
+      Some((node, end_fence_line_idx - state.line + 1))
+    } else {
+      None
+    }
+  }
+}
+
+pub fn add(markdown_parser: &mut MarkdownIt) {
+  markdown_parser.block.add_rule::<SpoilerBlockScanner>();
+}

--- a/crates/utils/src/utils/markdown/spoiler_rule.rs
+++ b/crates/utils/src/utils/markdown/spoiler_rule.rs
@@ -6,8 +6,23 @@
 // https://github.com/markdown-it/markdown-it-container/tree/master#example
 //
 // FORMAT:
-// Input Markdown: ::: spoiler THE_LEAD_IN\nTHE_HIDDEN_SPOILER\n:::\n
-// Output HTML: <details><summary>THE_LEAD_IN</summary><p>THE_HIDDEN_SPOILER</p></details>
+// Input Markdown: ::: spoiler VISIBLE_TEXT\nHIDDEN_SPOILER\n:::\n
+// Output HTML: <details><summary>VISIBLE_TEXT</summary><p>nHIDDEN_SPOILER</p></details>
+//
+// Anatomy of a spoiler:
+//     keyword
+//        ^
+// ::: spoiler VISIBLE_HINT
+//  ^                ^
+// begin fence   visible text
+//
+// HIDDEN_SPOILER
+//      ^
+//  hidden text
+//
+// :::
+//  ^
+// end fence
 
 use markdown_it::{
   parser::{
@@ -24,7 +39,7 @@ use regex::Regex;
 
 #[derive(Debug)]
 struct SpoilerBlock {
-  call_to_action: String,
+  visible_text: String,
 }
 
 const SPOILER_PREFIX: &str = "::: spoiler ";
@@ -35,11 +50,15 @@ static SPOILER_REGEX: Lazy<Regex> =
   Lazy::new(|| Regex::new(r"^::: spoiler .*$").expect("compile spoiler markdown regex."));
 
 impl NodeValue for SpoilerBlock {
+  // Formats any node marked as a 'SpoilerBlock' into HTML.
+  // See the SpoilerBlockScanner#run implementation to see how these nodes get added to the tree.
   fn render(&self, node: &Node, fmt: &mut dyn Renderer) {
     fmt.cr();
     fmt.open("details", &node.attrs);
     fmt.open("summary", &[]);
-    fmt.text(&self.call_to_action); // Not allowing special styling here to keep it simple.
+    // Not allowing special styling to the visible text to keep it simple.
+    // If allowed, would need to parse the child nodes to assign to visible vs hidden text sections.
+    fmt.text(&self.visible_text);
     fmt.close("summary");
     fmt.open("p", &[]);
     fmt.contents(&node.children);
@@ -52,51 +71,57 @@ impl NodeValue for SpoilerBlock {
 struct SpoilerBlockScanner;
 
 impl BlockRule for SpoilerBlockScanner {
+  // Invoked on every line in the provided Markdown text to check if the BlockRule applies.
+  //
+  // NOTE: This does NOT support nested spoilers at this time.
   fn run(state: &mut BlockState) -> Option<(Node, usize)> {
     let first_line: &str = state.get_line(state.line).trim();
 
-    // Check if the first line contains the spoiler syntax...
+    // 1. Check if the first line contains the spoiler syntax...
     if !SPOILER_REGEX.is_match(first_line) {
       return None;
     }
 
-    let begin_fence_line_idx: usize = state.line + 1;
-    let mut end_fence_line_idx: usize = begin_fence_line_idx;
-    let mut has_end_marker: bool = false;
+    let begin_spoiler_line_idx: usize = state.line + 1;
+    let mut end_fence_line_idx: usize = begin_spoiler_line_idx;
+    let mut has_end_fence: bool = false;
 
-    // Search for the end of the spoiler; there could potentially be multiple lines between
-    // the beginning and end of the block.
+    // 2. Search for the end of the spoiler and find the index of the last line of the spoiler.
+    // There could potentially be multiple lines between the beginning and end of the block.
     //
     // Block ends with a line with ':::' or ':::\n'; it must be isolated from other markdown.
-    while end_fence_line_idx < state.line_max && !has_end_marker {
+    while end_fence_line_idx < state.line_max && !has_end_fence {
       let next_line: &str = state.get_line(end_fence_line_idx).trim();
 
       if next_line.eq(SPOILER_SUFFIX) || next_line.eq(SPOILER_SUFFIX_NEWLINE) {
-        has_end_marker = true;
+        has_end_fence = true;
         break;
       }
 
       end_fence_line_idx += 1;
     }
 
-    if has_end_marker {
+    // 3. If available, construct and return the spoiler node to add to the tree.
+    if has_end_fence {
       let (spoiler_content, mapping) = state.get_lines(
-        begin_fence_line_idx,
+        begin_spoiler_line_idx,
         end_fence_line_idx,
         state.blk_indent,
         true,
       );
 
       let mut node = Node::new(SpoilerBlock {
-        call_to_action: String::from(first_line.replace(SPOILER_PREFIX, "").trim()),
+        visible_text: String::from(first_line.replace(SPOILER_PREFIX, "").trim()),
       });
 
+      // Add the spoiler content as children; marking as a child tells the tree to process the
+      // node again, which means other Markdown syntax (ex: emphasis, links) can be rendered.
       node
         .children
         .push(Node::new(InlineRoot::new(spoiler_content, mapping)));
 
-      // NOTE: Not using begin_fence_line_idx here because of incorrect results when state.line == 0
-      //       (subtract an idx) vs the expected correct result (add an idx).
+      // NOTE: Not using begin_spoiler_line_idx here because of incorrect results when
+      //       state.line == 0 (subtracts an idx) vs the expected correct result (adds an idx).
       Some((node, end_fence_line_idx - state.line + 1))
     } else {
       None
@@ -106,4 +131,70 @@ impl BlockRule for SpoilerBlockScanner {
 
 pub fn add(markdown_parser: &mut MarkdownIt) {
   markdown_parser.block.add_rule::<SpoilerBlockScanner>();
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::utils::markdown::spoiler_rule::add;
+  use markdown_it::MarkdownIt;
+
+  #[test]
+  fn test_spoiler_markdown() {
+    let tests: Vec<_> = vec![
+      (
+        "invalid spoiler",
+        "::: spoiler click to see more\nbut I never finished",
+        "<p>::: spoiler click to see more\nbut I never finished</p>\n",
+      ),
+      (
+        "another invalid spoiler",
+        "::: spoiler\nnever added the lead in\n:::",
+        "<p>::: spoiler\nnever added the lead in\n:::</p>\n",
+      ),
+      (
+        "basic spoiler, but no newline at the end",
+        "::: spoiler click to see more\nhow spicy!\n:::",
+        "<details><summary>click to see more</summary><p>how spicy!\n</p></details>\n"
+      ),
+      (
+        "basic spoiler with a newline at the end",
+        "::: spoiler click to see more\nhow spicy!\n:::\n",
+        "<details><summary>click to see more</summary><p>how spicy!\n</p></details>\n"
+      ),
+      (
+        "spoiler with extra markdown on the call to action (no extra parsing)",
+        "::: spoiler _click to see more_\nhow spicy!\n:::\n",
+        "<details><summary>_click to see more_</summary><p>how spicy!\n</p></details>\n"
+      ),
+      (
+        "spoiler with extra markdown in the fenced spoiler block",
+        "::: spoiler click to see more\n**how spicy!**\n*i have many lines*\n:::\n",
+        "<details><summary>click to see more</summary><p><strong>how spicy!</strong>\n<em>i have many lines</em>\n</p></details>\n"
+      ),
+      (
+        "spoiler mixed with other content",
+        "hey you\npsst, wanna hear a secret?\n::: spoiler lean in and i'll tell you\n**you are breathtaking!**\n:::\nwhatcha think about that?",
+        "<p>hey you\npsst, wanna hear a secret?</p>\n<details><summary>lean in and i'll tell you</summary><p><strong>you are breathtaking!</strong>\n</p></details>\n<p>whatcha think about that?</p>\n"
+      ),
+      (
+        "spoiler mixed with indented content",
+        "- did you know that\n::: spoiler the call was\n***coming from inside the house!***\n:::\n - crazy, right?",
+        "<ul>\n<li>did you know that</li>\n</ul>\n<details><summary>the call was</summary><p><em><strong>coming from inside the house!</strong></em>\n</p></details>\n<ul>\n<li>crazy, right?</li>\n</ul>\n"
+      )
+    ];
+
+    tests.iter().for_each(|&(msg, input, expected)| {
+      let md = &mut MarkdownIt::new();
+      markdown_it::plugins::cmark::add(md);
+      add(md);
+
+      assert_eq!(
+        md.parse(input).xrender(),
+        expected,
+        "Testing {}, with original input '{}'",
+        msg,
+        input
+      );
+    });
+  }
 }


### PR DESCRIPTION
# WHAT & WHY

Adds support for managing spoiler blocks by:
- Switching to [markdown-it.rs](https://github.com/rlidwka/markdown-it.rs), a Rust port of the`markdown-it` library used by the UI and, more importantly, supports adding and creating custom plugins.
  - Unfortunately, the library `comrak` nor another potentially performant library `pulldown-cmark` do not appear to have any support for plugins so the library switch is necessary.
- Adding a custom spoiler plugin to handle parsing spoiler tags.
- Writing basic tests to ensure that nothing should change due to the library swap. If the library needs to be changed again later, it should help with backwards compatibility checking.

This is my first time writing in Rust, so apologies for any obvious semantic mistakes 🙏