### PR TITLE
Only create ltree postgres extension in migration if doesn't already exist …

### DIFF
--- a/migrations/2022-07-07-182650_comment_ltrees/up.sql
+++ b/migrations/2022-07-07-182650_comment_ltrees/up.sql
@@ -30,7 +30,7 @@ drop view comment_alias_1;
 
 alter table comment drop column read;
 
-create extension ltree;
+create extension if not exists ltree;
 
 alter table comment add column path ltree not null default '0';
 alter table comment_aggregates add column child_count integer not null default 0;


### PR DESCRIPTION
I manually added required extensions to the `lemmy` database as I didn't want to give lemmy permissions to load postgresql extensions.
That made the migrations fail as the extension already existed.

Generally it seems prudent that migrations should have an `if not exists` guard around extensions loading.