### PR TITLE
Add --disable-scheduled-tasks CLI flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,8 @@ pub async fn start_lemmy_server() -> Result<(), LemmyError> {
     return Ok(());
   }
 
+  let scheduled_tasks_enabled = args.get(1) != Some(&"--disable-scheduled-tasks".to_string());
+
   let settings = SETTINGS.to_owned();
 
   // Run the DB migrations
@@ -118,10 +120,12 @@ pub async fn start_lemmy_server() -> Result<(), LemmyError> {
     .with(TracingMiddleware::default())
     .build();
 
-  // Schedules various cleanup tasks for the DB
-  thread::spawn(move || {
-    scheduled_tasks::setup(db_url).expect("Couldn't set up scheduled_tasks");
-  });
+  if scheduled_tasks_enabled {
+    // Schedules various cleanup tasks for the DB
+    thread::spawn(move || {
+      scheduled_tasks::setup(db_url).expect("Couldn't set up scheduled_tasks");
+    });
+  }
 
   let chat_server = ChatServer::default().start();
 


### PR DESCRIPTION
This is a quick and easy fix for #3076 - by allowing instance admins to disable scheduled tasks on all but one node, deadlocks can be avoided.

This is quite a critical issue for any instance that is trying to horizontally scale, so I thought it would be most useful to base the changes off the `release/v0.17` branch, but please let me know if I should rebase onto any other branch.