### PR TITLE
Remove networks from docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,20 +6,9 @@ x-logging: &default-logging
     max-size: "50m"
     max-file: 4
 
-networks:
-  # communication to web and clients
-  lemmyexternalproxy:
-  # communication between lemmy services
-  lemmyinternal:
-    driver: bridge
-    internal: true
-
 services:
   proxy:
     image: nginx:1-alpine
-    networks:
-      - lemmyinternal
-      - lemmyexternalproxy
     ports:
       # actual and only port facing any connection from outside
       # Note, change the left number if port 1236 is already in use on your system
@@ -45,9 +34,6 @@ services:
       #   RUST_RELEASE_MODE: release
     # this hostname is used in nginx reverse proxy and also for lemmy ui to connect to the backend, do not change
     hostname: lemmy
-    networks:
-      - lemmyinternal
-      - lemmyexternalproxy
     restart: always
     environment:
       - RUST_LOG="warn,lemmy_server=debug,lemmy_api=debug,lemmy_api_common=debug,lemmy_api_crud=debug,lemmy_apub=debug,lemmy_db_schema=debug,lemmy_db_views=debug,lemmy_db_views_actor=debug,lemmy_db_views_moderator=debug,lemmy_routes=debug,lemmy_utils=debug,lemmy_websocket=debug"
@@ -67,8 +53,6 @@ services:
     # build:
     #   context: ../../lemmy-ui
     #   dockerfile: dev.dockerfile
-    networks:
-      - lemmyinternal
     environment:
       # this needs to match the hostname defined in the lemmy service
       - LEMMY_UI_LEMMY_INTERNAL_HOST=lemmy:8536
@@ -88,8 +72,6 @@ services:
     hostname: pictrs
     # we can set options to pictrs like this, here we set max. image size and forced format for conversion
     # entrypoint: /sbin/tini -- /usr/local/bin/pict-rs -p /mnt -m 4 --image-format webp
-    networks:
-      - lemmyinternal
     environment:
       - PICTRS_OPENTELEMETRY_URL=http://otel:4137
       - PICTRS__API_KEY=API_KEY
@@ -126,10 +108,6 @@ services:
         "-c",
         "track_activity_query_size=1048576",
       ]
-    networks:
-      - lemmyinternal
-      # adding the external facing network to allow direct db access for devs
-      - lemmyexternalproxy
     ports:
       # use a different port so it doesnt conflict with potential postgres db running on the host
       - "5433:5432"


### PR DESCRIPTION
These networks dont add any value and only make things more complicated. Every container needs external network access one way or another so we might as well use the defaults. Replaces https://github.com/LemmyNet/lemmy/pull/3268#issue-1769613018