### PR TITLE
Add option to not save read posts

### DIFF
--- a/crates/api/src/local_user/save_settings.rs
+++ b/crates/api/src/local_user/save_settings.rs
@@ -10,11 +10,12 @@ use lemmy_db_schema::{
     actor_language::LocalUserLanguage,
     local_user::{LocalUser, LocalUserUpdateForm},
     person::{Person, PersonUpdateForm},
+    post::PostRead,
   },
-  traits::Crud,
-  utils::{diesel_option_overwrite, diesel_option_overwrite_to_url},
+  traits::{Crud, Readable},
+  utils::{diesel_option_overwrite, diesel_option_overwrite_to_url, DbPool},
 };
-use lemmy_db_views::structs::SiteView;
+use lemmy_db_views::structs::{LocalUserView, SiteView};
 use lemmy_utils::{
   claims::Claims,
   error::LemmyError,
@@ -112,9 +113,12 @@ impl Perform for SaveUserSettings {
       (None, None)
     };
 
+    handle_save_read_posts_change(self, &local_user_view, context.pool()).await?;
+
     let local_user_form = LocalUserUpdateForm::builder()
       .email(email)
       .show_avatars(data.show_avatars)
+      .save_read_posts(data.save_read_posts)
       .show_read_posts(data.show_read_posts)
       .show_new_post_notifs(data.show_new_post_notifs)
       .send_notifications_to_email(data.send_notifications_to_email)
@@ -159,5 +163,116 @@ impl Perform for SaveUserSettings {
       verify_email_sent: false,
       registration_created: false,
     })
+  }
+}
+
+async fn handle_save_read_posts_change(
+  data: &SaveUserSettings,
+  local_user_view: &LocalUserView,
+  pool: &DbPool,
+) -> Result<usize, LemmyError> {
+  if let Some(save_read_posts) = data.save_read_posts {
+    if !save_read_posts && local_user_view.local_user.save_read_posts {
+      // Delete all read posts
+      return PostRead::delete_all(pool, &local_user_view.person.id)
+        .await
+        .map_err(|e| LemmyError::from_error_message(e, "couldnt_mark_delete_past_read_posts"));
+    }
+  }
+
+  Ok(0)
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::local_user::save_settings::handle_save_read_posts_change;
+  use lemmy_api_common::person::SaveUserSettings;
+  use lemmy_db_schema::{
+    aggregates::structs::PersonAggregates,
+    source::{
+      community::{Community, CommunityInsertForm},
+      instance::Instance,
+      local_user::{LocalUser, LocalUserInsertForm},
+      person::{Person, PersonInsertForm},
+      post::{Post, PostInsertForm, PostRead, PostReadForm},
+    },
+    traits::{Crud, Readable},
+    utils::build_db_pool_for_tests,
+  };
+  use lemmy_db_views::structs::LocalUserView;
+
+  #[tokio::test]
+  async fn test_disable_save_read_posts() {
+    let pool = &build_db_pool_for_tests().await;
+
+    let person_name = "tegan".to_string();
+
+    let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
+      .await
+      .unwrap();
+
+    let new_community = CommunityInsertForm::builder()
+      .name("test_community_3".to_string())
+      .title("nada".to_owned())
+      .public_key("pubkey".to_string())
+      .instance_id(inserted_instance.id)
+      .build();
+
+    let inserted_community = Community::create(pool, &new_community).await.unwrap();
+
+    let new_person = PersonInsertForm::builder()
+      .name(person_name.clone())
+      .public_key("pubkey".to_string())
+      .instance_id(inserted_instance.id)
+      .build();
+
+    let inserted_person = Person::create(pool, &new_person).await.unwrap();
+
+    let local_user_form = LocalUserInsertForm::builder()
+      .person_id(inserted_person.id)
+      .password_encrypted(String::new())
+      .save_read_posts(Some(true))
+      .build();
+    let inserted_local_user = LocalUser::create(pool, &local_user_form).await.unwrap();
+
+    let local_user_view = LocalUserView {
+      local_user: inserted_local_user.clone(),
+      person: inserted_person.clone(),
+      counts: PersonAggregates::default(),
+    };
+
+    // Insert a read post
+    let new_post = PostInsertForm::builder()
+      .name("A test post".into())
+      .creator_id(inserted_person.id)
+      .community_id(inserted_community.id)
+      .build();
+
+    let inserted_post = Post::create(pool, &new_post).await.unwrap();
+
+    let post_read_form = PostReadForm {
+      post_id: inserted_post.id,
+      person_id: inserted_person.id,
+    };
+
+    PostRead::mark_as_read(pool, &post_read_form).await.unwrap();
+
+    let save_user_settings = SaveUserSettings {
+      save_read_posts: Some(false),
+      ..Default::default()
+    };
+
+    let read_removed = handle_save_read_posts_change(&save_user_settings, &local_user_view, pool)
+      .await
+      .unwrap();
+
+    assert_eq!(read_removed, 1);
+
+    let redundant_read_removed = PostRead::mark_as_unread(pool, &post_read_form)
+      .await
+      .unwrap();
+
+    // Should be 0 since posts are already removed
+    assert_eq!(redundant_read_removed, 0);
   }
 }

--- a/crates/api/src/post/like.rs
+++ b/crates/api/src/post/like.rs
@@ -61,7 +61,13 @@ impl Perform for CreatePostLike {
     }
 
     // Mark the post as read
-    mark_post_as_read(person_id, post_id, context.pool()).await?;
+    mark_post_as_read(
+      person_id,
+      post_id,
+      local_user_view.local_user,
+      context.pool(),
+    )
+    .await?;
 
     build_post_response(
       context,

--- a/crates/api/src/post/mark_read.rs
+++ b/crates/api/src/post/mark_read.rs
@@ -22,7 +22,13 @@ impl Perform for MarkPostAsRead {
 
     // Mark the post as read / unread
     if data.read {
-      mark_post_as_read(person_id, post_id, context.pool()).await?;
+      mark_post_as_read(
+        person_id,
+        post_id,
+        local_user_view.local_user,
+        context.pool(),
+      )
+      .await?;
     } else {
       mark_post_as_unread(person_id, post_id, context.pool()).await?;
     }

--- a/crates/api/src/post/save.rs
+++ b/crates/api/src/post/save.rs
@@ -41,7 +41,13 @@ impl Perform for SavePost {
     let post_view = PostView::read(context.pool(), post_id, Some(person_id), None).await?;
 
     // Mark the post as read
-    mark_post_as_read(person_id, post_id, context.pool()).await?;
+    mark_post_as_read(
+      person_id,
+      post_id,
+      local_user_view.local_user,
+      context.pool(),
+    )
+    .await?;
 
     Ok(PostResponse { post_view })
   }

--- a/crates/api_common/src/person.rs
+++ b/crates/api_common/src/person.rs
@@ -119,6 +119,8 @@ pub struct SaveUserSettings {
   pub bot_account: Option<bool>,
   /// Whether to show bot accounts.
   pub show_bot_accounts: Option<bool>,
+  /// Whether to save read posts.
+  pub save_read_posts: Option<bool>,
   /// Whether to show read posts.
   pub show_read_posts: Option<bool>,
   /// Whether to show notifications for new posts.

--- a/crates/api_crud/src/post/create.rs
+++ b/crates/api_crud/src/post/create.rs
@@ -140,7 +140,13 @@ impl PerformCrud for CreatePost {
       .map_err(|e| LemmyError::from_error_message(e, "couldnt_like_post"))?;
 
     // Mark the post as read
-    mark_post_as_read(person_id, post_id, context.pool()).await?;
+    mark_post_as_read(
+      person_id,
+      post_id,
+      local_user_view.local_user,
+      context.pool(),
+    )
+    .await?;
 
     if let Some(url) = &updated_post.url {
       let mut webmention =

--- a/crates/api_crud/src/post/read.rs
+++ b/crates/api_crud/src/post/read.rs
@@ -59,7 +59,15 @@ impl PerformCrud for GetPost {
     // Mark the post as read
     let post_id = post_view.post.id;
     if let Some(person_id) = person_id {
-      mark_post_as_read(person_id, post_id, context.pool()).await?;
+      if let Some(local_user_view) = local_user_view {
+        mark_post_as_read(
+          person_id,
+          post_id,
+          local_user_view.local_user,
+          context.pool(),
+        )
+        .await?;
+      }
     }
 
     // Necessary for the sidebar subscribed

--- a/crates/db_schema/src/schema.rs
+++ b/crates/db_schema/src/schema.rs
@@ -400,6 +400,7 @@ diesel::table! {
         validator_time -> Timestamp,
         show_scores -> Bool,
         show_bot_accounts -> Bool,
+        save_read_posts -> Bool,
         show_read_posts -> Bool,
         show_new_post_notifs -> Bool,
         email_verified -> Bool,

--- a/crates/db_schema/src/source/local_user.rs
+++ b/crates/db_schema/src/source/local_user.rs
@@ -39,6 +39,8 @@ pub struct LocalUser {
   pub show_scores: bool,
   /// Whether to show bot accounts.
   pub show_bot_accounts: bool,
+  /// Whether to save read posts.
+  pub save_read_posts: bool,
   /// Whether to show read posts.
   pub show_read_posts: bool,
   /// Whether to show new posts as notifications.
@@ -74,6 +76,7 @@ pub struct LocalUserInsertForm {
   pub send_notifications_to_email: Option<bool>,
   pub show_bot_accounts: Option<bool>,
   pub show_scores: Option<bool>,
+  pub save_read_posts: Option<bool>,
   pub show_read_posts: Option<bool>,
   pub show_new_post_notifs: Option<bool>,
   pub email_verified: Option<bool>,
@@ -99,6 +102,7 @@ pub struct LocalUserUpdateForm {
   pub send_notifications_to_email: Option<bool>,
   pub show_bot_accounts: Option<bool>,
   pub show_scores: Option<bool>,
+  pub save_read_posts: Option<bool>,
   pub show_read_posts: Option<bool>,
   pub show_new_post_notifs: Option<bool>,
   pub email_verified: Option<bool>,

--- a/crates/db_schema/src/traits.rs
+++ b/crates/db_schema/src/traits.rs
@@ -115,6 +115,7 @@ pub trait Readable {
   async fn mark_as_unread(pool: &DbPool, form: &Self::Form) -> Result<usize, Error>
   where
     Self: Sized;
+  async fn delete_all(pool: &DbPool, person_id: &PersonId) -> Result<usize, Error>;
 }
 
 #[async_trait]

--- a/crates/db_views/src/registration_application_view.rs
+++ b/crates/db_views/src/registration_application_view.rs
@@ -280,6 +280,7 @@ mod tests {
         validator_time: inserted_sara_local_user.validator_time,
         show_bot_accounts: inserted_sara_local_user.show_bot_accounts,
         show_scores: inserted_sara_local_user.show_scores,
+        save_read_posts: inserted_sara_local_user.save_read_posts,
         show_read_posts: inserted_sara_local_user.show_read_posts,
         show_new_post_notifs: inserted_sara_local_user.show_new_post_notifs,
         email_verified: inserted_sara_local_user.email_verified,

--- a/migrations/2023-07-05-211630_add_save_read_posts/down.sql
+++ b/migrations/2023-07-05-211630_add_save_read_posts/down.sql
@@ -1,0 +1,1 @@
+alter table local_user drop column save_read_posts;

--- a/migrations/2023-07-05-211630_add_save_read_posts/up.sql
+++ b/migrations/2023-07-05-211630_add_save_read_posts/up.sql
@@ -1,0 +1,1 @@
+alter table local_user add column save_read_posts boolean default true not null;


### PR DESCRIPTION
Requires https://github.com/LemmyNet/lemmy-translations/pull/80

This user option will make it not add posts to the read posts list to not save a browsing history for this user.

When disabled, it will delete all existing browsing history.