### PR TITLE
Make sure hot rank sorts for post and community filter by positive hot ranks.

### DIFF
--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -392,6 +392,8 @@ impl<'a> PostQuery<'a> {
 
     query = match self.sort.unwrap_or(SortType::Hot) {
       SortType::Active => query
+        // Hot ranks fade to zero after a few days, and this filter drastically reduces
+        // the number of rows needed to be joined to.
         .filter(post_aggregates::hot_rank_active.gt(1))
         .then_order_by(post_aggregates::hot_rank_active.desc()),
       SortType::Hot => query

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -391,8 +391,12 @@ impl<'a> PostQuery<'a> {
     }
 
     query = match self.sort.unwrap_or(SortType::Hot) {
-      SortType::Active => query.then_order_by(post_aggregates::hot_rank_active.desc()),
-      SortType::Hot => query.then_order_by(post_aggregates::hot_rank.desc()),
+      SortType::Active => query
+        .filter(post_aggregates::hot_rank_active.gt(1))
+        .then_order_by(post_aggregates::hot_rank_active.desc()),
+      SortType::Hot => query
+        .filter(post_aggregates::hot_rank.gt(1))
+        .then_order_by(post_aggregates::hot_rank.desc()),
       SortType::New => query.then_order_by(post_aggregates::published.desc()),
       SortType::Old => query.then_order_by(post_aggregates::published.asc()),
       SortType::NewComments => query.then_order_by(post_aggregates::newest_comment_time.desc()),

--- a/crates/db_views_actor/src/community_view.rs
+++ b/crates/db_views_actor/src/community_view.rs
@@ -184,7 +184,11 @@ impl<'a> CommunityQuery<'a> {
         );
     }
     match self.sort.unwrap_or(Hot) {
-      Hot | Active => query = query.order_by(community_aggregates::hot_rank.desc()),
+      Hot | Active => {
+        query = query
+          .filter(community_aggregates::hot_rank.gt(1))
+          .order_by(community_aggregates::hot_rank.desc())
+      }
       NewComments | TopDay | TopTwelveHour | TopSixHour | TopHour => {
         query = query.order_by(community_aggregates::users_active_day.desc())
       }


### PR DESCRIPTION
- Context #2994 

This drastically decreases the number of rows fetched / needed to be joined to.