### PR TITLE
Allow wildcard imports in schema.rs

### DIFF
--- a/crates/db_schema/src/lib.rs
+++ b/crates/db_schema/src/lib.rs
@@ -26,6 +26,7 @@ pub mod impls;
 pub mod newtypes;
 #[cfg(feature = "full")]
 #[rustfmt::skip]
+#[allow(clippy::wildcard_imports)]
 pub mod schema;
 pub mod source;
 #[cfg(feature = "full")]

--- a/crates/db_schema/src/schema.rs
+++ b/crates/db_schema/src/schema.rs
@@ -65,7 +65,7 @@ diesel::table! {
 }
 
 diesel::table! {
-    use diesel::sql_types::{Bool, Int4, Nullable, Text, Timestamp, Varchar};
+    use diesel::sql_types::*;
     use diesel_ltree::sql_types::Ltree;
 
     comment (id) {
@@ -317,7 +317,7 @@ diesel::table! {
 }
 
 diesel::table! {
-    use diesel::sql_types::{Bool, Int4, Nullable, Text, Timestamp, Varchar};
+    use diesel::sql_types::*;
     use super::sql_types::ListingTypeEnum;
     use super::sql_types::RegistrationModeEnum;
 
@@ -372,7 +372,7 @@ diesel::table! {
 }
 
 diesel::table! {
-    use diesel::sql_types::{Bool, Int4, Nullable, Text, Timestamp, Varchar};
+    use diesel::sql_types::*;
     use super::sql_types::SortTypeEnum;
     use super::sql_types::ListingTypeEnum;
 


### PR DESCRIPTION
Dont mess with auto-generated code, this avoids problems with clippy after running diesel commands