### PR TITLE
prototype / proof of concept - do not send comment/post upvotes/likes…

### DIFF
--- a/crates/apub/src/activities/community/mod.rs
+++ b/crates/apub/src/activities/community/mod.rs
@@ -53,9 +53,26 @@ pub(crate) async fn send_activity_in_community(
 
   if community.local {
     // send directly to community followers
-    AnnounceActivity::send(activity.clone().try_into()?, community, context).await?;
+    // PERFORMANCE CRISIS NOTE: if the activity is a Vote on a comment or post, this is the ideal point
+    //    to match the activity type and SKIP this send call to not have to federate votes to all the instances
+    //    following your community. Busy servers (examples: lemmy.world, lemmy.me, beehaw.org) have many instances
+    //    following their local communities. This is the point where content is sent to each of those remote instances.
+    //    Specifically targeting post votes and comment votes is a proposed emergency performance measure for overloaded senders.
+    //    There are also PostgreSQL operations in this send activity that will also be bypassed, further reducing server overload.
+    //    1==1 if: Intention here is that if a site setting or envionment variable is set to skip sending outbound post and comment votes, check that value.
+    if 1==1 {
+      if let AnnouncableActivities::UndoVote(_) = activity {
+        warn!("zebratrace310 SKIP UndoVote");
+      } else if let AnnouncableActivities::Vote(_) = activity {
+        warn!("zebratrace310A SKIP Vote");
+      } else {
+        warn!("zebratrace311 send");
+        AnnounceActivity::send(activity.clone().try_into()?, community, context).await?;
+      };
+    };
   } else {
     // send to the community, which will then forward to followers
+    // Another instance is home to the community, only one single outbound notificaiton is required to send a vote, so go ahead.
     inboxes.push(community.shared_inbox_or_inbox());
   }
 


### PR DESCRIPTION
… to peer servers due to **performance crisis**

DRAFT: add Linux environment variable or site settings to allow instances with large numbers of servers wanting comment/post copies to skip vote replication.