### PR TITLE
logger: Use forwarded instead of peer IP address

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,10 @@ pub async fn start_lemmy_server() -> Result<(), LemmyError> {
     };
 
     App::new()
-      .wrap(middleware::Logger::default())
+      .wrap(middleware::Logger::new(
+        // This is the default log format save for the usage of %{r}a over %a to guarantee to record the client's (forwarded) IP and not the last peer address, since the latter is frequently just a reverse proxy
+        "%{r}a '%r' %s %b '%{Referer}i' '%{User-Agent}i' %T",
+      ))
       .wrap(cors_config)
       .wrap(TracingLogger::<QuieterRootSpanBuilder>::new())
       .app_data(Data::new(context))


### PR DESCRIPTION
According to [documentation](https://docs.rs/actix-web/latest/actix_web/middleware/struct.Logger.html) the default logger format is the next:

> %a %r %s %b %{Referer}i %{User-Agent}i %T

Which basically stands for:

> PEER-ADDRESS   REQUEST   STATUS-CODE   SIZE   REFERER   USER-AGENT   TIME-SPENT

I kept the entire line the same for the exception of `%a`, which was replaced with `%{r}a` which intends instead to log real IP address (at least the one provided via Forwarded headers)

Without this change the logs always shows the last source of the request, which might be most of the time the address of the reverse proxy. Tested on a local instance for sample outputs:

Before (Showing docker address):

> 2023-06-20T10:41:43.951634Z  INFO actix_web::middleware::logger: 192.168.32.4 GET /api/v3/site HTTP/1.1 200 11455 - node-fetch/1.0 (+https://github.com/bitinn/node-fetch) 0.013345

After (Showing client address):

> 2023-06-20T10:50:50.355095Z  INFO actix_web::middleware::logger: 192.168.1.7 GET /api/v3/site HTTP/1.1 200 11455 - node-fetch/1.0 (+https://github.com/bitinn/node-fetch) 0.015205