### PR TITLE
Remove e-mail verification success e-mails

### DIFF
--- a/crates/api/src/local_user/verify_email.rs
+++ b/crates/api/src/local_user/verify_email.rs
@@ -3,7 +3,6 @@ use actix_web::web::Data;
 use lemmy_api_common::{
   context::LemmyContext,
   person::{VerifyEmail, VerifyEmailResponse},
-  utils::send_email_verification_success,
 };
 use lemmy_db_schema::{
   source::{
@@ -12,7 +11,6 @@ use lemmy_db_schema::{
   },
   traits::Crud,
 };
-use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::LemmyError;
 
 #[async_trait::async_trait(?Send)]
@@ -34,10 +32,6 @@ impl Perform for VerifyEmail {
     let local_user_id = verification.local_user_id;
 
     LocalUser::update(context.pool(), local_user_id, &form).await?;
-
-    let local_user_view = LocalUserView::read(context.pool(), local_user_id).await?;
-
-    send_email_verification_success(&local_user_view, context.settings())?;
 
     EmailVerification::delete_old_tokens_for_local_user(context.pool(), local_user_id).await?;
 

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -403,17 +403,6 @@ pub async fn send_verification_email(
   Ok(())
 }
 
-pub fn send_email_verification_success(
-  user: &LocalUserView,
-  settings: &Settings,
-) -> Result<(), LemmyError> {
-  let email = &user.local_user.email.clone().expect("email");
-  let lang = get_interface_language(user);
-  let subject = &lang.email_verified_subject(&user.person.actor_id);
-  let body = &lang.email_verified_body();
-  send_email(subject, email, &user.person.name, body, settings)
-}
-
 pub fn get_interface_language(user: &LocalUserView) -> Lang {
   lang_str_to_lang(&user.local_user.interface_language)
 }


### PR DESCRIPTION
This is a proposed change to completely remove the e-mail verification success e-mails from Lemmy.

For context, when a user signs up on an instance that requires e-mail verification:
* They first receive an e-mail with a link they need to click to verify their e-mail
* On clicking this link, they are directed to their home instance, where they see an "E-mail verified" success message
* Finally, they receive a second e-mail which tells them that their e-mail has successfully been verified <---- **This is the e-mail that this PR proposes to remove**

Arguments for removal:
* From the perspective of users, this e-mail doesn't add a lot of vaue, because they receive it at the same time as the website notifies them that their e-mail was verified anyway. Basically, it's a duplicated notification, which I'm sure many users might even consider  a form of spam.
* From the perspective of instance admins, this e-mail doubles the e-mail related costs of any new user. On lemm.ee, we have sent 1400 of these e-mails in the past week, which accounts for 14% of our currently active e-mail plan for this month. 

This PR is related to #3011 