### PR TITLE
Application Rejection Handling

### DIFF
--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -472,6 +472,20 @@ pub fn send_application_approved_email(
   send_email(&subject, email, &user.person.name, &body, settings)
 }
 
+
+/// IMPLEMENT ME
+pub fn send_application_denied_email(
+  user: &LocalUserView,
+  settings: &Settings,
+) -> Result<(), LemmyError> {
+  let email = &user.local_user.email.clone().expect("email");
+  let lang = get_interface_language(user);
+  let subject = lang.registration_denied_subject(&user.person.actor_id);
+  let body = lang.registration_denied_body();
+  send_email(&subject, email, &user.person.name, &body, settings)
+}
+
+
 /// Send a new applicant email notification to all admins
 pub async fn send_new_applicant_email_to_admins(
   applicant_username: &str,


### PR DESCRIPTION
Following https://github.com/LemmyNet/lemmy-ui/issues/1096

It appears approve.rs wasn't handling rejected applications. This change adds a default Application Denied email, and deletes the account in question.

Change is not verified due to environment issues - seeking help on this to get them validated (I'm so close! Running locally, but the login button doesn't seem to do anything). Also new to pull requests so any advice appreciated.

Also requires strings to be added to the translations submodule.