### PR TITLE
feat: allow all admins to purge content

### DIFF
--- a/crates/api/src/site/purge/comment.rs
+++ b/crates/api/src/site/purge/comment.rs
@@ -3,7 +3,7 @@ use actix_web::web::Data;
 use lemmy_api_common::{
   context::LemmyContext,
   site::{PurgeComment, PurgeItemResponse},
-  utils::{is_top_admin, local_user_view_from_jwt},
+  utils::{is_admin, local_user_view_from_jwt},
 };
 use lemmy_db_schema::{
   source::{
@@ -23,8 +23,8 @@ impl Perform for PurgeComment {
     let data: &Self = self;
     let local_user_view = local_user_view_from_jwt(&data.auth, context).await?;
 
-    // Only let the top admin purge an item
-    is_top_admin(context.pool(), local_user_view.person.id).await?;
+    // Only let admin purge an item
+    is_admin(&local_user_view)?;
 
     let comment_id = data.comment_id;
 

--- a/crates/api/src/site/purge/community.rs
+++ b/crates/api/src/site/purge/community.rs
@@ -4,7 +4,7 @@ use lemmy_api_common::{
   context::LemmyContext,
   request::purge_image_from_pictrs,
   site::{PurgeCommunity, PurgeItemResponse},
-  utils::{is_top_admin, local_user_view_from_jwt, purge_image_posts_for_community},
+  utils::{is_admin, local_user_view_from_jwt, purge_image_posts_for_community},
 };
 use lemmy_db_schema::{
   source::{
@@ -24,8 +24,8 @@ impl Perform for PurgeCommunity {
     let data: &Self = self;
     let local_user_view = local_user_view_from_jwt(&data.auth, context).await?;
 
-    // Only let the top admin purge an item
-    is_top_admin(context.pool(), local_user_view.person.id).await?;
+    // Only let admin purge an item
+    is_admin(&local_user_view)?;
 
     let community_id = data.community_id;
 

--- a/crates/api/src/site/purge/person.rs
+++ b/crates/api/src/site/purge/person.rs
@@ -4,7 +4,7 @@ use lemmy_api_common::{
   context::LemmyContext,
   request::purge_image_from_pictrs,
   site::{PurgeItemResponse, PurgePerson},
-  utils::{is_top_admin, local_user_view_from_jwt, purge_image_posts_for_person},
+  utils::{is_admin, local_user_view_from_jwt, purge_image_posts_for_person},
 };
 use lemmy_db_schema::{
   source::{
@@ -24,8 +24,8 @@ impl Perform for PurgePerson {
     let data: &Self = self;
     let local_user_view = local_user_view_from_jwt(&data.auth, context).await?;
 
-    // Only let the top admin purge an item
-    is_top_admin(context.pool(), local_user_view.person.id).await?;
+    // Only let admin purge an item
+    is_admin(&local_user_view)?;
 
     // Read the person to get their images
     let person_id = data.person_id;

--- a/crates/api/src/site/purge/post.rs
+++ b/crates/api/src/site/purge/post.rs
@@ -4,7 +4,7 @@ use lemmy_api_common::{
   context::LemmyContext,
   request::purge_image_from_pictrs,
   site::{PurgeItemResponse, PurgePost},
-  utils::{is_top_admin, local_user_view_from_jwt},
+  utils::{is_admin, local_user_view_from_jwt},
 };
 use lemmy_db_schema::{
   source::{
@@ -24,8 +24,8 @@ impl Perform for PurgePost {
     let data: &Self = self;
     let local_user_view = local_user_view_from_jwt(&data.auth, context).await?;
 
-    // Only let the top admin purge an item
-    is_top_admin(context.pool(), local_user_view.person.id).await?;
+    // Only let admin purge an item
+    is_admin(&local_user_view)?;
 
     let post_id = data.post_id;
 

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -32,7 +32,6 @@ use lemmy_db_views_actor::structs::{
   CommunityModeratorView,
   CommunityPersonBanView,
   CommunityView,
-  PersonView,
 };
 use lemmy_utils::{
   claims::Claims,
@@ -77,18 +76,6 @@ pub async fn is_mod_or_admin_opt(
   } else {
     Err(LemmyError::from_message("not_a_mod_or_admin"))
   }
-}
-
-pub async fn is_top_admin(pool: &DbPool, person_id: PersonId) -> Result<(), LemmyError> {
-  let admins = PersonView::admins(pool).await?;
-  let top_admin = admins
-    .first()
-    .ok_or_else(|| LemmyError::from_message("no admins"))?;
-
-  if top_admin.person.id != person_id {
-    return Err(LemmyError::from_message("not_top_admin"));
-  }
-  Ok(())
 }
 
 pub fn is_admin(local_user_view: &LocalUserView) -> Result<(), LemmyError> {


### PR DESCRIPTION
as discussed in issue: https://github.com/LemmyNet/lemmy/issues/2976

this removes the `is_top_admin` check from all purges, i've also deleted the `is_top_admin` function itself since it's no longer used

as an aside in relation to the safety concerns, i believe a long term solution to this would be moving from a coarse-grained role-based system, to a fine-grained permissions + role system, where permissions can be defined for pretty much every server interaction and roles are just named bundles of permissions which can be assigned to users