### PR TITLE
fix: add CORS origin environment variable

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -50,6 +50,8 @@ services:
       - lemmyexternalproxy
     restart: always
     environment:
+      # set this to the public origin that requests will come from
+      - LEMMY_CORS_ORIGIN=http://localhost
       - RUST_LOG="warn,lemmy_server=debug,lemmy_api=debug,lemmy_api_common=debug,lemmy_api_crud=debug,lemmy_apub=debug,lemmy_db_schema=debug,lemmy_db_views=debug,lemmy_db_views_actor=debug,lemmy_db_views_moderator=debug,lemmy_routes=debug,lemmy_utils=debug,lemmy_websocket=debug"
       - RUST_BACKTRACE=full
     volumes:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,10 +150,11 @@ pub async fn start_lemmy_server() -> Result<(), LemmyError> {
       .build()
       .expect("configure federation");
 
+    let cors_origin = std::env::var("LEMMY_CORS_ORIGIN").unwrap_or_default()
     let cors_config = if cfg!(debug_assertions) {
       Cors::permissive()
     } else {
-      Cors::default()
+      Cors::default().allowed_origin(cors_origin)
     };
 
     App::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,8 @@ pub async fn start_lemmy_server() -> Result<(), LemmyError> {
       .build()
       .expect("configure federation");
 
-    let cors_origin = std::env::var("LEMMY_CORS_ORIGIN").unwrap_or_default()
+    let cors_origin = std::env::var("LEMMY_CORS_ORIGIN").unwrap_or_default();
+
     let cors_config = if cfg!(debug_assertions) {
       Cors::permissive()
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@ pub async fn start_lemmy_server() -> Result<(), LemmyError> {
     let cors_config = if cfg!(debug_assertions) {
       Cors::permissive()
     } else {
-      Cors::default().allowed_origin(cors_origin)
+      Cors::default().allowed_origin(&cors_origin)
     };
 
     App::new()


### PR DESCRIPTION
This PR adds an environment variable, `LEMMY_CORS_ORIGIN`, which allows the user to specify a CORS origin to whitelist if not building in debug mode.