### PR TITLE
fix(search): parse the instance_name from query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2781,6 +2781,7 @@ dependencies = [
  "lemmy_utils",
  "moka",
  "once_cell",
+ "regex",
  "reqwest",
  "reqwest-middleware",
  "serde",

--- a/crates/apub/Cargo.toml
+++ b/crates/apub/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/lib.rs"
 doctest = false
 
 [dependencies]
+regex = { workspace = true }
 lemmy_utils = { workspace = true }
 lemmy_db_schema = { workspace = true, features = ["full"] }
 lemmy_db_views = { workspace = true, features = ["full"] }

--- a/crates/apub/src/api/search.rs
+++ b/crates/apub/src/api/search.rs
@@ -18,7 +18,7 @@ use lemmy_db_views_actor::{community_view::CommunityQuery, person_view::PersonQu
 use lemmy_utils::error::LemmyError;
 
 static SEARCH_REGEX: Lazy<Regex> = Lazy::new(|| {
-  Regex::new(r"(?P<term>[\w.]+)@(?P<domain>[a-zA-Z0-9._:-]+)").expect("search regex")
+  Regex::new(r"(?P<term>[\w.]?)@(?P<domain>[a-zA-Z0-9._:-]+)").expect("search regex")
 });
 
 #[tracing::instrument(skip(context))]

--- a/crates/db_views_actor/src/community_view.rs
+++ b/crates/db_views_actor/src/community_view.rs
@@ -12,7 +12,14 @@ use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
   aggregates::structs::CommunityAggregates,
   newtypes::{CommunityId, PersonId},
-  schema::{community, community_aggregates, community_block, community_follower, local_user,instance},
+  schema::{
+    community,
+    community_aggregates,
+    community_block,
+    community_follower,
+    instance,
+    local_user,
+  },
   source::{
     community::{Community, CommunityFollower},
     community_block::CommunityBlock,
@@ -160,10 +167,9 @@ impl<'a> CommunityQuery<'a> {
 
     if let Some(domain_name) = self.domain_name {
       let searcher = fuzzy_search(&domain_name);
-      query = query
-        .filter(instance::domain.ilike(searcher));
+      query = query.filter(instance::domain.ilike(searcher));
     };
-    
+
     // Hide deleted and removed for non-admins or mods
     if !self.is_mod_or_admin.unwrap_or(false) {
       query = query
@@ -211,7 +217,7 @@ impl<'a> CommunityQuery<'a> {
         query = query.filter(community::nsfw.eq(false));
       }
     }
-    
+
     let (limit, offset) = limit_and_offset(self.page, self.limit)?;
     let res = query
       .limit(limit)


### PR DESCRIPTION
Actually I'm not sure if it's a bug or intended behaviour, but anyway, following #3498, I tried to add some logic on search queries.

Currently, the search will take the **"@"** character literally, and since in the database the object only have their "local" names, you won't find anything.

The idea of this fix is that if you put a **"@"** in the search bar, you are searching for a remote object, so the api should probably take that into account.
To do so, I use a regexp on the search term, and anything after the  **"@"** is considered the `domain_name` and a filter is added to the request accordingly. If there is no such character, that filter is not applied.

Let me know if you think this is the correct way to tackle is issue.

Fixes #3498

[EDIT] : @L3v3L mentionned to me that by tweaking the PR slightly, we could also resolve https://github.com/LemmyNet/lemmy/issues/3207 so I allowed to have no `search_term` in the regexp while still having a `domain_name`.
I also added the same logic for user searches, I'm not sure if that makes sense for other objects such as posts or comments