### PR TITLE
after 30 days, replace comment.content and post.body with 'Deleted'

### DIFF
--- a/crates/db_schema/src/impls/comment.rs
+++ b/crates/db_schema/src/impls/comment.rs
@@ -11,7 +11,7 @@ use crate::{
     CommentUpdateForm,
   },
   traits::{Crud, Likeable, Saveable},
-  utils::{get_conn, naive_now, DbPool},
+  utils::{get_conn, naive_now, DbPool, DELETED_REPLACEMENT_TEXT},
 };
 use diesel::{
   dsl::{insert_into, sql_query},
@@ -29,9 +29,10 @@ impl Comment {
     for_creator_id: PersonId,
   ) -> Result<Vec<Self>, Error> {
     let conn = &mut get_conn(pool).await?;
+
     diesel::update(comment.filter(creator_id.eq(for_creator_id)))
       .set((
-        content.eq("*Permananently Deleted*"),
+        content.eq(DELETED_REPLACEMENT_TEXT),
         deleted.eq(true),
         updated.eq(naive_now()),
       ))

--- a/crates/db_schema/src/impls/post.rs
+++ b/crates/db_schema/src/impls/post.rs
@@ -27,7 +27,14 @@ use crate::{
     PostUpdateForm,
   },
   traits::{Crud, Likeable, Readable, Saveable},
-  utils::{get_conn, naive_now, DbPool, FETCH_LIMIT_MAX},
+  utils::{
+    get_conn,
+    naive_now,
+    DbPool,
+    DELETED_REPLACEMENT_TEXT,
+    DELETED_REPLACEMENT_URL,
+    FETCH_LIMIT_MAX,
+  },
 };
 use ::url::Url;
 use diesel::{dsl::insert_into, result::Error, ExpressionMethods, QueryDsl, TextExpressionMethods};
@@ -111,14 +118,11 @@ impl Post {
   ) -> Result<Vec<Self>, Error> {
     let conn = &mut get_conn(pool).await?;
 
-    let perma_deleted = "*Permananently Deleted*";
-    let perma_deleted_url = "https://deleted.com";
-
     diesel::update(post.filter(creator_id.eq(for_creator_id)))
       .set((
-        name.eq(perma_deleted),
-        url.eq(perma_deleted_url),
-        body.eq(perma_deleted),
+        name.eq(DELETED_REPLACEMENT_TEXT),
+        url.eq(DELETED_REPLACEMENT_URL),
+        body.eq(DELETED_REPLACEMENT_TEXT),
         deleted.eq(true),
         updated.eq(naive_now()),
       ))

--- a/crates/db_schema/src/utils.rs
+++ b/crates/db_schema/src/utils.rs
@@ -222,6 +222,9 @@ pub mod functions {
   sql_function!(fn lower(x: Text) -> Text);
 }
 
+pub const DELETED_REPLACEMENT_TEXT: &str = "*Permanently Deleted*";
+pub const DELETED_REPLACEMENT_URL: &str = "https://join-lemmy.org/";
+
 impl ToSql<Text, Pg> for DbUrl {
   fn to_sql(&self, out: &mut Output<Pg>) -> diesel::serialize::Result {
     <std::string::String as ToSql<Text, Pg>>::to_sql(&self.0.to_string(), &mut out.reborrow())


### PR DESCRIPTION
fixes #2977

on server startup, and then with a daily scheduler thread - 

check for all posts & comments where deleted = true && updated < 30 days ago && body/content != "Deleted" and sets it to "Deleted"  

this way deletes for comments & posts get federated after 30 days by default. 