### PR TITLE
Prevent making an instance private if federation is enabled.

### DIFF
--- a/crates/api_crud/src/site/update.rs
+++ b/crates/api_crud/src/site/update.rs
@@ -76,9 +76,21 @@ impl PerformCrud for EditSite {
       }
     }
 
-    if data.private_instance == Some(true) && local_site.federation_enabled {
+    if data.private_instance == Some(true)
+      && data
+        .federation_enabled
+        .unwrap_or(local_site.federation_enabled)
+    {
       return Err(LemmyError::from_message(
         "cant_enable_private_instance_if_federation_enabled",
+      ));
+    }
+
+    if data.federation_enabled == Some(true)
+      && data.private_instance.unwrap_or(local_site.private_instance)
+    {
+      return Err(LemmyError::from_message(
+        "cant_enable_federation_if_private_instance",
       ));
     }
 

--- a/crates/api_crud/src/site/update.rs
+++ b/crates/api_crud/src/site/update.rs
@@ -76,21 +76,16 @@ impl PerformCrud for EditSite {
       }
     }
 
-    if data.private_instance == Some(true)
+    let enabled_private_instance_with_federation = data.private_instance == Some(true)
       && data
         .federation_enabled
-        .unwrap_or(local_site.federation_enabled)
-    {
-      return Err(LemmyError::from_message(
-        "cant_enable_private_instance_if_federation_enabled",
-      ));
-    }
+        .unwrap_or(local_site.federation_enabled);
+    let enabled_federation_with_private_instance = data.federation_enabled == Some(true)
+      && data.private_instance.unwrap_or(local_site.private_instance);
 
-    if data.federation_enabled == Some(true)
-      && data.private_instance.unwrap_or(local_site.private_instance)
-    {
+    if enabled_private_instance_with_federation || enabled_federation_with_private_instance {
       return Err(LemmyError::from_message(
-        "cant_enable_federation_if_private_instance",
+        "cant_enable_private_instance_and_federation_together",
       ));
     }
 

--- a/crates/api_crud/src/site/update.rs
+++ b/crates/api_crud/src/site/update.rs
@@ -76,6 +76,12 @@ impl PerformCrud for EditSite {
       }
     }
 
+    if data.private_instance == Some(true) && local_site.federation_enabled {
+      return Err(LemmyError::from_message(
+        "cant_enable_private_instance_if_federation_enabled",
+      ));
+    }
+
     if let Some(discussion_languages) = data.discussion_languages.clone() {
       SiteLanguage::update(context.pool(), discussion_languages.clone(), &site).await?;
     }


### PR DESCRIPTION
Related to https://github.com/LemmyNet/lemmy/issues/3073.

Issue linked above. This commit will resolve the immediate issue by checking to see if the user is setting the instance to private, and returning an error if the instance is currently set to federated.

Note: Is there anything else I need to do with the error? I feel like this is just raising some snake_case string. Does this need to be handled somewhere to expose it to the user?