### PR TITLE
Add test to check reading and listing posts return my_vote

### DIFF
--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -734,6 +734,42 @@ mod tests {
     };
     assert_eq!(expected_post_like, inserted_post_like);
 
+    let post_listing_single_with_person = PostView::read(
+      pool,
+      data.inserted_post.id,
+      Some(data.inserted_person.id),
+      None,
+    )
+    .await
+    .unwrap();
+
+    let mut expected_post_with_upvote = expected_post_view(&data, pool).await;
+    expected_post_with_upvote.my_vote = Some(1);
+    expected_post_with_upvote.counts.score = 1;
+    expected_post_with_upvote.counts.upvotes = 1;
+    assert_eq!(expected_post_with_upvote, post_listing_single_with_person);
+
+    let local_user_form = LocalUserUpdateForm::builder()
+      .show_bot_accounts(Some(false))
+      .build();
+    let inserted_local_user =
+      LocalUser::update(pool, data.inserted_local_user.id, &local_user_form)
+        .await
+        .unwrap();
+
+    let read_post_listing = PostQuery::builder()
+      .pool(pool)
+      .sort(Some(SortType::New))
+      .community_id(Some(data.inserted_community.id))
+      .local_user(Some(&inserted_local_user))
+      .build()
+      .list()
+      .await
+      .unwrap();
+    assert_eq!(1, read_post_listing.len());
+
+    assert_eq!(expected_post_with_upvote, read_post_listing[0]);
+
     let like_removed = PostLike::remove(pool, data.inserted_person.id, data.inserted_post.id)
       .await
       .unwrap();


### PR DESCRIPTION
To try to reproduce #3197 but it does work fine. But now the tests does verify the counts and my_vote are right when reading.