### PR TITLE
Enable opentelemetry when compiling for production (fixes #3294)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/app/target \
 RUN \
     if [ "$RUST_RELEASE_MODE" = "release" ] ; then \
       echo "pub const VERSION: &str = \"$(git describe --tag)\";" > "crates/utils/src/version.rs" \
-      && cargo build --target ${CARGO_BUILD_TARGET} --release \
+      && cargo build --target ${CARGO_BUILD_TARGET} --release --features console \
       && cp ./target/$CARGO_BUILD_TARGET/$RUST_RELEASE_MODE/lemmy_server /app/lemmy_server; \
     fi
 


### PR DESCRIPTION
Reasoning is explained in https://github.com/LemmyNet/lemmy/pull/3280#issuecomment-1604326904. Doing it this way means that opentelemetry is only enabled for production builds, but doesnt increase build time for debug builds.