### PR TITLE
Re-add cors origin, default to *

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -36,6 +36,9 @@ services:
     hostname: lemmy
     restart: always
     environment:
+      # set this to the public origin that requests will come from
+      # allow all origins by default to enable API access from web browsers
+      - LEMMY_CORS_ORIGIN=*
       - RUST_LOG="warn,lemmy_server=debug,lemmy_api=debug,lemmy_api_common=debug,lemmy_api_crud=debug,lemmy_apub=debug,lemmy_db_schema=debug,lemmy_db_views=debug,lemmy_db_views_actor=debug,lemmy_db_views_moderator=debug,lemmy_routes=debug,lemmy_utils=debug,lemmy_websocket=debug"
       - RUST_BACKTRACE=full
     volumes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     environment:
       # set this to the public origin that requests will come from
       # allow all origins by default to enable API access from web browsers
-      - LEMMY_CORS_ORIGIN=*
+      - LEMMY_CORS_ORIGIN="wildcard"
       - RUST_LOG="warn,lemmy_server=debug,lemmy_api=debug,lemmy_api_common=debug,lemmy_api_crud=debug,lemmy_apub=debug,lemmy_db_schema=debug,lemmy_db_views=debug,lemmy_db_views_actor=debug,lemmy_db_views_moderator=debug,lemmy_routes=debug,lemmy_utils=debug,lemmy_websocket=debug"
       - RUST_BACKTRACE=full
     volumes:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,8 +144,8 @@ pub async fn start_lemmy_server() -> Result<(), LemmyError> {
         Cors::default().send_wildcard()
       } else {
         Cors::default()
-        .allowed_origin(&cors_origin)
-        .allowed_origin(&settings.get_protocol_and_hostname())
+          .allowed_origin(&cors_origin)
+          .allowed_origin(&settings.get_protocol_and_hostname())
       }
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ pub async fn start_lemmy_server() -> Result<(), LemmyError> {
       Cors::permissive()
     } else {
       let cors_origin = std::env::var("LEMMY_CORS_ORIGIN").unwrap_or("http://localhost".into());
-      if cors_origin == "*" {
+      if cors_origin == "wildcard" {
         Cors::default().send_wildcard()
       } else {
         Cors::default()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,8 +140,8 @@ pub async fn start_lemmy_server() -> Result<(), LemmyError> {
       Cors::permissive()
     } else {
       let cors_origin = std::env::var("LEMMY_CORS_ORIGIN").unwrap_or("http://localhost".into());
-      if (cors_origin == "*") {
-        Cors::send_wildcard()
+      if cors_origin == "*" {
+        Cors::default().send_wildcard()
       } else {
         Cors::default()
         .allowed_origin(&cors_origin)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,9 +140,13 @@ pub async fn start_lemmy_server() -> Result<(), LemmyError> {
       Cors::permissive()
     } else {
       let cors_origin = std::env::var("LEMMY_CORS_ORIGIN").unwrap_or("http://localhost".into());
-      Cors::default()
+      if (cors_origin == "*") {
+        Cors::send_wildcard()
+      } else {
+        Cors::default()
         .allowed_origin(&cors_origin)
         .allowed_origin(&settings.get_protocol_and_hostname())
+      }
     };
 
     App::new()


### PR DESCRIPTION
This re-adds the `LEMMY_CORS_ORIGIN` environment variable which was removed after being merged in #3191 

This also defaults the value to `*`, which enables browser-based clients using the Lemmy API to makes requests.
If server operators which to disable or restrict API access from web browsers they can modify this environment variable, but the default should be to allow web based clients API access.