### PR TITLE
fix(posts): return error on invalid community name

### DIFF
--- a/crates/apub/src/api/list_comments.rs
+++ b/crates/apub/src/api/list_comments.rs
@@ -27,9 +27,7 @@ pub async fn list_comments(
   check_private_instance(&local_user_view, &local_site)?;
 
   let community_id = if let Some(name) = &data.community_name {
-    resolve_actor_identifier::<ApubCommunity, Community>(name, &context, &None, true)
-      .await
-      .ok()
+    Some(resolve_actor_identifier::<ApubCommunity, Community>(name, &context, &None, true).await?)
       .map(|c| c.id)
   } else {
     data.community_id

--- a/crates/apub/src/api/list_posts.rs
+++ b/crates/apub/src/api/list_posts.rs
@@ -29,9 +29,7 @@ pub async fn list_posts(
   let page = data.page;
   let limit = data.limit;
   let community_id = if let Some(name) = &data.community_name {
-    resolve_actor_identifier::<ApubCommunity, Community>(name, &context, &None, true)
-      .await
-      .ok()
+    Some(resolve_actor_identifier::<ApubCommunity, Community>(name, &context, &None, true).await?)
       .map(|c| c.id)
   } else {
     data.community_id

--- a/crates/apub/src/api/search.rs
+++ b/crates/apub/src/api/search.rs
@@ -41,10 +41,11 @@ pub async fn search(
   let listing_type = data.listing_type;
   let search_type = data.type_.unwrap_or(SearchType::All);
   let community_id = if let Some(name) = &data.community_name {
-    resolve_actor_identifier::<ApubCommunity, Community>(name, &context, &local_user_view, false)
-      .await
-      .ok()
-      .map(|c| c.id)
+    Some(
+      resolve_actor_identifier::<ApubCommunity, Community>(name, &context, &local_user_view, false)
+        .await?,
+    )
+    .map(|c| c.id)
   } else {
     data.community_id
   };


### PR DESCRIPTION
This should fix https://github.com/LemmyNet/lemmy/issues/3383

Before when we get an error while listing posts on a community, because the community does not exists, we transform the Result we get into an Option, after that there is no way to recognize whether a community name was given and not found, or if no name was given at all.

To fix this, I'm simply returning the error if there is one, if not I simply wrap the value we get in an Option.

This gives a 404 error when requesting `http://localhost:8536/api/v3/post/list?community_name=InvalidCommunityName` with the Record not found message which from my testing is the same behavior we get if we try to follow a community that does not exists.

I'm just starting out Rust so please don't hesitate to let me know if that's not a good way to implement it.