### PR TITLE
Adding current domain from settings to CORs.

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -164,7 +164,8 @@ pipeline:
       repo: dessalines/lemmy
       dockerfile: docker/Dockerfile
       platforms: linux/amd64
-      build_args: RUST_RELEASE_MODE=release
+      build_args:
+        - RUST_RELEASE_MODE=release
       auto_tag: true
     when:
       event: tag
@@ -176,7 +177,8 @@ pipeline:
       repo: dessalines/lemmy
       dockerfile: docker/Dockerfile
       platforms: linux/amd64
-      build_args: RUST_RELEASE_MODE=release
+      build_args:
+        - RUST_RELEASE_MODE=release
       tag: dev
     when:
       event: cron

--- a/docker/test_deploy.sh
+++ b/docker/test_deploy.sh
@@ -5,8 +5,8 @@ export COMPOSE_DOCKER_CLI_BUILD=1
 export DOCKER_BUILDKIT=1
 
 # Rebuilding dev docker
-sudo docker build ../ -f . -t "dessalines/lemmy:dev"
-sudo docker push "dessalines/lemmy:dev"
+pushd ..
+sudo docker build . -f docker/Dockerfile --build-arg RUST_RELEASE_MODE=release -t "dessalines/lemmy:dev" --platform=linux/amd64 --push
 
 # Run the playbook
 # pushd ../../../lemmy-ansible

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,12 +150,13 @@ pub async fn start_lemmy_server() -> Result<(), LemmyError> {
       .build()
       .expect("configure federation");
 
-    let cors_origin = std::env::var("LEMMY_CORS_ORIGIN").unwrap_or("http://localhost".into());
-
-    let cors_config = if !cfg!(debug_assertions) {
+    let cors_config = if cfg!(debug_assertions) {
       Cors::permissive()
     } else {
-      Cors::default().allowed_origin(&cors_origin)
+      let cors_origin = std::env::var("LEMMY_CORS_ORIGIN").unwrap_or("http://localhost".into());
+      Cors::default()
+        .allowed_origin(&cors_origin)
+        .allowed_origin(&settings.get_protocol_and_hostname())
     };
 
     App::new()


### PR DESCRIPTION
Turns out someone flipped the CORs logic, and also we needed to add the current domain.