### PR TITLE
Update federated posts to not cache sensitive images if not allow by local site

### DIFF
--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -193,6 +193,7 @@ pub async fn fetch_site_data(
   client: &ClientWithMiddleware,
   settings: &Settings,
   url: Option<&Url>,
+  include_image: bool,
 ) -> (Option<SiteMetadata>, Option<DbUrl>) {
   match &url {
     Some(url) => {
@@ -200,6 +201,9 @@ pub async fn fetch_site_data(
       // Ignore errors, since it may be an image, or not have the data.
       // Warning, this may ignore SSL errors
       let metadata_option = fetch_site_metadata(client, url).await.ok();
+      if !include_image {
+        return (metadata_option, None);
+      }
 
       let missing_pictrs_file =
         |r: PictrsResponse| r.files.first().expect("missing pictrs file").file.clone();

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -428,6 +428,13 @@ pub fn local_site_opt_to_slur_regex(local_site: &Option<LocalSite>) -> Option<Re
     .unwrap_or(None)
 }
 
+pub fn local_site_opt_to_sensitive(local_site: &Option<LocalSite>) -> bool {
+  local_site
+    .as_ref()
+    .map(|site| site.enable_nsfw)
+    .unwrap_or(false)
+}
+
 pub fn send_application_approved_email(
   user: &LocalUserView,
   settings: &Settings,

--- a/crates/api_crud/src/post/create.rs
+++ b/crates/api_crud/src/post/create.rs
@@ -79,7 +79,7 @@ impl PerformCrud for CreatePost {
 
     // Fetch post links and pictrs cached image
     let (metadata_res, thumbnail_url) =
-      fetch_site_data(context.client(), context.settings(), data_url).await;
+      fetch_site_data(context.client(), context.settings(), data_url, true).await;
     let (embed_title, embed_description, embed_video_url) = metadata_res
       .map(|u| (u.title, u.description, u.embed_video_url))
       .unwrap_or_default();

--- a/crates/api_crud/src/post/update.rs
+++ b/crates/api_crud/src/post/update.rs
@@ -69,7 +69,7 @@ impl PerformCrud for EditPost {
     // Fetch post links and Pictrs cached image
     let data_url = data.url.as_ref();
     let (metadata_res, thumbnail_url) =
-      fetch_site_data(context.client(), context.settings(), data_url).await;
+      fetch_site_data(context.client(), context.settings(), data_url, true).await;
     let (embed_title, embed_description, embed_video_url) = metadata_res
       .map(|u| (Some(u.title), Some(u.description), Some(u.embed_video_url)))
       .unwrap_or_default();


### PR DESCRIPTION
This should prevent federated images from getting locally stored on servers that don't allow sensitive content. Instead, it will rely on the provided image URL if available.

Let me know if I'm overlooking anything obvious or there's a better way to approach.

Issue: https://github.com/LemmyNet/lemmy/issues/3276
