### PR TITLE
Add toki pona as a supported language

### DIFF
--- a/migrations/2022-06-21-123144_language-tags/up.sql
+++ b/migrations/2022-06-21-123144_language-tags/up.sql
@@ -177,6 +177,7 @@ insert into language(code, name) values ('tk', 'Türkmençe');
 insert into language(code, name) values ('tl', 'Wikang Tagalog');
 insert into language(code, name) values ('tn', 'Setswana');
 insert into language(code, name) values ('to', 'faka Tonga');
+insert into language(code, name) values ('tok' 'toki pona');
 insert into language(code, name) values ('tr', 'Türkçe');
 insert into language(code, name) values ('ts', 'Xitsonga');
 insert into language(code, name) values ('tt', 'татар теле');


### PR DESCRIPTION
[Toki Pona](https://en.wikipedia.org/wiki/Toki_Pona) is a constructed language known for its small vocabulary, simplicity, and ease of learning. It's quite a small language, only having an ISO 639-3 language code (so no two-letter code), but it has quite the active communities over on Reddit and Discord. And considering that other constructed languages like Esperanto and Volapük are here too, adding it seems appropriate.