### PR TITLE
Use async email sender

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2990,10 +2990,12 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eabca5e0b4d0e98e7f2243fb5b7520b6af2b65d8f87bcc86f2c75185a6ff243"
 dependencies = [
+ "async-trait",
  "base64 0.13.1",
  "email-encoding",
  "email_address",
  "fastrand",
+ "futures-io",
  "futures-util",
  "hostname",
  "httpdate",
@@ -3004,6 +3006,8 @@ dependencies = [
  "once_cell",
  "quoted_printable",
  "socket2 0.4.9",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]

--- a/crates/api/src/site/registration_applications/approve.rs
+++ b/crates/api/src/site/registration_applications/approve.rs
@@ -51,7 +51,7 @@ impl Perform for ApproveRegistrationApplication {
       let approved_local_user_view = LocalUserView::read(context.pool(), approved_user_id).await?;
 
       if approved_local_user_view.local_user.email.is_some() {
-        send_application_approved_email(&approved_local_user_view, context.settings())?;
+        send_application_approved_email(&approved_local_user_view, context.settings()).await?;
       }
     }
 

--- a/crates/api_common/src/build_response.rs
+++ b/crates/api_common/src/build_response.rs
@@ -128,6 +128,7 @@ pub async fn send_local_notifs(
           &lang.notification_mentioned_by_body(&comment.content, &inbox_link, &person.name),
           context.settings(),
         )
+        .await
       }
     }
   }
@@ -170,6 +171,7 @@ pub async fn send_local_notifs(
             &lang.notification_comment_reply_body(&comment.content, &inbox_link, &person.name),
             context.settings(),
           )
+          .await
         }
       }
     }
@@ -206,6 +208,7 @@ pub async fn send_local_notifs(
             &lang.notification_post_reply_body(&comment.content, &inbox_link, &person.name),
             context.settings(),
           )
+          .await
         }
       }
     }

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -308,7 +308,7 @@ pub fn honeypot_check(honeypot: &Option<String>) -> Result<(), LemmyError> {
   }
 }
 
-pub fn send_email_to_user(
+pub async fn send_email_to_user(
   local_user_view: &LocalUserView,
   subject: &str,
   body: &str,
@@ -325,7 +325,9 @@ pub fn send_email_to_user(
       &local_user_view.person.name,
       body,
       settings,
-    ) {
+    )
+    .await
+    {
       Ok(_o) => _o,
       Err(e) => warn!("{}", e),
     };
@@ -351,7 +353,7 @@ pub async fn send_password_reset_email(
   let protocol_and_hostname = settings.get_protocol_and_hostname();
   let reset_link = format!("{}/password_change/{}", protocol_and_hostname, &token);
   let body = &lang.password_reset_body(reset_link, &user.person.name);
-  send_email(subject, email, &user.person.name, body, settings)
+  send_email(subject, email, &user.person.name, body, settings).await
 }
 
 /// Send a verification email
@@ -376,7 +378,7 @@ pub async fn send_verification_email(
   let lang = get_interface_language(user);
   let subject = lang.verify_email_subject(&settings.hostname);
   let body = lang.verify_email_body(&settings.hostname, &user.person.name, verify_link);
-  send_email(&subject, new_email, &user.person.name, &body, settings)?;
+  send_email(&subject, new_email, &user.person.name, &body, settings).await?;
 
   Ok(())
 }
@@ -435,7 +437,7 @@ pub fn local_site_opt_to_sensitive(local_site: &Option<LocalSite>) -> bool {
     .unwrap_or(false)
 }
 
-pub fn send_application_approved_email(
+pub async fn send_application_approved_email(
   user: &LocalUserView,
   settings: &Settings,
 ) -> Result<(), LemmyError> {
@@ -443,7 +445,7 @@ pub fn send_application_approved_email(
   let lang = get_interface_language(user);
   let subject = lang.registration_approved_subject(&user.person.actor_id);
   let body = lang.registration_approved_body(&settings.hostname);
-  send_email(&subject, email, &user.person.name, &body, settings)
+  send_email(&subject, email, &user.person.name, &body, settings).await
 }
 
 /// Send a new applicant email notification to all admins
@@ -465,7 +467,7 @@ pub async fn send_new_applicant_email_to_admins(
     let lang = get_interface_language_from_settings(admin);
     let subject = lang.new_application_subject(&settings.hostname, applicant_username);
     let body = lang.new_application_body(applications_link);
-    send_email(&subject, email, &admin.person.name, &body, settings)?;
+    send_email(&subject, email, &admin.person.name, &body, settings).await?;
   }
   Ok(())
 }
@@ -487,7 +489,7 @@ pub async fn send_new_report_email_to_admins(
     let lang = get_interface_language_from_settings(admin);
     let subject = lang.new_report_subject(&settings.hostname, reported_username, reporter_username);
     let body = lang.new_report_body(reports_link);
-    send_email(&subject, email, &admin.person.name, &body, settings)?;
+    send_email(&subject, email, &admin.person.name, &body, settings).await?;
   }
   Ok(())
 }

--- a/crates/api_crud/src/private_message/create.rs
+++ b/crates/api_crud/src/private_message/create.rs
@@ -95,7 +95,8 @@ impl PerformCrud for CreatePrivateMessage {
         &lang.notification_private_message_subject(sender_name),
         &lang.notification_private_message_body(inbox_link, &content_slurs_removed, sender_name),
         context.settings(),
-      );
+      )
+      .await;
     }
 
     Ok(PrivateMessageResponse {

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -42,7 +42,7 @@ html2text = "0.6.0"
 deser-hjson = "1.0.2"
 smart-default = "0.7.1"
 jsonwebtoken = "8.1.1"
-lettre = "0.10.1"
+lettre = { version = "0.10.1", features = ["tokio1", "tokio1-native-tls"] }
 markdown-it = "0.5.1"
 totp-rs = { version = "5.0.2", features = ["gen_secret", "otpauth"] }
 enum-map = "2.5"

--- a/src/prometheus_metrics.rs
+++ b/src/prometheus_metrics.rs
@@ -47,7 +47,7 @@ pub fn serve_prometheus(config: Option<&PrometheusConfig>, lemmy_context: LemmyC
           .route("/metrics", web::get().to(metrics))
       })
       .bind((bind, port as u16))
-      .expect(&format!("Cannot bind to {}:{}", bind, port))
+      .unwrap_or_else(|_| panic!("Cannot bind to {}:{}", bind, port))
       .run();
 
       if let Err(err) = server.await {
@@ -103,7 +103,7 @@ fn create_db_pool_metrics() -> DbPoolMetrics {
     .register(Box::new(metrics.available.clone()))
     .unwrap();
 
-  return metrics;
+  metrics
 }
 
 async fn collect_db_pool_metrics(context: &PromContext) {


### PR DESCRIPTION
The non-async sender prevents an HTTP worker (1 per CPU core) from doing anything else until the email is sent.