### PR TITLE
remove debugging println

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,6 @@ pub async fn main() -> Result<(), LemmyError> {
       .port()
       .unwrap_or(8080);
     let pictrs_address = ["127.0.0.1", &pictrs_port.to_string()].join(":");
-    println!("pictrs_address = {}", pictrs_address);
     pict_rs::ConfigSource::memory(serde_json::json!({
         "server": {
             "address": pictrs_address


### PR DESCRIPTION
Remove `println!` that was added for testing #3201
