### PR TITLE
Upgrade crossbeam-channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,9 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",


### PR DESCRIPTION
Current version is yanked and breaks crates.io publish. I originally tried to upgrade all deps, but that results in weird build errors from syn crate.