### PR TITLE
Fix lemmy UI environment variable in docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -74,7 +74,7 @@ services:
       - LEMMY_UI_LEMMY_INTERNAL_HOST=lemmy:8536
       # set the outside hostname here
       - LEMMY_UI_LEMMY_EXTERNAL_HOST=localhost:1236
-      - LEMMY_HTTPS=false
+      - LEMMY_UI_HTTPS=false
       - LEMMY_UI_DEBUG=true
     depends_on:
       - lemmy


### PR DESCRIPTION
I believe the correct environment variable here is LEMMY_UI_HTTPS ([ref](https://github.com/LemmyNet/lemmy-ui/blob/d0a40f66907d52f292bda2da7525543543577690/src/shared/utils/env/get-secure.ts#L7))