### PR TITLE
improve admin and mod check to not do seq scans and return unnecessary data

### DIFF
--- a/crates/db_views_actor/src/community_moderator_view.rs
+++ b/crates/db_views_actor/src/community_moderator_view.rs
@@ -17,7 +17,11 @@ impl CommunityModeratorView {
     find_community_id: CommunityId,
     find_person_id: PersonId,
   ) -> Result<bool, Error> {
-    use lemmy_db_schema::schema::community_moderator::dsl::{community_id, community_moderator, person_id};
+    use lemmy_db_schema::schema::community_moderator::dsl::{
+      community_id,
+      community_moderator,
+      person_id,
+    };
     let conn = &mut get_conn(pool).await?;
     select(exists(
       community_moderator

--- a/crates/db_views_actor/src/community_moderator_view.rs
+++ b/crates/db_views_actor/src/community_moderator_view.rs
@@ -17,8 +17,8 @@ impl CommunityModeratorView {
     find_community_id: CommunityId,
     find_person_id: PersonId,
   ) -> Result<bool, Error> {
+    use lemmy_db_schema::schema::community_moderator::dsl::{community_id, community_moderator, person_id};
     let conn = &mut get_conn(pool).await?;
-    use lemmy_db_schema::schema::community_moderator::dsl::*;
     select(exists(
       community_moderator
         .filter(community_id.eq(find_community_id))

--- a/crates/db_views_actor/src/community_view.rs
+++ b/crates/db_views_actor/src/community_view.rs
@@ -90,29 +90,13 @@ impl CommunityView {
     person_id: PersonId,
     community_id: CommunityId,
   ) -> Result<bool, Error> {
-    let is_mod = CommunityModeratorView::for_community(pool, community_id)
-      .await
-      .map(|v| {
-        v.into_iter()
-          .map(|m| m.moderator.id)
-          .collect::<Vec<PersonId>>()
-      })
-      .unwrap_or_default()
-      .contains(&person_id);
+    let is_mod =
+      CommunityModeratorView::is_community_moderator(pool, community_id, person_id).await?;
     if is_mod {
       return Ok(true);
     }
 
-    let is_admin = PersonView::admins(pool)
-      .await
-      .map(|v| {
-        v.into_iter()
-          .map(|a| a.person.id)
-          .collect::<Vec<PersonId>>()
-      })
-      .unwrap_or_default()
-      .contains(&person_id);
-    Ok(is_admin)
+    PersonView::is_admin(pool, person_id).await
   }
 }
 

--- a/crates/db_views_actor/src/person_view.rs
+++ b/crates/db_views_actor/src/person_view.rs
@@ -36,7 +36,7 @@ impl PersonView {
   }
 
   pub async fn is_admin(pool: &DbPool, person_id: PersonId) -> Result<bool, Error> {
-    use schema::person::dsl::*;
+    use schema::person::dsl::{admin, id, person};
     let conn = &mut get_conn(pool).await?;
     let is_admin = person
       .filter(id.eq(person_id))

--- a/crates/db_views_actor/src/person_view.rs
+++ b/crates/db_views_actor/src/person_view.rs
@@ -11,6 +11,7 @@ use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
   aggregates::structs::PersonAggregates,
   newtypes::PersonId,
+  schema,
   schema::{person, person_aggregates},
   source::person::Person,
   traits::JoinView,
@@ -34,6 +35,16 @@ impl PersonView {
     Ok(Self::from_tuple(res))
   }
 
+  pub async fn is_admin(pool: &DbPool, person_id: PersonId) -> Result<bool, Error> {
+    use schema::person::dsl::*;
+    let conn = &mut get_conn(pool).await?;
+    let is_admin = person
+      .filter(id.eq(person_id))
+      .select(admin)
+      .first::<bool>(conn)
+      .await?;
+    Ok(is_admin)
+  }
   pub async fn admins(pool: &DbPool) -> Result<Vec<Self>, Error> {
     let conn = &mut get_conn(pool).await?;
     let admins = person::table

--- a/migrations/2023-07-04-153335_add_optimized_indexes/up.sql
+++ b/migrations/2023-07-04-153335_add_optimized_indexes/up.sql
@@ -1,5 +1,5 @@
 -- Create an admin person index
-create index idx_person_admin on person (admin);
+create index if not exists idx_person_admin on person (admin);
 
 -- Compound indexes, using featured_, then the other sorts, proved to be much faster
 -- Drop the old indexes

--- a/migrations/2023-07-04-153335_add_optimized_indexes/up.sql
+++ b/migrations/2023-07-04-153335_add_optimized_indexes/up.sql
@@ -1,5 +1,5 @@
 -- Create an admin person index
-create index if not exists idx_person_admin on person (admin) where admin;
+create index idx_person_admin on person (admin);
 
 -- Compound indexes, using featured_, then the other sorts, proved to be much faster
 -- Drop the old indexes

--- a/migrations/2023-07-04-153335_add_optimized_indexes/up.sql
+++ b/migrations/2023-07-04-153335_add_optimized_indexes/up.sql
@@ -1,5 +1,5 @@
 -- Create an admin person index
-create index idx_person_admin on person (admin);
+create index if not exists idx_person_admin on person (admin) where admin;
 
 -- Compound indexes, using featured_, then the other sorts, proved to be much faster
 -- Drop the old indexes

--- a/migrations/2023-07-05-000058_person-admin/down.sql
+++ b/migrations/2023-07-05-000058_person-admin/down.sql
@@ -1,1 +1,0 @@
-drop index idx_person_admin;

--- a/migrations/2023-07-05-000058_person-admin/down.sql
+++ b/migrations/2023-07-05-000058_person-admin/down.sql
@@ -1,1 +1,2 @@
 drop index idx_person_admin;
+create index idx_person_admin on person(admin);

--- a/migrations/2023-07-05-000058_person-admin/down.sql
+++ b/migrations/2023-07-05-000058_person-admin/down.sql
@@ -1,0 +1,1 @@
+drop index idx_person_admin;

--- a/migrations/2023-07-05-000058_person-admin/up.sql
+++ b/migrations/2023-07-05-000058_person-admin/up.sql
@@ -1,1 +1,0 @@
-create index idx_person_admin on person(admin) where admin; -- allow quickly finding all admins (PersonView::admins)

--- a/migrations/2023-07-05-000058_person-admin/up.sql
+++ b/migrations/2023-07-05-000058_person-admin/up.sql
@@ -1,1 +1,2 @@
+drop index if exists idx_person_admin;
 create index idx_person_admin on person(admin) where admin; -- allow quickly finding all admins (PersonView::admins)

--- a/migrations/2023-07-05-000058_person-admin/up.sql
+++ b/migrations/2023-07-05-000058_person-admin/up.sql
@@ -1,0 +1,1 @@
+create index idx_person_admin on person(admin) where admin; -- allow quickly finding all admins (PersonView::admins)


### PR DESCRIPTION
the PersonView::admins query currently does a seq scan on all persons because admin is not indexed.

Also, the CommunityView::is_mod_or_admin function does a seq scan on all persons because it uses PersonView::admins.

is_mod_or_admin is used in tons of places, e.g. createpost.

This PR adds an index on the admin field to improve the `api/v3/site` and community fetches.

It also replaces the is_mod_or_admin function to just return a boolean and also not do any seq scans.

This should improve page load times that fetch admins (e.g. / ) and also everything.

The `PersonView::admins` is the second-most expensive query after #3482 on lemmy.world with 1.5 million calls returning 10 million rows and 27 hours of execution time in one day. This should reduce that to almost zero.


I did not test this.