### PR TITLE
Allow filtering posts and comments by whether they were liked/disliked - fixes #3401

### DIFF
--- a/crates/api_common/src/comment.rs
+++ b/crates/api_common/src/comment.rs
@@ -126,6 +126,7 @@ pub struct GetComments {
   pub post_id: Option<PostId>,
   pub parent_id: Option<CommentId>,
   pub saved_only: Option<bool>,
+  pub liked_only: Option<i16>,
   pub auth: Option<Sensitive<String>>,
 }
 

--- a/crates/api_common/src/comment.rs
+++ b/crates/api_common/src/comment.rs
@@ -126,7 +126,8 @@ pub struct GetComments {
   pub post_id: Option<PostId>,
   pub parent_id: Option<CommentId>,
   pub saved_only: Option<bool>,
-  pub liked_only: Option<i16>,
+  pub liked_only: bool,
+  pub disliked_only: bool,
   pub auth: Option<Sensitive<String>>,
 }
 

--- a/crates/api_common/src/comment.rs
+++ b/crates/api_common/src/comment.rs
@@ -126,8 +126,8 @@ pub struct GetComments {
   pub post_id: Option<PostId>,
   pub parent_id: Option<CommentId>,
   pub saved_only: Option<bool>,
-  pub liked_only: bool,
-  pub disliked_only: bool,
+  pub liked_only: Option<bool>,
+  pub disliked_only: Option<bool>,
   pub auth: Option<Sensitive<String>>,
 }
 

--- a/crates/api_common/src/post.rs
+++ b/crates/api_common/src/post.rs
@@ -75,8 +75,8 @@ pub struct GetPosts {
   pub community_id: Option<CommunityId>,
   pub community_name: Option<String>,
   pub saved_only: Option<bool>,
-  pub liked_only: bool,
-  pub disliked_only: bool,
+  pub liked_only: Option<bool>,
+  pub disliked_only: Option<bool>,
   pub moderator_view: Option<bool>,
   pub auth: Option<Sensitive<String>>,
 }

--- a/crates/api_common/src/post.rs
+++ b/crates/api_common/src/post.rs
@@ -75,6 +75,7 @@ pub struct GetPosts {
   pub community_id: Option<CommunityId>,
   pub community_name: Option<String>,
   pub saved_only: Option<bool>,
+  pub liked_only: Option<i16>,
   pub moderator_view: Option<bool>,
   pub auth: Option<Sensitive<String>>,
 }

--- a/crates/api_common/src/post.rs
+++ b/crates/api_common/src/post.rs
@@ -75,7 +75,8 @@ pub struct GetPosts {
   pub community_id: Option<CommunityId>,
   pub community_name: Option<String>,
   pub saved_only: Option<bool>,
-  pub liked_only: Option<i16>,
+  pub liked_only: bool,
+  pub disliked_only: bool,
   pub moderator_view: Option<bool>,
   pub auth: Option<Sensitive<String>>,
 }

--- a/crates/apub/src/api/list_comments.rs
+++ b/crates/apub/src/api/list_comments.rs
@@ -35,6 +35,12 @@ pub async fn list_comments(
   let sort = data.sort;
   let max_depth = data.max_depth;
   let saved_only = data.saved_only;
+
+  let liked_only = data.liked_only;
+  if liked_only.is_some_and(|score| score == -1 || score == 1) {
+    return Err(LemmyError::from_message("invalid score filter"));
+  }
+
   let page = data.page;
   let limit = data.limit;
   let parent_id = data.parent_id;
@@ -59,6 +65,7 @@ pub async fn list_comments(
     sort,
     max_depth,
     saved_only,
+    liked_only,
     community_id,
     parent_path: parent_path_cloned,
     post_id,

--- a/crates/apub/src/api/list_comments.rs
+++ b/crates/apub/src/api/list_comments.rs
@@ -38,7 +38,7 @@ pub async fn list_comments(
 
   let liked_only = data.liked_only;
   let disliked_only = data.disliked_only;
-  if liked_only && disliked_only {
+  if liked_only.unwrap_or_default() && disliked_only.unwrap_or_default() {
     return Err(LemmyError::from(LemmyErrorType::ContradictingFilters));
   }
 

--- a/crates/apub/src/api/list_comments.rs
+++ b/crates/apub/src/api/list_comments.rs
@@ -37,8 +37,9 @@ pub async fn list_comments(
   let saved_only = data.saved_only;
 
   let liked_only = data.liked_only;
-  if liked_only.is_some_and(|score| score == -1 || score == 1) {
-    return Err(LemmyError::from_message("invalid score filter"));
+  let disliked_only = data.disliked_only;
+  if liked_only && disliked_only {
+    return Err(LemmyError::from(LemmyErrorType::ContradictingFilters));
   }
 
   let page = data.page;
@@ -66,6 +67,7 @@ pub async fn list_comments(
     max_depth,
     saved_only,
     liked_only,
+    disliked_only,
     community_id,
     parent_path: parent_path_cloned,
     post_id,

--- a/crates/apub/src/api/list_posts.rs
+++ b/crates/apub/src/api/list_posts.rs
@@ -36,6 +36,11 @@ pub async fn list_posts(
   };
   let saved_only = data.saved_only;
 
+  let liked_only = data.liked_only;
+  if liked_only.is_some_and(|score| score == -1 || score == 1) {
+    return Err(LemmyError::from_message("invalid score filter"));
+  }
+
   let moderator_view = data.moderator_view;
 
   let listing_type = Some(listing_type_with_default(
@@ -50,6 +55,7 @@ pub async fn list_posts(
     sort,
     community_id,
     saved_only,
+    liked_only,
     moderator_view,
     page,
     limit,

--- a/crates/apub/src/api/list_posts.rs
+++ b/crates/apub/src/api/list_posts.rs
@@ -38,7 +38,7 @@ pub async fn list_posts(
 
   let liked_only = data.liked_only;
   let disliked_only = data.disliked_only;
-  if liked_only && disliked_only {
+  if liked_only.unwrap_or_default() && disliked_only.unwrap_or_default() {
     return Err(LemmyError::from(LemmyErrorType::ContradictingFilters));
   }
 

--- a/crates/apub/src/api/list_posts.rs
+++ b/crates/apub/src/api/list_posts.rs
@@ -37,8 +37,9 @@ pub async fn list_posts(
   let saved_only = data.saved_only;
 
   let liked_only = data.liked_only;
-  if liked_only.is_some_and(|score| score == -1 || score == 1) {
-    return Err(LemmyError::from_message("invalid score filter"));
+  let disliked_only = data.disliked_only;
+  if liked_only && disliked_only {
+    return Err(LemmyError::from(LemmyErrorType::ContradictingFilters));
   }
 
   let moderator_view = data.moderator_view;
@@ -56,6 +57,7 @@ pub async fn list_posts(
     community_id,
     saved_only,
     liked_only,
+    disliked_only,
     moderator_view,
     page,
     limit,

--- a/crates/db_views/src/comment_view.rs
+++ b/crates/db_views/src/comment_view.rs
@@ -195,8 +195,10 @@ fn queries<'a>() -> Queries<
       query = query.filter(comment_saved::comment_id.is_not_null());
     }
 
-    if options.liked_only.is_some() {
-      query = query.filter(comment_like::score.eq(options.liked_only.unwrap_or_default()));
+    if options.liked_only {
+      query = query.filter(comment_like::score.eq(1));
+    } else if options.disliked_only {
+      query = query.filter(comment_like::score.eq(-1));
     }
 
     let is_creator = options.creator_id == options.local_user.map(|l| l.person.id);
@@ -313,7 +315,8 @@ pub struct CommentQuery<'a> {
   pub local_user: Option<&'a LocalUserView>,
   pub search_term: Option<String>,
   pub saved_only: Option<bool>,
-  pub liked_only: Option<i16>,
+  pub liked_only: bool,
+  pub disliked_only: bool,
   pub is_profile_view: bool,
   pub page: Option<i64>,
   pub limit: Option<i64>,
@@ -615,7 +618,7 @@ mod tests {
 
     let read_liked_comment_views = CommentQuery {
       local_user: (Some(&data.local_user_view)),
-      liked_only: (Some(1)),
+      liked_only: (true),
       ..Default::default()
     }
     .list(pool)
@@ -631,7 +634,7 @@ mod tests {
 
     let read_disliked_comment_views: Vec<CommentView> = CommentQuery {
       local_user: (Some(&data.local_user_view)),
-      liked_only: (Some(-1)),
+      disliked_only: (true),
       ..Default::default()
     }
     .list(pool)

--- a/crates/db_views/src/comment_view.rs
+++ b/crates/db_views/src/comment_view.rs
@@ -195,9 +195,9 @@ fn queries<'a>() -> Queries<
       query = query.filter(comment_saved::comment_id.is_not_null());
     }
 
-    if options.liked_only {
+    if options.liked_only.unwrap_or_default() {
       query = query.filter(comment_like::score.eq(1));
-    } else if options.disliked_only {
+    } else if options.disliked_only.unwrap_or_default() {
       query = query.filter(comment_like::score.eq(-1));
     }
 
@@ -315,8 +315,8 @@ pub struct CommentQuery<'a> {
   pub local_user: Option<&'a LocalUserView>,
   pub search_term: Option<String>,
   pub saved_only: Option<bool>,
-  pub liked_only: bool,
-  pub disliked_only: bool,
+  pub liked_only: Option<bool>,
+  pub disliked_only: Option<bool>,
   pub is_profile_view: bool,
   pub page: Option<i64>,
   pub limit: Option<i64>,
@@ -618,7 +618,7 @@ mod tests {
 
     let read_liked_comment_views = CommentQuery {
       local_user: (Some(&data.local_user_view)),
-      liked_only: (true),
+      liked_only: (Some(true)),
       ..Default::default()
     }
     .list(pool)
@@ -634,7 +634,7 @@ mod tests {
 
     let read_disliked_comment_views: Vec<CommentView> = CommentQuery {
       local_user: (Some(&data.local_user_view)),
-      disliked_only: (true),
+      disliked_only: (Some(true)),
       ..Default::default()
     }
     .list(pool)

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -308,7 +308,7 @@ fn queries<'a>() -> Queries<
       .unwrap_or(true)
     {
       // Do not hide read posts when it is a user profile view
-      if !is_profile_view {
+      if !options.is_profile_view {
         query = query.filter(post_read::post_id.is_null());
       }
     }

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -312,8 +312,11 @@ fn queries<'a>() -> Queries<
         query = query.filter(post_read::post_id.is_null());
       }
     }
-    if options.liked_only.is_some() {
-      query = query.filter(post_like::score.eq(options.liked_only.unwrap_or_default()));
+
+    if options.liked_only {
+      query = query.filter(post_like::score.eq(1));
+    } else if options.disliked_only {
+      query = query.filter(post_like::score.eq(-1));
     }
 
     if options.local_user.is_some() {
@@ -429,7 +432,8 @@ pub struct PostQuery<'a> {
   pub search_term: Option<String>,
   pub url_search: Option<String>,
   pub saved_only: Option<bool>,
-  pub liked_only: Option<i16>,
+  pub liked_only: bool,
+  pub disliked_only: bool,
   pub moderator_view: Option<bool>,
   pub is_profile_view: bool,
   pub page: Option<i64>,
@@ -803,7 +807,7 @@ mod tests {
     let read_liked_post_listing = PostQuery {
       community_id: (Some(data.inserted_community.id)),
       local_user: (Some(&data.local_user_view)),
-      liked_only: (Some(1)),
+      liked_only: (true),
       ..Default::default()
     }
     .list(pool)
@@ -814,7 +818,7 @@ mod tests {
     let read_disliked_post_listing = PostQuery {
       community_id: (Some(data.inserted_community.id)),
       local_user: (Some(&data.local_user_view)),
-      liked_only: (Some(-1)),
+      disliked_only: (false),
       ..Default::default()
     }
     .list(pool)

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -313,9 +313,9 @@ fn queries<'a>() -> Queries<
       }
     }
 
-    if options.liked_only {
+    if options.liked_only.unwrap_or_default() {
       query = query.filter(post_like::score.eq(1));
-    } else if options.disliked_only {
+    } else if options.disliked_only.unwrap_or_default() {
       query = query.filter(post_like::score.eq(-1));
     }
 
@@ -432,8 +432,8 @@ pub struct PostQuery<'a> {
   pub search_term: Option<String>,
   pub url_search: Option<String>,
   pub saved_only: Option<bool>,
-  pub liked_only: bool,
-  pub disliked_only: bool,
+  pub liked_only: Option<bool>,
+  pub disliked_only: Option<bool>,
   pub moderator_view: Option<bool>,
   pub is_profile_view: bool,
   pub page: Option<i64>,
@@ -807,7 +807,7 @@ mod tests {
     let read_liked_post_listing = PostQuery {
       community_id: (Some(data.inserted_community.id)),
       local_user: (Some(&data.local_user_view)),
-      liked_only: (true),
+      liked_only: (Some(true)),
       ..Default::default()
     }
     .list(pool)
@@ -818,7 +818,7 @@ mod tests {
     let read_disliked_post_listing = PostQuery {
       community_id: (Some(data.inserted_community.id)),
       local_user: (Some(&data.local_user_view)),
-      disliked_only: (false),
+      disliked_only: (Some(true)),
       ..Default::default()
     }
     .list(pool)

--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -207,6 +207,7 @@ pub enum LemmyErrorType {
   CouldntCreateAudioCaptcha,
   InvalidUrlScheme,
   CouldntSendWebmention,
+  ContradictingFilters,
   Unknown(String),
 }
 


### PR DESCRIPTION
I've added new filters that allow showing only comments/posts that were liked/disliked by the current user. A simple input verification and unit tests are included. Fixes #3401.