### PR TITLE
Only update site_aggregates for local site

### DIFF
--- a/src/scheduled_tasks.rs
+++ b/src/scheduled_tasks.rs
@@ -273,7 +273,7 @@ fn active_counts(conn: &mut PgConnection) {
 
   for i in &intervals {
     let update_site_stmt = format!(
-      "update site_aggregates set users_active_{} = (select * from site_aggregates_activity('{}'))",
+      "update site_aggregates set users_active_{} = (select * from site_aggregates_activity('{}')) where site_id = 1",
       i.1, i.0
     );
     match sql_query(update_site_stmt).execute(conn) {


### PR DESCRIPTION
Currently, scheduled tasks write site_aggregates values of the current site into rows for all sites due to a missing WHERE clause. This PR limits it only to the row where site_id = 1 (in other words, the local site).