### PR TITLE
Adding a person.admin index, and featured_local/community indexes.

### DIFF
--- a/migrations/2023-07-04-153335_add_optimized_indexes/down.sql
+++ b/migrations/2023-07-04-153335_add_optimized_indexes/down.sql
@@ -1,0 +1,27 @@
+-- Drop the new indexes
+drop index idx_person_admin;
+
+drop index idx_post_aggregates_featured_local_score;
+drop index idx_post_aggregates_featured_local_newest_comment_time;
+drop index idx_post_aggregates_featured_local_newest_comment_time_necro;
+drop index idx_post_aggregates_featured_local_hot;
+drop index idx_post_aggregates_featured_local_active;
+drop index idx_post_aggregates_featured_local_published;
+drop index idx_post_aggregates_published;
+
+drop index idx_post_aggregates_featured_community_score;
+drop index idx_post_aggregates_featured_community_newest_comment_time;
+drop index idx_post_aggregates_featured_community_newest_comment_time_necro;
+drop index idx_post_aggregates_featured_community_hot;
+drop index idx_post_aggregates_featured_community_active;
+drop index idx_post_aggregates_featured_community_published;
+
+-- Create single column indexes again
+create index idx_post_aggregates_score on post_aggregates (score desc);
+create index idx_post_aggregates_published on post_aggregates (published desc);
+create index idx_post_aggregates_newest_comment_time on post_aggregates (newest_comment_time desc);
+create index idx_post_aggregates_newest_comment_time_necro on post_aggregates (newest_comment_time_necro desc);
+create index idx_post_aggregates_featured_community on post_aggregates (featured_community desc);
+create index idx_post_aggregates_featured_local on post_aggregates (featured_local desc);
+create index idx_post_aggregates_hot on post_aggregates (hot_rank desc);
+create index idx_post_aggregates_active on post_aggregates (hot_rank_active desc);

--- a/migrations/2023-07-04-153335_add_optimized_indexes/up.sql
+++ b/migrations/2023-07-04-153335_add_optimized_indexes/up.sql
@@ -1,0 +1,32 @@
+-- Create an admin person index
+create index idx_person_admin on person (admin);
+
+-- Compound indexes, using featured_, then the other sorts, proved to be much faster
+-- Drop the old indexes
+drop index idx_post_aggregates_score;
+drop index idx_post_aggregates_published;
+drop index idx_post_aggregates_newest_comment_time;
+drop index idx_post_aggregates_newest_comment_time_necro;
+drop index idx_post_aggregates_featured_community;
+drop index idx_post_aggregates_featured_local;
+drop index idx_post_aggregates_hot;
+drop index idx_post_aggregates_active;
+
+-- featured_local
+create index idx_post_aggregates_featured_local_score on post_aggregates (featured_local desc, score desc);
+create index idx_post_aggregates_featured_local_newest_comment_time on post_aggregates (featured_local desc, newest_comment_time desc);
+create index idx_post_aggregates_featured_local_newest_comment_time_necro on post_aggregates (featured_local desc, newest_comment_time_necro desc);
+create index idx_post_aggregates_featured_local_hot on post_aggregates (featured_local desc, hot_rank desc);
+create index idx_post_aggregates_featured_local_active on post_aggregates (featured_local desc, hot_rank_active desc);
+create index idx_post_aggregates_featured_local_published on post_aggregates (featured_local desc, published desc);
+create index idx_post_aggregates_published on post_aggregates (published desc);
+
+-- featured_community
+create index idx_post_aggregates_featured_community_score on post_aggregates (featured_community desc, score desc);
+create index idx_post_aggregates_featured_community_newest_comment_time on post_aggregates (featured_community desc, newest_comment_time desc);
+create index idx_post_aggregates_featured_community_newest_comment_time_necro on post_aggregates (featured_community desc, newest_comment_time_necro desc);
+create index idx_post_aggregates_featured_community_hot on post_aggregates (featured_community desc, hot_rank desc);
+create index idx_post_aggregates_featured_community_active on post_aggregates (featured_community desc, hot_rank_active desc);
+create index idx_post_aggregates_featured_community_published on post_aggregates (featured_community desc, published desc);
+
+


### PR DESCRIPTION
These turned out to make a difference. In my testing, unprimed queries went from ~ 100ms down to 30ms, and primed ones went under 10ms.

Still doesn't address #2994 , but there might not be a good way to do subquery from selects in diesel, and we might have to use the `sql_query` function for that one.