### PR TITLE
Fix #2910 person aggregate count

### DIFF
--- a/migrations/2022-04-04-183652_update_community_aggregates_on_soft_delete/down.sql
+++ b/migrations/2022-04-04-183652_update_community_aggregates_on_soft_delete/down.sql
@@ -231,8 +231,8 @@ set comment_score = cd.score
                         coalesce(sum(cl.score),0) as score
                         -- User join because comments could be empty
                  from person u
-                          inner join comment c on u.id = c.creator_id
-                          inner join comment_like cl on c.id = cl.comment_id
+                          left join comment c on u.id = c.creator_id
+                          left join comment_like cl on c.id = cl.comment_id
                  where u.id = OLD.creator_id
                  group by u.id
              ) cd

--- a/migrations/2022-04-04-183652_update_community_aggregates_on_soft_delete/down.sql
+++ b/migrations/2022-04-04-183652_update_community_aggregates_on_soft_delete/down.sql
@@ -228,14 +228,15 @@ update person_aggregates ua
 set comment_score = cd.score
     from (
                  select u.id,
-                        coalesce(0, sum(cl.score)) as score
+                        coalesce(sum(cl.score),0) as score
                         -- User join because comments could be empty
                  from person u
-                          left join comment c on u.id = c.creator_id
-                          left join comment_like cl on c.id = cl.comment_id
+                          inner join comment c on u.id = c.creator_id
+                          inner join comment_like cl on c.id = cl.comment_id
+                 where u.id = OLD.creator_id
                  group by u.id
              ) cd
-where ua.person_id = OLD.creator_id;
+where ua.person_id = cd.id;
 END IF;
 return null;
 end $$;


### PR DESCRIPTION
I've fixed the issue whereby a user score will always get set to 0 regardless of the actual count. The performance should be improved now too as we are only calculating the user required, not all users, prior to the update.