### PR TITLE
Made inbox_irl optional

### DIFF
--- a/crates/db_schema/src/source/community.rs
+++ b/crates/db_schema/src/source/community.rs
@@ -45,7 +45,7 @@ pub struct Community {
   #[serde(skip_serializing)]
   pub followers_url: DbUrl,
   #[serde(skip_serializing)]
-  pub inbox_url: DbUrl,
+  pub inbox_url: Option<DbUrl>,
   #[serde(skip)]
   pub shared_inbox_url: Option<DbUrl>,
   /// Whether the community is hidden.

--- a/crates/db_schema/src/source/person.rs
+++ b/crates/db_schema/src/source/person.rs
@@ -41,7 +41,7 @@ pub struct Person {
   /// Whether the person is deleted.
   pub deleted: bool,
   #[serde(skip_serializing)]
-  pub inbox_url: DbUrl,
+  pub inbox_url: Option<DbUrl>,
   #[serde(skip)]
   pub shared_inbox_url: Option<DbUrl>,
   /// A matrix id, usually given an @person:matrix.org


### PR DESCRIPTION
They are not always present in responses except for /site, therefore should be optional in rust structs.