### PR TITLE
Use serde(skip) instead of skip_serializing, add placeholder values

### DIFF
--- a/crates/db_schema/src/source/community.rs
+++ b/crates/db_schema/src/source/community.rs
@@ -42,9 +42,9 @@ pub struct Community {
   pub icon: Option<DbUrl>,
   /// A URL for a banner.
   pub banner: Option<DbUrl>,
-  #[serde(skip_serializing)]
+  #[serde(skip)]
   pub followers_url: DbUrl,
-  #[serde(skip_serializing)]
+  #[serde(skip)]
   pub inbox_url: DbUrl,
   #[serde(skip)]
   pub shared_inbox_url: Option<DbUrl>,

--- a/crates/db_schema/src/source/community.rs
+++ b/crates/db_schema/src/source/community.rs
@@ -1,6 +1,9 @@
-use crate::newtypes::{CommunityId, DbUrl, InstanceId, PersonId};
 #[cfg(feature = "full")]
 use crate::schema::{community, community_follower, community_moderator, community_person_ban};
+use crate::{
+  newtypes::{CommunityId, DbUrl, InstanceId, PersonId},
+  source::placeholder_apub_url,
+};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 #[cfg(feature = "full")]
@@ -42,10 +45,10 @@ pub struct Community {
   pub icon: Option<DbUrl>,
   /// A URL for a banner.
   pub banner: Option<DbUrl>,
-  #[serde(skip)]
-  pub followers_url: Option<DbUrl>,
-  #[serde(skip)]
-  pub inbox_url: Option<DbUrl>,
+  #[serde(skip, default = "placeholder_apub_url")]
+  pub followers_url: DbUrl,
+  #[serde(skip, default = "placeholder_apub_url")]
+  pub inbox_url: DbUrl,
   #[serde(skip)]
   pub shared_inbox_url: Option<DbUrl>,
   /// Whether the community is hidden.

--- a/crates/db_schema/src/source/community.rs
+++ b/crates/db_schema/src/source/community.rs
@@ -43,9 +43,9 @@ pub struct Community {
   /// A URL for a banner.
   pub banner: Option<DbUrl>,
   #[serde(skip)]
-  pub followers_url: DbUrl,
+  pub followers_url: Option<DbUrl>,
   #[serde(skip)]
-  pub inbox_url: DbUrl,
+  pub inbox_url: Option<DbUrl>,
   #[serde(skip)]
   pub shared_inbox_url: Option<DbUrl>,
   /// Whether the community is hidden.

--- a/crates/db_schema/src/source/mod.rs
+++ b/crates/db_schema/src/source/mod.rs
@@ -39,5 +39,7 @@ pub mod tagline;
 /// This is necessary so they can be successfully deserialized from API responses, even though the
 /// value is not sent by Lemmy. Necessary for crates which rely on Rust API such as lemmy-stats-crawler.
 fn placeholder_apub_url() -> DbUrl {
-  DbUrl(Box::new(Url::parse("http://example.com").unwrap()))
+  DbUrl(Box::new(
+    Url::parse("http://example.com").expect("parse placeholer url"),
+  ))
 }

--- a/crates/db_schema/src/source/mod.rs
+++ b/crates/db_schema/src/source/mod.rs
@@ -1,3 +1,6 @@
+use crate::newtypes::DbUrl;
+use url::Url;
+
 #[cfg(feature = "full")]
 pub mod activity;
 pub mod actor_language;
@@ -30,3 +33,11 @@ pub mod registration_application;
 pub mod secret;
 pub mod site;
 pub mod tagline;
+
+/// Default value for columns like [community::Community.inbox_url] which are marked as serde(skip).
+///
+/// This is necessary so they can be successfully deserialized from API responses, even though the
+/// value is not sent by Lemmy. Necessary for crates which rely on Rust API such as lemmy-stats-crawler.
+fn placeholder_apub_url() -> DbUrl {
+  DbUrl(Box::new(Url::parse("http://example.com").unwrap()))
+}

--- a/crates/db_schema/src/source/person.rs
+++ b/crates/db_schema/src/source/person.rs
@@ -41,7 +41,7 @@ pub struct Person {
   /// Whether the person is deleted.
   pub deleted: bool,
   #[serde(skip)]
-  pub inbox_url: DbUrl,
+  pub inbox_url: Option<DbUrl>,
   #[serde(skip)]
   pub shared_inbox_url: Option<DbUrl>,
   /// A matrix id, usually given an @person:matrix.org

--- a/crates/db_schema/src/source/person.rs
+++ b/crates/db_schema/src/source/person.rs
@@ -1,6 +1,9 @@
-use crate::newtypes::{DbUrl, InstanceId, PersonId};
 #[cfg(feature = "full")]
 use crate::schema::{person, person_follower};
+use crate::{
+  newtypes::{DbUrl, InstanceId, PersonId},
+  source::placeholder_apub_url,
+};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 #[cfg(feature = "full")]
@@ -40,8 +43,8 @@ pub struct Person {
   pub banner: Option<DbUrl>,
   /// Whether the person is deleted.
   pub deleted: bool,
-  #[serde(skip)]
-  pub inbox_url: Option<DbUrl>,
+  #[serde(skip, default = "placeholder_apub_url")]
+  pub inbox_url: DbUrl,
   #[serde(skip)]
   pub shared_inbox_url: Option<DbUrl>,
   /// A matrix id, usually given an @person:matrix.org

--- a/crates/db_schema/src/source/person.rs
+++ b/crates/db_schema/src/source/person.rs
@@ -40,7 +40,7 @@ pub struct Person {
   pub banner: Option<DbUrl>,
   /// Whether the person is deleted.
   pub deleted: bool,
-  #[serde(skip_serializing)]
+  #[serde(skip)]
   pub inbox_url: DbUrl,
   #[serde(skip)]
   pub shared_inbox_url: Option<DbUrl>,


### PR DESCRIPTION
The latter breaks lemmy_crawler as the field is not included in the Lemmy API, but is required when attempting to parse API responses. Should only use serde(skip) to avoid this problem. I also had to add placeholder values so that deserialization works even though these mandatory fields arent being sent by Lemmy.