### PR TITLE
test: Add missing tokio test macro dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ anyhow = "1.0.71"
 diesel_ltree = "0.3.0"
 typed-builder = "0.10.0"
 serial_test = "0.9.0"
-tokio = "1.28.2"
+tokio = { version = "1.28.2", features = ["macros"] }
 sha2 = "0.10.6"
 regex = "1.8.4"
 once_cell = "1.18.0"


### PR DESCRIPTION
The tests make use of the `#[tokio::test]` macro, but the `tokio` dependency default features do not include them. Running `cargo test` in the root directory fails.

By including the `macros` feature on the `tokio` dependency, `cargo test` works by default.

---

cargo test fails with

```
error[E0433]: failed to resolve: could not find `test` in `tokio`
   --> src\scheduled_tasks.rs:295:12
    |
295 |   #[tokio::test]
    |            ^^^^ could not find `test` in `tokio`
```

---

Looking at your CI (Woodpecker) it looks like it does not run tests? I set up GitHub Actions to verify:

* Proof of failure: https://github.com/Kissaki/lemmy/actions/runs/5365120571/jobs/9733731556#step:4:430
* Proof of resolve: https://github.com/Kissaki/lemmy/actions/runs/5365125239/jobs/9733740653

---

I don't know if this has an impact on `scripts/test.sh`, which when called with no arg passes `--all-features` to `cargo test` (are other not referenced features used?), and otherwise does not use that flag.