### PR TITLE
Adjust the config check to be a separate faster to compile binary

### DIFF
--- a/crates/utils/src/main.rs
+++ b/crates/utils/src/main.rs
@@ -1,0 +1,16 @@
+use doku::json::{AutoComments, CommentsStyle, Formatting, ObjectsStyle};
+use lemmy_utils::settings::structs::Settings;
+fn main() {
+  let fmt = Formatting {
+    auto_comments: AutoComments::none(),
+    comments_style: CommentsStyle {
+      separator: "#".to_owned(),
+    },
+    objects_style: ObjectsStyle {
+      surround_keys_with_quotes: false,
+      use_comma_as_separator: false,
+    },
+    ..Default::default()
+  };
+  println!("{}", doku::to_json_fmt_val(&fmt, &Settings::default()));
+}

--- a/scripts/update_config_defaults.sh
+++ b/scripts/update_config_defaults.sh
@@ -3,4 +3,4 @@ set -e
 
 dest=${1-config/defaults.hjson}
 
-cargo run -- --print-config-docs > "$dest"
+cargo run  --manifest-path crates/utils/Cargo.toml > "$dest"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@ use crate::{code_migrations::run_advanced_migrations, root_span_builder::Quieter
 use activitypub_federation::config::{FederationConfig, FederationMiddleware};
 use actix_cors::Cors;
 use actix_web::{middleware, web::Data, App, HttpServer, Result};
-use doku::json::{AutoComments, CommentsStyle, Formatting, ObjectsStyle};
 use lemmy_api_common::{
   context::LemmyContext,
   lemmy_db_views::structs::SiteView,
@@ -25,11 +24,7 @@ use lemmy_db_schema::{
   utils::{build_db_pool, get_database_url, run_migrations},
 };
 use lemmy_routes::{feeds, images, nodeinfo, webfinger};
-use lemmy_utils::{
-  error::LemmyError,
-  rate_limit::RateLimitCell,
-  settings::{structs::Settings, SETTINGS},
-};
+use lemmy_utils::{error::LemmyError, rate_limit::RateLimitCell, settings::SETTINGS};
 use reqwest::Client;
 use reqwest_middleware::ClientBuilder;
 use reqwest_tracing::TracingMiddleware;
@@ -47,21 +42,6 @@ pub(crate) const REQWEST_TIMEOUT: Duration = Duration::from_secs(10);
 /// Placing the main function in lib.rs allows other crates to import it and embed Lemmy
 pub async fn start_lemmy_server() -> Result<(), LemmyError> {
   let args: Vec<String> = env::args().collect();
-  if args.get(1) == Some(&"--print-config-docs".to_string()) {
-    let fmt = Formatting {
-      auto_comments: AutoComments::none(),
-      comments_style: CommentsStyle {
-        separator: "#".to_owned(),
-      },
-      objects_style: ObjectsStyle {
-        surround_keys_with_quotes: false,
-        use_comma_as_separator: false,
-      },
-      ..Default::default()
-    };
-    println!("{}", doku::to_json_fmt_val(&fmt, &Settings::default()));
-    return Ok(());
-  }
 
   let scheduled_tasks_enabled = args.get(1) != Some(&"--disable-scheduled-tasks".to_string());
 


### PR DESCRIPTION
This moves the print-config-check to a binary hosted by the `crates/utils` crate.  Rather than build the *entire* lemmy server to check the config is updated, this will compile less & hopefully reduce the `check_defaults_hjson_updated` step in CI