### PR TITLE
Remove excessive content_type header configuration

### DIFF
--- a/crates/apub/src/http/mod.rs
+++ b/crates/apub/src/http/mod.rs
@@ -48,7 +48,6 @@ where
   Ok(
     HttpResponse::Ok()
       .content_type(FEDERATION_CONTENT_TYPE)
-      .content_type("application/activity+json")
       .body(json),
   )
 }
@@ -61,7 +60,6 @@ fn create_apub_tombstone_response<T: Into<Url>>(id: T) -> LemmyResult<HttpRespon
     HttpResponse::Gone()
       .content_type(FEDERATION_CONTENT_TYPE)
       .status(StatusCode::GONE)
-      .content_type("application/activity+json")
       .body(json),
   )
 }


### PR DESCRIPTION
Amendment of #3353 

This patch removes excessive content_type header configuration and use default FEDERATION_CONTENT_TYPE constant.