### PR TITLE
Fix concatenation of audio captcha wav files

### DIFF
--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -30,6 +30,7 @@ captcha = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 chrono = { workspace = true }
+wav = "1.0.0"
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -4,7 +4,6 @@ use lemmy_api_common::{context::LemmyContext, utils::local_site_to_slur_regex};
 use lemmy_db_schema::source::local_site::LocalSite;
 use lemmy_utils::{error::LemmyError, utils::slurs::check_slurs};
 use std::io::Cursor;
-use tracing::error;
 use wav;
 
 mod comment;
@@ -25,18 +24,7 @@ pub trait Perform {
 }
 
 /// Converts the captcha to a base64 encoded wav audio file
-pub(crate) fn captcha_as_wav_base64(captcha: &Captcha) -> String {
-  match captcha_as_wav(captcha) {
-    Ok(wav_bytes) => base64::encode(wav_bytes),
-    Err(e) => {
-      error!("Error generating captcha: {}", e);
-      String::new()
-    }
-  }
-}
-
-/// Concatenate the wav files from each individual letter into a single wav audio file
-fn captcha_as_wav(captcha: &Captcha) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+pub(crate) fn captcha_as_wav_base64(captcha: &Captcha) -> Result<String, Box<dyn std::error::Error>> {
   let letters = captcha.as_wav();
 
   // Decode each wav file, concatenate the samples
@@ -55,7 +43,7 @@ fn captcha_as_wav(captcha: &Captcha) -> Result<Vec<u8>, Box<dyn std::error::Erro
                      &wav::BitDepth::Sixteen(concat_samples),
                      &mut output_buffer);
 
-  Ok(output_buffer.into_inner())
+  Ok(base64::encode(output_buffer.into_inner()))
 }
 
 /// Check size of report and remove whitespace

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -4,7 +4,6 @@ use lemmy_api_common::{context::LemmyContext, utils::local_site_to_slur_regex};
 use lemmy_db_schema::source::local_site::LocalSite;
 use lemmy_utils::{error::LemmyError, utils::slurs::check_slurs};
 use std::io::Cursor;
-use wav;
 
 mod comment;
 mod comment_report;

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -46,9 +46,17 @@ pub(crate) fn captcha_as_wav_base64(captcha: &Captcha) -> Result<String, LemmyEr
   if any_header.is_none() {
     return Err(LemmyError::from_message("couldnt_create_audio_captcha"));
   }
-  let _ = wav::write(any_header.unwrap(),
-                     &wav::BitDepth::Sixteen(concat_samples),
-                     &mut output_buffer);
+  let wav_write_result = wav::write(
+    any_header.unwrap(),
+    &wav::BitDepth::Sixteen(concat_samples),
+    &mut output_buffer,
+  );
+  if let Err(e) = wav_write_result {
+    return Err(LemmyError::from_error_message(
+      e,
+      "couldnt_create_audio_captcha",
+    ));
+  }
 
   Ok(base64::encode(output_buffer.into_inner()))
 }

--- a/crates/api/src/local_user/get_captcha.rs
+++ b/crates/api/src/local_user/get_captcha.rs
@@ -10,6 +10,7 @@ use lemmy_db_schema::source::{
   local_site::LocalSite,
 };
 use lemmy_utils::error::LemmyError;
+use tracing::error;
 
 #[async_trait::async_trait(?Send)]
 impl Perform for GetCaptcha {
@@ -33,7 +34,10 @@ impl Perform for GetCaptcha {
 
     let png = captcha.as_base64().expect("failed to generate captcha");
 
-    let wav = captcha_as_wav_base64(&captcha);
+    let wav = captcha_as_wav_base64(&captcha).unwrap_or_else(|err| {
+      error!("failed to generate audio captcha {}", err);
+      String::new()
+    });
 
     let captcha_form: CaptchaAnswerForm = CaptchaAnswerForm { answer };
     // Stores the captcha item in the db

--- a/crates/api/src/local_user/get_captcha.rs
+++ b/crates/api/src/local_user/get_captcha.rs
@@ -10,7 +10,6 @@ use lemmy_db_schema::source::{
   local_site::LocalSite,
 };
 use lemmy_utils::error::LemmyError;
-use tracing::error;
 
 #[async_trait::async_trait(?Send)]
 impl Perform for GetCaptcha {
@@ -34,10 +33,7 @@ impl Perform for GetCaptcha {
 
     let png = captcha.as_base64().expect("failed to generate captcha");
 
-    let wav = captcha_as_wav_base64(&captcha).unwrap_or_else(|err| {
-      error!("failed to generate audio captcha {}", err);
-      String::new()
-    });
+    let wav = captcha_as_wav_base64(&captcha)?;
 
     let captcha_form: CaptchaAnswerForm = CaptchaAnswerForm { answer };
     // Stores the captcha item in the db


### PR DESCRIPTION
This is for after the captcha code is merged again. No rush.

The existing code doesn't work, it tries to concatenate the raw bytes of the wav files, which results in only the first letter being played and the rest ignored.

Please let me know if you'd prefer different patterns or more error checking, or if you'd prefer to do it without introducing a dependency. Happy to adjust the code to your preferences.
