### PR TITLE
Shrink capacity in `RateLimitStorage::remove_older_than`

### DIFF
--- a/crates/utils/src/rate_limit/rate_limiter.rs
+++ b/crates/utils/src/rate_limit/rate_limiter.rs
@@ -227,10 +227,7 @@ where
   F: FnMut(&K, &mut V) -> bool,
 {
   map.retain(f);
-  // `shrink_to_fit` is not used because it would cause the capacity to be doubled when more capacity is needed
-  if let Some(min_capacity) = map.len().checked_mul(2) {
-    map.shrink_to(min_capacity);
-  }
+  map.shrink_to_fit();
 }
 
 fn split_ipv6(ip: Ipv6Addr) -> ([u8; 6], u8, u8) {

--- a/crates/utils/src/rate_limit/rate_limiter.rs
+++ b/crates/utils/src/rate_limit/rate_limiter.rs
@@ -223,7 +223,7 @@ impl RateLimitStorage {
 
 fn retain_and_shrink<K, V, F>(map: &mut HashMap<K, V>, f: F)
 where
-  K: Hash + Eq,
+  K: Eq + Hash,
   F: FnMut(&K, &mut V) -> bool,
 {
   map.retain(f);

--- a/crates/utils/src/rate_limit/rate_limiter.rs
+++ b/crates/utils/src/rate_limit/rate_limiter.rs
@@ -2,6 +2,7 @@ use enum_map::{enum_map, EnumMap};
 use once_cell::sync::Lazy;
 use std::{
   collections::HashMap,
+  hash::Hash,
   net::{IpAddr, Ipv4Addr, Ipv6Addr},
   time::{Duration, Instant},
 };
@@ -222,6 +223,7 @@ impl RateLimitStorage {
 
 fn retain_and_shrink<K, V, F>(map: &mut HashMap<K, V>, f: F)
 where
+  K: Eq + Hash,
   F: FnMut(&K, &mut V) -> bool,
 {
   map.retain(f);

--- a/crates/utils/src/rate_limit/rate_limiter.rs
+++ b/crates/utils/src/rate_limit/rate_limiter.rs
@@ -223,7 +223,7 @@ impl RateLimitStorage {
 
 fn retain_and_shrink<K, V, F>(map: &mut HashMap<K, V>, f: F)
 where
-  K: Eq + Hash,
+  K: Hash + Eq,
   F: FnMut(&K, &mut V) -> bool,
 {
   map.retain(f);


### PR DESCRIPTION
This prevents spikes in traffic from causing permanently increased memory usage.