### PR TITLE
improve performance of community followers inbox query

### DIFF
--- a/crates/apub/src/objects/community.rs
+++ b/crates/apub/src/objects/community.rs
@@ -14,7 +14,6 @@ use activitypub_federation::{
   traits::{Actor, Object},
 };
 use chrono::NaiveDateTime;
-use itertools::Itertools;
 use lemmy_api_common::{
   context::LemmyContext,
   utils::{generate_featured_url, generate_moderators_url, generate_outbox_url},
@@ -188,17 +187,10 @@ impl ApubCommunity {
     let id = self.id;
 
     let local_site_data = fetch_local_site_data(context.pool()).await?;
-    let follows = CommunityFollowerView::for_community(context.pool(), id).await?;
+    let follows = CommunityFollowerView::get_community_follower_inboxes(context.pool(), id).await?;
     let inboxes: Vec<Url> = follows
       .into_iter()
-      .filter(|f| !f.follower.local)
-      .map(|f| {
-        f.follower
-          .shared_inbox_url
-          .unwrap_or(f.follower.inbox_url)
-          .into()
-      })
-      .unique()
+      .map(|inbox| inbox.into())
       .filter(|inbox: &Url| inbox.host_str() != Some(&context.settings().hostname))
       // Don't send to blocked instances
       .filter(|inbox| {

--- a/crates/apub/src/objects/community.rs
+++ b/crates/apub/src/objects/community.rs
@@ -190,7 +190,7 @@ impl ApubCommunity {
     let follows = CommunityFollowerView::get_community_follower_inboxes(context.pool(), id).await?;
     let inboxes: Vec<Url> = follows
       .into_iter()
-      .map(|inbox| inbox.into())
+      .map(Into::into)
       .filter(|inbox: &Url| inbox.host_str() != Some(&context.settings().hostname))
       // Don't send to blocked instances
       .filter(|inbox| {

--- a/crates/apub/src/protocol/collections/group_followers.rs
+++ b/crates/apub/src/protocol/collections/group_followers.rs
@@ -22,12 +22,12 @@ impl GroupFollowers {
   ) -> Result<GroupFollowers, LemmyError> {
     let community_id = community.id;
     let community_followers =
-      CommunityFollowerView::for_community(context.pool(), community_id).await?;
+      CommunityFollowerView::count_community_followers(context.pool(), community_id).await?;
 
     Ok(GroupFollowers {
       id: generate_followers_url(&community.actor_id)?.into(),
       r#type: CollectionType::Collection,
-      total_items: community_followers.len() as i32,
+      total_items: community_followers as i32,
       items: vec![],
     })
   }

--- a/crates/db_views_actor/src/community_follower_view.rs
+++ b/crates/db_views_actor/src/community_follower_view.rs
@@ -1,8 +1,8 @@
 use crate::structs::CommunityFollowerView;
-use diesel::{result::Error, ExpressionMethods, QueryDsl};
+use diesel::{result::Error, ExpressionMethods, QueryDsl, sql_function, dsl::{not,  count_star}};
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  newtypes::{CommunityId, PersonId},
+  newtypes::{CommunityId, PersonId, DbUrl},
   schema::{community, community_follower, person},
   source::{community::Community, person::Person},
   traits::JoinView,
@@ -11,19 +11,33 @@ use lemmy_db_schema::{
 
 type CommunityFollowerViewTuple = (Community, Person);
 
+sql_function!(fn coalesce(x: diesel::sql_types::Nullable<diesel::sql_types::Text>, y: diesel::sql_types::Text) -> diesel::sql_types::Text);
+
+
 impl CommunityFollowerView {
-  pub async fn for_community(pool: &DbPool, community_id: CommunityId) -> Result<Vec<Self>, Error> {
+  pub async fn get_community_follower_inboxes(pool: &DbPool, community_id: CommunityId) -> Result<Vec<DbUrl>, Error> {
     let conn = &mut get_conn(pool).await?;
     let res = community_follower::table
-      .inner_join(community::table)
-      .inner_join(person::table)
-      .select((community::all_columns, person::all_columns))
       .filter(community_follower::community_id.eq(community_id))
-      .order_by(community::title)
-      .load::<CommunityFollowerViewTuple>(conn)
+      .filter(not(person::local))
+      .inner_join(person::table)
+      .select(coalesce(person::shared_inbox_url, person::inbox_url))
+      .distinct()
+      .load::<DbUrl>(conn)
       .await?;
 
-    Ok(res.into_iter().map(Self::from_tuple).collect())
+    Ok(res)
+  }
+  pub async fn count_community_followers(pool: &DbPool, community_id: CommunityId) -> Result<i64, Error> {
+    let conn = &mut get_conn(pool).await?;
+    let res = community_follower::table
+      .filter(community_follower::community_id.eq(community_id))
+      .select(count_star())
+      .distinct()
+      .first::<i64>(conn)
+      .await?;
+
+    Ok(res)
   }
 
   pub async fn for_person(pool: &DbPool, person_id: PersonId) -> Result<Vec<Self>, Error> {

--- a/crates/db_views_actor/src/community_follower_view.rs
+++ b/crates/db_views_actor/src/community_follower_view.rs
@@ -1,8 +1,14 @@
 use crate::structs::CommunityFollowerView;
-use diesel::{result::Error, ExpressionMethods, QueryDsl, sql_function, dsl::{not,  count_star}};
+use diesel::{
+  dsl::{count_star, not},
+  result::Error,
+  sql_function,
+  ExpressionMethods,
+  QueryDsl,
+};
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  newtypes::{CommunityId, PersonId, DbUrl},
+  newtypes::{CommunityId, DbUrl, PersonId},
   schema::{community, community_follower, person},
   source::{community::Community, person::Person},
   traits::JoinView,
@@ -13,9 +19,11 @@ type CommunityFollowerViewTuple = (Community, Person);
 
 sql_function!(fn coalesce(x: diesel::sql_types::Nullable<diesel::sql_types::Text>, y: diesel::sql_types::Text) -> diesel::sql_types::Text);
 
-
 impl CommunityFollowerView {
-  pub async fn get_community_follower_inboxes(pool: &DbPool, community_id: CommunityId) -> Result<Vec<DbUrl>, Error> {
+  pub async fn get_community_follower_inboxes(
+    pool: &DbPool,
+    community_id: CommunityId,
+  ) -> Result<Vec<DbUrl>, Error> {
     let conn = &mut get_conn(pool).await?;
     let res = community_follower::table
       .filter(community_follower::community_id.eq(community_id))
@@ -28,12 +36,14 @@ impl CommunityFollowerView {
 
     Ok(res)
   }
-  pub async fn count_community_followers(pool: &DbPool, community_id: CommunityId) -> Result<i64, Error> {
+  pub async fn count_community_followers(
+    pool: &DbPool,
+    community_id: CommunityId,
+  ) -> Result<i64, Error> {
     let conn = &mut get_conn(pool).await?;
     let res = community_follower::table
       .filter(community_follower::community_id.eq(community_id))
       .select(count_star())
-      .distinct()
       .first::<i64>(conn)
       .await?;
 


### PR DESCRIPTION
i found a huge perf issue. get_follower_inboxes fetches all followers of a community (including thousands of copies of the whole damn community object, person object, and community_follower object) for every single action (e.g. like). it transfers that list to rust (like 20000 elements with huge objects each, including private keys and whatever). rust then finds all the federated instances it has to send the like to from that list (like 100 strings).

so basically the query uselessly transfers huge amounts of data just to get a list of instance_count urls.

on [lemmy.world](http://lemmy.world/) we looked at pg_stats_statements (thanks jelloeater) and that community_follower query absolutely dominates the stats, eating up **8 days of query time per day**. Since yesterday, it has fetched *over 4 billion rows*.
that query is also timing out a lot due to the statement_timeout=10s we set.

This PR improves on the situation by doing the filtering on the database side. It's not optimal since the result can't be perfectly indexed, but it seems the main issue is the huge amount of data transfer between rust and PG. after some quick testing: the new query takes around 100ms and returns only tiny amounts of data. it should basically fix a huge amount of lemmys current perf problems.

i also replaced the second query in followers which was doing a similar amount of unnecessary work (but much more seldom).

i did not extensively test this for correctness.