### PR TITLE
[WIP] grouped tests into lint, test and build to (hopefully) decrease pipeline time #3308

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -26,6 +26,7 @@ pipeline:
       - tar -xvf sccache-v0.5.4-aarch64-unknown-linux-musl.tar.gz
       - mkdir -p .cargo/bin
       - mv sccache-v0.5.4-aarch64-unknown-linux-musl/sccache .cargo/bin
+      - rm -rvf sccache-v0.5.4-aarch64-unknown-linux-musl*
 
   prettier_check:
     group: lint

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -44,15 +44,36 @@ pipeline:
       RUSTC_WRAPPER: sccache
     commands:
       # need make existing toolchain available
-      - cp ~/.cargo . -r
+      - cp -n ~/.cargo . -r
       - rustup toolchain install nightly
       - rustup component add rustfmt --toolchain nightly
       - cargo +nightly fmt -- --check
     # when:
     #   platform: linux/amd64
 
+  # make sure api builds with default features (used by other crates relying on lemmy api)
+  cargo_check:
+    image: *muslrust_image
+    environment:
+      CARGO_HOME: .cargo
+      RUSTC_WRAPPER: sccache
+    commands:
+      - cargo check --package lemmy_api_common
+    # when:
+    #   platform: linux/amd64
+
+  cargo_build:
+    image: *muslrust_image
+    environment:
+      CARGO_HOME: .cargo
+      RUSTC_WRAPPER: sccache
+    commands:
+      - cargo build
+      - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server
+    # when:
+    #   platform: linux/amd64
+
   cargo_clippy:
-    group: lint
     image: *muslrust_image
     environment:
       CARGO_HOME: .cargo
@@ -76,30 +97,6 @@ pipeline:
         -D clippy::needless_collect
         -D clippy::unwrap_used
         -D clippy::indexing_slicing
-    # when:
-    #   platform: linux/amd64
-
-  # make sure api builds with default features (used by other crates relying on lemmy api)
-  cargo_check:
-    group: lint
-    image: *muslrust_image
-    environment:
-      CARGO_HOME: .cargo
-      RUSTC_WRAPPER: sccache
-    commands:
-      - cargo check --package lemmy_api_common
-    # when:
-    #   platform: linux/amd64
-
-  cargo_build:
-    group: build
-    image: *muslrust_image
-    environment:
-      CARGO_HOME: .cargo
-      RUSTC_WRAPPER: sccache
-    commands:
-      - cargo build
-      - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server
     # when:
     #   platform: linux/amd64
 

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -22,11 +22,11 @@ pipeline:
       - git submodule init
       - git submodule update
       # install sccache for faster compiletime
-      - wget https://github.com/mozilla/sccache/releases/download/v0.5.4/sccache-v0.5.4-aarch64-unknown-linux-musl.tar.gz
-      - tar -xvf sccache-v0.5.4-aarch64-unknown-linux-musl.tar.gz
+      - wget https://github.com/mozilla/sccache/releases/download/v0.5.4/sccache-v0.5.4-x86_64-unknown-linux-musl.tar.gz
+      - tar -xvf sccache-v0.5.4-x86_64-unknown-linux-musl.tar.gz
       - mkdir -p .cargo/bin
-      - mv sccache-v0.5.4-aarch64-unknown-linux-musl/sccache .cargo/bin
-      - rm -rvf sccache-v0.5.4-aarch64-unknown-linux-musl*
+      - mv sccache-v0.5.4-x86_64-unknown-linux-musl/sccache .cargo/bin
+      - rm -rvf sccache-v0.5.4-x86_64-unknown-linux-musl*
 
   prettier_check:
     group: lint

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -23,12 +23,14 @@ pipeline:
       - git submodule update
 
   prettier_check:
+    group: lint
     image: tmknom/prettier
     commands:
       - prettier -c . '!**/volumes' '!**/dist' '!target' '!**/translations'
 
   # use minimum supported rust version for most steps
   cargo_fmt:
+    group: lint
     image: *muslrust_image
     environment:
       # store cargo data in repo folder so that it gets cached between steps
@@ -43,6 +45,7 @@ pipeline:
     #   platform: linux/amd64
 
   cargo_clippy:
+    group: lint
     image: *muslrust_image
     environment:
       CARGO_HOME: .cargo
@@ -71,6 +74,7 @@ pipeline:
 
   # make sure api builds with default features (used by other crates relying on lemmy api)
   cargo_check:
+    group: lint
     image: *muslrust_image
     environment:
       CARGO_HOME: .cargo
@@ -80,6 +84,7 @@ pipeline:
     #   platform: linux/amd64
 
   lemmy_api_common_doesnt_depend_on_diesel:
+    group: test
     image: *muslrust_image
     environment:
       CARGO_HOME: .cargo
@@ -89,6 +94,7 @@ pipeline:
     #   platform: linux/amd64
 
   check_defaults_hjson_updated:
+    group: test
     image: *muslrust_image
     environment:
       CARGO_HOME: .cargo
@@ -100,6 +106,7 @@ pipeline:
     #   platform: linux/amd64
 
   check_diesel_schema:
+    group: test
     image: willsquire/diesel-cli
     environment:
       CARGO_HOME: .cargo
@@ -110,6 +117,7 @@ pipeline:
       - diff tmp.schema crates/db_schema/src/schema.rs
 
   cargo_test:
+    group: test
     image: *muslrust_image
     environment:
       LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
@@ -123,6 +131,7 @@ pipeline:
     #   platform: linux/amd64
 
   cargo_build:
+    group: build
     image: *muslrust_image
     environment:
       CARGO_HOME: .cargo
@@ -133,6 +142,7 @@ pipeline:
     #   platform: linux/amd64
 
   run_federation_tests:
+    group: test
     image: node:alpine
     environment:
       LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -17,10 +17,15 @@ pipeline:
   prepare_repo:
     image: alpine:3
     commands:
-      - apk add git
+      - apk add git wget tar
         #- git fetch --tags
       - git submodule init
       - git submodule update
+      # install sccache for faster compiletime
+      - wget https://github.com/mozilla/sccache/releases/download/v0.5.4/sccache-v0.5.4-aarch64-unknown-linux-musl.tar.gz
+      - tar -xvf sccache-v0.5.4-aarch64-unknown-linux-musl.tar.gz
+      - mkdir -p .cargo/bin
+      - mv sccache-v0.5.4-aarch64-unknown-linux-musl/sccache .cargo/bin
 
   prettier_check:
     group: lint
@@ -35,6 +40,7 @@ pipeline:
     environment:
       # store cargo data in repo folder so that it gets cached between steps
       CARGO_HOME: .cargo
+      RUSTC_WRAPPER: sccache
     commands:
       # need make existing toolchain available
       - cp ~/.cargo . -r
@@ -49,6 +55,7 @@ pipeline:
     image: *muslrust_image
     environment:
       CARGO_HOME: .cargo
+      RUSTC_WRAPPER: sccache
     commands:
       # latest rust for clippy to get extra checks
       # when adding new clippy lints, make sure to also add them in scripts/fix-clippy.sh
@@ -66,7 +73,6 @@ pipeline:
         -D clippy::explicit_into_iter_loop
         -D clippy::explicit_iter_loop
         -D clippy::needless_collect
-      - cargo clippy --workspace --features console --
         -D clippy::unwrap_used
         -D clippy::indexing_slicing
     # when:
@@ -78,8 +84,21 @@ pipeline:
     image: *muslrust_image
     environment:
       CARGO_HOME: .cargo
+      RUSTC_WRAPPER: sccache
     commands:
       - cargo check --package lemmy_api_common
+    # when:
+    #   platform: linux/amd64
+
+  cargo_build:
+    group: build
+    image: *muslrust_image
+    environment:
+      CARGO_HOME: .cargo
+      RUSTC_WRAPPER: sccache
+    commands:
+      - cargo build
+      - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server
     # when:
     #   platform: linux/amd64
 
@@ -88,6 +107,7 @@ pipeline:
     image: *muslrust_image
     environment:
       CARGO_HOME: .cargo
+      RUSTC_WRAPPER: sccache
     commands:
       - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
     # when:
@@ -98,6 +118,7 @@ pipeline:
     image: *muslrust_image
     environment:
       CARGO_HOME: .cargo
+      RUSTC_WRAPPER: sccache
     commands:
       - export LEMMY_CONFIG_LOCATION=./config/config.hjson
       - ./scripts/update_config_defaults.sh config/defaults_current.hjson
@@ -110,6 +131,7 @@ pipeline:
     image: willsquire/diesel-cli
     environment:
       CARGO_HOME: .cargo
+      RUSTC_WRAPPER: sccache
       DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
     commands:
       - diesel migration run
@@ -121,23 +143,13 @@ pipeline:
     image: *muslrust_image
     environment:
       LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
+      RUSTC_WRAPPER: sccache
       RUST_BACKTRACE: "1"
       RUST_TEST_THREADS: "1"
       CARGO_HOME: .cargo
     commands:
       - export LEMMY_CONFIG_LOCATION=../../config/config.hjson
       - cargo test --workspace --no-fail-fast
-    # when:
-    #   platform: linux/amd64
-
-  cargo_build:
-    group: build
-    image: *muslrust_image
-    environment:
-      CARGO_HOME: .cargo
-    commands:
-      - cargo build
-      - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server
     # when:
     #   platform: linux/amd64
 

--- a/crates/utils/src/rate_limit/rate_limiter.rs
+++ b/crates/utils/src/rate_limit/rate_limiter.rs
@@ -195,7 +195,9 @@ impl RateLimitStorage {
   /// Remove buckets older than the given duration
   pub(super) fn remove_older_than(&mut self, duration: Duration, now: InstantSecs) {
     // Only retain buckets that were last used after `instant`
-    let Some(instant) = now.to_instant().checked_sub(duration) else { return };
+    let Some(instant) = now.to_instant().checked_sub(duration) else {
+      return;
+    };
 
     let is_recently_used = |group: &RateLimitedGroup<_>| {
       group


### PR DESCRIPTION
I've grouped them into this order:
```
[lint]
cargo_check
cargo_clippy
cargo_fmt
prettier_check

[test]
lemmy_api_common_doesnt_depend_on_diesel
check_defaults_hjson_updated
check_diesel_schema
cargo_test
run_federation_tests

[build]
cargo_build

[ungrouped]
prepare_repo
publish_release_docker
nightly_build
publish_to_crates_io
notify_on_failure
notify_on_tag_deploy
```

From the output and job actions it seems that you can roughly put them into these categories without changing the bahivour of the pipeline too much. We'll see about that and the time speedup tho.