### PR TITLE
Add "show_nsfw" to the Community API.

### DIFF
--- a/crates/api_common/src/community.rs
+++ b/crates/api_common/src/community.rs
@@ -76,6 +76,7 @@ pub struct CommunityResponse {
 pub struct ListCommunities {
   pub type_: Option<ListingType>,
   pub sort: Option<SortType>,
+  pub show_nsfw: Option<bool>,
   pub page: Option<i64>,
   pub limit: Option<i64>,
   pub auth: Option<Sensitive<String>>,

--- a/crates/api_crud/src/community/list.rs
+++ b/crates/api_crud/src/community/list.rs
@@ -27,12 +27,14 @@ impl PerformCrud for ListCommunities {
 
     let sort = data.sort;
     let listing_type = data.type_;
+    let show_nsfw = data.show_nsfw;
     let page = data.page;
     let limit = data.limit;
     let local_user = local_user_view.map(|l| l.local_user);
     let communities = CommunityQuery::builder()
       .pool(context.pool())
       .listing_type(listing_type)
+      .show_nsfw(show_nsfw)
       .sort(sort)
       .local_user(local_user.as_ref())
       .page(page)

--- a/crates/db_views_actor/src/community_view.rs
+++ b/crates/db_views_actor/src/community_view.rs
@@ -126,6 +126,7 @@ pub struct CommunityQuery<'a> {
   local_user: Option<&'a LocalUser>,
   search_term: Option<String>,
   is_mod_or_admin: Option<bool>,
+  show_nsfw: Option<bool>,
   page: Option<i64>,
   limit: Option<i64>,
 }
@@ -203,8 +204,8 @@ impl<'a> CommunityQuery<'a> {
       query = query.filter(community_block::person_id.is_null());
       query = query.filter(community::nsfw.eq(false).or(local_user::show_nsfw.eq(true)));
     } else {
-      // No person in request, only show nsfw communities if show_nsfw passed into request
-      if !self.local_user.map(|l| l.show_nsfw).unwrap_or(false) {
+      // No person in request, only show nsfw communities if show_nsfw is passed into request
+      if !self.show_nsfw.unwrap_or(false) {
         query = query.filter(community::nsfw.eq(false));
       }
     }


### PR DESCRIPTION
This functionality seems to have been removed in 0.18.0, [the comment](https://github.com/LemmyNet/lemmy/pull/2105/files#diff-0066fa66e09e9c0f906660e681ed172505a1859e59bef51d6f4c675121e3c1caR249) references a non-existant flag, and also seems to look at `self.local_user` where it would not be defined.

I added a `show_nsfw` query parameter that can be used to show all communities.