### PR TITLE
Don't check verified email when an admin logs in

### DIFF
--- a/crates/api/src/local_user/login.rs
+++ b/crates/api/src/local_user/login.rs
@@ -40,7 +40,11 @@ impl Perform for Login {
       local_user_view.person.deleted,
     )?;
 
-    if site_view.local_site.require_email_verification && !local_user_view.local_user.email_verified
+    // Check if the user's email is verified if email verification is turned on
+    // However, skip checking verification if the user is an admin
+    if !local_user_view.person.admin
+      && site_view.local_site.require_email_verification
+      && !local_user_view.local_user.email_verified
     {
       return Err(LemmyError::from_message("email_not_verified"));
     }


### PR DESCRIPTION
Workaround for instance admins getting locked out when they turn on the email verification requirement without having verified their own email.

Fixes #3079.