### PR TITLE
Ensure site can only either be a private instance or federated when creating or editing site

### DIFF
--- a/crates/api_crud/src/site/create.rs
+++ b/crates/api_crud/src/site/create.rs
@@ -32,7 +32,6 @@ use lemmy_utils::{
     validation::{check_site_visibility_valid, is_valid_body_field},
   },
 };
-use std::ops::Deref;
 use url::Url;
 
 #[async_trait::async_trait(?Send)]

--- a/crates/api_crud/src/site/create.rs
+++ b/crates/api_crud/src/site/create.rs
@@ -1,4 +1,3 @@
-use std::ops::Deref;
 use crate::{site::check_application_question, PerformCrud};
 use activitypub_federation::http_signatures::generate_actor_keypair;
 use actix_web::web::Data;
@@ -30,12 +29,10 @@ use lemmy_utils::{
   error::LemmyError,
   utils::{
     slurs::{check_slurs, check_slurs_opt},
-    validation::{
-      is_valid_body_field,
-      check_site_visibility_valid
-    }
+    validation::{check_site_visibility_valid, is_valid_body_field},
   },
 };
+use std::ops::Deref;
 use url::Url;
 
 #[async_trait::async_trait(?Send)]
@@ -57,10 +54,12 @@ impl PerformCrud for CreateSite {
     // Make sure user is an admin
     is_admin(&local_user_view)?;
 
-    check_site_visibility_valid(local_site.private_instance,
-                                local_site.federation_enabled,
-                                &data.private_instance,
-                                &data.federation_enabled)?;
+    check_site_visibility_valid(
+      local_site.private_instance,
+      local_site.federation_enabled,
+      &data.private_instance,
+      &data.federation_enabled,
+    )?;
 
     let sidebar = diesel_option_overwrite(&data.sidebar);
     let description = diesel_option_overwrite(&data.description);

--- a/crates/api_crud/src/site/update.rs
+++ b/crates/api_crud/src/site/update.rs
@@ -30,7 +30,10 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::SiteView;
 use lemmy_utils::{
   error::LemmyError,
-  utils::{slurs::check_slurs_opt, validation::is_valid_body_field},
+  utils::{slurs::check_slurs_opt,
+          validation::{
+    is_valid_body_field,
+    check_site_visibility_valid}},
 };
 
 #[async_trait::async_trait(?Send)]
@@ -47,6 +50,11 @@ impl PerformCrud for EditSite {
 
     // Make sure user is an admin
     is_admin(&local_user_view)?;
+
+    check_site_visibility_valid(local_site.private_instance,
+                                local_site.federation_enabled,
+                                &data.private_instance,
+                                &data.federation_enabled)?;
 
     let slur_regex = local_site_to_slur_regex(&local_site);
 

--- a/crates/api_crud/src/site/update.rs
+++ b/crates/api_crud/src/site/update.rs
@@ -86,19 +86,6 @@ impl PerformCrud for EditSite {
       }
     }
 
-    let enabled_private_instance_with_federation = data.private_instance == Some(true)
-      && data
-        .federation_enabled
-        .unwrap_or(local_site.federation_enabled);
-    let enabled_federation_with_private_instance = data.federation_enabled == Some(true)
-      && data.private_instance.unwrap_or(local_site.private_instance);
-
-    if enabled_private_instance_with_federation || enabled_federation_with_private_instance {
-      return Err(LemmyError::from_message(
-        "cant_enable_private_instance_and_federation_together",
-      ));
-    }
-
     if let Some(discussion_languages) = data.discussion_languages.clone() {
       SiteLanguage::update(context.pool(), discussion_languages.clone(), &site).await?;
     }

--- a/crates/api_crud/src/site/update.rs
+++ b/crates/api_crud/src/site/update.rs
@@ -30,10 +30,10 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::SiteView;
 use lemmy_utils::{
   error::LemmyError,
-  utils::{slurs::check_slurs_opt,
-          validation::{
-    is_valid_body_field,
-    check_site_visibility_valid}},
+  utils::{
+    slurs::check_slurs_opt,
+    validation::{check_site_visibility_valid, is_valid_body_field},
+  },
 };
 
 #[async_trait::async_trait(?Send)]
@@ -51,10 +51,12 @@ impl PerformCrud for EditSite {
     // Make sure user is an admin
     is_admin(&local_user_view)?;
 
-    check_site_visibility_valid(local_site.private_instance,
-                                local_site.federation_enabled,
-                                &data.private_instance,
-                                &data.federation_enabled)?;
+    check_site_visibility_valid(
+      local_site.private_instance,
+      local_site.federation_enabled,
+      &data.private_instance,
+      &data.federation_enabled,
+    )?;
 
     let slur_regex = local_site_to_slur_regex(&local_site);
 

--- a/crates/utils/src/utils/validation.rs
+++ b/crates/utils/src/utils/validation.rs
@@ -160,7 +160,7 @@ pub fn check_site_visibility_valid(
 
   if private_instance && federation_enabled {
     return Err(LemmyError::from_message(
-      "site_cannot_be_private_and_federated",
+      "cant_enable_private_instance_and_federation_together",
     ));
   }
 

--- a/crates/utils/src/utils/validation.rs
+++ b/crates/utils/src/utils/validation.rs
@@ -153,13 +153,15 @@ pub fn check_site_visibility_valid(
   current_private_instance: bool,
   current_federation_enabled: bool,
   new_private_instance: &Option<bool>,
-  new_federation_enabled: &Option<bool>) -> LemmyResult<()> {
-
+  new_federation_enabled: &Option<bool>,
+) -> LemmyResult<()> {
   let private_instance = new_private_instance.unwrap_or(current_private_instance);
   let federation_enabled = new_federation_enabled.unwrap_or(current_federation_enabled);
 
   if private_instance && federation_enabled {
-    return Err(LemmyError::from_message("site_cannot_be_private_and_federated"));
+    return Err(LemmyError::from_message(
+      "site_cannot_be_private_and_federated",
+    ));
   }
 
   Ok(())
@@ -169,13 +171,13 @@ pub fn check_site_visibility_valid(
 mod tests {
   use super::build_totp_2fa;
   use crate::utils::validation::{
+    check_site_visibility_valid,
     clean_url_params,
     generate_totp_2fa_secret,
     is_valid_actor_name,
     is_valid_display_name,
     is_valid_matrix_id,
     is_valid_post_title,
-    check_site_visibility_valid
   };
   use url::Url;
 
@@ -245,7 +247,7 @@ mod tests {
   }
 
   #[test]
-  fn test_check_site_visibility_valid(){
+  fn test_check_site_visibility_valid() {
     assert!(check_site_visibility_valid(true, true, &None, &None).is_err());
     assert!(check_site_visibility_valid(true, false, &None, &Some(true)).is_err());
     assert!(check_site_visibility_valid(false, true, &Some(true), &None).is_err());


### PR DESCRIPTION
On start-up Lemmy checks if both the `private_instance` and `federation_enabled` flags are set. If they are, it raises and error which stops start-up meaning administrators are unable to edit the settings which cause the error.

As a means of prevention, I've added some validation when editing or creating a site to ensure that both options are never selected at the same time.

I thought about adjusting start-up behaviour to disregard one of the flags (like ignore federation if the private flag is set) but I thought it would be easier to just prevent the invalid state from being saved.

This could probably coincide with a change to the UI as well but I can do that after.

Solves #3138