### PR TITLE
fix(api): Fix generating of TypeScript bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ strum_macros = "0.24.3"
 itertools = "0.10.5"
 futures = "0.3.28"
 http = "0.2.9"
-actix-rt = { version = "2.8.0", default-features = false }
+actix-rt = { version = "2.8.0" }
 percent-encoding = "2.3.0"
 rosetta-i18n = "0.1.2"
 rand = "0.8.5"


### PR DESCRIPTION
The lemmy_api_common crate makes use of the actix-rt attribute `#[actix_rt::test]`. Running `cargo test --features full` fails because it is unable to resolve the attribute.

lemmy_api_common depends on actix-rt as a workspace dependency. The workspace dependency excludes default features - which currently is only the `macros` feature[1].

Dropping the `default-features = false` effectively includes the `macros` feature and resolves the full cargo test failing to resolve the test attribute.

[1]: https://docs.rs/crate/actix-rt/2.8.0/features