### PR TITLE
Changed github issue template to align logically with the question asked

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -21,7 +21,7 @@ body:
         - label: Is this only a single bug? Do not put multiple bugs in one issue.
           required: true
         - label: Is this a UI / front end issue? Use the [lemmy-ui](https://github.com/LemmyNet/lemmy-ui) repo.
-          required: true
+          required: false
   - type: textarea
     id: summary
     attributes:

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
@@ -19,7 +19,7 @@ body:
         - label: Is this only a feature request? Do not put multiple feature requests in one issue.
           required: true
         - label: Is this a UI / front end issue? Use the [lemmy-ui](https://github.com/LemmyNet/lemmy-ui) repo.
-          required: true
+          required: false
   - type: textarea
     id: problem
     attributes:


### PR DESCRIPTION
When filling an issue I noticed that the checkbox required to be checked even though question asked to not be filled. I changed the template to reflect question asked. 