### PR TITLE
upgrade markdown-it to fix panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3065,9 +3065,9 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "markdown-it"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53107ab22a09ae3b2eaedccf1d1c6aa58c1aa77e15689a799e0d8eda2b1a7d54"
+checksum = "c44ffb00018b76ef3c6eff5e17d34b44f0bbded0b70291940564c527cba07ad8"
 dependencies = [
  "argparse",
  "const_format",

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -43,7 +43,7 @@ deser-hjson = "1.0.2"
 smart-default = "0.7.1"
 jsonwebtoken = "8.1.1"
 lettre = "0.10.1"
-markdown-it = "0.5.0"
+markdown-it = "0.5.1"
 totp-rs = { version = "5.0.2", features = ["gen_secret", "otpauth"] }
 enum-map = "2.5"
 


### PR DESCRIPTION
This fixes #3411 by upgrading markdown-it (see https://github.com/rlidwka/markdown-it.rs/issues/26 )