### PR TITLE
Add initial skeleton of image proxy improvements for feedback

### DIFF
--- a/crates/api_common/src/site.rs
+++ b/crates/api_common/src/site.rs
@@ -3,6 +3,7 @@ use lemmy_db_schema::{
   newtypes::{CommentId, CommunityId, LanguageId, PersonId, PostId},
   source::{instance::Instance, language::Language, tagline::Tagline},
   ListingType,
+  MediaPolicy,
   ModlogActionType,
   RegistrationMode,
   SearchType,
@@ -183,6 +184,7 @@ pub struct CreateSite {
   pub blocked_instances: Option<Vec<String>>,
   pub taglines: Option<Vec<String>>,
   pub registration_mode: Option<RegistrationMode>,
+  pub media_policy: Option<MediaPolicy>,
   pub auth: Sensitive<String>,
 }
 
@@ -262,6 +264,8 @@ pub struct EditSite {
   pub registration_mode: Option<RegistrationMode>,
   /// Whether to email admins for new reports.
   pub reports_email_admins: Option<bool>,
+  /// How supported media is proxied.
+  pub media_policy: Option<MediaPolicy>,
   pub auth: Sensitive<String>,
 }
 

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -25,6 +25,7 @@ use lemmy_db_schema::{
   },
   traits::{Crud, Readable},
   utils::DbPool,
+  MediaPolicy,
   RegistrationMode,
 };
 use lemmy_db_views::{comment_view::CommentQuery, structs::LocalUserView};
@@ -433,6 +434,13 @@ pub fn local_site_opt_to_sensitive(local_site: &Option<LocalSite>) -> bool {
     .as_ref()
     .map(|site| site.enable_nsfw)
     .unwrap_or(false)
+}
+
+pub fn local_site_opt_to_media_policy(local_site: &Option<LocalSite>) -> MediaPolicy {
+  local_site
+      .as_ref()
+      .map(|site| site.media_policy)
+      .unwrap_or(MediaPolicy::Proxy)
 }
 
 pub fn send_application_approved_email(

--- a/crates/api_crud/src/site/create.rs
+++ b/crates/api_crud/src/site/create.rs
@@ -97,6 +97,7 @@ impl PerformCrud for CreateSite {
       .federation_enabled(data.federation_enabled)
       .captcha_enabled(data.captcha_enabled)
       .captcha_difficulty(data.captcha_difficulty.clone())
+      .media_policy(data.media_policy)
       .build();
 
     LocalSite::update(context.pool(), &local_site_form).await?;

--- a/crates/api_crud/src/site/update.rs
+++ b/crates/api_crud/src/site/update.rs
@@ -94,6 +94,7 @@ impl PerformCrud for EditSite {
       .captcha_enabled(data.captcha_enabled)
       .captcha_difficulty(data.captcha_difficulty.clone())
       .reports_email_admins(data.reports_email_admins)
+      .media_policy(data.media_policy)
       .build();
 
     let update_local_site = LocalSite::update(context.pool(), &local_site_form)

--- a/crates/db_schema/src/lib.rs
+++ b/crates/db_schema/src/lib.rs
@@ -101,6 +101,22 @@ pub enum ListingType {
 #[cfg_attr(feature = "full", derive(DbEnum, TS))]
 #[cfg_attr(
   feature = "full",
+  ExistingTypePath = "crate::schema::sql_types::MediaPolicy"
+)]
+#[cfg_attr(feature = "full", DbValueStyle = "verbatim")]
+#[cfg_attr(feature = "full", ts(export))]
+/// The media policy for your site. Determines how media is handled.
+pub enum MediaPolicy {
+  /// Proxy all supported media locally. Sensitive content respects site settings.
+  Proxy,
+  /// Proxy only supported media uploaded locally by your users.
+  Local,
+}
+
+#[derive(EnumString, Display, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "full", derive(DbEnum, TS))]
+#[cfg_attr(
+  feature = "full",
   ExistingTypePath = "crate::schema::sql_types::RegistrationModeEnum"
 )]
 #[cfg_attr(feature = "full", DbValueStyle = "verbatim")]

--- a/crates/db_schema/src/source/local_media_image.rs
+++ b/crates/db_schema/src/source/local_media_image.rs
@@ -1,0 +1,21 @@
+// #[cfg(feature = "full")]
+// use crate::schema::local_media_image;
+
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+#[cfg(feature = "full")]
+use ts_rs::TS;
+use typed_builder::TypedBuilder;
+
+#[skip_serializing_none]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "full", derive(Queryable, Identifiable, TS))]
+#[cfg_attr(feature = "full", diesel(table_name = local_user))]
+#[cfg_attr(feature = "full", ts(export))]
+/// A local media image.
+pub struct LocalMediaImage {
+    // pub id: ImageId,
+    pub source_url: String,
+    pub local_url: String,
+    pub token: String,
+}

--- a/crates/db_schema/src/source/local_site.rs
+++ b/crates/db_schema/src/source/local_site.rs
@@ -3,6 +3,7 @@ use crate::schema::local_site;
 use crate::{
   newtypes::{LocalSiteId, SiteId},
   ListingType,
+  MediaPolicy,
   RegistrationMode,
 };
 use serde::{Deserialize, Serialize};
@@ -59,6 +60,8 @@ pub struct LocalSite {
   pub registration_mode: RegistrationMode,
   /// Whether to email admins on new reports.
   pub reports_email_admins: bool,
+  /// How supported media is proxied.
+  pub media_policy: MediaPolicy,
 }
 
 #[derive(Clone, TypedBuilder)]
@@ -87,6 +90,7 @@ pub struct LocalSiteInsertForm {
   pub captcha_difficulty: Option<String>,
   pub registration_mode: Option<RegistrationMode>,
   pub reports_email_admins: Option<bool>,
+  pub media_policy: Option<MediaPolicy>,
 }
 
 #[derive(Clone, TypedBuilder)]
@@ -113,5 +117,6 @@ pub struct LocalSiteUpdateForm {
   pub captcha_difficulty: Option<String>,
   pub registration_mode: Option<RegistrationMode>,
   pub reports_email_admins: Option<bool>,
+  pub media_policy: Option<MediaPolicy>,
   pub updated: Option<Option<chrono::NaiveDateTime>>,
 }

--- a/crates/db_schema/src/source/mod.rs
+++ b/crates/db_schema/src/source/mod.rs
@@ -17,6 +17,7 @@ pub mod federation_allowlist;
 pub mod federation_blocklist;
 pub mod instance;
 pub mod language;
+pub mod local_media_image;
 pub mod local_site;
 pub mod local_site_rate_limit;
 pub mod local_user;

--- a/crates/utils/src/utils/media.rs
+++ b/crates/utils/src/utils/media.rs
@@ -1,0 +1,15 @@
+use once_cell::sync::Lazy;
+use regex::{Regex, RegexBuilder};
+use crate::error::{LemmyError, LemmyResult};
+
+static IMAGE_URL_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(http)?s?:?(\/\/.*\.(?:jpg|jpeg|gif|png|svg|webp))").expect("compile regex")
+});
+
+pub fn is_url_image(url: &str) -> LemmyResult<()> {
+    if !IMAGE_URL_REGEX.is_match(url) {
+        Err(LemmyError::from_message("invalid_post_title"))
+    } else {
+        Ok(())
+    }
+}

--- a/crates/utils/src/utils/mod.rs
+++ b/crates/utils/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod markdown;
+pub mod media;
 pub mod mention;
 pub mod slurs;
 pub mod time;


### PR DESCRIPTION
This is a **very** rough-draft of an initial approach to improving how image content is handled and providing some control to admins. I figured it'd be good to put something together to see if the approach is on the right path and gauge interest in collaboration.

Apologies in advance if this isn't the right format. I figured it was the easiest way to get eyes while making some progress.

## Purpose
There's been a lot of discussion regarding how images should be used by the local site. I'm mainly coming from the user's UX as it doesn't look good to see a feed with a bunch of broken images. That said, I feel that a solution can be implemented that most can agree with.

Ultimately, I think the solution will require allowing the admin to choose how they want to handle content on their site. These options would be:
* `Proxy` -> proxy all images
* `Local` -> allow only local images
* `None` -> disable all local image uploads

The `None` option is out-of-scope for now, but I think we can put in a foundation to easily support it later.

For sake of discussion, the first two options could be reduced to the following analogy:
* `Proxy` -> Site should be a museum:
  * Content should be preserved by the local site for their users.
    * It can potentially be phased out at a later date. 
  * When viewing the local site all images should be load through it, where possible.
    * This provides the best UX in the event content disappears or goes offline.
    * Reduces the likelihood of user's IP's being exposed.
    * Reduces load on origin instances as the admin is now responsible for their user's traffic.
* `Local` -> Site should be a window:
  * Content should (mostly) be viewed only by looking out from the local site. 
  * When viewing the local site, all images should load externally, unless uploaded locally.
    * This reduces costs and legal concerns, at the cost of UX and privacy.

## Scope
* Post images, user icon/banner, and community icon/banner.
* Storing delete tokens and source URL for future cleanup.
  * For example, media could be purged after a period of time and rely on source URL going forward. 

## Out-of-scope
* Disabling all local `pict-rs`.
  * This could likely be extended to support it once the initial implementation is done.
* Images embedded in post and comment bodies.
  * It could be done, but will take additional work.
* Full webpage render.
  * Would be cool, but let's KISS for now. :stuck_out_tongue: 
* Videos and/or frame capture for thumbnail.
  * Again, cool but would require a lot of additional support.
* Clearing content after set period of time.
  * Not sure on the best approach for this as of yet.

## Changes

* Added the options to the `local_site` so they could be configured by the admin. This would let them set their preference and it should be respected wherever images are copied locally.
* Updated incoming posts with an example of what that logic would look like.
* Added a DB table for tracking local media. Initially supporting images, but the pattern could be expanded in the future.
* Updates the `post` URL when it's an image and reuses it for the `thumbnail_url`.
  * This ensures all clients get the correct value. 

## TODOs
* Clean up code to be workable
* Refactor duplicated logic
* Implement the DB-logic & migrations.
* Add logic for handling other images.
* Store `delete_tokens` for images to enable purging.

## Questions

* Is this approach on the right path? Am I missing anything obvious?
* Any guidance on naming patterns? I loosely based it off of existing code.
* Does this satisfy enough admins to continue pursuing? And is anyone interested in collaborating? :grin: 

## References:
* https://github.com/LemmyNet/lemmy/issues/2947
* https://github.com/LemmyNet/lemmy/issues/3474
* https://github.com/LemmyNet/lemmy/issues/3276
