### PR TITLE
Auth overhaul (access tokens, refresh tokens, api tokens)

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -12,7 +12,7 @@ use std::io::Cursor;
 mod comment;
 mod comment_report;
 mod community;
-mod local_user;
+pub mod local_user;
 mod post;
 mod post_report;
 mod private_message;

--- a/crates/api/src/local_user/auth.rs
+++ b/crates/api/src/local_user/auth.rs
@@ -1,0 +1,193 @@
+use actix_web::{
+  cookie::{time::Duration, Cookie, SameSite},
+  web::{Data, Json},
+  HttpRequest,
+  HttpResponse,
+};
+use bcrypt::verify;
+use lemmy_api_common::{
+  context::LemmyContext,
+  person::{AccessTokenResponse, GetAccessToken, GetRefreshToken},
+  utils::{check_registration_application, check_user_valid},
+};
+use lemmy_db_schema::{
+  source::{
+    auth_api_token::{AuthApiToken, AuthApiTokenUpdateForm},
+    auth_refresh_token::{
+      AuthRefreshToken,
+      AuthRefreshTokenCreateForm,
+      AuthRefreshTokenUpdateForm,
+    },
+  },
+  utils::naive_now,
+};
+use lemmy_db_views::structs::{LocalUserView, SiteView};
+use lemmy_utils::{
+  claims::{AuthMethod, Claims},
+  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+  utils::validation::check_totp_2fa_valid,
+};
+
+const REFRESH_TOKEN_EXPIRY_WEEKS: i64 = 2;
+
+pub async fn auth_access_token(
+  req: HttpRequest,
+  data: Json<GetAccessToken>,
+  context: Data<LemmyContext>,
+) -> Result<HttpResponse, LemmyError> {
+  let local_user_id = match req.cookie("refresh_token") {
+    Some(cookie) => {
+      let refresh_token =
+        AuthRefreshToken::read_from_token(&mut context.pool(), cookie.value()).await?;
+      if (naive_now() - refresh_token.last_used).num_weeks() >= REFRESH_TOKEN_EXPIRY_WEEKS {
+        return Err(LemmyErrorType::TokenNotFound)?;
+      }
+      refresh_token.local_user_id
+    }
+    None => {
+      // If no refresh_token cookie exists, then assume this request is made with an api token
+      let token = data
+        .api_token
+        .as_ref()
+        .expect("No api_token or refresh_token provided");
+
+      let api_token = AuthApiToken::read_from_token(&mut context.pool(), token).await?;
+      if naive_now() > api_token.expires {
+        return Err(LemmyErrorType::TokenNotFound)?;
+      }
+      api_token.local_user_id
+    }
+  };
+
+  let local_user_view = LocalUserView::read(&mut context.pool(), local_user_id).await?;
+
+  check_user_valid(
+    local_user_view.person.banned,
+    local_user_view.person.ban_expires,
+    local_user_view.person.deleted,
+  )?;
+
+  let mut response_builder = HttpResponse::Ok();
+
+  let auth_method = match req.cookie("refresh_token") {
+    Some(mut cookie) => {
+      // Update refresh token & cookie
+      let token_update_form = AuthRefreshTokenUpdateForm {
+        last_used: naive_now(),
+        last_ip: req
+          .connection_info()
+          .realip_remote_addr()
+          .unwrap()
+          .to_string(),
+      };
+
+      AuthRefreshToken::update_token(&mut context.pool(), cookie.value(), &token_update_form)
+        .await?;
+      cookie.set_max_age(Duration::weeks(REFRESH_TOKEN_EXPIRY_WEEKS));
+      response_builder.cookie(cookie);
+      AuthMethod::Password
+    }
+    None => {
+      // Update api token
+      let token_update_form = AuthApiTokenUpdateForm {
+        last_used: naive_now(),
+        last_ip: req
+          .connection_info()
+          .realip_remote_addr()
+          .unwrap()
+          .to_string(),
+      };
+
+      AuthApiToken::update_token(
+        &mut context.pool(),
+        data.api_token.as_ref().unwrap(),
+        &token_update_form,
+      )
+      .await?;
+      AuthMethod::Api
+    }
+  };
+
+  response_builder.json(AccessTokenResponse {
+    jwt: Claims::jwt_with_exp(
+      local_user_view.local_user.id.0,
+      &context.secret().jwt_secret,
+      &context.settings().hostname,
+      auth_method,
+    )?
+    .into(),
+  });
+
+  Ok(response_builder.finish())
+}
+
+pub async fn auth_refresh_token(
+  req: HttpRequest,
+  data: Json<GetRefreshToken>,
+  context: Data<LemmyContext>,
+) -> Result<HttpResponse, LemmyError> {
+  let site_view = SiteView::read_local(&mut context.pool()).await?;
+
+  // Fetch that username / email
+  let username_or_email = data.username_or_email.clone();
+  let local_user_view =
+    LocalUserView::find_by_email_or_name(&mut context.pool(), &username_or_email)
+      .await
+      .with_lemmy_type(LemmyErrorType::IncorrectLogin)?;
+
+  // Verify the password
+  let valid: bool = verify(
+    &data.password,
+    &local_user_view.local_user.password_encrypted,
+  )
+  .unwrap_or(false);
+  if !valid {
+    return Err(LemmyErrorType::IncorrectLogin)?;
+  }
+  check_user_valid(
+    local_user_view.person.banned,
+    local_user_view.person.ban_expires,
+    local_user_view.person.deleted,
+  )?;
+
+  // Check if the user's email is verified if email verification is turned on
+  // However, skip checking verification if the user is an admin
+  if !local_user_view.person.admin
+    && site_view.local_site.require_email_verification
+    && !local_user_view.local_user.email_verified
+  {
+    return Err(LemmyErrorType::EmailNotVerified)?;
+  }
+
+  check_registration_application(&local_user_view, &site_view.local_site, &mut context.pool())
+    .await?;
+
+  // Check the totp
+  check_totp_2fa_valid(
+    &local_user_view.local_user.totp_2fa_secret,
+    &data.totp_2fa_token,
+    &site_view.site.name,
+    &local_user_view.person.name,
+  )?;
+
+  // Create refresh token
+  let form = AuthRefreshTokenCreateForm {
+    local_user_id: local_user_view.local_user.id,
+    last_ip: req
+      .connection_info()
+      .realip_remote_addr()
+      .unwrap()
+      .to_string(),
+  };
+  let refresh_token = AuthRefreshToken::create(&mut context.pool(), &form).await?;
+
+  let cookie = Cookie::build("refresh_token", refresh_token.token)
+    .same_site(SameSite::Strict)
+    .max_age(Duration::weeks(REFRESH_TOKEN_EXPIRY_WEEKS))
+    .path("/api/v3/access_token") // This can only be used for getting access tokens
+    .secure(true)
+    .http_only(true)
+    .finish();
+
+  Ok(HttpResponse::Ok().cookie(cookie).finish())
+}

--- a/crates/api/src/local_user/mod.rs
+++ b/crates/api/src/local_user/mod.rs
@@ -1,4 +1,5 @@
 mod add_admin;
+pub mod auth;
 mod ban_person;
 mod block;
 mod change_password;

--- a/crates/api_common/src/person.rs
+++ b/crates/api_common/src/person.rs
@@ -21,12 +21,42 @@ use ts_rs::TS;
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 #[cfg_attr(feature = "full", derive(TS))]
 #[cfg_attr(feature = "full", ts(export))]
-/// Logging into lemmy.
+/// Logging into lemmy. DEPRECATED and will be removed, use refresh tokens or API tokens instead!
 pub struct Login {
   pub username_or_email: Sensitive<String>,
   pub password: Sensitive<String>,
   /// May be required, if totp is enabled for their account.
   pub totp_2fa_token: Option<String>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+#[cfg_attr(feature = "full", derive(TS))]
+#[cfg_attr(feature = "full", ts(export))]
+/// Username + password authentication. Puts the refresh token into a httpOnly cookie.
+pub struct GetRefreshToken {
+  pub username_or_email: Sensitive<String>,
+  pub password: Sensitive<String>,
+  /// May be required, if totp is enabled for their account.
+  pub totp_2fa_token: Option<String>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+#[cfg_attr(feature = "full", derive(TS))]
+#[cfg_attr(feature = "full", ts(export))]
+/// Marks refresh token as expired and removes the cookie.
+pub struct RevokeRefreshToken {}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+#[cfg_attr(feature = "full", derive(TS))]
+#[cfg_attr(feature = "full", ts(export))]
+/// Gets a short lived access token (jwt) which must be provided for authentication with other
+/// endpoints.
+pub struct GetAccessToken {
+  /// If the refreshToken cookie exists, then this parameter is ignored.
+  pub api_token: Option<String>,
 }
 
 #[skip_serializing_none]
@@ -160,6 +190,15 @@ pub struct LoginResponse {
   pub registration_created: bool,
   /// If email verifications are required, this will return true for a signup response.
   pub verify_email_sent: bool,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "full", derive(TS))]
+#[cfg_attr(feature = "full", ts(export))]
+/// Short lived access token that can be used to authenticate future requests.
+pub struct AccessTokenResponse {
+  pub jwt: Sensitive<String>,
 }
 
 #[skip_serializing_none]

--- a/crates/db_schema/src/impls/auth_api_token.rs
+++ b/crates/db_schema/src/impls/auth_api_token.rs
@@ -1,0 +1,39 @@
+use crate::{
+  schema::auth_api_token::dsl::{auth_api_token, token},
+  source::auth_api_token::{AuthApiToken, AuthApiTokenCreateForm, AuthApiTokenUpdateForm},
+  utils::{get_conn, DbPool},
+};
+use diesel::{dsl::insert_into, result::Error, ExpressionMethods, QueryDsl};
+use diesel_async::RunQueryDsl;
+
+impl AuthApiToken {
+  pub async fn create(pool: &mut DbPool<'_>, form: &AuthApiTokenCreateForm) -> Result<Self, Error> {
+    let conn = &mut get_conn(pool).await?;
+    insert_into(auth_api_token)
+      .values(form)
+      .get_result::<Self>(conn)
+      .await
+  }
+
+  pub async fn update_token(
+    pool: &mut DbPool<'_>,
+    input_token: &str,
+    form: &AuthApiTokenUpdateForm,
+  ) -> Result<AuthApiToken, Error> {
+    let conn = &mut get_conn(pool).await?;
+    diesel::update(auth_api_token.filter(token.eq(input_token)))
+      .set(form)
+      .get_result::<Self>(conn)
+      .await
+  }
+  pub async fn read_from_token(
+    pool: &mut DbPool<'_>,
+    input_token: &str,
+  ) -> Result<AuthApiToken, Error> {
+    let conn = &mut get_conn(pool).await?;
+    auth_api_token
+      .filter(token.eq(input_token))
+      .first::<Self>(conn)
+      .await
+  }
+}

--- a/crates/db_schema/src/impls/auth_refresh_token.rs
+++ b/crates/db_schema/src/impls/auth_refresh_token.rs
@@ -1,0 +1,46 @@
+use crate::{
+  schema::auth_refresh_token::dsl::{auth_refresh_token, token},
+  source::auth_refresh_token::{
+    AuthRefreshToken,
+    AuthRefreshTokenCreateForm,
+    AuthRefreshTokenUpdateForm,
+  },
+  utils::{get_conn, DbPool},
+};
+use diesel::{dsl::insert_into, result::Error, ExpressionMethods, QueryDsl};
+use diesel_async::RunQueryDsl;
+
+impl AuthRefreshToken {
+  pub async fn create(
+    pool: &mut DbPool<'_>,
+    form: &AuthRefreshTokenCreateForm,
+  ) -> Result<Self, Error> {
+    let conn = &mut get_conn(pool).await?;
+    insert_into(auth_refresh_token)
+      .values(form)
+      .get_result::<Self>(conn)
+      .await
+  }
+
+  pub async fn update_token(
+    pool: &mut DbPool<'_>,
+    input_token: &str,
+    form: &AuthRefreshTokenUpdateForm,
+  ) -> Result<AuthRefreshToken, Error> {
+    let conn = &mut get_conn(pool).await?;
+    diesel::update(auth_refresh_token.filter(token.eq(input_token)))
+      .set(form)
+      .get_result::<Self>(conn)
+      .await
+  }
+  pub async fn read_from_token(
+    pool: &mut DbPool<'_>,
+    input_token: &str,
+  ) -> Result<AuthRefreshToken, Error> {
+    let conn = &mut get_conn(pool).await?;
+    auth_refresh_token
+      .filter(token.eq(input_token))
+      .first::<Self>(conn)
+      .await
+  }
+}

--- a/crates/db_schema/src/impls/mod.rs
+++ b/crates/db_schema/src/impls/mod.rs
@@ -1,5 +1,7 @@
 pub mod activity;
 pub mod actor_language;
+pub mod auth_api_token;
+pub mod auth_refresh_token;
 pub mod captcha_answer;
 pub mod comment;
 pub mod comment_reply;

--- a/crates/db_schema/src/schema.rs
+++ b/crates/db_schema/src/schema.rs
@@ -53,6 +53,28 @@ diesel::table! {
 }
 
 diesel::table! {
+    auth_api_token (id) {
+        id -> Int4,
+        local_user_id -> Int4,
+        label -> Text,
+        token -> Text,
+        expires -> Timestamp,
+        last_used -> Timestamp,
+        last_ip -> Text,
+    }
+}
+
+diesel::table! {
+    auth_refresh_token (id) {
+        id -> Int4,
+        local_user_id -> Int4,
+        token -> Text,
+        last_used -> Timestamp,
+        last_ip -> Text,
+    }
+}
+
+diesel::table! {
     captcha_answer (id) {
         id -> Int4,
         uuid -> Uuid,
@@ -848,6 +870,8 @@ diesel::joinable!(admin_purge_community -> person (admin_person_id));
 diesel::joinable!(admin_purge_person -> person (admin_person_id));
 diesel::joinable!(admin_purge_post -> community (community_id));
 diesel::joinable!(admin_purge_post -> person (admin_person_id));
+diesel::joinable!(auth_api_token -> local_user (local_user_id));
+diesel::joinable!(auth_refresh_token -> local_user (local_user_id));
 diesel::joinable!(comment -> language (language_id));
 diesel::joinable!(comment -> person (creator_id));
 diesel::joinable!(comment -> post (post_id));
@@ -930,6 +954,8 @@ diesel::allow_tables_to_appear_in_same_query!(
     admin_purge_community,
     admin_purge_person,
     admin_purge_post,
+    auth_api_token,
+    auth_refresh_token,
     captcha_answer,
     comment,
     comment_aggregates,

--- a/crates/db_schema/src/source/auth_api_token.rs
+++ b/crates/db_schema/src/source/auth_api_token.rs
@@ -1,0 +1,30 @@
+use crate::newtypes::LocalUserId;
+#[cfg(feature = "full")]
+use crate::schema::auth_api_token;
+
+#[derive(PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "full", derive(Queryable, Identifiable))]
+#[cfg_attr(feature = "full", diesel(table_name = auth_api_token))]
+pub struct AuthApiToken {
+  pub id: i32,
+  pub local_user_id: LocalUserId,
+  pub token: String,
+  pub label: String,
+  pub expires: chrono::NaiveDateTime,
+  pub last_used: chrono::NaiveDateTime,
+  pub last_ip: String,
+}
+
+#[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
+#[cfg_attr(feature = "full", diesel(table_name = auth_api_token))]
+pub struct AuthApiTokenCreateForm {
+  pub local_user_id: LocalUserId,
+  pub last_ip: String,
+}
+
+#[cfg_attr(feature = "full", derive(AsChangeset))]
+#[cfg_attr(feature = "full", diesel(table_name = auth_api_token))]
+pub struct AuthApiTokenUpdateForm {
+  pub last_used: chrono::NaiveDateTime,
+  pub last_ip: String,
+}

--- a/crates/db_schema/src/source/auth_refresh_token.rs
+++ b/crates/db_schema/src/source/auth_refresh_token.rs
@@ -1,0 +1,28 @@
+use crate::newtypes::LocalUserId;
+#[cfg(feature = "full")]
+use crate::schema::auth_refresh_token;
+
+#[derive(PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "full", derive(Queryable, Identifiable))]
+#[cfg_attr(feature = "full", diesel(table_name = auth_refresh_token))]
+pub struct AuthRefreshToken {
+  pub id: i32,
+  pub local_user_id: LocalUserId,
+  pub token: String,
+  pub last_used: chrono::NaiveDateTime,
+  pub last_ip: String,
+}
+
+#[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
+#[cfg_attr(feature = "full", diesel(table_name = auth_refresh_token))]
+pub struct AuthRefreshTokenCreateForm {
+  pub local_user_id: LocalUserId,
+  pub last_ip: String,
+}
+
+#[cfg_attr(feature = "full", derive(AsChangeset))]
+#[cfg_attr(feature = "full", diesel(table_name = auth_refresh_token))]
+pub struct AuthRefreshTokenUpdateForm {
+  pub last_used: chrono::NaiveDateTime,
+  pub last_ip: String,
+}

--- a/crates/db_schema/src/source/mod.rs
+++ b/crates/db_schema/src/source/mod.rs
@@ -4,6 +4,8 @@ use url::Url;
 #[cfg(feature = "full")]
 pub mod activity;
 pub mod actor_language;
+pub mod auth_api_token;
+pub mod auth_refresh_token;
 pub mod captcha_answer;
 pub mod comment;
 pub mod comment_reply;

--- a/crates/utils/src/claims.rs
+++ b/crates/utils/src/claims.rs
@@ -1,9 +1,15 @@
 use crate::error::LemmyError;
-use chrono::Utc;
+use chrono::{Duration, Utc};
 use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, TokenData, Validation};
 use serde::{Deserialize, Serialize};
 
 type Jwt = String;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum AuthMethod {
+  Password,
+  Api,
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {
@@ -12,22 +18,59 @@ pub struct Claims {
   pub iss: String,
   /// Time when this token was issued as UNIX-timestamp in seconds
   pub iat: i64,
+  // TODO: This should be made non-optional once deprecated /login endpoint has been removed
+  pub exp: Option<i64>,
+  // TODO: This should be made non-optional once deprecated /login endpoint has been removed
+  pub method: Option<AuthMethod>,
 }
 
 impl Claims {
   pub fn decode(jwt: &str, jwt_secret: &str) -> Result<TokenData<Claims>, LemmyError> {
     let mut validation = Validation::default();
-    validation.validate_exp = false;
-    validation.required_spec_claims.remove("exp");
     let key = DecodingKey::from_secret(jwt_secret.as_ref());
-    Ok(decode::<Claims>(jwt, &key, &validation)?)
+
+    let decoded_token = match decode::<Claims>(jwt, &key, &validation) {
+      Ok(res) => res,
+      Err(_) => {
+        // For backwards compatibility with deprecated authentication, we also allow JWTs with no
+        // expiry.
+        // TODO: This should be removed once the deprecated /login endpoint has been removed
+        validation.validate_exp = false;
+        validation.required_spec_claims.remove("exp");
+        decode::<Claims>(jwt, &key, &validation)?
+      }
+    };
+
+    Ok(decoded_token)
   }
 
+  // Used for deprecated /login endpoint, does not have an expiry
+  // TODO: This should be removed once the deprecated /login endpoint has been removed
   pub fn jwt(local_user_id: i32, jwt_secret: &str, hostname: &str) -> Result<Jwt, LemmyError> {
     let my_claims = Claims {
       sub: local_user_id,
       iss: hostname.to_string(),
       iat: Utc::now().timestamp(),
+      exp: None,
+      method: None,
+    };
+
+    let key = EncodingKey::from_secret(jwt_secret.as_ref());
+    Ok(encode(&Header::default(), &my_claims, &key)?)
+  }
+
+  pub fn jwt_with_exp(
+    local_user_id: i32,
+    jwt_secret: &str,
+    hostname: &str,
+    method: AuthMethod,
+  ) -> Result<Jwt, LemmyError> {
+    let my_claims = Claims {
+      sub: local_user_id,
+      iss: hostname.to_string(),
+      iat: Utc::now().timestamp(),
+      exp: Some((Utc::now() + Duration::minutes(5)).timestamp()),
+      method: Some(method),
     };
 
     let key = EncodingKey::from_secret(jwt_secret.as_ref());

--- a/migrations/2023-07-16-123316_auth_overhaul/down.sql
+++ b/migrations/2023-07-16-123316_auth_overhaul/down.sql
@@ -1,0 +1,5 @@
+-- This file should undo anything in `up.sql`
+DROP INDEX idx_auth_api_token_token;
+DROP TABLE auth_api_token;
+DROP INDEX idx_auth_refresh_token_token;
+DROP TABLE auth_refresh_token;

--- a/migrations/2023-07-16-123316_auth_overhaul/up.sql
+++ b/migrations/2023-07-16-123316_auth_overhaul/up.sql
@@ -1,0 +1,28 @@
+-- Your SQL goes here
+CREATE TABLE auth_refresh_token
+(
+    id            serial PRIMARY KEY,
+    local_user_id int REFERENCES local_user ON UPDATE CASCADE ON DELETE CASCADE NOT NULL,
+    token         text                                                          NOT NULL DEFAULT encode(digest(gen_random_bytes(1024), 'sha512'), 'hex'),
+
+    last_used     timestamp                                                     NOT NULL DEFAULT now(),
+    last_ip       text                                                          NOT NULL
+);
+
+CREATE INDEX idx_auth_refresh_token_token ON auth_refresh_token (token);
+
+
+CREATE TABLE auth_api_token
+(
+    id            serial PRIMARY KEY,
+    local_user_id int REFERENCES local_user ON UPDATE CASCADE ON DELETE CASCADE NOT NULL,
+    label         text                                                          NOT NULL,
+    token         text                                                          NOT NULL DEFAULT 'lemmyv1_' ||
+                                                                                                 encode(digest(gen_random_bytes(1024), 'sha512'), 'hex'),
+    expires       timestamp                                                     NOT NULL DEFAULT now(),
+    last_used     timestamp                                                     NOT NULL DEFAULT now(),
+    last_ip       text                                                          NOT NULL
+);
+
+
+CREATE INDEX idx_auth_api_token_token ON auth_api_token (token);

--- a/src/api_routes_http.rs
+++ b/src/api_routes_http.rs
@@ -1,5 +1,8 @@
 use actix_web::{guard, web, Error, HttpResponse, Result};
-use lemmy_api::Perform;
+use lemmy_api::{
+  local_user::auth::{auth_access_token, auth_refresh_token},
+  Perform,
+};
 use lemmy_api_common::{
   comment::{
     CreateComment,
@@ -300,6 +303,8 @@ pub fn config(cfg: &mut web::ServiceConfig, rate_limit: &RateLimitCell) {
           .route("/block", web::post().to(route_post::<BlockPerson>))
           // Account actions. I don't like that they're in /user maybe /accounts
           .route("/login", web::post().to(route_post::<Login>))
+          .route("/get_refresh_token", web::post().to(auth_refresh_token))
+          .route("/get_access_token", web::post().to(auth_access_token))
           .route(
             "/delete_account",
             web::post().to(route_post_crud::<DeleteAccount>),


### PR DESCRIPTION
**This PR is not complete (missing items detailed below), but I am submitting it already as a draft to get some early feedback.** Please check the description below before checking code - I would really appreciate feedback on the overall design which is included in the description. But comments on the partially complete code are of course welcome as well.

----

# Introduction

This PR contains an overhaul of Lemmy authentication. It introduces three new authentication tokens: access tokens, refresh tokens, and api tokens (more details below).

The changes are intended to be backwards compatible - the existing /login endpoint will become deprecated but will remain operational until we are ready to remove it in a future version.

## What is wrong with our current authentication?

1. Auth tokens never expire: https://github.com/LemmyNet/lemmy/issues/3364
2. Auth sessions can't be revoked by users
3. There is no support for httpOnly cookie based auth: https://github.com/LemmyNet/lemmy-ui/issues/1252
4. There is no support for api token based auth - all 3rd party apps require user passwords
5. All auth tokens have full access to everything, their scope can't be limited

This PR contains intends to solve all these issues.

## Proposed solution

This PR proposes to replace the existing auth token with 3 new types of tokens:

### Access token

This token can be acquired with either a refresh token or an API token.

The new access token is intended to be a backwards compatible drop-in replacement for the existing auth token, with a few key differences:
* It expires within 5 minutes (so even if it leaks, it can only be abused within 5 minutes of the leak)
* It contains a `method` claim, which can be used later to limit certain activities to specific methods (for example, disallow password changes if the access token was obtained via an API token)


### Refresh token

This token can be acquired using username + password (+ 2fa). 

It lives in a secure httpOnly cookie (can't be read from browser js), which is limited only to the /api/v3/get_access_token path.

This is intended only for trusted web interfaces (such as lemmy-ui) and can be used to create access tokens with full access to the user. Each refresh token can be considered a separate "session". Each token records its last use time, as well as last use ip address - these values can be displayed to users in some new security UI so they get an overview of their active sessions. Each refresh token expires 2 weeks after it was last used, or when revoked manually by a user.

### API token

This token must be manually created by users with a specific label and expiry date.

This is intended for 3rd party apps to avoid users from entering their passwords directly into untrusted code. The api token can be used similarly to refresh tokens to request access tokens, but the created access tokens would have limited access. Each API token will also record their last use time as well as last use ip address. API tokens expire after their user defined expiry date, or when revoked manually.


----

To summarize the general flow:
1. Acquire either a refresh token (if trusted web ui) or an API token (if 3rd party app)
2. Request access token using the token from step 1
3. Make all API requests with access token from step 2
4. If access token is close to expiry (or last request failed due to token), get a new access token (and retry last request)
5. If getting access token fails due to a token error, assume the (refresh or api) token has expired and go back to step 1

## Rollout plan
1. Release the new logic in a minor Lemmy version
2. Add a migration guide to release notes to allow app developers to migrate to the new APIs
3. Update Lemmy-ui to use the new endpoints
4. After some time has passed, remove the old /login endpoint in a backwards-incompatible Lemmy update

## TODO in this PR
* Add refresh token list & revoke endpoints
* Add api token create & list & revoke endpoints
* Disallow some actions (new api token creation + password change + reading user e-mail?) when access token method is `Api`
* Add some tests

## TODO in future PRs
* Switch lemmy-ui to use new authentication
* Add security page to lemmy-ui, where users can see and revoke their sessions (refresh tokens), as well as see/revoke/create API tokens
* Add method for 3rd party apps to redirect users to an API token creation page (with a potential return_url to automatically get back to the app with the created token)

