### PR TITLE
fix race condition on community fetch (and improve performance)

### DIFF
--- a/crates/db_schema/src/impls/actor_language.rs
+++ b/crates/db_schema/src/impls/actor_language.rs
@@ -293,25 +293,37 @@ impl CommunityLanguage {
       return Ok(());
     }
 
+    let form = lang_ids
+      .into_iter()
+      .map(|language_id| CommunityLanguageForm {
+        community_id: for_community_id,
+        language_id,
+      })
+      .collect::<Vec<_>>();
+
     conn
       .build_transaction()
       .run(|conn| {
         Box::pin(async move {
           use crate::schema::community_language::dsl::{community_id, community_language};
+          use diesel::result::DatabaseErrorKind::UniqueViolation;
           // Clear the current languages
           delete(community_language.filter(community_id.eq(for_community_id)))
             .execute(conn)
             .await?;
 
-          for l in lang_ids {
-            let form = CommunityLanguageForm {
-              community_id: for_community_id,
-              language_id: l,
-            };
-            insert_into(community_language)
-              .values(form)
-              .get_result::<Self>(conn)
-              .await?;
+          let insert_res = insert_into(community_language)
+            .values(form)
+            .get_result::<Self>(conn)
+            .await;
+
+          if let Err(Error::DatabaseError(UniqueViolation, _info)) = insert_res {
+            // race condition: this function was probably called simultaneously from another caller. ignore error
+            // tracing::warn!("unique error: {_info:#?}");
+            // _info.constraint_name() should be = "community_language_community_id_language_id_key"
+            return Ok(());
+          } else {
+            insert_res?;
           }
           Ok(())
         }) as _


### PR DESCRIPTION
This should fix https://github.com/LemmyNet/lemmy/issues/3335 as well as a "No community found in cc" error that sometimes shows up.

The error is caused by a race condition of the inserts into community_language when the `<ApubCommunity As Object>::from_json` method is called for a new community two times simultaneously.

This PR both reduces the likelihood for the race condition to appear (by inserting as a batch instead of inserting individually and thus waiting for 100 rust-pg roundtrips) as well as ignores the error when it shows up.

I've tested this with my script that imports a reddit dump as quickly as possible ([code here](https://github.com/phiresky/lemmy/tree/reddit-importer)) and "no community found in cc" don't happen anymore. I have not confirmed whether it fixes #3335 but since it uses the same code it should.