### PR TITLE
Fixed Otel breaking logging. Fixes #2642

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ debug = 0
 [features]
 embed-pictrs = ["pict-rs"]
 console = ["console-subscriber", "opentelemetry", "opentelemetry-otlp", "tracing-opentelemetry", "reqwest-tracing/opentelemetry_0_16"]
-default = []
+default = ["console"]
 
 [workspace]
 members = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,7 +212,11 @@ pub fn init_logging(opentelemetry_url: &Option<Url>) -> Result<(), LemmyError> {
     .with(ErrorLayer::default());
 
   if let Some(_url) = opentelemetry_url {
+    #[cfg(feature = "console")]
     telemetry::init_tracing(_url.as_ref(), subscriber, targets)?;
+    #[cfg(not(feature = "console"))]
+    set_global_default(subscriber)?;
+    tracing::error!("Feature `console` must be enabled for opentelemetry tracing");
   } else {
     set_global_default(subscriber)?;
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,9 +214,10 @@ pub fn init_logging(opentelemetry_url: &Option<Url>) -> Result<(), LemmyError> {
   if let Some(_url) = opentelemetry_url {
     #[cfg(feature = "console")]
     telemetry::init_tracing(_url.as_ref(), subscriber, targets)?;
-    #[cfg(not(feature = "console"))]
+    #[cfg(not(feature = "console"))] {
     set_global_default(subscriber)?;
     tracing::error!("Feature `console` must be enabled for opentelemetry tracing");
+    }
   } else {
     set_global_default(subscriber)?;
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,10 +207,7 @@ pub fn init_logging(opentelemetry_url: &Option<Url>) -> Result<(), LemmyError> {
     .with(ErrorLayer::default());
 
   if let Some(_url) = opentelemetry_url {
-    #[cfg(feature = "console")]
     telemetry::init_tracing(_url.as_ref(), subscriber, targets)?;
-    #[cfg(not(feature = "console"))]
-    tracing::error!("Feature `console` must be enabled for opentelemetry tracing");
   } else {
     set_global_default(subscriber)?;
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,9 +214,10 @@ pub fn init_logging(opentelemetry_url: &Option<Url>) -> Result<(), LemmyError> {
   if let Some(_url) = opentelemetry_url {
     #[cfg(feature = "console")]
     telemetry::init_tracing(_url.as_ref(), subscriber, targets)?;
-    #[cfg(not(feature = "console"))] {
-    set_global_default(subscriber)?;
-    tracing::error!("Feature `console` must be enabled for opentelemetry tracing");
+    #[cfg(not(feature = "console"))] 
+    {
+      set_global_default(subscriber)?;
+      tracing::error!("Feature `console` must be enabled for opentelemetry tracing");
     }
   } else {
     set_global_default(subscriber)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,7 +214,7 @@ pub fn init_logging(opentelemetry_url: &Option<Url>) -> Result<(), LemmyError> {
   if let Some(_url) = opentelemetry_url {
     #[cfg(feature = "console")]
     telemetry::init_tracing(_url.as_ref(), subscriber, targets)?;
-    #[cfg(not(feature = "console"))] 
+    #[cfg(not(feature = "console"))]
     {
       set_global_default(subscriber)?;
       tracing::error!("Feature `console` must be enabled for opentelemetry tracing");


### PR DESCRIPTION
I'm not entirely sure why all the otel features are disabled by default, but obviously reenabling them addresses the issue.
In the existing configuration otel is behind feature which isn't enabled moving to the error log statement, but because tracing/logging hasn't been initialized no logs appear. A fix for that would be to just move [the set_global_default](https://github.com/LemmyNet/lemmy/blob/main/src/lib.rs#L220C5-L220C37) into the `#[cfg(not(feature = "console"))` [block](https://github.com/LemmyNet/lemmy/blob/main/src/lib.rs#L217-L218) and it will log the error and allow logs to work, but then otel doesn't forward traces or even work, so I am not entirely sure what this block is for at all other than only to allow otel traces in a dev setting with the console feature enabled.

Either way, these changes allow the otel traces and logs to work when the otel url is enabled, otherwise it will just default to the default logging. Fixes #2642.