### PR TITLE
Added gitattributes to normalize all files to lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Normalize EOL for all files that Git considers text files.
+* text=auto eol=lf


### PR DESCRIPTION
I was trying to build this on Windows through Docker and WSL and I ran into the problem that the docker_update.sh was using crlf line endings. I converted it to lf no problem but it's probably better to just normalize the line endings of everything for better consistency. I'm not sure if this breaks anything in the rest of the code though, so I could edit this to only effect docker/docker_update.sh if necessary. Either way, having git normalize the file to lf makes it less annoying to build on Windows/Mac.