### PR TITLE
Fix: added missing quotes to max-file in docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,7 +4,7 @@ x-logging: &default-logging
   driver: "json-file"
   options:
     max-size: "50m"
-    max-file: 4
+    max-file: "4"
 
 services:
   proxy:


### PR DESCRIPTION
The quotes fixes the error bellow:
```
$ docker-compose up -d
Creating network "docker_default" with the default driver
Creating docker_pictrs_1   ... error
Creating docker_postgres_1 ... 

ERROR: for docker_pictrs_1  Cannot create container for service pictrs: invalid JSON: json: cannot unmarshal number into Go struct field LogConfig.HostConfig.LogConfig.Config oCreating docker_postgres_1 ... error

ERROR: for docker_postgres_1  Cannot create container for service postgres: invalid JSON: json: cannot unmarshal number into Go struct field LogConfig.HostConfig.LogConfig.Config of type string

ERROR: for pictrs  Cannot create container for service pictrs: invalid JSON: json: cannot unmarshal number into Go struct field LogConfig.HostConfig.LogConfig.Config of type string

ERROR: for postgres  Cannot create container for service postgres: invalid JSON: json: cannot unmarshal number into Go struct field LogConfig.HostConfig.LogConfig.Config of type string
ERROR: Encountered errors while bringing up the project.
```

Testet with docker-compose version 1.29.2.

Note: The value is already in quotes in https://github.com/LemmyNet/lemmy-ansible/blob/main/templates/docker-compose.yml