### PR TITLE
wip: proof of concept permissions/roles

### DIFF
--- a/crates/api/src/comment/distinguish.rs
+++ b/crates/api/src/comment/distinguish.rs
@@ -3,11 +3,12 @@ use actix_web::web::Data;
 use lemmy_api_common::{
   comment::{CommentResponse, DistinguishComment},
   context::LemmyContext,
-  utils::{check_community_ban, is_mod_or_admin, local_user_view_from_jwt},
+  utils::{check_community_ban, is_mod_or_has_site_permission, local_user_view_from_jwt},
 };
 use lemmy_db_schema::{
   source::comment::{Comment, CommentUpdateForm},
   traits::Crud,
+  SitePermission,
 };
 use lemmy_db_views::structs::CommentView;
 use lemmy_utils::error::LemmyError;
@@ -32,10 +33,11 @@ impl Perform for DistinguishComment {
     .await?;
 
     // Verify that only a mod or admin can distinguish a comment
-    is_mod_or_admin(
+    is_mod_or_has_site_permission(
       context.pool(),
       local_user_view.person.id,
       orig_comment.community.id,
+      SitePermission::DistinguishComment,
     )
     .await?;
 

--- a/crates/api/src/comment_report/list.rs
+++ b/crates/api/src/comment_report/list.rs
@@ -23,7 +23,7 @@ impl Perform for ListCommentReports {
     let local_user_view = local_user_view_from_jwt(&data.auth, context).await?;
 
     let person_id = local_user_view.person.id;
-    let admin = local_user_view.person.admin;
+    let can_see_comment_reports = local_user_view.site_role.view_comment_reports;
     let community_id = data.community_id;
     let unresolved_only = data.unresolved_only;
 
@@ -32,7 +32,7 @@ impl Perform for ListCommentReports {
     let comment_reports = CommentReportQuery::builder()
       .pool(context.pool())
       .my_person_id(person_id)
-      .admin(admin)
+      .can_see_comment_reports(can_see_comment_reports)
       .community_id(community_id)
       .unresolved_only(unresolved_only)
       .page(page)

--- a/crates/api/src/community/hide.rs
+++ b/crates/api/src/community/hide.rs
@@ -4,7 +4,7 @@ use lemmy_api_common::{
   build_response::build_community_response,
   community::{CommunityResponse, HideCommunity},
   context::LemmyContext,
-  utils::{is_admin, local_user_view_from_jwt},
+  utils::{has_site_permission, local_user_view_from_jwt},
 };
 use lemmy_db_schema::{
   source::{
@@ -12,6 +12,7 @@ use lemmy_db_schema::{
     moderator::{ModHideCommunity, ModHideCommunityForm},
   },
   traits::Crud,
+  SitePermission,
 };
 use lemmy_utils::error::LemmyError;
 
@@ -25,7 +26,7 @@ impl Perform for HideCommunity {
 
     // Verify its a admin (only admin can hide or unhide it)
     let local_user_view = local_user_view_from_jwt(&data.auth, context).await?;
-    is_admin(&local_user_view)?;
+    has_site_permission(&local_user_view, SitePermission::HideCommunity)?;
 
     let community_form = CommunityUpdateForm::builder()
       .hidden(Some(data.hidden))

--- a/crates/api/src/community/transfer.rs
+++ b/crates/api/src/community/transfer.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use lemmy_api_common::{
   community::{GetCommunityResponse, TransferCommunity},
   context::LemmyContext,
-  utils::{is_admin, is_top_mod, local_user_view_from_jwt},
+  utils::{has_site_permission, is_top_mod, local_user_view_from_jwt},
 };
 use lemmy_db_schema::{
   source::{
@@ -12,6 +12,7 @@ use lemmy_db_schema::{
     moderator::{ModTransferCommunity, ModTransferCommunityForm},
   },
   traits::{Crud, Joinable},
+  SitePermission,
 };
 use lemmy_db_views_actor::structs::{CommunityModeratorView, CommunityView};
 use lemmy_utils::{error::LemmyError, location_info};
@@ -37,7 +38,7 @@ impl Perform for TransferCommunity {
 
     // Make sure transferrer is either the top community mod, or an admin
     if !(is_top_mod(&local_user_view, &community_mods).is_ok()
-      || is_admin(&local_user_view).is_ok())
+      || has_site_permission(&local_user_view, SitePermission::TransferCommunity).is_ok())
     {
       return Err(LemmyError::from_message("not_an_admin"));
     }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -38,6 +38,7 @@ pub(crate) fn check_report_reason(reason: &str, local_site: &LocalSite) -> Resul
 mod tests {
   use lemmy_api_common::utils::check_validator_time;
   use lemmy_db_schema::{
+    newtypes::SiteRoleId,
     source::{
       instance::Instance,
       local_user::{LocalUser, LocalUserInsertForm},
@@ -65,6 +66,7 @@ mod tests {
       .name("Gerry9812".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let inserted_person = Person::create(pool, &new_person).await.unwrap();

--- a/crates/api/src/local_user/add_admin.rs
+++ b/crates/api/src/local_user/add_admin.rs
@@ -3,14 +3,16 @@ use actix_web::web::Data;
 use lemmy_api_common::{
   context::LemmyContext,
   person::{AddAdmin, AddAdminResponse},
-  utils::{is_admin, local_user_view_from_jwt},
+  utils::{has_site_permission, local_user_view_from_jwt},
 };
 use lemmy_db_schema::{
   source::{
+    local_site::LocalSite,
     moderator::{ModAdd, ModAddForm},
     person::{Person, PersonUpdateForm},
   },
   traits::Crud,
+  SitePermission,
 };
 use lemmy_db_views_actor::structs::PersonView;
 use lemmy_utils::error::LemmyError;
@@ -24,15 +26,23 @@ impl Perform for AddAdmin {
     let data: &AddAdmin = self;
     let local_user_view = local_user_view_from_jwt(&data.auth, context).await?;
 
+    let local_site = LocalSite::read(context.pool()).await?;
+
     // Make sure user is an admin
-    is_admin(&local_user_view)?;
+    has_site_permission(&local_user_view, SitePermission::AssignUserRoles)?;
 
     let added = data.added;
     let added_person_id = data.person_id;
     let added_admin = Person::update(
       context.pool(),
       added_person_id,
-      &PersonUpdateForm::builder().admin(Some(added)).build(),
+      &PersonUpdateForm::builder()
+        .site_role_id(Some(if added {
+          local_site.top_admin_role_id
+        } else {
+          local_site.default_site_role_id
+        }))
+        .build(),
     )
     .await
     .map_err(|e| LemmyError::from_error_message(e, "couldnt_update_user"))?;

--- a/crates/api/src/local_user/ban_person.rs
+++ b/crates/api/src/local_user/ban_person.rs
@@ -3,7 +3,7 @@ use actix_web::web::Data;
 use lemmy_api_common::{
   context::LemmyContext,
   person::{BanPerson, BanPersonResponse},
-  utils::{is_admin, local_user_view_from_jwt, remove_user_data},
+  utils::{has_site_permission, local_user_view_from_jwt, remove_user_data},
 };
 use lemmy_db_schema::{
   source::{
@@ -11,6 +11,7 @@ use lemmy_db_schema::{
     person::{Person, PersonUpdateForm},
   },
   traits::Crud,
+  SitePermission,
 };
 use lemmy_db_views_actor::structs::PersonView;
 use lemmy_utils::{
@@ -28,7 +29,7 @@ impl Perform for BanPerson {
     let local_user_view = local_user_view_from_jwt(&data.auth, context).await?;
 
     // Make sure user is an admin
-    is_admin(&local_user_view)?;
+    has_site_permission(&local_user_view, SitePermission::BanPerson)?;
 
     is_valid_body_field(&data.reason)?;
 

--- a/crates/api/src/local_user/block.rs
+++ b/crates/api/src/local_user/block.rs
@@ -36,7 +36,7 @@ impl Perform for BlockPerson {
 
     let target_person_view = PersonView::read(context.pool(), target_id).await?;
 
-    if target_person_view.person.admin {
+    if target_person_view.site_role.unblockable {
       return Err(LemmyError::from_message("cant_block_admin"));
     }
 

--- a/crates/api/src/local_user/list_banned.rs
+++ b/crates/api/src/local_user/list_banned.rs
@@ -3,8 +3,9 @@ use actix_web::web::Data;
 use lemmy_api_common::{
   context::LemmyContext,
   person::{BannedPersonsResponse, GetBannedPersons},
-  utils::{is_admin, local_user_view_from_jwt},
+  utils::{has_site_permission, local_user_view_from_jwt},
 };
+use lemmy_db_schema::SitePermission;
 use lemmy_db_views_actor::structs::PersonView;
 use lemmy_utils::error::LemmyError;
 
@@ -17,7 +18,7 @@ impl Perform for GetBannedPersons {
     let local_user_view = local_user_view_from_jwt(&data.auth, context).await?;
 
     // Make sure user is an admin
-    is_admin(&local_user_view)?;
+    has_site_permission(&local_user_view, SitePermission::ViewBannedPersons)?;
 
     let banned = PersonView::banned(context.pool()).await?;
 

--- a/crates/api/src/local_user/login.rs
+++ b/crates/api/src/local_user/login.rs
@@ -42,7 +42,7 @@ impl Perform for Login {
 
     // Check if the user's email is verified if email verification is turned on
     // However, skip checking verification if the user is an admin
-    if !local_user_view.person.admin
+    if local_user_view.person.site_role_id != site_view.local_site.top_admin_role_id
       && site_view.local_site.require_email_verification
       && !local_user_view.local_user.email_verified
     {

--- a/crates/api/src/post/feature.rs
+++ b/crates/api/src/post/feature.rs
@@ -7,8 +7,8 @@ use lemmy_api_common::{
   utils::{
     check_community_ban,
     check_community_deleted_or_removed,
-    is_admin,
-    is_mod_or_admin,
+    has_site_permission,
+    is_mod_or_has_site_permission,
     local_user_view_from_jwt,
   },
 };
@@ -19,6 +19,7 @@ use lemmy_db_schema::{
   },
   traits::Crud,
   PostFeatureType,
+  SitePermission,
 };
 use lemmy_utils::error::LemmyError;
 
@@ -44,14 +45,15 @@ impl Perform for FeaturePost {
 
     if data.feature_type == PostFeatureType::Community {
       // Verify that only the mods can feature in community
-      is_mod_or_admin(
+      is_mod_or_has_site_permission(
         context.pool(),
         local_user_view.person.id,
         orig_post.community_id,
+        SitePermission::FeaturePost,
       )
       .await?;
     } else {
-      is_admin(&local_user_view)?;
+      has_site_permission(&local_user_view, SitePermission::FeaturePost)?;
     }
 
     // Update the post

--- a/crates/api/src/post/lock.rs
+++ b/crates/api/src/post/lock.rs
@@ -7,7 +7,7 @@ use lemmy_api_common::{
   utils::{
     check_community_ban,
     check_community_deleted_or_removed,
-    is_mod_or_admin,
+    is_mod_or_has_site_permission,
     local_user_view_from_jwt,
   },
 };
@@ -17,6 +17,7 @@ use lemmy_db_schema::{
     post::{Post, PostUpdateForm},
   },
   traits::Crud,
+  SitePermission,
 };
 use lemmy_utils::error::LemmyError;
 
@@ -41,10 +42,11 @@ impl Perform for LockPost {
     check_community_deleted_or_removed(orig_post.community_id, context.pool()).await?;
 
     // Verify that only the mods can lock
-    is_mod_or_admin(
+    is_mod_or_has_site_permission(
       context.pool(),
       local_user_view.person.id,
       orig_post.community_id,
+      SitePermission::LockUnlockPost,
     )
     .await?;
 

--- a/crates/api/src/post_report/list.rs
+++ b/crates/api/src/post_report/list.rs
@@ -23,7 +23,7 @@ impl Perform for ListPostReports {
     let local_user_view = local_user_view_from_jwt(&data.auth, context).await?;
 
     let person_id = local_user_view.person.id;
-    let admin = local_user_view.person.admin;
+    let can_view_post_reports = local_user_view.site_role.view_post_reports;
     let community_id = data.community_id;
     let unresolved_only = data.unresolved_only;
 
@@ -32,7 +32,7 @@ impl Perform for ListPostReports {
     let post_reports = PostReportQuery::builder()
       .pool(context.pool())
       .my_person_id(person_id)
-      .admin(admin)
+      .can_view_post_reports(can_view_post_reports)
       .community_id(community_id)
       .unresolved_only(unresolved_only)
       .page(page)

--- a/crates/api/src/private_message_report/list.rs
+++ b/crates/api/src/private_message_report/list.rs
@@ -3,8 +3,9 @@ use actix_web::web::Data;
 use lemmy_api_common::{
   context::LemmyContext,
   private_message::{ListPrivateMessageReports, ListPrivateMessageReportsResponse},
-  utils::{is_admin, local_user_view_from_jwt},
+  utils::{has_site_permission, local_user_view_from_jwt},
 };
+use lemmy_db_schema::SitePermission;
 use lemmy_db_views::private_message_report_view::PrivateMessageReportQuery;
 use lemmy_utils::error::LemmyError;
 
@@ -16,7 +17,7 @@ impl Perform for ListPrivateMessageReports {
   async fn perform(&self, context: &Data<LemmyContext>) -> Result<Self::Response, LemmyError> {
     let local_user_view = local_user_view_from_jwt(&self.auth, context).await?;
 
-    is_admin(&local_user_view)?;
+    has_site_permission(&local_user_view, SitePermission::ViewPrivateMessageReports)?;
 
     let unresolved_only = self.unresolved_only;
     let page = self.page;

--- a/crates/api/src/private_message_report/resolve.rs
+++ b/crates/api/src/private_message_report/resolve.rs
@@ -3,9 +3,13 @@ use actix_web::web::Data;
 use lemmy_api_common::{
   context::LemmyContext,
   private_message::{PrivateMessageReportResponse, ResolvePrivateMessageReport},
-  utils::{is_admin, local_user_view_from_jwt},
+  utils::{has_site_permission, local_user_view_from_jwt},
 };
-use lemmy_db_schema::{source::private_message_report::PrivateMessageReport, traits::Reportable};
+use lemmy_db_schema::{
+  source::private_message_report::PrivateMessageReport,
+  traits::Reportable,
+  SitePermission,
+};
 use lemmy_db_views::structs::PrivateMessageReportView;
 use lemmy_utils::error::LemmyError;
 
@@ -17,7 +21,10 @@ impl Perform for ResolvePrivateMessageReport {
   async fn perform(&self, context: &Data<LemmyContext>) -> Result<Self::Response, LemmyError> {
     let local_user_view = local_user_view_from_jwt(&self.auth, context).await?;
 
-    is_admin(&local_user_view)?;
+    has_site_permission(
+      &local_user_view,
+      SitePermission::ResolvePrivateMessageReports,
+    )?;
 
     let report_id = self.report_id;
     let person_id = local_user_view.person.id;

--- a/crates/api/src/site/purge/comment.rs
+++ b/crates/api/src/site/purge/comment.rs
@@ -3,7 +3,7 @@ use actix_web::web::Data;
 use lemmy_api_common::{
   context::LemmyContext,
   site::{PurgeComment, PurgeItemResponse},
-  utils::{is_top_admin, local_user_view_from_jwt},
+  utils::{has_site_permission, local_user_view_from_jwt},
 };
 use lemmy_db_schema::{
   source::{
@@ -11,6 +11,7 @@ use lemmy_db_schema::{
     moderator::{AdminPurgeComment, AdminPurgeCommentForm},
   },
   traits::Crud,
+  SitePermission,
 };
 use lemmy_utils::error::LemmyError;
 
@@ -23,8 +24,8 @@ impl Perform for PurgeComment {
     let data: &Self = self;
     let local_user_view = local_user_view_from_jwt(&data.auth, context).await?;
 
-    // Only let the top admin purge an item
-    is_top_admin(context.pool(), local_user_view.person.id).await?;
+    // check site permissions
+    has_site_permission(&local_user_view, SitePermission::PurgeComment)?;
 
     let comment_id = data.comment_id;
 

--- a/crates/api/src/site/purge/community.rs
+++ b/crates/api/src/site/purge/community.rs
@@ -4,7 +4,7 @@ use lemmy_api_common::{
   context::LemmyContext,
   request::purge_image_from_pictrs,
   site::{PurgeCommunity, PurgeItemResponse},
-  utils::{is_top_admin, local_user_view_from_jwt, purge_image_posts_for_community},
+  utils::{has_site_permission, local_user_view_from_jwt, purge_image_posts_for_community},
 };
 use lemmy_db_schema::{
   source::{
@@ -12,6 +12,7 @@ use lemmy_db_schema::{
     moderator::{AdminPurgeCommunity, AdminPurgeCommunityForm},
   },
   traits::Crud,
+  SitePermission,
 };
 use lemmy_utils::error::LemmyError;
 
@@ -24,8 +25,8 @@ impl Perform for PurgeCommunity {
     let data: &Self = self;
     let local_user_view = local_user_view_from_jwt(&data.auth, context).await?;
 
-    // Only let the top admin purge an item
-    is_top_admin(context.pool(), local_user_view.person.id).await?;
+    // check site permissions
+    has_site_permission(&local_user_view, SitePermission::PurgeCommunity)?;
 
     let community_id = data.community_id;
 

--- a/crates/api/src/site/purge/person.rs
+++ b/crates/api/src/site/purge/person.rs
@@ -4,7 +4,7 @@ use lemmy_api_common::{
   context::LemmyContext,
   request::purge_image_from_pictrs,
   site::{PurgeItemResponse, PurgePerson},
-  utils::{is_top_admin, local_user_view_from_jwt, purge_image_posts_for_person},
+  utils::{has_site_permission, local_user_view_from_jwt, purge_image_posts_for_person},
 };
 use lemmy_db_schema::{
   source::{
@@ -12,6 +12,7 @@ use lemmy_db_schema::{
     person::Person,
   },
   traits::Crud,
+  SitePermission,
 };
 use lemmy_utils::error::LemmyError;
 
@@ -24,8 +25,8 @@ impl Perform for PurgePerson {
     let data: &Self = self;
     let local_user_view = local_user_view_from_jwt(&data.auth, context).await?;
 
-    // Only let the top admin purge an item
-    is_top_admin(context.pool(), local_user_view.person.id).await?;
+    // check site permissions
+    has_site_permission(&local_user_view, SitePermission::PurgePerson)?;
 
     // Read the person to get their images
     let person_id = data.person_id;

--- a/crates/api/src/site/purge/post.rs
+++ b/crates/api/src/site/purge/post.rs
@@ -4,7 +4,7 @@ use lemmy_api_common::{
   context::LemmyContext,
   request::purge_image_from_pictrs,
   site::{PurgeItemResponse, PurgePost},
-  utils::{is_top_admin, local_user_view_from_jwt},
+  utils::{has_site_permission, local_user_view_from_jwt},
 };
 use lemmy_db_schema::{
   source::{
@@ -12,6 +12,7 @@ use lemmy_db_schema::{
     post::Post,
   },
   traits::Crud,
+  SitePermission,
 };
 use lemmy_utils::error::LemmyError;
 
@@ -24,8 +25,8 @@ impl Perform for PurgePost {
     let data: &Self = self;
     let local_user_view = local_user_view_from_jwt(&data.auth, context).await?;
 
-    // Only let the top admin purge an item
-    is_top_admin(context.pool(), local_user_view.person.id).await?;
+    // check site permissions
+    has_site_permission(&local_user_view, SitePermission::PurgePost)?;
 
     let post_id = data.post_id;
 

--- a/crates/api/src/site/registration_applications/approve.rs
+++ b/crates/api/src/site/registration_applications/approve.rs
@@ -3,7 +3,7 @@ use actix_web::web::Data;
 use lemmy_api_common::{
   context::LemmyContext,
   site::{ApproveRegistrationApplication, RegistrationApplicationResponse},
-  utils::{is_admin, local_user_view_from_jwt, send_application_approved_email},
+  utils::{has_site_permission, local_user_view_from_jwt, send_application_approved_email},
 };
 use lemmy_db_schema::{
   source::{
@@ -12,6 +12,7 @@ use lemmy_db_schema::{
   },
   traits::Crud,
   utils::diesel_option_overwrite,
+  SitePermission,
 };
 use lemmy_db_views::structs::{LocalUserView, RegistrationApplicationView};
 use lemmy_utils::error::LemmyError;
@@ -27,7 +28,7 @@ impl Perform for ApproveRegistrationApplication {
     let app_id = data.id;
 
     // Only let admins do this
-    is_admin(&local_user_view)?;
+    has_site_permission(&local_user_view, SitePermission::ApproveRegistration)?;
 
     // Update the registration with reason, admin_id
     let deny_reason = diesel_option_overwrite(&data.deny_reason);

--- a/crates/api/src/site/registration_applications/list.rs
+++ b/crates/api/src/site/registration_applications/list.rs
@@ -3,9 +3,9 @@ use actix_web::web::Data;
 use lemmy_api_common::{
   context::LemmyContext,
   site::{ListRegistrationApplications, ListRegistrationApplicationsResponse},
-  utils::{is_admin, local_user_view_from_jwt},
+  utils::{has_site_permission, local_user_view_from_jwt},
 };
-use lemmy_db_schema::source::local_site::LocalSite;
+use lemmy_db_schema::{source::local_site::LocalSite, SitePermission};
 use lemmy_db_views::registration_application_view::RegistrationApplicationQuery;
 use lemmy_utils::error::LemmyError;
 
@@ -20,7 +20,7 @@ impl Perform for ListRegistrationApplications {
     let local_site = LocalSite::read(context.pool()).await?;
 
     // Make sure user is an admin
-    is_admin(&local_user_view)?;
+    has_site_permission(&local_user_view, SitePermission::ViewRegistration)?;
 
     let unread_only = data.unread_only;
     let verified_email_only = local_site.require_email_verification;

--- a/crates/api/src/site/registration_applications/unread_count.rs
+++ b/crates/api/src/site/registration_applications/unread_count.rs
@@ -3,9 +3,9 @@ use actix_web::web::Data;
 use lemmy_api_common::{
   context::LemmyContext,
   site::{GetUnreadRegistrationApplicationCount, GetUnreadRegistrationApplicationCountResponse},
-  utils::{is_admin, local_user_view_from_jwt},
+  utils::{has_site_permission, local_user_view_from_jwt},
 };
-use lemmy_db_schema::source::local_site::LocalSite;
+use lemmy_db_schema::{source::local_site::LocalSite, SitePermission};
 use lemmy_db_views::structs::RegistrationApplicationView;
 use lemmy_utils::error::LemmyError;
 
@@ -19,7 +19,7 @@ impl Perform for GetUnreadRegistrationApplicationCount {
     let local_site = LocalSite::read(context.pool()).await?;
 
     // Only let admins do this
-    is_admin(&local_user_view)?;
+    has_site_permission(&local_user_view, SitePermission::ViewRegistration)?;
 
     let verified_email_only = local_site.require_email_verification;
 

--- a/crates/api_crud/src/comment/remove.rs
+++ b/crates/api_crud/src/comment/remove.rs
@@ -4,7 +4,7 @@ use lemmy_api_common::{
   build_response::{build_comment_response, send_local_notifs},
   comment::{CommentResponse, RemoveComment},
   context::LemmyContext,
-  utils::{check_community_ban, is_mod_or_admin, local_user_view_from_jwt},
+  utils::{check_community_ban, is_mod_or_has_site_permission, local_user_view_from_jwt},
 };
 use lemmy_db_schema::{
   source::{
@@ -13,6 +13,7 @@ use lemmy_db_schema::{
     post::Post,
   },
   traits::Crud,
+  SitePermission,
 };
 use lemmy_db_views::structs::CommentView;
 use lemmy_utils::error::LemmyError;
@@ -37,10 +38,11 @@ impl PerformCrud for RemoveComment {
     .await?;
 
     // Verify that only a mod or admin can remove
-    is_mod_or_admin(
+    is_mod_or_has_site_permission(
       context.pool(),
       local_user_view.person.id,
       orig_comment.community.id,
+      SitePermission::RemoveComment,
     )
     .await?;
 

--- a/crates/api_crud/src/community/create.rs
+++ b/crates/api_crud/src/community/create.rs
@@ -10,7 +10,7 @@ use lemmy_api_common::{
     generate_inbox_url,
     generate_local_apub_endpoint,
     generate_shared_inbox_url,
-    is_admin,
+    has_site_permission,
     local_site_to_slur_regex,
     local_user_view_from_jwt,
     EndpointType,
@@ -30,6 +30,7 @@ use lemmy_db_schema::{
   },
   traits::{ApubActor, Crud, Followable, Joinable},
   utils::diesel_option_overwrite_to_url_create,
+  SitePermission,
 };
 use lemmy_db_views::structs::SiteView;
 use lemmy_utils::{
@@ -51,7 +52,9 @@ impl PerformCrud for CreateCommunity {
     let site_view = SiteView::read_local(context.pool()).await?;
     let local_site = site_view.local_site;
 
-    if local_site.community_creation_admin_only && is_admin(&local_user_view).is_err() {
+    if local_site.community_creation_admin_only
+      && has_site_permission(&local_user_view, SitePermission::CreateCommunity).is_err()
+    {
       return Err(LemmyError::from_message(
         "only_admins_can_create_communities",
       ));

--- a/crates/api_crud/src/community/list.rs
+++ b/crates/api_crud/src/community/list.rs
@@ -3,9 +3,9 @@ use actix_web::web::Data;
 use lemmy_api_common::{
   community::{ListCommunities, ListCommunitiesResponse},
   context::LemmyContext,
-  utils::{check_private_instance, is_admin, local_user_view_from_jwt_opt},
+  utils::{check_private_instance, has_site_permission, local_user_view_from_jwt_opt},
 };
-use lemmy_db_schema::source::local_site::LocalSite;
+use lemmy_db_schema::{source::local_site::LocalSite, SitePermission};
 use lemmy_db_views_actor::community_view::CommunityQuery;
 use lemmy_utils::error::LemmyError;
 
@@ -21,7 +21,9 @@ impl PerformCrud for ListCommunities {
     let data: &ListCommunities = self;
     let local_user_view = local_user_view_from_jwt_opt(data.auth.as_ref(), context).await;
     let local_site = LocalSite::read(context.pool()).await?;
-    let is_admin = local_user_view.as_ref().map(|luv| is_admin(luv).is_ok());
+    let can_see_removed_content = local_user_view
+      .as_ref()
+      .map(|luv| has_site_permission(luv, SitePermission::ViewRemovedContent).is_ok());
 
     check_private_instance(&local_user_view, &local_site)?;
 
@@ -37,7 +39,7 @@ impl PerformCrud for ListCommunities {
       .local_user(local_user.as_ref())
       .page(page)
       .limit(limit)
-      .is_mod_or_admin(is_admin)
+      .can_see_removed_content(can_see_removed_content)
       .build()
       .list()
       .await?;

--- a/crates/api_crud/src/community/remove.rs
+++ b/crates/api_crud/src/community/remove.rs
@@ -4,7 +4,7 @@ use lemmy_api_common::{
   build_response::build_community_response,
   community::{CommunityResponse, RemoveCommunity},
   context::LemmyContext,
-  utils::{is_admin, local_user_view_from_jwt},
+  utils::{has_site_permission, local_user_view_from_jwt},
 };
 use lemmy_db_schema::{
   source::{
@@ -12,6 +12,7 @@ use lemmy_db_schema::{
     moderator::{ModRemoveCommunity, ModRemoveCommunityForm},
   },
   traits::Crud,
+  SitePermission,
 };
 use lemmy_utils::{error::LemmyError, utils::time::naive_from_unix};
 
@@ -25,7 +26,7 @@ impl PerformCrud for RemoveCommunity {
     let local_user_view = local_user_view_from_jwt(&data.auth, context).await?;
 
     // Verify its an admin (only an admin can remove a community)
-    is_admin(&local_user_view)?;
+    has_site_permission(&local_user_view, SitePermission::RemoveCommunity)?;
 
     // Do the remove
     let community_id = data.community_id;

--- a/crates/api_crud/src/custom_emoji/create.rs
+++ b/crates/api_crud/src/custom_emoji/create.rs
@@ -3,12 +3,15 @@ use actix_web::web::Data;
 use lemmy_api_common::{
   context::LemmyContext,
   custom_emoji::{CreateCustomEmoji, CustomEmojiResponse},
-  utils::{is_admin, local_user_view_from_jwt},
+  utils::{has_site_permission, local_user_view_from_jwt},
 };
-use lemmy_db_schema::source::{
-  custom_emoji::{CustomEmoji, CustomEmojiInsertForm},
-  custom_emoji_keyword::{CustomEmojiKeyword, CustomEmojiKeywordInsertForm},
-  local_site::LocalSite,
+use lemmy_db_schema::{
+  source::{
+    custom_emoji::{CustomEmoji, CustomEmojiInsertForm},
+    custom_emoji_keyword::{CustomEmojiKeyword, CustomEmojiKeywordInsertForm},
+    local_site::LocalSite,
+  },
+  SitePermission,
 };
 use lemmy_db_views::structs::CustomEmojiView;
 use lemmy_utils::error::LemmyError;
@@ -24,7 +27,7 @@ impl PerformCrud for CreateCustomEmoji {
 
     let local_site = LocalSite::read(context.pool()).await?;
     // Make sure user is an admin
-    is_admin(&local_user_view)?;
+    has_site_permission(&local_user_view, SitePermission::ModifyCustomEmoji)?;
 
     let emoji_form = CustomEmojiInsertForm::builder()
       .local_site_id(local_site.id)

--- a/crates/api_crud/src/custom_emoji/delete.rs
+++ b/crates/api_crud/src/custom_emoji/delete.rs
@@ -3,9 +3,9 @@ use actix_web::web::Data;
 use lemmy_api_common::{
   context::LemmyContext,
   custom_emoji::{DeleteCustomEmoji, DeleteCustomEmojiResponse},
-  utils::{is_admin, local_user_view_from_jwt},
+  utils::{has_site_permission, local_user_view_from_jwt},
 };
-use lemmy_db_schema::source::custom_emoji::CustomEmoji;
+use lemmy_db_schema::{source::custom_emoji::CustomEmoji, SitePermission};
 use lemmy_utils::error::LemmyError;
 
 #[async_trait::async_trait(?Send)]
@@ -21,7 +21,7 @@ impl PerformCrud for DeleteCustomEmoji {
     let local_user_view = local_user_view_from_jwt(&data.auth, context).await?;
 
     // Make sure user is an admin
-    is_admin(&local_user_view)?;
+    has_site_permission(&local_user_view, SitePermission::ModifyCustomEmoji)?;
     CustomEmoji::delete(context.pool(), data.id).await?;
     Ok(DeleteCustomEmojiResponse {
       id: data.id,

--- a/crates/api_crud/src/custom_emoji/update.rs
+++ b/crates/api_crud/src/custom_emoji/update.rs
@@ -3,12 +3,15 @@ use actix_web::web::Data;
 use lemmy_api_common::{
   context::LemmyContext,
   custom_emoji::{CustomEmojiResponse, EditCustomEmoji},
-  utils::{is_admin, local_user_view_from_jwt},
+  utils::{has_site_permission, local_user_view_from_jwt},
 };
-use lemmy_db_schema::source::{
-  custom_emoji::{CustomEmoji, CustomEmojiUpdateForm},
-  custom_emoji_keyword::{CustomEmojiKeyword, CustomEmojiKeywordInsertForm},
-  local_site::LocalSite,
+use lemmy_db_schema::{
+  source::{
+    custom_emoji::{CustomEmoji, CustomEmojiUpdateForm},
+    custom_emoji_keyword::{CustomEmojiKeyword, CustomEmojiKeywordInsertForm},
+    local_site::LocalSite,
+  },
+  SitePermission,
 };
 use lemmy_db_views::structs::CustomEmojiView;
 use lemmy_utils::error::LemmyError;
@@ -24,7 +27,7 @@ impl PerformCrud for EditCustomEmoji {
 
     let local_site = LocalSite::read(context.pool()).await?;
     // Make sure user is an admin
-    is_admin(&local_user_view)?;
+    has_site_permission(&local_user_view, SitePermission::ModifyCustomEmoji)?;
 
     let emoji_form = CustomEmojiUpdateForm::builder()
       .local_site_id(local_site.id)

--- a/crates/api_crud/src/post/remove.rs
+++ b/crates/api_crud/src/post/remove.rs
@@ -4,7 +4,7 @@ use lemmy_api_common::{
   build_response::build_post_response,
   context::LemmyContext,
   post::{PostResponse, RemovePost},
-  utils::{check_community_ban, is_mod_or_admin, local_user_view_from_jwt},
+  utils::{check_community_ban, is_mod_or_has_site_permission, local_user_view_from_jwt},
 };
 use lemmy_db_schema::{
   source::{
@@ -12,6 +12,7 @@ use lemmy_db_schema::{
     post::{Post, PostUpdateForm},
   },
   traits::Crud,
+  SitePermission,
 };
 use lemmy_utils::error::LemmyError;
 
@@ -35,10 +36,11 @@ impl PerformCrud for RemovePost {
     .await?;
 
     // Verify that only the mods can remove
-    is_mod_or_admin(
+    is_mod_or_has_site_permission(
       context.pool(),
       local_user_view.person.id,
       orig_post.community_id,
+      SitePermission::RemovePost,
     )
     .await?;
 

--- a/crates/api_crud/src/site/create.rs
+++ b/crates/api_crud/src/site/create.rs
@@ -6,7 +6,7 @@ use lemmy_api_common::{
   site::{CreateSite, SiteResponse},
   utils::{
     generate_site_inbox_url,
-    is_admin,
+    has_site_permission,
     local_site_rate_limit_to_rate_limit_config,
     local_site_to_slur_regex,
     local_user_view_from_jwt,
@@ -23,6 +23,7 @@ use lemmy_db_schema::{
   },
   traits::Crud,
   utils::{diesel_option_overwrite, diesel_option_overwrite_to_url, naive_now},
+  SitePermission,
 };
 use lemmy_db_views::structs::SiteView;
 use lemmy_utils::{
@@ -51,7 +52,7 @@ impl PerformCrud for CreateSite {
     let local_user_view = local_user_view_from_jwt(&data.auth, context).await?;
 
     // Make sure user is an admin
-    is_admin(&local_user_view)?;
+    has_site_permission(&local_user_view, SitePermission::UpdateSiteDetails)?;
 
     check_site_visibility_valid(
       local_site.private_instance,

--- a/crates/api_crud/src/site/update.rs
+++ b/crates/api_crud/src/site/update.rs
@@ -4,7 +4,7 @@ use lemmy_api_common::{
   context::LemmyContext,
   site::{EditSite, SiteResponse},
   utils::{
-    is_admin,
+    has_site_permission,
     local_site_rate_limit_to_rate_limit_config,
     local_site_to_slur_regex,
     local_user_view_from_jwt,
@@ -26,6 +26,7 @@ use lemmy_db_schema::{
   utils::{diesel_option_overwrite, diesel_option_overwrite_to_url, naive_now},
   ListingType,
   RegistrationMode,
+  SitePermission,
 };
 use lemmy_db_views::structs::SiteView;
 use lemmy_utils::{
@@ -49,7 +50,7 @@ impl PerformCrud for EditSite {
     let site = site_view.site;
 
     // Make sure user is an admin
-    is_admin(&local_user_view)?;
+    has_site_permission(&local_user_view, SitePermission::UpdateSiteDetails)?;
 
     check_site_visibility_valid(
       local_site.private_instance,

--- a/crates/apub/src/activities/community/lock_page.rs
+++ b/crates/apub/src/activities/community/lock_page.rs
@@ -31,6 +31,7 @@ use lemmy_db_schema::{
     post::{Post, PostUpdateForm},
   },
   traits::Crud,
+  SitePermission,
 };
 use lemmy_utils::error::LemmyError;
 use url::Url;
@@ -53,7 +54,14 @@ impl ActivityHandler for LockPage {
     let community = self.community(context).await?;
     verify_person_in_community(&self.actor, &community, context).await?;
     check_community_deleted_or_removed(&community)?;
-    verify_mod_action(&self.actor, self.object.inner(), community.id, context).await?;
+    verify_mod_action(
+      &self.actor,
+      self.object.inner(),
+      community.id,
+      context,
+      SitePermission::LockUnlockPost,
+    )
+    .await?;
     Ok(())
   }
 
@@ -88,6 +96,7 @@ impl ActivityHandler for UndoLockPage {
       self.object.object.inner(),
       community.id,
       context,
+      SitePermission::LockUnlockPost,
     )
     .await?;
     Ok(())

--- a/crates/apub/src/activities/community/update.rs
+++ b/crates/apub/src/activities/community/update.rs
@@ -22,7 +22,7 @@ use lemmy_api_common::{
   context::LemmyContext,
   utils::local_user_view_from_jwt,
 };
-use lemmy_db_schema::{source::community::Community, traits::Crud};
+use lemmy_db_schema::{source::community::Community, traits::Crud, SitePermission};
 use lemmy_utils::error::LemmyError;
 use url::Url;
 
@@ -85,7 +85,14 @@ impl ActivityHandler for UpdateCommunity {
     verify_is_public(&self.to, &self.cc)?;
     let community = self.community(context).await?;
     verify_person_in_community(&self.actor, &community, context).await?;
-    verify_mod_action(&self.actor, self.object.id.inner(), community.id, context).await?;
+    verify_mod_action(
+      &self.actor,
+      self.object.id.inner(),
+      community.id,
+      context,
+      SitePermission::ModifyCommunity,
+    )
+    .await?;
     ApubCommunity::verify(&self.object, &community.actor_id.clone().into(), context).await?;
     Ok(())
   }

--- a/crates/apub/src/api/read_community.rs
+++ b/crates/apub/src/api/read_community.rs
@@ -7,13 +7,20 @@ use activitypub_federation::config::Data;
 use lemmy_api_common::{
   community::{GetCommunity, GetCommunityResponse},
   context::LemmyContext,
-  utils::{check_private_instance, is_mod_or_admin_opt, local_user_view_from_jwt_opt},
+  utils::{
+    check_private_instance,
+    is_mod_or_has_site_permission_opt,
+    local_user_view_from_jwt_opt,
+  },
 };
-use lemmy_db_schema::source::{
-  actor_language::CommunityLanguage,
-  community::Community,
-  local_site::LocalSite,
-  site::Site,
+use lemmy_db_schema::{
+  source::{
+    actor_language::CommunityLanguage,
+    community::Community,
+    local_site::LocalSite,
+    site::Site,
+  },
+  SitePermission,
 };
 use lemmy_db_views_actor::structs::{CommunityModeratorView, CommunityView};
 use lemmy_utils::error::LemmyError;
@@ -50,16 +57,20 @@ impl PerformApub for GetCommunity {
       }
     };
 
-    let is_mod_or_admin =
-      is_mod_or_admin_opt(context.pool(), local_user_view.as_ref(), Some(community_id))
-        .await
-        .is_ok();
+    let can_view_removed_content = is_mod_or_has_site_permission_opt(
+      context.pool(),
+      local_user_view.as_ref(),
+      Some(community_id),
+      SitePermission::ViewRemovedContent,
+    )
+    .await
+    .is_ok();
 
     let community_view = CommunityView::read(
       context.pool(),
       community_id,
       person_id,
-      Some(is_mod_or_admin),
+      Some(can_view_removed_content),
     )
     .await
     .map_err(|e| LemmyError::from_error_message(e, "couldnt_find_community"))?;

--- a/crates/apub/src/collections/community_moderators.rs
+++ b/crates/apub/src/collections/community_moderators.rs
@@ -110,6 +110,7 @@ mod tests {
     protocol::tests::file_to_json_object,
   };
   use lemmy_db_schema::{
+    newtypes::SiteRoleId,
     source::{
       community::Community,
       instance::Instance,
@@ -136,6 +137,7 @@ mod tests {
       .name("holly".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let old_mod = Person::create(context.pool(), &old_mod).await.unwrap();

--- a/crates/db_schema/Cargo.toml
+++ b/crates/db_schema/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = { workspace = true, optional = true }
 activitypub_federation = { workspace = true, optional = true }
 lemmy_utils = { workspace = true, optional = true }
 bcrypt = { workspace = true, optional = true }
-diesel = { workspace = true, features = ["postgres","chrono", "serde_json"], optional = true }
+diesel = { workspace = true, features = ["postgres","chrono", "serde_json", "huge-tables"], optional = true }
 diesel-derive-newtype = { workspace = true, optional = true }
 diesel-derive-enum = { workspace = true, optional = true }
 diesel_migrations = { workspace = true, optional = true }

--- a/crates/db_schema/src/aggregates/comment_aggregates.rs
+++ b/crates/db_schema/src/aggregates/comment_aggregates.rs
@@ -34,6 +34,7 @@ impl CommentAggregates {
 mod tests {
   use crate::{
     aggregates::comment_aggregates::CommentAggregates,
+    newtypes::SiteRoleId,
     source::{
       comment::{Comment, CommentInsertForm, CommentLike, CommentLikeForm},
       community::{Community, CommunityInsertForm},
@@ -59,6 +60,7 @@ mod tests {
       .name("thommy_comment_agg".into())
       .public_key("pubkey".into())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let inserted_person = Person::create(pool, &new_person).await.unwrap();
@@ -67,6 +69,7 @@ mod tests {
       .name("jerry_comment_agg".into())
       .public_key("pubkey".into())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let another_inserted_person = Person::create(pool, &another_person).await.unwrap();

--- a/crates/db_schema/src/aggregates/community_aggregates.rs
+++ b/crates/db_schema/src/aggregates/community_aggregates.rs
@@ -21,6 +21,7 @@ impl CommunityAggregates {
 mod tests {
   use crate::{
     aggregates::community_aggregates::CommunityAggregates,
+    newtypes::SiteRoleId,
     source::{
       comment::{Comment, CommentInsertForm},
       community::{Community, CommunityFollower, CommunityFollowerForm, CommunityInsertForm},
@@ -46,6 +47,7 @@ mod tests {
       .name("thommy_community_agg".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let inserted_person = Person::create(pool, &new_person).await.unwrap();
@@ -54,6 +56,7 @@ mod tests {
       .name("jerry_community_agg".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let another_inserted_person = Person::create(pool, &another_person).await.unwrap();

--- a/crates/db_schema/src/aggregates/person_aggregates.rs
+++ b/crates/db_schema/src/aggregates/person_aggregates.rs
@@ -21,6 +21,7 @@ impl PersonAggregates {
 mod tests {
   use crate::{
     aggregates::person_aggregates::PersonAggregates,
+    newtypes::SiteRoleId,
     source::{
       comment::{Comment, CommentInsertForm, CommentLike, CommentLikeForm},
       community::{Community, CommunityInsertForm},
@@ -46,6 +47,7 @@ mod tests {
       .name("thommy_user_agg".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let inserted_person = Person::create(pool, &new_person).await.unwrap();
@@ -54,6 +56,7 @@ mod tests {
       .name("jerry_user_agg".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let another_inserted_person = Person::create(pool, &another_person).await.unwrap();

--- a/crates/db_schema/src/aggregates/post_aggregates.rs
+++ b/crates/db_schema/src/aggregates/post_aggregates.rs
@@ -37,6 +37,7 @@ impl PostAggregates {
 mod tests {
   use crate::{
     aggregates::post_aggregates::PostAggregates,
+    newtypes::SiteRoleId,
     source::{
       comment::{Comment, CommentInsertForm},
       community::{Community, CommunityInsertForm},
@@ -62,6 +63,7 @@ mod tests {
       .name("thommy_community_agg".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let inserted_person = Person::create(pool, &new_person).await.unwrap();
@@ -70,6 +72,7 @@ mod tests {
       .name("jerry_community_agg".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let another_inserted_person = Person::create(pool, &another_person).await.unwrap();

--- a/crates/db_schema/src/aggregates/site_aggregates.rs
+++ b/crates/db_schema/src/aggregates/site_aggregates.rs
@@ -17,6 +17,7 @@ impl SiteAggregates {
 mod tests {
   use crate::{
     aggregates::site_aggregates::SiteAggregates,
+    newtypes::SiteRoleId,
     source::{
       comment::{Comment, CommentInsertForm},
       community::{Community, CommunityInsertForm},
@@ -43,6 +44,7 @@ mod tests {
       .name("thommy_site_agg".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let inserted_person = Person::create(pool, &new_person).await.unwrap();

--- a/crates/db_schema/src/impls/activity.rs
+++ b/crates/db_schema/src/impls/activity.rs
@@ -59,7 +59,7 @@ impl Activity {
 mod tests {
   use super::*;
   use crate::{
-    newtypes::DbUrl,
+    newtypes::{DbUrl, SiteRoleId},
     source::{
       activity::{Activity, ActivityInsertForm},
       instance::Instance,
@@ -84,6 +84,7 @@ mod tests {
       .name("activity_creator_ pm".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let inserted_creator = Person::create(pool, &creator_form).await.unwrap();

--- a/crates/db_schema/src/impls/actor_language.rs
+++ b/crates/db_schema/src/impls/actor_language.rs
@@ -406,6 +406,7 @@ mod tests {
       RunQueryDsl,
       SiteLanguage,
     },
+    newtypes::SiteRoleId,
     source::{
       community::{Community, CommunityInsertForm},
       instance::Instance,
@@ -542,6 +543,7 @@ mod tests {
       .name("my test person".to_string())
       .public_key("pubkey".to_string())
       .instance_id(instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
     let person = Person::create(pool, &person_form).await.unwrap();
     let local_user_form = LocalUserInsertForm::builder()
@@ -657,6 +659,7 @@ mod tests {
       .name("my test person".to_string())
       .public_key("pubkey".to_string())
       .instance_id(instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
     let person = Person::create(pool, &person_form).await.unwrap();
     let local_user_form = LocalUserInsertForm::builder()

--- a/crates/db_schema/src/impls/comment.rs
+++ b/crates/db_schema/src/impls/comment.rs
@@ -243,7 +243,7 @@ impl Saveable for CommentSaved {
 #[cfg(test)]
 mod tests {
   use crate::{
-    newtypes::LanguageId,
+    newtypes::{LanguageId, SiteRoleId},
     source::{
       comment::{
         Comment,
@@ -278,6 +278,7 @@ mod tests {
       .name("terry".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let inserted_person = Person::create(pool, &new_person).await.unwrap();

--- a/crates/db_schema/src/impls/comment_reply.rs
+++ b/crates/db_schema/src/impls/comment_reply.rs
@@ -76,6 +76,7 @@ impl CommentReply {
 #[cfg(test)]
 mod tests {
   use crate::{
+    newtypes::SiteRoleId,
     source::{
       comment::{Comment, CommentInsertForm},
       comment_reply::{CommentReply, CommentReplyInsertForm, CommentReplyUpdateForm},
@@ -102,6 +103,7 @@ mod tests {
       .name("terrylake".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let inserted_person = Person::create(pool, &new_person).await.unwrap();
@@ -110,6 +112,7 @@ mod tests {
       .name("terrylakes recipient".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let inserted_recipient = Person::create(pool, &recipient_form).await.unwrap();

--- a/crates/db_schema/src/impls/community.rs
+++ b/crates/db_schema/src/impls/community.rs
@@ -329,6 +329,7 @@ impl ApubActor for Community {
 #[cfg(test)]
 mod tests {
   use crate::{
+    newtypes::SiteRoleId,
     source::{
       community::{
         Community,
@@ -362,6 +363,7 @@ mod tests {
       .name("bobbee".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let inserted_person = Person::create(pool, &new_person).await.unwrap();

--- a/crates/db_schema/src/impls/mod.rs
+++ b/crates/db_schema/src/impls/mod.rs
@@ -26,4 +26,5 @@ pub mod private_message_report;
 pub mod registration_application;
 pub mod secret;
 pub mod site;
+pub mod site_role;
 pub mod tagline;

--- a/crates/db_schema/src/impls/moderator.rs
+++ b/crates/db_schema/src/impls/moderator.rs
@@ -512,6 +512,7 @@ impl Crud for AdminPurgeComment {
 #[cfg(test)]
 mod tests {
   use crate::{
+    newtypes::SiteRoleId,
     source::{
       comment::{Comment, CommentInsertForm},
       community::{Community, CommunityInsertForm},
@@ -557,6 +558,7 @@ mod tests {
       .name("the mod".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let inserted_mod = Person::create(pool, &new_mod).await.unwrap();
@@ -565,6 +567,7 @@ mod tests {
       .name("jim2".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let inserted_person = Person::create(pool, &new_person).await.unwrap();

--- a/crates/db_schema/src/impls/password_reset_request.rs
+++ b/crates/db_schema/src/impls/password_reset_request.rs
@@ -87,6 +87,7 @@ fn bytes_to_hex(bytes: Vec<u8>) -> String {
 #[cfg(test)]
 mod tests {
   use crate::{
+    newtypes::SiteRoleId,
     source::{
       instance::Instance,
       local_user::{LocalUser, LocalUserInsertForm},
@@ -111,6 +112,7 @@ mod tests {
       .name("thommy prw".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let inserted_person = Person::create(pool, &new_person).await.unwrap();

--- a/crates/db_schema/src/impls/person.rs
+++ b/crates/db_schema/src/impls/person.rs
@@ -198,6 +198,7 @@ impl PersonFollower {
 #[cfg(test)]
 mod tests {
   use crate::{
+    newtypes::SiteRoleId,
     source::{
       instance::Instance,
       person::{Person, PersonFollower, PersonFollowerForm, PersonInsertForm, PersonUpdateForm},
@@ -220,6 +221,7 @@ mod tests {
       .name("holly".into())
       .public_key("nada".to_owned())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let inserted_person = Person::create(pool, &new_person).await.unwrap();
@@ -238,7 +240,7 @@ mod tests {
       bio: None,
       local: true,
       bot_account: false,
-      admin: false,
+      site_role_id: SiteRoleId(2),
       private_key: None,
       public_key: "nada".to_owned(),
       last_refreshed_at: inserted_person.published,
@@ -279,12 +281,14 @@ mod tests {
       .name("erich".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
     let person_1 = Person::create(pool, &person_form_1).await.unwrap();
     let person_form_2 = PersonInsertForm::builder()
       .name("michele".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
     let person_2 = Person::create(pool, &person_form_2).await.unwrap();
 

--- a/crates/db_schema/src/impls/person_mention.rs
+++ b/crates/db_schema/src/impls/person_mention.rs
@@ -80,6 +80,7 @@ impl PersonMention {
 #[cfg(test)]
 mod tests {
   use crate::{
+    newtypes::SiteRoleId,
     source::{
       comment::{Comment, CommentInsertForm},
       community::{Community, CommunityInsertForm},
@@ -106,6 +107,7 @@ mod tests {
       .name("terrylake".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let inserted_person = Person::create(pool, &new_person).await.unwrap();
@@ -114,6 +116,7 @@ mod tests {
       .name("terrylakes recipient".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let inserted_recipient = Person::create(pool, &recipient_form).await.unwrap();

--- a/crates/db_schema/src/impls/post.rs
+++ b/crates/db_schema/src/impls/post.rs
@@ -320,6 +320,7 @@ impl Readable for PostRead {
 #[cfg(test)]
 mod tests {
   use crate::{
+    newtypes::SiteRoleId,
     source::{
       community::{Community, CommunityInsertForm},
       instance::Instance,
@@ -354,6 +355,7 @@ mod tests {
       .name("jim".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let inserted_person = Person::create(pool, &new_person).await.unwrap();

--- a/crates/db_schema/src/impls/private_message.rs
+++ b/crates/db_schema/src/impls/private_message.rs
@@ -89,6 +89,7 @@ impl PrivateMessage {
 #[cfg(test)]
 mod tests {
   use crate::{
+    newtypes::SiteRoleId,
     source::{
       instance::Instance,
       person::{Person, PersonInsertForm},
@@ -112,6 +113,7 @@ mod tests {
       .name("creator_pm".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let inserted_creator = Person::create(pool, &creator_form).await.unwrap();
@@ -120,6 +122,7 @@ mod tests {
       .name("recipient_pm".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let inserted_recipient = Person::create(pool, &recipient_form).await.unwrap();

--- a/crates/db_schema/src/impls/site_role.rs
+++ b/crates/db_schema/src/impls/site_role.rs
@@ -1,0 +1,60 @@
+use crate::{
+  newtypes::SiteRoleId,
+  schema::site_role::dsl::site_role,
+  source::site_role::SiteRole,
+  traits::Crud,
+  utils::{get_conn, DbPool},
+};
+use diesel::{result::Error, QueryDsl};
+use diesel_async::RunQueryDsl;
+
+#[async_trait]
+impl Crud for SiteRole {
+  type InsertForm = SiteRole;
+  type UpdateForm = SiteRole;
+  type IdType = SiteRoleId;
+
+  async fn read(pool: &DbPool, site_role_id: SiteRoleId) -> Result<Self, Error> {
+    let conn = &mut get_conn(pool).await?;
+    site_role.find(site_role_id).first::<Self>(conn).await
+  }
+
+  async fn delete(pool: &DbPool, site_role_id: SiteRoleId) -> Result<usize, Error> {
+    let conn = &mut get_conn(pool).await?;
+    diesel::delete(site_role.find(site_role_id))
+      .execute(conn)
+      .await
+  }
+
+  async fn create(pool: &DbPool, form: &Self::InsertForm) -> Result<Self, Error> {
+    let conn = &mut get_conn(pool).await?;
+
+    diesel::insert_into(site_role)
+      .values(form)
+      .get_result::<Self>(conn)
+      .await
+  }
+
+  async fn update(
+    pool: &DbPool,
+    site_role_id: SiteRoleId,
+    form: &Self::UpdateForm,
+  ) -> Result<Self, Error> {
+    let conn = &mut get_conn(pool).await?;
+
+    diesel::update(site_role.find(site_role_id))
+      .set(form)
+      .get_result::<Self>(conn)
+      .await
+  }
+}
+
+impl SiteRole {
+  pub async fn read_all(pool: &DbPool) -> Result<Vec<Self>, Error> {
+    let conn = &mut get_conn(pool).await?;
+    site_role
+      .get_results::<Self>(conn)
+      .await
+      .map(|results| results.into_iter().collect::<Vec<Self>>())
+  }
+}

--- a/crates/db_schema/src/lib.rs
+++ b/crates/db_schema/src/lib.rs
@@ -170,3 +170,42 @@ pub enum PostFeatureType {
   /// Features to the top of the community.
   Community,
 }
+
+#[derive(EnumString, Display, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "full", derive(TS))]
+#[cfg_attr(feature = "full", ts(export))]
+// Individual site permissions
+pub enum SitePermission {
+  ConfigureSiteRoles,
+  AssignUserRoles,
+  UpdateSiteDetails,
+  HideCommunity,
+  TransferCommunity,
+  FeaturePost,
+  CreateCommunity,
+  RemoveCommunity,
+  ModifyCommunity,
+  ViewRemovedContent,
+  DistinguishComment,
+  LockUnlockPost,
+  ManageCommunityMods,
+  RemoveComment,
+  RemovePost,
+  BanPerson,
+  ViewBannedPersons,
+  ViewPrivateMessageReports,
+  ResolvePrivateMessageReports,
+  ViewPostReports,
+  ResolvePostReports,
+  ViewCommentReports,
+  ResolveCommentReports,
+  ApproveRegistration,
+  ViewRegistration,
+  PurgeComment,
+  PurgeCommunity,
+  PurgePerson,
+  PurgePost,
+  ViewModlogNames,
+  ModifyCustomEmoji,
+  Unblockable,
+}

--- a/crates/db_schema/src/newtypes.rs
+++ b/crates/db_schema/src/newtypes.rs
@@ -155,6 +155,12 @@ pub struct LocalSiteId(i32);
 /// The custom emoji id.
 pub struct CustomEmojiId(i32);
 
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize, Default)]
+#[cfg_attr(feature = "full", derive(DieselNewType, TS))]
+#[cfg_attr(feature = "full", ts(export))]
+// Site role id.
+pub struct SiteRoleId(pub i32);
+
 #[cfg(feature = "full")]
 #[derive(Serialize, Deserialize)]
 #[serde(remote = "Ltree")]

--- a/crates/db_schema/src/schema.rs
+++ b/crates/db_schema/src/schema.rs
@@ -347,6 +347,8 @@ diesel::table! {
         updated -> Nullable<Timestamp>,
         registration_mode -> RegistrationModeEnum,
         reports_email_admins -> Bool,
+        top_admin_role_id -> Int4,
+        default_site_role_id -> Int4,
     }
 }
 
@@ -566,10 +568,10 @@ diesel::table! {
         #[max_length = 255]
         shared_inbox_url -> Nullable<Varchar>,
         matrix_user_id -> Nullable<Text>,
-        admin -> Bool,
         bot_account -> Bool,
         ban_expires -> Nullable<Timestamp>,
         instance_id -> Int4,
+        site_role_id -> Int4,
     }
 }
 
@@ -818,6 +820,45 @@ diesel::table! {
 }
 
 diesel::table! {
+    site_role (id) {
+        id -> Int4,
+        name -> Text,
+        configure_site_roles -> Bool,
+        assign_user_roles -> Bool,
+        update_site_details -> Bool,
+        hide_community -> Bool,
+        transfer_community -> Bool,
+        feature_post -> Bool,
+        create_community -> Bool,
+        remove_community -> Bool,
+        modify_community -> Bool,
+        view_removed_content -> Bool,
+        distinguish_comment -> Bool,
+        remove_comment -> Bool,
+        remove_post -> Bool,
+        lock_unlock_post -> Bool,
+        manage_community_mods -> Bool,
+        ban_person -> Bool,
+        view_banned_persons -> Bool,
+        view_private_message_reports -> Bool,
+        resolve_private_message_reports -> Bool,
+        view_post_reports -> Bool,
+        resolve_post_reports -> Bool,
+        view_comment_reports -> Bool,
+        resolve_comment_reports -> Bool,
+        approve_registration -> Bool,
+        view_registration -> Bool,
+        purge_comment -> Bool,
+        purge_community -> Bool,
+        purge_person -> Bool,
+        purge_post -> Bool,
+        view_modlog_names -> Bool,
+        modify_custom_emoji -> Bool,
+        unblockable -> Bool,
+    }
+}
+
+diesel::table! {
     tagline (id) {
         id -> Int4,
         local_site_id -> Int4,
@@ -884,6 +925,7 @@ diesel::joinable!(mod_remove_post -> post (post_id));
 diesel::joinable!(mod_transfer_community -> community (community_id));
 diesel::joinable!(password_reset_request -> local_user (local_user_id));
 diesel::joinable!(person -> instance (instance_id));
+diesel::joinable!(person -> site_role (site_role_id));
 diesel::joinable!(person_aggregates -> person (person_id));
 diesel::joinable!(person_ban -> person (person_id));
 diesel::joinable!(person_mention -> comment (comment_id));
@@ -972,5 +1014,6 @@ diesel::allow_tables_to_appear_in_same_query!(
     site,
     site_aggregates,
     site_language,
+    site_role,
     tagline,
 );

--- a/crates/db_schema/src/source/local_site.rs
+++ b/crates/db_schema/src/source/local_site.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "full")]
 use crate::schema::local_site;
 use crate::{
-  newtypes::{LocalSiteId, SiteId},
+  newtypes::{LocalSiteId, SiteId, SiteRoleId},
   ListingType,
   RegistrationMode,
 };
@@ -61,6 +61,8 @@ pub struct LocalSite {
   pub registration_mode: RegistrationMode,
   /// Whether to email admins on new reports.
   pub reports_email_admins: bool,
+  pub top_admin_role_id: SiteRoleId,
+  pub default_site_role_id: SiteRoleId,
 }
 
 #[derive(Clone, TypedBuilder)]

--- a/crates/db_schema/src/source/mod.rs
+++ b/crates/db_schema/src/source/mod.rs
@@ -28,4 +28,5 @@ pub mod private_message_report;
 pub mod registration_application;
 pub mod secret;
 pub mod site;
+pub mod site_role;
 pub mod tagline;

--- a/crates/db_schema/src/source/person.rs
+++ b/crates/db_schema/src/source/person.rs
@@ -1,4 +1,4 @@
-use crate::newtypes::{DbUrl, InstanceId, PersonId};
+use crate::newtypes::{DbUrl, InstanceId, PersonId, SiteRoleId};
 #[cfg(feature = "full")]
 use crate::schema::{person, person_follower};
 use serde::{Deserialize, Serialize};
@@ -46,13 +46,13 @@ pub struct Person {
   pub shared_inbox_url: Option<DbUrl>,
   /// A matrix id, usually given an @person:matrix.org
   pub matrix_user_id: Option<String>,
-  /// Whether the person is an admin.
-  pub admin: bool,
   /// Whether the person is a bot account.
   pub bot_account: bool,
   /// When their ban, if it exists, expires, if at all.
   pub ban_expires: Option<chrono::NaiveDateTime>,
   pub instance_id: InstanceId,
+  // user's site role
+  pub site_role_id: SiteRoleId,
 }
 
 #[derive(Clone, TypedBuilder)]
@@ -66,6 +66,8 @@ pub struct PersonInsertForm {
   pub public_key: String,
   #[builder(!default)]
   pub instance_id: InstanceId,
+  #[builder(!default)]
+  pub site_role_id: SiteRoleId,
   pub display_name: Option<String>,
   pub avatar: Option<DbUrl>,
   pub banned: Option<bool>,
@@ -81,7 +83,6 @@ pub struct PersonInsertForm {
   pub inbox_url: Option<DbUrl>,
   pub shared_inbox_url: Option<DbUrl>,
   pub matrix_user_id: Option<String>,
-  pub admin: Option<bool>,
   pub bot_account: Option<bool>,
   pub ban_expires: Option<chrono::NaiveDateTime>,
 }
@@ -106,9 +107,9 @@ pub struct PersonUpdateForm {
   pub inbox_url: Option<DbUrl>,
   pub shared_inbox_url: Option<Option<DbUrl>>,
   pub matrix_user_id: Option<Option<String>>,
-  pub admin: Option<bool>,
   pub bot_account: Option<bool>,
   pub ban_expires: Option<Option<chrono::NaiveDateTime>>,
+  pub site_role_id: Option<SiteRoleId>,
 }
 
 #[derive(PartialEq, Eq, Debug)]

--- a/crates/db_schema/src/source/site_role.rs
+++ b/crates/db_schema/src/source/site_role.rs
@@ -1,0 +1,53 @@
+use crate::newtypes::SiteRoleId;
+#[cfg(feature = "full")]
+use crate::schema::site_role;
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+#[cfg(feature = "full")]
+use ts_rs::TS;
+
+#[skip_serializing_none]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(
+  feature = "full",
+  derive(Queryable, Identifiable, Insertable, AsChangeset, TS)
+)]
+#[cfg_attr(feature = "full", diesel(table_name = site_role))]
+#[cfg_attr(feature = "full", ts(export))]
+/// A site role
+pub struct SiteRole {
+  pub id: SiteRoleId,
+  pub name: String,
+  pub configure_site_roles: bool,
+  pub assign_user_roles: bool,
+  pub update_site_details: bool,
+  pub hide_community: bool,
+  pub transfer_community: bool,
+  pub feature_post: bool,
+  pub create_community: bool,
+  pub remove_community: bool,
+  pub modify_community: bool,
+  pub view_removed_content: bool,
+  pub distinguish_comment: bool,
+  pub remove_comment: bool,
+  pub remove_post: bool,
+  pub lock_unlock_post: bool,
+  pub manage_community_mods: bool,
+  pub ban_person: bool,
+  pub view_banned_persons: bool,
+  pub view_private_message_reports: bool,
+  pub resolve_private_message_reports: bool,
+  pub view_post_reports: bool,
+  pub resolve_post_reports: bool,
+  pub view_comment_reports: bool,
+  pub resolve_comment_reports: bool,
+  pub approve_registration: bool,
+  pub view_registration: bool,
+  pub purge_comment: bool,
+  pub purge_community: bool,
+  pub purge_person: bool,
+  pub purge_post: bool,
+  pub view_modlog_names: bool,
+  pub modify_custom_emoji: bool,
+  pub unblockable: bool,
+}

--- a/crates/db_views/src/comment_report_view.rs
+++ b/crates/db_views/src/comment_report_view.rs
@@ -145,7 +145,7 @@ pub struct CommentReportQuery<'a> {
   #[builder(!default)]
   my_person_id: PersonId,
   #[builder(!default)]
-  admin: bool,
+  can_see_comment_reports: bool,
   community_id: Option<CommunityId>,
   page: Option<i64>,
   limit: Option<i64>,
@@ -220,7 +220,7 @@ impl<'a> CommentReportQuery<'a> {
       .offset(offset);
 
     // If its not an admin, get only the ones you mod
-    let res = if !self.admin {
+    let res = if !self.can_see_comment_reports {
       query
         .inner_join(
           community_moderator::table.on(
@@ -276,6 +276,7 @@ mod tests {
   use crate::comment_report_view::{CommentReportQuery, CommentReportView};
   use lemmy_db_schema::{
     aggregates::structs::CommentAggregates,
+    newtypes::SiteRoleId,
     source::{
       comment::{Comment, CommentInsertForm},
       comment_report::{CommentReport, CommentReportForm},
@@ -302,6 +303,7 @@ mod tests {
       .name("timmy_crv".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let inserted_timmy = Person::create(pool, &new_person).await.unwrap();
@@ -310,6 +312,7 @@ mod tests {
       .name("sara_crv".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let inserted_sara = Person::create(pool, &new_person_2).await.unwrap();
@@ -319,6 +322,7 @@ mod tests {
       .name("jessica_crv".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let inserted_jessica = Person::create(pool, &new_person_3).await.unwrap();
@@ -430,7 +434,7 @@ mod tests {
         local: true,
         banned: false,
         deleted: false,
-        admin: false,
+        site_role_id: SiteRoleId(2),
         bot_account: false,
         bio: None,
         banner: None,
@@ -454,7 +458,7 @@ mod tests {
         local: true,
         banned: false,
         deleted: false,
-        admin: false,
+        site_role_id: SiteRoleId(2),
         bot_account: false,
         bio: None,
         banner: None,
@@ -497,7 +501,7 @@ mod tests {
       local: true,
       banned: false,
       deleted: false,
-      admin: false,
+      site_role_id: SiteRoleId(2),
       bot_account: false,
       bio: None,
       banner: None,
@@ -516,7 +520,7 @@ mod tests {
     let reports = CommentReportQuery::builder()
       .pool(pool)
       .my_person_id(inserted_timmy.id)
-      .admin(false)
+      .can_see_comment_reports(false)
       .build()
       .list()
       .await
@@ -567,7 +571,7 @@ mod tests {
       local: true,
       banned: false,
       deleted: false,
-      admin: false,
+      site_role_id: SiteRoleId(2),
       bot_account: false,
       bio: None,
       banner: None,
@@ -592,7 +596,7 @@ mod tests {
     let reports_after_resolve = CommentReportQuery::builder()
       .pool(pool)
       .my_person_id(inserted_timmy.id)
-      .admin(false)
+      .can_see_comment_reports(false)
       .unresolved_only(Some(true))
       .build()
       .list()

--- a/crates/db_views/src/local_user_view.rs
+++ b/crates/db_views/src/local_user_view.rs
@@ -4,26 +4,28 @@ use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
   aggregates::structs::PersonAggregates,
   newtypes::{LocalUserId, PersonId},
-  schema::{local_user, person, person_aggregates},
-  source::{local_user::LocalUser, person::Person},
+  schema::{local_site, local_user, person, person_aggregates, site_role},
+  source::{local_user::LocalUser, person::Person, site_role::SiteRole},
   traits::JoinView,
   utils::{functions::lower, get_conn, DbPool},
 };
 
-type LocalUserViewTuple = (LocalUser, Person, PersonAggregates);
+type LocalUserViewTuple = (LocalUser, Person, PersonAggregates, SiteRole);
 
 impl LocalUserView {
   pub async fn read(pool: &DbPool, local_user_id: LocalUserId) -> Result<Self, Error> {
     let conn = &mut get_conn(pool).await?;
 
-    let (local_user, person, counts) = local_user::table
+    let (local_user, person, counts, site_role) = local_user::table
       .find(local_user_id)
       .inner_join(person::table)
       .inner_join(person_aggregates::table.on(person::id.eq(person_aggregates::person_id)))
+      .inner_join(site_role::table.on(site_role::id.eq(person::site_role_id)))
       .select((
         local_user::all_columns,
         person::all_columns,
         person_aggregates::all_columns,
+        site_role::all_columns,
       ))
       .first::<LocalUserViewTuple>(conn)
       .await?;
@@ -31,19 +33,22 @@ impl LocalUserView {
       local_user,
       person,
       counts,
+      site_role,
     })
   }
 
   pub async fn read_person(pool: &DbPool, person_id: PersonId) -> Result<Self, Error> {
     let conn = &mut get_conn(pool).await?;
-    let (local_user, person, counts) = local_user::table
+    let (local_user, person, counts, site_role) = local_user::table
       .filter(person::id.eq(person_id))
       .inner_join(person::table)
       .inner_join(person_aggregates::table.on(person::id.eq(person_aggregates::person_id)))
+      .inner_join(site_role::table.on(site_role::id.eq(person::site_role_id)))
       .select((
         local_user::all_columns,
         person::all_columns,
         person_aggregates::all_columns,
+        site_role::all_columns,
       ))
       .first::<LocalUserViewTuple>(conn)
       .await?;
@@ -51,19 +56,22 @@ impl LocalUserView {
       local_user,
       person,
       counts,
+      site_role,
     })
   }
 
   pub async fn read_from_name(pool: &DbPool, name: &str) -> Result<Self, Error> {
     let conn = &mut get_conn(pool).await?;
-    let (local_user, person, counts) = local_user::table
+    let (local_user, person, counts, site_role) = local_user::table
       .filter(lower(person::name).eq(name.to_lowercase()))
       .inner_join(person::table)
       .inner_join(person_aggregates::table.on(person::id.eq(person_aggregates::person_id)))
+      .inner_join(site_role::table.on(site_role::id.eq(person::site_role_id)))
       .select((
         local_user::all_columns,
         person::all_columns,
         person_aggregates::all_columns,
+        site_role::all_columns,
       ))
       .first::<LocalUserViewTuple>(conn)
       .await?;
@@ -71,14 +79,16 @@ impl LocalUserView {
       local_user,
       person,
       counts,
+      site_role,
     })
   }
 
   pub async fn find_by_email_or_name(pool: &DbPool, name_or_email: &str) -> Result<Self, Error> {
     let conn = &mut get_conn(pool).await?;
-    let (local_user, person, counts) = local_user::table
+    let (local_user, person, counts, site_role) = local_user::table
       .inner_join(person::table)
       .inner_join(person_aggregates::table.on(person::id.eq(person_aggregates::person_id)))
+      .inner_join(site_role::table.on(site_role::id.eq(person::site_role_id)))
       .filter(
         lower(person::name)
           .eq(lower(name_or_email))
@@ -88,6 +98,7 @@ impl LocalUserView {
         local_user::all_columns,
         person::all_columns,
         person_aggregates::all_columns,
+        site_role::all_columns,
       ))
       .first::<LocalUserViewTuple>(conn)
       .await?;
@@ -95,19 +106,22 @@ impl LocalUserView {
       local_user,
       person,
       counts,
+      site_role,
     })
   }
 
   pub async fn find_by_email(pool: &DbPool, from_email: &str) -> Result<Self, Error> {
     let conn = &mut get_conn(pool).await?;
-    let (local_user, person, counts) = local_user::table
+    let (local_user, person, counts, site_role) = local_user::table
       .inner_join(person::table)
       .inner_join(person_aggregates::table.on(person::id.eq(person_aggregates::person_id)))
+      .inner_join(site_role::table.on(site_role::id.eq(person::site_role_id)))
       .filter(local_user::email.eq(from_email))
       .select((
         local_user::all_columns,
         person::all_columns,
         person_aggregates::all_columns,
+        site_role::all_columns,
       ))
       .first::<LocalUserViewTuple>(conn)
       .await?;
@@ -115,20 +129,23 @@ impl LocalUserView {
       local_user,
       person,
       counts,
+      site_role,
     })
   }
 
   pub async fn list_admins_with_emails(pool: &DbPool) -> Result<Vec<Self>, Error> {
     let conn = &mut get_conn(pool).await?;
     let res = local_user::table
-      .filter(person::admin.eq(true))
-      .filter(local_user::email.is_not_null())
       .inner_join(person::table)
+      .inner_join(site_role::table.on(site_role::id.eq(person::site_role_id)))
+      .inner_join(local_site::table.on(local_site::top_admin_role_id.eq(site_role::id)))
+      .filter(local_user::email.is_not_null())
       .inner_join(person_aggregates::table.on(person::id.eq(person_aggregates::person_id)))
       .select((
         local_user::all_columns,
         person::all_columns,
         person_aggregates::all_columns,
+        site_role::all_columns,
       ))
       .load::<LocalUserViewTuple>(conn)
       .await?;
@@ -144,6 +161,7 @@ impl JoinView for LocalUserView {
       local_user: a.0,
       person: a.1,
       counts: a.2,
+      site_role: a.3,
     }
   }
 }

--- a/crates/db_views/src/post_report_view.rs
+++ b/crates/db_views/src/post_report_view.rs
@@ -167,7 +167,7 @@ pub struct PostReportQuery<'a> {
   #[builder(!default)]
   my_person_id: PersonId,
   #[builder(!default)]
-  admin: bool,
+  can_view_post_reports: bool,
   community_id: Option<CommunityId>,
   page: Option<i64>,
   limit: Option<i64>,
@@ -231,7 +231,7 @@ impl<'a> PostReportQuery<'a> {
       .offset(offset);
 
     // If its not an admin, get only the ones you mod
-    let res = if !self.admin {
+    let res = if !self.can_view_post_reports {
       query
         .inner_join(
           community_moderator::table.on(
@@ -272,6 +272,7 @@ mod tests {
   use crate::post_report_view::{PostReportQuery, PostReportView};
   use lemmy_db_schema::{
     aggregates::structs::PostAggregates,
+    newtypes::SiteRoleId,
     source::{
       community::{Community, CommunityInsertForm, CommunityModerator, CommunityModeratorForm},
       instance::Instance,
@@ -297,6 +298,7 @@ mod tests {
       .name("timmy_prv".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let inserted_timmy = Person::create(pool, &new_person).await.unwrap();
@@ -305,6 +307,7 @@ mod tests {
       .name("sara_prv".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let inserted_sara = Person::create(pool, &new_person_2).await.unwrap();
@@ -314,6 +317,7 @@ mod tests {
       .name("jessica_prv".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let inserted_jessica = Person::create(pool, &new_person_3).await.unwrap();
@@ -416,7 +420,7 @@ mod tests {
         local: true,
         banned: false,
         deleted: false,
-        admin: false,
+        site_role_id: SiteRoleId(2),
         bot_account: false,
         bio: None,
         banner: None,
@@ -440,7 +444,7 @@ mod tests {
         local: true,
         banned: false,
         deleted: false,
-        admin: false,
+        site_role_id: SiteRoleId(2),
         bot_account: false,
         bio: None,
         banner: None,
@@ -489,7 +493,7 @@ mod tests {
       local: true,
       banned: false,
       deleted: false,
-      admin: false,
+      site_role_id: SiteRoleId(2),
       bot_account: false,
       bio: None,
       banner: None,
@@ -508,7 +512,7 @@ mod tests {
     let reports = PostReportQuery::builder()
       .pool(pool)
       .my_person_id(inserted_timmy.id)
-      .admin(false)
+      .can_view_post_reports(false)
       .build()
       .list()
       .await
@@ -557,7 +561,7 @@ mod tests {
       local: true,
       banned: false,
       deleted: false,
-      admin: false,
+      site_role_id: SiteRoleId(2),
       bot_account: false,
       bio: None,
       banner: None,
@@ -582,7 +586,7 @@ mod tests {
     let reports_after_resolve = PostReportQuery::builder()
       .pool(pool)
       .my_person_id(inserted_timmy.id)
-      .admin(false)
+      .can_view_post_reports(false)
       .unresolved_only(Some(true))
       .build()
       .list()

--- a/crates/db_views/src/private_message_report_view.rs
+++ b/crates/db_views/src/private_message_report_view.rs
@@ -151,6 +151,7 @@ impl JoinView for PrivateMessageReportView {
 mod tests {
   use crate::private_message_report_view::PrivateMessageReportQuery;
   use lemmy_db_schema::{
+    newtypes::SiteRoleId,
     source::{
       instance::Instance,
       person::{Person, PersonInsertForm},
@@ -175,6 +176,7 @@ mod tests {
       .name("timmy_mrv".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
     let inserted_timmy = Person::create(pool, &new_person_1).await.unwrap();
 
@@ -182,6 +184,7 @@ mod tests {
       .name("jessica_mrv".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
     let inserted_jessica = Person::create(pool, &new_person_2).await.unwrap();
 
@@ -221,6 +224,7 @@ mod tests {
       .name("admin_mrv".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(1)) // site_role_id 1 is the default admin user
       .build();
     let inserted_admin = Person::create(pool, &new_person_3).await.unwrap();
 

--- a/crates/db_views/src/registration_application_view.rs
+++ b/crates/db_views/src/registration_application_view.rs
@@ -160,6 +160,7 @@ mod tests {
     RegistrationApplicationView,
   };
   use lemmy_db_schema::{
+    newtypes::SiteRoleId,
     source::{
       instance::Instance,
       local_user::{LocalUser, LocalUserInsertForm, LocalUserUpdateForm},
@@ -186,7 +187,7 @@ mod tests {
 
     let timmy_person_form = PersonInsertForm::builder()
       .name("timmy_rav".into())
-      .admin(Some(true))
+      .site_role_id(SiteRoleId(1)) // site_role_id 1 is the default admin user
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
       .build();
@@ -206,6 +207,7 @@ mod tests {
       .name("sara_rav".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let inserted_sara_person = Person::create(pool, &sara_person_form).await.unwrap();
@@ -237,6 +239,7 @@ mod tests {
       .name("jess_rav".into())
       .public_key("pubkey".to_string())
       .instance_id(inserted_instance.id)
+      .site_role_id(SiteRoleId(2)) // site_role_id 2 is the default non-admin user
       .build();
 
     let inserted_jess_person = Person::create(pool, &jess_person_form).await.unwrap();
@@ -299,7 +302,7 @@ mod tests {
         banned: false,
         ban_expires: None,
         deleted: false,
-        admin: false,
+        site_role_id: SiteRoleId(2), // site_role_id 2 is the default non-admin user
         bot_account: false,
         bio: None,
         banner: None,
@@ -377,7 +380,7 @@ mod tests {
       banned: false,
       ban_expires: None,
       deleted: false,
-      admin: true,
+      site_role_id: SiteRoleId(1),
       bot_account: false,
       bio: None,
       banner: None,

--- a/crates/db_views/src/structs.rs
+++ b/crates/db_views/src/structs.rs
@@ -16,6 +16,7 @@ use lemmy_db_schema::{
     private_message_report::PrivateMessageReport,
     registration_application::RegistrationApplication,
     site::Site,
+    site_role::SiteRole,
   },
   SubscribedType,
 };
@@ -68,6 +69,7 @@ pub struct LocalUserView {
   pub local_user: LocalUser,
   pub person: Person,
   pub counts: PersonAggregates,
+  pub site_role: SiteRole,
 }
 
 #[skip_serializing_none]

--- a/crates/db_views_actor/src/structs.rs
+++ b/crates/db_views_actor/src/structs.rs
@@ -7,6 +7,7 @@ use lemmy_db_schema::{
     person::Person,
     person_mention::PersonMention,
     post::Post,
+    site_role::SiteRole,
   },
   SubscribedType,
 };
@@ -116,4 +117,5 @@ pub struct CommentReplyView {
 pub struct PersonView {
   pub person: Person,
   pub counts: PersonAggregates,
+  pub site_role: SiteRole,
 }

--- a/migrations/2023-06-22-163346_add_site_permissions_and_roles/down.sql
+++ b/migrations/2023-06-22-163346_add_site_permissions_and_roles/down.sql
@@ -1,0 +1,12 @@
+-- re-add admin column
+alter table person add column admin boolean default false not null,
+    drop column site_role_id;
+
+-- we can't assume roles haven't changed, so if we downgrade the database we'll just restore the first user as admin
+-- todo: this seems dodgy
+update person 
+    set admin = true
+    where id = 1;
+alter table local_site drop column default_site_role_id, drop column top_admin_role_id;
+
+drop table site_role;

--- a/migrations/2023-06-22-163346_add_site_permissions_and_roles/up.sql
+++ b/migrations/2023-06-22-163346_add_site_permissions_and_roles/up.sql
@@ -1,0 +1,70 @@
+-- create site_role table listing all permissions
+create table site_role (
+    id serial primary key not null,
+    name text not null,
+    -- roles management
+    configure_site_roles boolean not null,
+    assign_user_roles boolean not null,
+    -- site management
+    update_site_details boolean not null,
+    -- community management
+    hide_community boolean not null,
+    transfer_community boolean not null,
+    feature_post boolean not null,
+    create_community boolean not null,
+    remove_community boolean not null,
+    modify_community boolean not null,
+    view_removed_content boolean not null,
+    distinguish_comment boolean not null,
+    remove_comment boolean not null,
+    remove_post boolean not null,
+    lock_unlock_post boolean not null,
+    manage_community_mods boolean not null,
+    -- people management
+    ban_person boolean not null,
+    view_banned_persons boolean not null,
+    -- report management
+    view_private_message_reports boolean not null,
+    resolve_private_message_reports boolean not null,
+    view_post_reports boolean not null,
+    resolve_post_reports boolean not null,
+    view_comment_reports boolean not null,
+    resolve_comment_reports boolean not null,
+    -- registrations
+    approve_registration boolean not null,
+    view_registration boolean not null,
+    -- purge content
+    purge_comment boolean not null,
+    purge_community boolean not null,
+    purge_person boolean not null,
+    purge_post boolean not null,
+    -- miscellaneous
+    view_modlog_names boolean not null,
+    modify_custom_emoji boolean not null,
+    unblockable boolean not null
+);
+
+-- insert the previously existing two roles (admin or regular user)
+insert into site_role (name, hide_community, transfer_community, configure_site_roles, assign_user_roles, ban_person,
+ view_banned_persons, feature_post, view_private_message_reports, resolve_private_message_reports, view_modlog_names,
+ approve_registration, view_registration, create_community, view_removed_content, remove_community,
+ modify_custom_emoji, update_site_details, purge_comment, purge_community, purge_person, purge_post, view_comment_reports,
+ unblockable, view_post_reports, resolve_post_reports, resolve_comment_reports, distinguish_comment, lock_unlock_post,
+ modify_community, remove_comment, remove_post, manage_community_mods)
+values 
+ ('admin', true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true),
+ ('user', false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false);
+
+-- add the site_role_id column to person, with default value as 'user' id
+alter table person add column site_role_id int not null references site_role(id) default 2;
+
+-- update existing users to get the correct role
+update person set site_role_id = case when admin then 1 else 2 end;
+
+-- drop unused admin column
+alter table person drop column admin;
+
+-- add default_site_role_id column to local_site with default value as 'user' id
+alter table local_site 
+    add column top_admin_role_id int not null references site_role(id) default 1,
+    add column default_site_role_id int not null references site_role(id) default 2; 


### PR DESCRIPTION
# Roles/Permissions Proof of Concept

I'd just first like to say to the  maintainers specifically thanks for all the work you're doing (especially recently!), it's much appreciated and I don't want to add to that workload. I'm aware this is a bit long so no worries if you want to give reading/responding a skip for a bit!

I just thought I'd throw this together to demonstrate a proof of concept for a simple role-based permission system to replace the current binary admin/not-admin system. The code here is not polished and tests etc. are not compiling since I didn't want to spend a huge amount of time on something before checking whether it's an idea that would be appreciated.

## Motivations

- https://github.com/LemmyNet/lemmy/issues/2976 currently has to be solved by allowing every admin the right to delete pretty much all content on an instance, which is not ideal;
- It's currently not possible to delegate certain admin functions to users (e.g. the ability to accept registrations) without also giving the users the ability to cause a lot of damage.

## Design

There's a lot of changes in this PR, but the actually important changes are:

- adding a `site_role` table which has: an id, a name and a bunch of boolean permission flags for each individual admin operation (e.g. `ban_person`, `purge_comment`, etc.)
  - the actual specific flags I've added here are probably wrong and need a fair bit of finessing
- removing the `admin` column from `person`
- added `site_role_id` column to `person`
- added two columns to `local_site`:
  - `top_admin_role_id` this references a role in `site_role` and represents the super-admin role, i.e. it has all permissions
  - `default_site_role_id` this references a role in `site_role` and represents a regular non-admin, i.e. it has no permissions
- on migrating, we create two `site_role`s which represent admins and non-admins and ensure any existing user with the `admin` flag gets assigned the admin role
- wherever we were previously checking `admin`, we now check for a specific site permission

With these changes, we end up with a system that's functionally identical to the current one, just with a different underlying mechanism.

## Enabled Features

It's fairly easy to imagine a UI letting anyone with the `configure_roles` permission add and modify these roles and then assign them to users on their instance. This would potentially go some way to lightening the administrative burden of running an instance, since functions like approving registrations (or even global community moderation) can be delegated to somewhat-but-not-completely-trusted users.

This role/permission system could potentially be extended to communities and mods as well, so specific moderation functions become specific permissions. Roles could be defined at the community level, or at the instance level?

For even further extension, this role/permission system could generically replace bans/mutes. If posting to communities/viewing communities became permissions, then a 'Banned' role could be created which isn't allowed to do these things and banning a user then becomes a matter of assigning them to a specific role.
