### PR TITLE
Add workaround for #3102 until cross-compile work complete

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,9 +24,11 @@ services:
     logging: *default-logging
 
   lemmy:
+    # use "image" to pull down an already compiled lemmy. make sure to comment out "build".
     # image: dessalines/lemmy:0.18.0
-    # use this to build your local lemmy server image for development
-    # run docker compose up --build
+    # platform: linux/x86_64 # no arm64 support. uncomment platform if using m1.
+    # use "build" to build your local lemmy server image for development. make sure to comment out "image".
+    # run: docker compose up --build
     build:
       context: ../
       dockerfile: docker/Dockerfile
@@ -46,12 +48,13 @@ services:
     logging: *default-logging
 
   lemmy-ui:
+    # use "image" to pull down an already compiled lemmy-ui. make sure to comment out "build".
     image: dessalines/lemmy-ui:0.18.0
-    # use this to build your local lemmy ui image for development
-    # run docker compose up --build
-    # assuming lemmy-ui is cloned besides lemmy directory
+    # platform: linux/x86_64 # no arm64 support. uncomment platform if using m1.
+    # use "build" to build your local lemmy ui image for development. make sure to comment out "image".
+    # run: docker compose up --build
     # build:
-    #   context: ../../lemmy-ui
+    #   context: ../../lemmy-ui # assuming lemmy-ui is cloned besides lemmy directory
     #   dockerfile: dev.dockerfile
     environment:
       # this needs to match the hostname defined in the lemmy service

--- a/docker/docker_update.sh
+++ b/docker/docker_update.sh
@@ -10,7 +10,7 @@ Help()
   echo ""
   echo "Options:"
   echo "-u Docker username. Only required if managing Docker via Docker Desktop with a personal access token."
-  echo "-h Print this help"
+  echo "-h Print this help."
 }
 
 while getopts ":hu:" option; do
@@ -24,30 +24,30 @@ while getopts ":hu:" option; do
   esac
 done
 
-# uname may not exist on windows machines; default to unknown to be safe.
-ARCH=$(uname -m 2>/dev/null || echo 'unknown')
+LOG_PREFIX="[🐀 lemmy]"
+ARCH=$(uname -m 2>/dev/null || echo 'unknown') # uname may not exist on windows machines; default to unknown to be safe.
 
 mkdir -p volumes/pictrs
 
-echo "[🐀 lemmy] Need user password to run 'sudo chown' for the pictrs volume."
+echo "$LOG_PREFIX Please provide your password to change ownership of the pictrs volume."
 sudo chown -R 991:991 volumes/pictrs
 
 if [ "$ARCH" = 'arm64' ]; then
-  echo "[🐀 lemmy] WARN: If building from images, make sure to uncomment 'platform' in the docker-compose.yml file!"
+  echo "$LOG_PREFIX WARN: If building from images, make sure to uncomment 'platform' in the docker-compose.yml file!"
 
   # You need a Docker account to pull images. Otherwise, you will get an error like: "error getting credentials"
   if [ -z "$DOCKER_USER" ]; then
-      echo "[🐀 lemmy] Logging into Docker Hub..."
+      echo "$LOG_PREFIX Logging into Docker Hub..."
       docker login
   else
-      echo "[🐀 lemmy] Logging into Docker Hub. Please provide your personal access token."
+      echo "$LOG_PREFIX Logging into Docker Hub. Please provide your personal access token."
       docker login --username="$DOCKER_USER"
   fi
 
-  echo "[🐀 lemmy] Initializing images in the background. Please be patient if compiling from source..."
+  echo "$LOG_PREFIX Initializing images in the background. Please be patient if compiling from source..."
   docker compose up -d --build
 else
   sudo docker compose up -d --build
 fi
 
-echo "[🐀 lemmy] Complete! You can now access the UI at http://localhost:1236."
+echo "$LOG_PREFIX Complete! You can now access the UI at http://localhost:1236."

--- a/docker/docker_update.sh
+++ b/docker/docker_update.sh
@@ -1,6 +1,53 @@
 #!/bin/sh
 set -e
 
+Help()
+{
+  # Display help
+  echo "Usage: ./docker_update.sh [OPTIONS]"
+  echo ""
+  echo "Start all docker containers required to run Lemmy."
+  echo ""
+  echo "Options:"
+  echo "-u Docker username. Only required if managing Docker via Docker Desktop with a personal access token."
+  echo "-h Print this help"
+}
+
+while getopts ":hu:" option; do
+  case $option in
+    h) Help
+       exit;;
+    u) DOCKER_USER=$OPTARG
+       ;;
+    *) echo "Invalid option $OPTARG."
+       exit;;
+  esac
+done
+
+# uname may not exist on windows machines; default to unknown to be safe.
+ARCH=$(uname -m 2>/dev/null || echo 'unknown')
+
 mkdir -p volumes/pictrs
+
+echo "[🐀 lemmy] Need user password to run 'sudo chown' for the pictrs volume."
 sudo chown -R 991:991 volumes/pictrs
-sudo docker compose up -d --build
+
+if [ "$ARCH" = 'arm64' ]; then
+  echo "[🐀 lemmy] WARN: If building from images, make sure to uncomment 'platform' in the docker-compose.yml file!"
+
+  # You need a Docker account to pull images. Otherwise, you will get an error like: "error getting credentials"
+  if [ -z "$DOCKER_USER" ]; then
+      echo "[🐀 lemmy] Logging into Docker Hub..."
+      docker login
+  else
+      echo "[🐀 lemmy] Logging into Docker Hub. Please provide your personal access token."
+      docker login --username="$DOCKER_USER"
+  fi
+
+  echo "[🐀 lemmy] Initializing images in the background. Please be patient if compiling from source..."
+  docker compose up -d --build
+else
+  sudo docker compose up -d --build
+fi
+
+echo "[🐀 lemmy] Complete! You can now access the UI at http://localhost:1236."


### PR DESCRIPTION
# What & Why

The `./docker_update.sh` script does not work for M1 Macs without messing with the script and Dockerfiles. This adds the commands required to get it working with minimum fuss.

Changes:
- Adds a help menu, since an option was added.
- Adds the -u option, which allows passing in a username and password. This will allow you to use a [personal access token](https://docs.docker.com/docker-hub/access-tokens/) if you do not wish to use your password.
- Echoes comments to make it easier to keep track of the progress of the script.
- Adds a check for the architecture, and runs different commands if M1.
- Adds docker desktop login, and removes sudo from the docker-compose command since that breaks things.

This should be backwards compatible for those not on an M1, but would love some verification. I do not have another machine to test this with.

# Proof
## Help
![docker-help](https://github.com/LemmyNet/lemmy/assets/17285719/09eec045-7a82-4f3c-ae4f-d1fa0ff1a2d3)

## Without username prompt
![docker-nouser](https://github.com/LemmyNet/lemmy/assets/17285719/80233a35-a4eb-482b-8d41-42c9ad687332)

## With username prompt
![docker-user](https://github.com/LemmyNet/lemmy/assets/17285719/67db91fd-8fdc-445c-a975-a6ff0a1907ea)

## Bad option
![docker-badopt](https://github.com/LemmyNet/lemmy/assets/17285719/d87a8758-4f1a-483e-b33c-a59923c4db41)
