### PR TITLE
Fix #3461 - Add API endpoint for getting registration requirements

### DIFF
--- a/crates/api/src/site/mod.rs
+++ b/crates/api/src/site/mod.rs
@@ -3,3 +3,4 @@ mod leave_admin;
 mod mod_log;
 mod purge;
 mod registration_applications;
+mod registration_requirements;

--- a/crates/api/src/site/registration_requirements.rs
+++ b/crates/api/src/site/registration_requirements.rs
@@ -1,0 +1,26 @@
+use crate::Perform;
+use actix_web::web::Data;
+use lemmy_api_common::{
+  context::LemmyContext,
+  site::{GetRegistrationRequirements, GetRegistrationRequirementsResponse},
+};
+use lemmy_db_schema::{source::local_site::LocalSite, RegistrationMode};
+use lemmy_utils::error::LemmyError;
+
+#[async_trait::async_trait(?Send)]
+impl Perform for GetRegistrationRequirements {
+  type Response = GetRegistrationRequirementsResponse;
+
+  async fn perform(&self, context: &Data<LemmyContext>) -> Result<Self::Response, LemmyError> {
+    let local_site = LocalSite::read(context.pool()).await?;
+
+    let answer_required = local_site.registration_mode == RegistrationMode::RequireApplication;
+
+    Ok(Self::Response {
+      question: local_site.application_question,
+      answer_required,
+      captcha_required: local_site.captcha_enabled,
+      email_verification_required: local_site.require_email_verification,
+    })
+  }
+}

--- a/crates/api_common/src/site.rs
+++ b/crates/api_common/src/site.rs
@@ -404,6 +404,27 @@ pub struct PurgeItemResponse {
 }
 
 #[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "full", derive(TS))]
+#[cfg_attr(feature = "full", ts(export))]
+/// Fetches the registration requirements.
+pub struct GetRegistrationRequirements {
+  pub auth: Sensitive<String>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "full", derive(TS))]
+#[cfg_attr(feature = "full", ts(export))]
+/// The current requirements for registering imposed by the site.
+pub struct GetRegistrationRequirementsResponse {
+  pub question: Option<String>,
+  pub answer_required: bool,
+  pub captcha_required: bool,
+  pub email_verification_required: bool,
+}
+
+#[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 #[cfg_attr(feature = "full", derive(TS))]
 #[cfg_attr(feature = "full", ts(export))]

--- a/crates/apub/src/activities/unfederated.rs
+++ b/crates/apub/src/activities/unfederated.rs
@@ -90,6 +90,8 @@ use lemmy_api_common::{
     GetFederatedInstancesResponse,
     GetModlog,
     GetModlogResponse,
+    GetRegistrationRequirements,
+    GetRegistrationRequirementsResponse,
     GetSite,
     GetSiteResponse,
     GetUnreadRegistrationApplicationCount,
@@ -241,6 +243,10 @@ impl SendActivity for ListPrivateMessageReports {
 
 impl SendActivity for GetModlog {
   type Response = GetModlogResponse;
+}
+
+impl SendActivity for GetRegistrationRequirements {
+  type Response = GetRegistrationRequirementsResponse;
 }
 
 impl SendActivity for PurgePerson {

--- a/src/api_routes_http.rs
+++ b/src/api_routes_http.rs
@@ -83,6 +83,7 @@ use lemmy_api_common::{
     EditSite,
     GetFederatedInstances,
     GetModlog,
+    GetRegistrationRequirements,
     GetSite,
     GetUnreadRegistrationApplicationCount,
     LeaveAdmin,
@@ -329,6 +330,11 @@ pub fn config(cfg: &mut web::ServiceConfig, rate_limit: &RateLimitCell) {
           .route("/unread_count", web::get().to(route_get::<GetUnreadCount>))
           .route("/verify_email", web::post().to(route_post::<VerifyEmail>))
           .route("/leave_admin", web::post().to(route_post::<LeaveAdmin>)),
+      )
+      .service(
+        web::resource("/registration_requirements")
+          .wrap(rate_limit.message())
+          .route(web::get().to(route_get::<GetRegistrationRequirements>)),
       )
       // Admin Actions
       .service(


### PR DESCRIPTION
I've created a new lightweight endpoint under `/registration_requirements` that allows fetching the new user registration requirements. I've decided to return all the requirements (except for the actual captcha since it has side effects on the db) instead of just the application question to satisfy additional needs without much extra work.

@dessalines @Nutomic if you think the location of the endpoint or the source files is wrong, I'll be happy to adjust it.

Fixes #3461.