### PR TITLE
Use fixed prettier version for CI

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -23,7 +23,7 @@ pipeline:
       - git submodule update
 
   prettier_check:
-    image: tmknom/prettier
+    image: tmknom/prettier:2.8.8
     commands:
       - prettier -c . '!**/volumes' '!**/dist' '!target' '!**/translations'
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4268,7 +4268,7 @@ dependencies = [
  "byteorder",
  "hex",
  "lazy_static",
- "rustix",
+ "rustix 0.36.5",
 ]
 
 [[package]]


### PR DESCRIPTION
3.0.0 was pushed to docker hub 2 hours ago, thats probably why builds are breaking now.