### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,10 +1,10 @@
-version: "3.3"
+version: "3.7"
 
 x-logging: &default-logging
   driver: "json-file"
   options:
     max-size: "50m"
-    max-file: 4
+    max-file: "4"
 
 networks:
   # communication to web and clients
@@ -35,12 +35,12 @@ services:
     logging: *default-logging
 
   lemmy:
-    # image: dessalines/lemmy:dev
+    image: dessalines/lemmy:0.17.4
     # use this to build your local lemmy server image for development
     # run docker compose up --build
-    build:
-      context: ../
-      dockerfile: docker/Dockerfile
+    # build:
+    #   context: ../
+    #   dockerfile: docker/Dockerfile
       # args:
       #   RUST_RELEASE_MODE: release
     # this hostname is used in nginx reverse proxy and also for lemmy ui to connect to the backend, do not change
@@ -60,7 +60,7 @@ services:
     logging: *default-logging
 
   lemmy-ui:
-    image: dessalines/lemmy-ui:0.17.1
+    image: dessalines/lemmy-ui:0.17.4
     # use this to build your local lemmy ui image for development
     # run docker compose up --build
     # assuming lemmy-ui is cloned besides lemmy directory


### PR DESCRIPTION
- loggin options have to be a string
- Updated the images to 0.17.4
- commented out the build options, easier for the non-dev end user
- updated the version to "3.7" otherwise it won't run