### PR TITLE
Expire password reset tokens when used (fixes #3270).

### DIFF
--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -341,15 +341,14 @@ pub async fn send_password_reset_email(
   let token = uuid::Uuid::new_v4().to_string();
 
   // Insert the row
-  let token2 = token.clone();
   let local_user_id = user.local_user.id;
-  PasswordResetRequest::create_token(pool, local_user_id, &token2).await?;
+  PasswordResetRequest::create_token(pool, local_user_id, &token).await?;
 
   let email = &user.local_user.email.clone().expect("email");
   let lang = get_interface_language(user);
   let subject = &lang.password_reset_subject(&user.person.name);
   let protocol_and_hostname = settings.get_protocol_and_hostname();
-  let reset_link = format!("{}/password_change/{}", protocol_and_hostname, &token);
+  let reset_link = format!("{}/password_change/{}", protocol_and_hostname, token);
   let body = &lang.password_reset_body(reset_link, &user.person.name);
   send_email(subject, email, &user.person.name, body, settings)
 }

--- a/crates/db_schema/src/schema.rs
+++ b/crates/db_schema/src/schema.rs
@@ -545,6 +545,7 @@ diesel::table! {
         token_encrypted -> Text,
         published -> Timestamp,
         local_user_id -> Int4,
+        expires_at -> Timestamp,
     }
 }
 

--- a/crates/db_schema/src/source/password_reset_request.rs
+++ b/crates/db_schema/src/source/password_reset_request.rs
@@ -10,6 +10,7 @@ pub struct PasswordResetRequest {
   pub token_encrypted: String,
   pub published: chrono::NaiveDateTime,
   pub local_user_id: LocalUserId,
+  pub expires_at: chrono::NaiveDateTime,
 }
 
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
@@ -17,4 +18,5 @@ pub struct PasswordResetRequest {
 pub struct PasswordResetRequestForm {
   pub local_user_id: LocalUserId,
   pub token_encrypted: String,
+  pub expires_at: chrono::NaiveDateTime,
 }

--- a/migrations/2023-06-23-172550_expire_password_reset_tokens/down.sql
+++ b/migrations/2023-06-23-172550_expire_password_reset_tokens/down.sql
@@ -1,0 +1,2 @@
+drop index idx_password_reset_request_token_encrypted;
+alter table password_reset_request drop column expires_at;

--- a/migrations/2023-06-23-172550_expire_password_reset_tokens/up.sql
+++ b/migrations/2023-06-23-172550_expire_password_reset_tokens/up.sql
@@ -1,0 +1,2 @@
+alter table password_reset_request add column expires_at timestamp not null;
+create index idx_password_reset_request_token_encrypted on password_reset_request using hash (token_encrypted);


### PR DESCRIPTION
Added an expires_at column for password reset requests that gets set to a few seconds in the past whenever a new password reset request is created for a user, or when it's used.
I also added a hash index on the hashed token since that's primarily what's going to be queried and a full table scan isn't great once the table gets larger.