### PR TITLE
Add awesome-lemmy to LemmyNet?

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Each Lemmy server can set its own moderation policy; appointing site-wide admins
 
 ## Lemmy Projects
 
+- [awesome-lemmy - A community driven list of apps and tools for lemmy](https://github.com/LemmyNet/awesome-lemmy)
+
 ### Apps
 
 - [lemmy-ui - The official web app for lemmy](https://github.com/LemmyNet/lemmy-ui)

--- a/README.md
+++ b/README.md
@@ -118,27 +118,6 @@ Each Lemmy server can set its own moderation policy; appointing site-wide admins
 
 - [awesome-lemmy - A community driven list of apps and tools for lemmy](https://github.com/LemmyNet/awesome-lemmy)
 
-### Apps
-
-- [lemmy-ui - The official web app for lemmy](https://github.com/LemmyNet/lemmy-ui)
-- [lemmyBB - A Lemmy forum UI based on phpBB](https://github.com/LemmyNet/lemmyBB)
-- [Jerboa - A native Android app made by Lemmy's developers](https://github.com/dessalines/jerboa)
-- [Mlem - A Lemmy client for iOS](https://github.com/buresdv/Mlem)
-- [Lemoa - A Gtk client for Lemmy on Linux](https://github.com/lemmy-gtk/lemoa)
-- [Liftoff - A Lemmy for Windows , Linux and Android ](https://github.com/liftoff-app/liftoff)
-
-### Libraries
-
-- [lemmy-js-client](https://github.com/LemmyNet/lemmy-js-client)
-- [lemmy-rust-client](https://github.com/LemmyNet/lemmy/tree/main/crates/api_common)
-- [go-lemmy](https://gitea.arsenm.dev/Arsen6331/go-lemmy)
-- [Dart API client](https://github.com/LemmurOrg/lemmy_api_client)
-- [Lemmy-Swift-Client](https://github.com/rrainn/Lemmy-Swift-Client)
-- [Reddit -> Lemmy Importer](https://github.com/rileynull/RedditLemmyImporter)
-- [lemmy-bot - Typescript library to make it easier to make bots for Lemmy](https://github.com/SleeplessOne1917/lemmy-bot)
-- [Reddit API wrapper for Lemmy](https://github.com/derivator/tafkars)
-- [Pythörhead - Python package for integrating with the Lemmy API](https://pypi.org/project/pythorhead/)
-
 ## Support / Donate
 
 Lemmy is free, open-source software, meaning no advertising, monetizing, or venture capital, ever. Your donations directly support full-time development of the project.


### PR DESCRIPTION
Hello,

I've created a list containing most of apps and tools related to lemmy under the "awesome" format: [awesome-lemmy](https://github.com/dbeley/awesome-lemmy/).

It has started to gain some traction and I'm creating this discussion because I think it would be great to have it under the LemmyNet organization to centralize all the efforts from the community.

If it's of interest to you I let you copy the project to the org, you don't need to give me credit (I might do some PRs though).

(Pruning the commit history might also be a good idea given it's a fork of awesome-scala and it has more than 1k commits already.)

Cheers and thanks for Lemmy!