### PR TITLE
docs: Add Lemoa to lemmy projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Each Lemmy server can set its own moderation policy; appointing site-wide admins
 - [lemmyBB - A Lemmy forum UI based on phpBB](https://github.com/LemmyNet/lemmyBB)
 - [Jerboa - A native Android app made by Lemmy's developers](https://github.com/dessalines/jerboa)
 - [Mlem - A Lemmy client for iOS](https://github.com/buresdv/Mlem)
+- [Lemoa - A Gtk client for Lemmy on Linux](https://github.com/lemmy-gtk/lemoa)
 
 ### Libraries
 


### PR DESCRIPTION
[Lemoa](https://github.com/lemmy-gtk/lemoa) is a Gtk desktop client for Lemoa build for Linux. (Might also work on Windows but that's untested, but the primary target is Linux).
