### PR TITLE
Feature add hours as sorting options backend

### DIFF
--- a/crates/db_schema/src/lib.rs
+++ b/crates/db_schema/src/lib.rs
@@ -59,6 +59,9 @@ pub enum SortType {
   TopAll,
   MostComments,
   NewComments,
+  TopHour,
+  TopSixHour,
+  TopTwelveHour,
 }
 
 #[derive(EnumString, Display, Debug, Serialize, Deserialize, Clone, Copy)]

--- a/crates/db_schema/src/utils.rs
+++ b/crates/db_schema/src/utils.rs
@@ -196,7 +196,10 @@ pub fn post_to_comment_sort_type(sort: SortType) -> CommentSortType {
     SortType::Active | SortType::Hot => CommentSortType::Hot,
     SortType::New | SortType::NewComments | SortType::MostComments => CommentSortType::New,
     SortType::Old => CommentSortType::Old,
-    SortType::TopDay
+    SortType::TopHour
+    | SortType::TopSixHour
+    | SortType::TopTwelveHour
+    | SortType::TopDay
     | SortType::TopAll
     | SortType::TopWeek
     | SortType::TopYear

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -414,6 +414,18 @@ impl<'a> PostQuery<'a> {
         .filter(post_aggregates::published.gt(now - 1.days()))
         .then_order_by(post_aggregates::score.desc())
         .then_order_by(post_aggregates::published.desc()),
+      SortType::TopHour=> query
+      .filter(post_aggregates::published.gt(now - 1.hours()))
+      .then_order_by(post_aggregates::score.desc())
+      .then_order_by(post_aggregates::published.desc()),
+      SortType::TopSixHour=> query
+      .filter(post_aggregates::published.gt(now - 6.hours()))
+      .then_order_by(post_aggregates::score.desc())
+      .then_order_by(post_aggregates::published.desc()),
+      SortType::TopTwelveHour=> query
+      .filter(post_aggregates::published.gt(now - 12.hours()))
+      .then_order_by(post_aggregates::score.desc())
+      .then_order_by(post_aggregates::published.desc()),
     };
 
     let (limit, offset) = limit_and_offset(self.page, self.limit)?;

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -414,18 +414,18 @@ impl<'a> PostQuery<'a> {
         .filter(post_aggregates::published.gt(now - 1.days()))
         .then_order_by(post_aggregates::score.desc())
         .then_order_by(post_aggregates::published.desc()),
-      SortType::TopHour=> query
-      .filter(post_aggregates::published.gt(now - 1.hours()))
-      .then_order_by(post_aggregates::score.desc())
-      .then_order_by(post_aggregates::published.desc()),
-      SortType::TopSixHour=> query
-      .filter(post_aggregates::published.gt(now - 6.hours()))
-      .then_order_by(post_aggregates::score.desc())
-      .then_order_by(post_aggregates::published.desc()),
-      SortType::TopTwelveHour=> query
-      .filter(post_aggregates::published.gt(now - 12.hours()))
-      .then_order_by(post_aggregates::score.desc())
-      .then_order_by(post_aggregates::published.desc()),
+      SortType::TopHour => query
+        .filter(post_aggregates::published.gt(now - 1.hours()))
+        .then_order_by(post_aggregates::score.desc())
+        .then_order_by(post_aggregates::published.desc()),
+      SortType::TopSixHour => query
+        .filter(post_aggregates::published.gt(now - 6.hours()))
+        .then_order_by(post_aggregates::score.desc())
+        .then_order_by(post_aggregates::published.desc()),
+      SortType::TopTwelveHour => query
+        .filter(post_aggregates::published.gt(now - 12.hours()))
+        .then_order_by(post_aggregates::score.desc())
+        .then_order_by(post_aggregates::published.desc()),
     };
 
     let (limit, offset) = limit_and_offset(self.page, self.limit)?;

--- a/crates/db_views_actor/src/person_view.rs
+++ b/crates/db_views_actor/src/person_view.rs
@@ -113,13 +113,13 @@ impl<'a> PersonQuery<'a> {
       SortType::TopDay => query
         .filter(person::published.gt(now - 1.days()))
         .order_by(person_aggregates::comment_score.desc()),
-        SortType::TopHour => query
+      SortType::TopHour => query
         .filter(person::published.gt(now - 1.hours()))
         .order_by(person_aggregates::comment_score.desc()),
-        SortType::TopSixHour => query
+      SortType::TopSixHour => query
         .filter(person::published.gt(now - 6.hours()))
         .order_by(person_aggregates::comment_score.desc()),
-        SortType::TopTwelveHour => query
+      SortType::TopTwelveHour => query
         .filter(person::published.gt(now - 12.hours()))
         .order_by(person_aggregates::comment_score.desc()),
     };

--- a/crates/db_views_actor/src/person_view.rs
+++ b/crates/db_views_actor/src/person_view.rs
@@ -113,6 +113,15 @@ impl<'a> PersonQuery<'a> {
       SortType::TopDay => query
         .filter(person::published.gt(now - 1.days()))
         .order_by(person_aggregates::comment_score.desc()),
+        SortType::TopHour => query
+        .filter(person::published.gt(now - 1.hours()))
+        .order_by(person_aggregates::comment_score.desc()),
+        SortType::TopSixHour => query
+        .filter(person::published.gt(now - 6.hours()))
+        .order_by(person_aggregates::comment_score.desc()),
+        SortType::TopTwelveHour => query
+        .filter(person::published.gt(now - 12.hours()))
+        .order_by(person_aggregates::comment_score.desc()),
     };
 
     let (limit, offset) = limit_and_offset(self.page, self.limit)?;

--- a/migrations/2023-06-17-175955_add_listingtype_sorttype_hour_enums/down.sql
+++ b/migrations/2023-06-17-175955_add_listingtype_sorttype_hour_enums/down.sql
@@ -1,0 +1,14 @@
+-- update the default sort type
+update local_user set default_sort_type = 'TopDay' where default_sort_type in ('TopHour', 'TopSixHour', 'TopTwelveHour');
+
+-- rename the old enum
+alter type sort_type_enum rename to sort_type_enum__;
+-- create the new enum
+CREATE TYPE sort_type_enum AS ENUM ('Active', 'Hot', 'New', 'Old', 'TopDay', 'TopWeek', 'TopMonth', 'TopYear', 'TopAll', 'MostComments', 'NewComments');
+
+-- alter all you enum columns
+alter table local_user
+  alter column default_sort_type type sort_type_enum using default_sort_type::text::sort_type_enum;
+
+-- drop the old enum
+drop type sort_type_enum__;

--- a/migrations/2023-06-17-175955_add_listingtype_sorttype_hour_enums/up.sql
+++ b/migrations/2023-06-17-175955_add_listingtype_sorttype_hour_enums/up.sql
@@ -1,0 +1,4 @@
+-- Update the enums
+ALTER TYPE sort_type_enum ADD VALUE 'TopHour';
+ALTER TYPE sort_type_enum ADD VALUE 'TopSixHour';
+ALTER TYPE sort_type_enum ADD VALUE 'TopTwelveHour';


### PR DESCRIPTION
This feature adds the possiblity to sort by Top Hour, Top Six Hours and Top Twelve Hours.

---

**Related issue:**
https://github.com/LemmyNet/lemmy/issues/3049

---

**This PR is part of a 3 PRs:**

Back End
https://github.com/LemmyNet/lemmy/pull/3161

Translation
https://github.com/LemmyNet/lemmy-translations/pull/63

Front End
https://github.com/LemmyNet/lemmy-ui/pull/1345