### PR TITLE
Align default DB password with documentation

### DIFF
--- a/scripts/db-init.sh
+++ b/scripts/db-init.sh
@@ -3,7 +3,7 @@ set -e
 
 # Default configurations
 username=lemmy
-password=lemmy
+password=password
 dbname=lemmy
 port=5432
 


### PR DESCRIPTION
The default password in the `db-init.sh` script does not match the documentation nor the rest of the app. This PR simply fixes this inconsistency to streamline setup using default values.