### PR TITLE
Register User: Unique email violation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ pictrs/
 
 # The generated typescript bindings
 bindings
+/node_modules/.yarn-integrity

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,7 @@ debug = 0
 lto = "thin"
 
 [profile.dev]
-strip = "symbols"
-debug = 0
+debug = 2
 
 [features]
 embed-pictrs = ["pict-rs"]

--- a/crates/api_crud/src/user/create.rs
+++ b/crates/api_crud/src/user/create.rs
@@ -5,9 +5,15 @@ use lemmy_api_common::{
   context::LemmyContext,
   person::{LoginResponse, Register},
   utils::{
-    generate_inbox_url, generate_local_apub_endpoint, generate_shared_inbox_url, honeypot_check,
-    local_site_to_slur_regex, password_length_check, send_new_applicant_email_to_admins,
-    send_verification_email, EndpointType,
+    generate_inbox_url,
+    generate_local_apub_endpoint,
+    generate_shared_inbox_url,
+    honeypot_check,
+    local_site_to_slur_regex,
+    password_length_check,
+    send_new_applicant_email_to_admins,
+    send_verification_email,
+    EndpointType,
   },
 };
 use lemmy_db_schema::{

--- a/crates/api_crud/src/user/create.rs
+++ b/crates/api_crud/src/user/create.rs
@@ -127,7 +127,7 @@ impl PerformCrud for Register {
           "user_already_exists"
         };
 
-        if err_type != "email_already_exists" {
+        if err_type != "email_already_exists" && err_type != "user_already_exists" {
           // If the local user creation errored, then delete that person
           // If we don't exclude 'email_already_exists' we get weird behavior where
           // the existing account is deleted

--- a/crates/api_crud/src/user/create.rs
+++ b/crates/api_crud/src/user/create.rs
@@ -99,9 +99,7 @@ impl PerformCrud for Register {
       .build();
 
     // insert the person
-    let inserted_person = Person::create(context.pool(), &person_form)
-      .await
-      .map_err(|e| LemmyError::from_error_message(e, "user_already_exists"))?;
+    let inserted_person = Person::create(context.pool(), &person_form).await?;
 
     // Automatically set their application as accepted, if they created this with open registration.
     // Also fixes a bug which allows users to log in when registrations are changed to closed.

--- a/crates/api_crud/src/user/create.rs
+++ b/crates/api_crud/src/user/create.rs
@@ -5,15 +5,9 @@ use lemmy_api_common::{
   context::LemmyContext,
   person::{LoginResponse, Register},
   utils::{
-    generate_inbox_url,
-    generate_local_apub_endpoint,
-    generate_shared_inbox_url,
-    honeypot_check,
-    local_site_to_slur_regex,
-    password_length_check,
-    send_new_applicant_email_to_admins,
-    send_verification_email,
-    EndpointType,
+    generate_inbox_url, generate_local_apub_endpoint, generate_shared_inbox_url, honeypot_check,
+    local_site_to_slur_regex, password_length_check, send_new_applicant_email_to_admins,
+    send_verification_email, EndpointType,
   },
 };
 use lemmy_db_schema::{
@@ -127,8 +121,12 @@ impl PerformCrud for Register {
           "user_already_exists"
         };
 
-        // If the local user creation errored, then delete that person
-        Person::delete(context.pool(), inserted_person.id).await?;
+        if err_type != "email_already_exists" {
+          // If the local user creation errored, then delete that person
+          // If we don't exclude 'email_already_exists' we get weird behavior where
+          // the existing account is deleted
+          Person::delete(context.pool(), inserted_person.id).await?;
+        }
 
         return Err(LemmyError::from_error_message(e, err_type));
       }

--- a/crates/db_schema/src/impls/local_user.rs
+++ b/crates/db_schema/src/impls/local_user.rs
@@ -1,11 +1,7 @@
 use crate::{
   newtypes::LocalUserId,
   schema::local_user::dsl::{
-    accepted_application,
-    email_verified,
-    local_user,
-    password_encrypted,
-    validator_time,
+    accepted_application, email_verified, local_user, password_encrypted, validator_time,
   },
   source::{
     actor_language::{LocalUserLanguage, SiteLanguage},
@@ -80,8 +76,7 @@ impl Crud for LocalUser {
     let local_user_ = insert_into(local_user)
       .values(form_with_encrypted_password)
       .get_result::<Self>(conn)
-      .await
-      .expect("couldnt create local user");
+      .await?;
 
     let site_languages = SiteLanguage::read_local_raw(pool).await;
     if let Ok(langs) = site_languages {

--- a/crates/db_schema/src/impls/local_user.rs
+++ b/crates/db_schema/src/impls/local_user.rs
@@ -1,7 +1,11 @@
 use crate::{
   newtypes::LocalUserId,
   schema::local_user::dsl::{
-    accepted_application, email_verified, local_user, password_encrypted, validator_time,
+    accepted_application,
+    email_verified,
+    local_user,
+    password_encrypted,
+    validator_time,
   },
   source::{
     actor_language::{LocalUserLanguage, SiteLanguage},

--- a/crates/db_schema/src/impls/person.rs
+++ b/crates/db_schema/src/impls/person.rs
@@ -37,9 +37,6 @@ impl Crud for Person {
     let conn = &mut get_conn(pool).await?;
     insert_into(person::table)
       .values(form)
-      .on_conflict(person::actor_id)
-      .do_update()
-      .set(form)
       .get_result::<Self>(conn)
       .await
   }

--- a/src/api_routes_http.rs
+++ b/src/api_routes_http.rs
@@ -461,6 +461,9 @@ where
                 // return a specific error for the email already being in use, so the frontend can display a nice error
                 Ok(HttpResponse::Conflict().json("Username is already in use"))
               }
+              "idx_person_lower_actor_id" => {
+                Ok(HttpResponse::Conflict().json("Username is already in use"))
+              }
               _ => {
                 // Any other constraint, we return this generic message
                 println!("Violation of constraint {}", constraint_name);

--- a/src/api_routes_http.rs
+++ b/src/api_routes_http.rs
@@ -1,39 +1,101 @@
-use actix_web::{error::ErrorBadRequest, guard, web, Error, HttpResponse, Result};
-use diesel::result::DatabaseErrorKind;
+use actix_web::{guard, web, Error, HttpResponse, Result};
 use lemmy_api::Perform;
 use lemmy_api_common::{
   comment::{
-    CreateComment, CreateCommentLike, CreateCommentReport, DeleteComment, DistinguishComment,
-    EditComment, GetComment, GetComments, ListCommentReports, RemoveComment, ResolveCommentReport,
+    CreateComment,
+    CreateCommentLike,
+    CreateCommentReport,
+    DeleteComment,
+    DistinguishComment,
+    EditComment,
+    GetComment,
+    GetComments,
+    ListCommentReports,
+    RemoveComment,
+    ResolveCommentReport,
     SaveComment,
   },
   community::{
-    AddModToCommunity, BanFromCommunity, BlockCommunity, CreateCommunity, DeleteCommunity,
-    EditCommunity, FollowCommunity, GetCommunity, HideCommunity, ListCommunities, RemoveCommunity,
+    AddModToCommunity,
+    BanFromCommunity,
+    BlockCommunity,
+    CreateCommunity,
+    DeleteCommunity,
+    EditCommunity,
+    FollowCommunity,
+    GetCommunity,
+    HideCommunity,
+    ListCommunities,
+    RemoveCommunity,
     TransferCommunity,
   },
   context::LemmyContext,
   custom_emoji::{CreateCustomEmoji, DeleteCustomEmoji, EditCustomEmoji},
   person::{
-    AddAdmin, BanPerson, BlockPerson, ChangePassword, DeleteAccount, GetBannedPersons,
-    GetPersonDetails, GetPersonMentions, GetReplies, GetReportCount, GetUnreadCount, Login,
-    MarkAllAsRead, MarkCommentReplyAsRead, MarkPersonMentionAsRead, PasswordChangeAfterReset,
-    PasswordReset, Register, SaveUserSettings, VerifyEmail,
+    AddAdmin,
+    BanPerson,
+    BlockPerson,
+    ChangePassword,
+    DeleteAccount,
+    GetBannedPersons,
+    GetPersonDetails,
+    GetPersonMentions,
+    GetReplies,
+    GetReportCount,
+    GetUnreadCount,
+    Login,
+    MarkAllAsRead,
+    MarkCommentReplyAsRead,
+    MarkPersonMentionAsRead,
+    PasswordChangeAfterReset,
+    PasswordReset,
+    Register,
+    SaveUserSettings,
+    VerifyEmail,
   },
   post::{
-    CreatePost, CreatePostLike, CreatePostReport, DeletePost, EditPost, FeaturePost, GetPost,
-    GetPosts, GetSiteMetadata, ListPostReports, LockPost, MarkPostAsRead, RemovePost,
-    ResolvePostReport, SavePost,
+    CreatePost,
+    CreatePostLike,
+    CreatePostReport,
+    DeletePost,
+    EditPost,
+    FeaturePost,
+    GetPost,
+    GetPosts,
+    GetSiteMetadata,
+    ListPostReports,
+    LockPost,
+    MarkPostAsRead,
+    RemovePost,
+    ResolvePostReport,
+    SavePost,
   },
   private_message::{
-    CreatePrivateMessage, CreatePrivateMessageReport, DeletePrivateMessage, EditPrivateMessage,
-    GetPrivateMessages, ListPrivateMessageReports, MarkPrivateMessageAsRead,
+    CreatePrivateMessage,
+    CreatePrivateMessageReport,
+    DeletePrivateMessage,
+    EditPrivateMessage,
+    GetPrivateMessages,
+    ListPrivateMessageReports,
+    MarkPrivateMessageAsRead,
     ResolvePrivateMessageReport,
   },
   site::{
-    ApproveRegistrationApplication, CreateSite, EditSite, GetFederatedInstances, GetModlog,
-    GetSite, GetUnreadRegistrationApplicationCount, LeaveAdmin, ListRegistrationApplications,
-    PurgeComment, PurgeCommunity, PurgePerson, PurgePost, ResolveObject, Search,
+    ApproveRegistrationApplication,
+    CreateSite,
+    EditSite,
+    GetFederatedInstances,
+    GetModlog,
+    GetSite,
+    GetUnreadRegistrationApplicationCount,
+    LeaveAdmin,
+    ListRegistrationApplications,
+    PurgeComment,
+    PurgeCommunity,
+    PurgePerson,
+    PurgePost,
+    ResolveObject,
+    Search,
   },
 };
 use lemmy_api_crud::PerformCrud;
@@ -383,7 +445,6 @@ where
       Ok(HttpResponse::Ok().json(crud_data))
     }
     Err(err) => {
-      println!("Error performing_crud: {:?}", err);
       match err.inner.downcast_ref::<diesel::result::Error>() {
         Some(diesel::result::Error::DatabaseError(
           diesel::result::DatabaseErrorKind::UniqueViolation,
@@ -394,13 +455,11 @@ where
             match constraint_name {
               "local_user_email_key" => {
                 // return a specific error for the email already being in use, so the frontend can display a nice error
-                return Ok(HttpResponse::Conflict().json("Email is already in use"));
+                Ok(HttpResponse::Conflict().json("Email is already in use"))
               }
               _ => {
                 // Any other constraint, we return this generic message
-                return Ok(
-                  HttpResponse::Conflict().json("Unexpected conflict while registering user"),
-                );
+                Ok(HttpResponse::Conflict().json("Unexpected conflict while registering user"))
               }
             }
           } else {

--- a/src/api_routes_http.rs
+++ b/src/api_routes_http.rs
@@ -457,8 +457,13 @@ where
                 // return a specific error for the email already being in use, so the frontend can display a nice error
                 Ok(HttpResponse::Conflict().json("Email is already in use"))
               }
+              "local_user_person_id_key" => {
+                // return a specific error for the email already being in use, so the frontend can display a nice error
+                Ok(HttpResponse::Conflict().json("Username is already in use"))
+              }
               _ => {
                 // Any other constraint, we return this generic message
+                println!("Violation of constraint {}", constraint_name);
                 Ok(HttpResponse::Conflict().json("Unexpected conflict while registering user"))
               }
             }

--- a/src/api_routes_http.rs
+++ b/src/api_routes_http.rs
@@ -1,101 +1,39 @@
-use actix_web::{guard, web, Error, HttpResponse, Result};
+use actix_web::{error::ErrorBadRequest, guard, web, Error, HttpResponse, Result};
+use diesel::result::DatabaseErrorKind;
 use lemmy_api::Perform;
 use lemmy_api_common::{
   comment::{
-    CreateComment,
-    CreateCommentLike,
-    CreateCommentReport,
-    DeleteComment,
-    DistinguishComment,
-    EditComment,
-    GetComment,
-    GetComments,
-    ListCommentReports,
-    RemoveComment,
-    ResolveCommentReport,
+    CreateComment, CreateCommentLike, CreateCommentReport, DeleteComment, DistinguishComment,
+    EditComment, GetComment, GetComments, ListCommentReports, RemoveComment, ResolveCommentReport,
     SaveComment,
   },
   community::{
-    AddModToCommunity,
-    BanFromCommunity,
-    BlockCommunity,
-    CreateCommunity,
-    DeleteCommunity,
-    EditCommunity,
-    FollowCommunity,
-    GetCommunity,
-    HideCommunity,
-    ListCommunities,
-    RemoveCommunity,
+    AddModToCommunity, BanFromCommunity, BlockCommunity, CreateCommunity, DeleteCommunity,
+    EditCommunity, FollowCommunity, GetCommunity, HideCommunity, ListCommunities, RemoveCommunity,
     TransferCommunity,
   },
   context::LemmyContext,
   custom_emoji::{CreateCustomEmoji, DeleteCustomEmoji, EditCustomEmoji},
   person::{
-    AddAdmin,
-    BanPerson,
-    BlockPerson,
-    ChangePassword,
-    DeleteAccount,
-    GetBannedPersons,
-    GetPersonDetails,
-    GetPersonMentions,
-    GetReplies,
-    GetReportCount,
-    GetUnreadCount,
-    Login,
-    MarkAllAsRead,
-    MarkCommentReplyAsRead,
-    MarkPersonMentionAsRead,
-    PasswordChangeAfterReset,
-    PasswordReset,
-    Register,
-    SaveUserSettings,
-    VerifyEmail,
+    AddAdmin, BanPerson, BlockPerson, ChangePassword, DeleteAccount, GetBannedPersons,
+    GetPersonDetails, GetPersonMentions, GetReplies, GetReportCount, GetUnreadCount, Login,
+    MarkAllAsRead, MarkCommentReplyAsRead, MarkPersonMentionAsRead, PasswordChangeAfterReset,
+    PasswordReset, Register, SaveUserSettings, VerifyEmail,
   },
   post::{
-    CreatePost,
-    CreatePostLike,
-    CreatePostReport,
-    DeletePost,
-    EditPost,
-    FeaturePost,
-    GetPost,
-    GetPosts,
-    GetSiteMetadata,
-    ListPostReports,
-    LockPost,
-    MarkPostAsRead,
-    RemovePost,
-    ResolvePostReport,
-    SavePost,
+    CreatePost, CreatePostLike, CreatePostReport, DeletePost, EditPost, FeaturePost, GetPost,
+    GetPosts, GetSiteMetadata, ListPostReports, LockPost, MarkPostAsRead, RemovePost,
+    ResolvePostReport, SavePost,
   },
   private_message::{
-    CreatePrivateMessage,
-    CreatePrivateMessageReport,
-    DeletePrivateMessage,
-    EditPrivateMessage,
-    GetPrivateMessages,
-    ListPrivateMessageReports,
-    MarkPrivateMessageAsRead,
+    CreatePrivateMessage, CreatePrivateMessageReport, DeletePrivateMessage, EditPrivateMessage,
+    GetPrivateMessages, ListPrivateMessageReports, MarkPrivateMessageAsRead,
     ResolvePrivateMessageReport,
   },
   site::{
-    ApproveRegistrationApplication,
-    CreateSite,
-    EditSite,
-    GetFederatedInstances,
-    GetModlog,
-    GetSite,
-    GetUnreadRegistrationApplicationCount,
-    LeaveAdmin,
-    ListRegistrationApplications,
-    PurgeComment,
-    PurgeCommunity,
-    PurgePerson,
-    PurgePost,
-    ResolveObject,
-    Search,
+    ApproveRegistrationApplication, CreateSite, EditSite, GetFederatedInstances, GetModlog,
+    GetSite, GetUnreadRegistrationApplicationCount, LeaveAdmin, ListRegistrationApplications,
+    PurgeComment, PurgeCommunity, PurgePerson, PurgePost, ResolveObject, Search,
   },
 };
 use lemmy_api_crud::PerformCrud;
@@ -438,9 +376,45 @@ where
     + Send
     + 'static,
 {
-  let res = data.perform(&context).await?;
-  SendActivity::send_activity(&data, &res, &apub_data).await?;
-  Ok(HttpResponse::Ok().json(res))
+  let res = data.perform(&context).await;
+  match res {
+    Ok(crud_data) => {
+      SendActivity::send_activity(&data, &crud_data, &apub_data).await?;
+      Ok(HttpResponse::Ok().json(crud_data))
+    }
+    Err(err) => {
+      println!("Error performing_crud: {:?}", err);
+      match err.inner.downcast_ref::<diesel::result::Error>() {
+        Some(diesel::result::Error::DatabaseError(
+          diesel::result::DatabaseErrorKind::UniqueViolation,
+          err,
+        )) => {
+          // Check the inner error constraint to see if the email is the issue
+          if let Some(constraint_name) = err.constraint_name() {
+            match constraint_name {
+              "local_user_email_key" => {
+                // return a specific error for the email already being in use, so the frontend can display a nice error
+                return Ok(HttpResponse::Conflict().json("Email is already in use"));
+              }
+              _ => {
+                // Any other constraint, we return this generic message
+                return Ok(
+                  HttpResponse::Conflict().json("Unexpected conflict while registering user"),
+                );
+              }
+            }
+          } else {
+            // some kind of UniqueViolation but no constraint_name
+            Ok(HttpResponse::BadRequest().json("Unexpected conflict while registering user"))
+          }
+        }
+        _ => {
+          // Any other error while registering
+          Ok(HttpResponse::BadRequest().json("Unexpected error registering user"))
+        }
+      }
+    }
+  }
 }
 
 async fn route_get_crud<'a, Data>(


### PR DESCRIPTION
Adjusts error handling around registration of users so if the unique constraint on email gets violated (user tries to sign up with an email that is already in use) the server sends back a 409 stating that, so that the frontend will be able to display a nice error message to the user