### PR TITLE
Site Metadata: resolve relative URLs for embedded images/videos

### DIFF
--- a/crates/api_common/Cargo.toml
+++ b/crates/api_common/Cargo.toml
@@ -33,7 +33,7 @@ reqwest-middleware = { workspace = true, optional = true }
 regex = { workspace = true }
 rosetta-i18n = { workspace = true, optional = true }
 percent-encoding = { workspace = true, optional = true }
-webpage = { version = "1.6.0", default-features = false, features = ["serde"], optional = true }
+webpage = { version = "1.6", default-features = false, features = ["serde"], optional = true }
 encoding = { version = "0.2.33", optional = true }
 anyhow = { workspace = true }
 futures = { workspace = true }

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -27,12 +27,12 @@ pub async fn fetch_site_metadata(
   // https://github.com/LemmyNet/lemmy/issues/1964
   let html_bytes = response.bytes().await.map_err(LemmyError::from)?.to_vec();
 
-  let tags = html_to_site_metadata(&html_bytes)?;
+  let tags = html_to_site_metadata(&html_bytes, url)?;
 
   Ok(tags)
 }
 
-fn html_to_site_metadata(html_bytes: &[u8]) -> Result<SiteMetadata, LemmyError> {
+fn html_to_site_metadata(html_bytes: &[u8], url: &Url) -> Result<SiteMetadata, LemmyError> {
   let html = String::from_utf8_lossy(html_bytes);
 
   // Make sure the first line is doctype html
@@ -81,12 +81,12 @@ fn html_to_site_metadata(html_bytes: &[u8]) -> Result<SiteMetadata, LemmyError> 
     .opengraph
     .images
     .first()
-    .and_then(|ogo| Url::parse(&ogo.url).ok());
+    .and_then(|ogo| url.join(&ogo.url).ok());
   let og_embed_url = page
     .opengraph
     .videos
     .first()
-    .and_then(|v| Url::parse(&v.url).ok());
+    .and_then(|v| url.join(&v.url).ok());
 
   Ok(SiteMetadata {
     title: og_title.or(page_title),
@@ -266,7 +266,7 @@ pub fn build_user_agent(settings: &Settings) -> String {
 
 #[cfg(test)]
 mod tests {
-  use crate::request::{build_user_agent, fetch_site_metadata, SiteMetadata};
+  use crate::request::{build_user_agent, fetch_site_metadata, html_to_site_metadata, SiteMetadata};
   use lemmy_utils::settings::SETTINGS;
   use url::Url;
 
@@ -305,4 +305,30 @@ mod tests {
   //   let res_other = fetch_pictshare("https://upload.wikimedia.org/wikipedia/en/2/27/The_Mandalorian_logo.jpgaoeu");
   //   assert!(res_other.is_err());
   // }
+
+  #[test]
+  fn test_resolve_image_url() {
+      // url that lists the opengraph fields
+      let url = Url::parse("https://example.com/one/two.html").unwrap();
+
+      // root relative url
+      let html_bytes = b"<!DOCTYPE html><html><head><meta property='og:image' content='/image.jpg'></head><body></body></html>";
+      let metadata = html_to_site_metadata(html_bytes, &url).expect("Unable to parse metadata");
+      assert_eq!(metadata.image, Some(Url::parse("https://example.com/image.jpg").unwrap().into()));
+
+      // base relative url
+      let html_bytes = b"<!DOCTYPE html><html><head><meta property='og:image' content='image.jpg'></head><body></body></html>";
+      let metadata = html_to_site_metadata(html_bytes, &url).expect("Unable to parse metadata");
+      assert_eq!(metadata.image, Some(Url::parse("https://example.com/one/image.jpg").unwrap().into()));
+
+      // full url
+      let html_bytes = b"<!DOCTYPE html><html><head><meta property='og:image' content='https://example.com/image.jpg'></head><body></body></html>";
+      let metadata = html_to_site_metadata(html_bytes, &url).expect("Unable to parse metadata");
+      assert_eq!(metadata.image, Some(Url::parse("https://example.com/image.jpg").unwrap().into()));
+
+      // protocol relative url
+      let html_bytes = b"<!DOCTYPE html><html><head><meta property='og:image' content='//example.com/image.jpg'></head><body></body></html>";
+      let metadata = html_to_site_metadata(html_bytes, &url).expect("Unable to parse metadata");
+      assert_eq!(metadata.image, Some(Url::parse("https://example.com/image.jpg").unwrap().into()));
+  }
 }

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -266,7 +266,12 @@ pub fn build_user_agent(settings: &Settings) -> String {
 
 #[cfg(test)]
 mod tests {
-  use crate::request::{build_user_agent, fetch_site_metadata, html_to_site_metadata, SiteMetadata};
+  use crate::request::{
+    build_user_agent,
+    fetch_site_metadata,
+    html_to_site_metadata,
+    SiteMetadata,
+  };
   use lemmy_utils::settings::SETTINGS;
   use url::Url;
 
@@ -308,27 +313,43 @@ mod tests {
 
   #[test]
   fn test_resolve_image_url() {
-      // url that lists the opengraph fields
-      let url = Url::parse("https://example.com/one/two.html").unwrap();
+    // url that lists the opengraph fields
+    let url = Url::parse("https://example.com/one/two.html").unwrap();
 
-      // root relative url
-      let html_bytes = b"<!DOCTYPE html><html><head><meta property='og:image' content='/image.jpg'></head><body></body></html>";
-      let metadata = html_to_site_metadata(html_bytes, &url).expect("Unable to parse metadata");
-      assert_eq!(metadata.image, Some(Url::parse("https://example.com/image.jpg").unwrap().into()));
+    // root relative url
+    let html_bytes = b"<!DOCTYPE html><html><head><meta property='og:image' content='/image.jpg'></head><body></body></html>";
+    let metadata = html_to_site_metadata(html_bytes, &url).expect("Unable to parse metadata");
+    assert_eq!(
+      metadata.image,
+      Some(Url::parse("https://example.com/image.jpg").unwrap().into())
+    );
 
-      // base relative url
-      let html_bytes = b"<!DOCTYPE html><html><head><meta property='og:image' content='image.jpg'></head><body></body></html>";
-      let metadata = html_to_site_metadata(html_bytes, &url).expect("Unable to parse metadata");
-      assert_eq!(metadata.image, Some(Url::parse("https://example.com/one/image.jpg").unwrap().into()));
+    // base relative url
+    let html_bytes = b"<!DOCTYPE html><html><head><meta property='og:image' content='image.jpg'></head><body></body></html>";
+    let metadata = html_to_site_metadata(html_bytes, &url).expect("Unable to parse metadata");
+    assert_eq!(
+      metadata.image,
+      Some(
+        Url::parse("https://example.com/one/image.jpg")
+          .unwrap()
+          .into()
+      )
+    );
 
-      // full url
-      let html_bytes = b"<!DOCTYPE html><html><head><meta property='og:image' content='https://example.com/image.jpg'></head><body></body></html>";
-      let metadata = html_to_site_metadata(html_bytes, &url).expect("Unable to parse metadata");
-      assert_eq!(metadata.image, Some(Url::parse("https://example.com/image.jpg").unwrap().into()));
+    // full url
+    let html_bytes = b"<!DOCTYPE html><html><head><meta property='og:image' content='https://example.com/image.jpg'></head><body></body></html>";
+    let metadata = html_to_site_metadata(html_bytes, &url).expect("Unable to parse metadata");
+    assert_eq!(
+      metadata.image,
+      Some(Url::parse("https://example.com/image.jpg").unwrap().into())
+    );
 
-      // protocol relative url
-      let html_bytes = b"<!DOCTYPE html><html><head><meta property='og:image' content='//example.com/image.jpg'></head><body></body></html>";
-      let metadata = html_to_site_metadata(html_bytes, &url).expect("Unable to parse metadata");
-      assert_eq!(metadata.image, Some(Url::parse("https://example.com/image.jpg").unwrap().into()));
+    // protocol relative url
+    let html_bytes = b"<!DOCTYPE html><html><head><meta property='og:image' content='//example.com/image.jpg'></head><body></body></html>";
+    let metadata = html_to_site_metadata(html_bytes, &url).expect("Unable to parse metadata");
+    assert_eq!(
+      metadata.image,
+      Some(Url::parse("https://example.com/image.jpg").unwrap().into())
+    );
   }
 }

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -81,11 +81,13 @@ fn html_to_site_metadata(html_bytes: &[u8], url: &Url) -> Result<SiteMetadata, L
     .opengraph
     .images
     .first()
+    // join also works if the target URL is absolute
     .and_then(|ogo| url.join(&ogo.url).ok());
   let og_embed_url = page
     .opengraph
     .videos
     .first()
+    // join also works if the target URL is absolute
     .and_then(|v| url.join(&v.url).ok());
 
   Ok(SiteMetadata {
@@ -336,12 +338,12 @@ mod tests {
       )
     );
 
-    // full url
-    let html_bytes = b"<!DOCTYPE html><html><head><meta property='og:image' content='https://example.com/image.jpg'></head><body></body></html>";
+    // absolute url
+    let html_bytes = b"<!DOCTYPE html><html><head><meta property='og:image' content='https://cdn.host.com/image.jpg'></head><body></body></html>";
     let metadata = html_to_site_metadata(html_bytes, &url).expect("Unable to parse metadata");
     assert_eq!(
       metadata.image,
-      Some(Url::parse("https://example.com/image.jpg").unwrap().into())
+      Some(Url::parse("https://cdn.host.com/image.jpg").unwrap().into())
     );
 
     // protocol relative url


### PR DESCRIPTION
Hey I'm the maintainer of the `webpage` crate you are using to fetch metadata about submitted urls.
An issue was raised https://github.com/orottier/webpage-rs/issues/8#issuecomment-1605725806 about relative URLs which I think should be fixed on your end.
This pull request contains the fix, and I also changed the dependency to opt into future 1.x versions of the lib. The linked issue contains some other stuff that I will probably fix in the 1.6+ versions.