### PR TITLE
Fix wrong SMTP port when TLS is being used (fixes #3574)

### DIFF
--- a/crates/utils/src/email.rs
+++ b/crates/utils/src/email.rs
@@ -68,12 +68,10 @@ pub async fn send_email(
   // is bad.
 
   // Set the TLS
-  let builder_dangerous = AsyncSmtpTransport::builder_dangerous(smtp_server).port(smtp_port);
-
   let mut builder = match email_config.tls_type.as_str() {
-    "starttls" => AsyncSmtpTransport::starttls_relay(smtp_server)?,
-    "tls" => AsyncSmtpTransport::relay(smtp_server)?,
-    _ => builder_dangerous,
+    "starttls" => AsyncSmtpTransport::starttls_relay(smtp_server)?.port(smtp_port),
+    "tls" => AsyncSmtpTransport::relay(smtp_server)?.port(smtp_port),
+    _ => AsyncSmtpTransport::builder_dangerous(smtp_server).port(smtp_port),
   };
 
   // Set the creds if they exist


### PR DESCRIPTION
See Issue https://github.com/LemmyNet/lemmy/issues/3574

The SMTP port will no longer be disregarded as soon as one of the TLS settings is enabled.