### PR TITLE
Fix cargo warnings

### DIFF
--- a/crates/api_crud/Cargo.toml
+++ b/crates/api_crud/Cargo.toml
@@ -22,5 +22,5 @@ tracing = { workspace = true }
 url = { workspace = true }
 async-trait = { workspace = true }
 webmention = "0.4.0"
-chrono = { worspace = true }
+chrono = { workspace = true }
 uuid = { workspace = true }

--- a/crates/db_schema/Cargo.toml
+++ b/crates/db_schema/Cargo.toml
@@ -48,7 +48,7 @@ rustls = { workspace = true }
 futures-util = { workspace = true }
 tokio-postgres = { workspace = true }
 tokio-postgres-rustls = { workspace = true }
-uuid = { features = ["v4"] }
+uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
 serial_test = { workspace = true }


### PR DESCRIPTION
```
warning: lemmy/crates/db_schema/Cargo.toml: dependency (uuid) specified without providing a local path, Git repository, or version to use. This will be considered an error in future versions
warning: lemmy/crates/api_crud/Cargo.toml: dependency (chrono) specified without providing a local path, Git repository, or version to use. This will be considered an error in future versions
```

Seems these slipped in with #3289 