### PR TITLE
Fix /admin/purge routes returning 404

### DIFF
--- a/src/api_routes_http.rs
+++ b/src/api_routes_http.rs
@@ -335,15 +335,14 @@ pub fn config(cfg: &mut web::ServiceConfig, rate_limit: &RateLimitCell) {
           .route(
             "/registration_application/approve",
             web::put().to(route_post::<ApproveRegistrationApplication>),
+          )
+          .service(
+            web::scope("/purge")
+              .route("/person", web::post().to(route_post::<PurgePerson>))
+              .route("/community", web::post().to(route_post::<PurgeCommunity>))
+              .route("/post", web::post().to(route_post::<PurgePost>))
+              .route("/comment", web::post().to(route_post::<PurgeComment>)),
           ),
-      )
-      .service(
-        web::scope("/admin/purge")
-          .wrap(rate_limit.message())
-          .route("/person", web::post().to(route_post::<PurgePerson>))
-          .route("/community", web::post().to(route_post::<PurgeCommunity>))
-          .route("/post", web::post().to(route_post::<PurgePost>))
-          .route("/comment", web::post().to(route_post::<PurgeComment>)),
       )
       .service(
         web::scope("/custom_emoji")


### PR DESCRIPTION
Endpoints like `/admin/purge/person` were returning a 404. Nesting `/purge` as a service inside the `/admin` service fixes the problem. I am guessing actix-web descends into the `/admin` block since it is placed first then returns 404 when it does not find a `/purge` route within it.

Calling the endpoint after these changes:

```
 ❯ ./purge_user.sh
+ data='{  "person_id": 3,  "auth": "authtoken",  "reason": "terrible poster"}'
+ curl -i -H 'Content-Type: application/json' -X POST -d '{  "person_id": 3,  "auth": "authtoken",  "reason": "terrible poster"}' http://localhost:8536/api/v3/admin/purge/person
HTTP/1.1 200 OK
content-length: 16
access-control-expose-headers: content-type
access-control-allow-credentials: true
vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
content-type: application/json
date: Wed, 21 Jun 2023 14:16:19 GMT

{"success":true}%
```