### PR TITLE
Move `tracing::warn` call in `spawn_try_task` to separate function

### DIFF
--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -54,9 +54,14 @@ pub fn spawn_try_task(task: impl Future<Output = Result<(), LemmyError>> + Send 
   tokio::spawn(
     async {
       if let Err(e) = task.await {
-        tracing::warn!("error in spawn: {e}");
+        // Directly using `tracing::warn` would generate the LLVM code for each type of `task`
+        warn_error(e)
       }
     }
     .in_current_span(), // this makes sure the inner tracing gets the same context as where spawn was called
   );
+}
+
+fn warn_error(e: LemmyError) {
+  tracing::warn!("error in spawn: {e}");
 }


### PR DESCRIPTION
I ran `cargo-llvm-lines`, and over 1% of the LLVM code comes from calls to `spawn_try_task`.

Generic functions cause separate LLVM code generation for each unique combination of generic arguments (each implementation of `Future` for the `task` parameter in this case). Moving part of the function to a separate non-generic function will reduce the amount of code generation, which can help with compilation speed. https://nnethercote.github.io/perf-book/compile-times.html#llvm-ir

The complexity of the output of the `tracing::warn` macro can be seen here by selecting "expand macros" under "tools": [playground link](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&code=use+tracing%3B+%2F%2F+0.1.37%0A%0Afn+warn_error%28e%3A+impl+std%3A%3Afmt%3A%3ADisplay%29+%7B%0A++++tracing%3A%3Awarn%21%28%22error+in+spawn%3A+%7Be%7D%22%29%3B%0A%7D)

Here's the output of `cargo-llvm-lines` on [this commit](https://github.com/dullbananas/lemmy/tree/26c9ce0a363c3d78a50216cc9df875869236b85f) using dev profile and fat LTO: 
[lineslib-lto.zip](https://github.com/LemmyNet/lemmy/files/12010680/lineslib-lto.zip)

I will make similar improvements in Tokio