### PR TITLE
Use Rust 1.70 for Docker and CI

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -2,7 +2,7 @@
 # See https://github.com/woodpecker-ci/woodpecker/issues/1677
 
 variables:
-  - &muslrust_image "clux/muslrust:1.67.0"
+  - &muslrust_image "clux/muslrust:1.70.0"
 
 # Broken for cron jobs currently, see
 # https://github.com/woodpecker-ci/woodpecker/issues/1716

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM clux/muslrust:1.67.0 as builder
+FROM clux/muslrust:1.70.0 as builder
 WORKDIR /app
 ARG CARGO_BUILD_TARGET=x86_64-unknown-linux-musl
 


### PR DESCRIPTION
This version is much faster when fetching the crates.io index.

https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html#sparse-by-default-for-cratesio