### PR TITLE
Remove TypedBuilder from db_views and db_views_actor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2769,7 +2769,6 @@ dependencies = [
  "tokio",
  "tracing",
  "ts-rs",
- "typed-builder",
 ]
 
 [[package]]
@@ -2782,7 +2781,6 @@ dependencies = [
  "serde",
  "serde_with",
  "ts-rs",
- "typed-builder",
 ]
 
 [[package]]

--- a/crates/api/src/comment_report/list.rs
+++ b/crates/api/src/comment_report/list.rs
@@ -30,7 +30,6 @@ impl Perform for ListCommentReports {
     let page = data.page;
     let limit = data.limit;
     let comment_reports = CommentReportQuery::builder()
-      .pool(&mut context.pool())
       .my_person_id(person_id)
       .admin(admin)
       .community_id(community_id)
@@ -38,7 +37,7 @@ impl Perform for ListCommentReports {
       .page(page)
       .limit(limit)
       .build()
-      .list()
+      .list(&mut context.pool())
       .await?;
 
     Ok(ListCommentReportsResponse { comment_reports })

--- a/crates/api/src/comment_report/list.rs
+++ b/crates/api/src/comment_report/list.rs
@@ -22,22 +22,18 @@ impl Perform for ListCommentReports {
     let data: &ListCommentReports = self;
     let local_user_view = local_user_view_from_jwt(&data.auth, context).await?;
 
-    let person_id = local_user_view.person.id;
-    let admin = local_user_view.person.admin;
     let community_id = data.community_id;
     let unresolved_only = data.unresolved_only;
 
     let page = data.page;
     let limit = data.limit;
     let comment_reports = CommentReportQuery::builder()
-      .my_person_id(person_id)
-      .admin(admin)
       .community_id(community_id)
       .unresolved_only(unresolved_only)
       .page(page)
       .limit(limit)
       .build()
-      .list(&mut context.pool())
+      .list(&mut context.pool(), &local_user_view.person)
       .await?;
 
     Ok(ListCommentReportsResponse { comment_reports })

--- a/crates/api/src/comment_report/list.rs
+++ b/crates/api/src/comment_report/list.rs
@@ -27,14 +27,14 @@ impl Perform for ListCommentReports {
 
     let page = data.page;
     let limit = data.limit;
-    let comment_reports = CommentReportQuery::builder()
-      .community_id(community_id)
-      .unresolved_only(unresolved_only)
-      .page(page)
-      .limit(limit)
-      .build()
-      .list(&mut context.pool(), &local_user_view.person)
-      .await?;
+    let comment_reports = CommentReportQuery {
+      community_id,
+      unresolved_only,
+      page,
+      limit,
+    }
+    .list(&mut context.pool(), &local_user_view.person)
+    .await?;
 
     Ok(ListCommentReportsResponse { comment_reports })
   }

--- a/crates/api/src/local_user/notifications/list_mentions.rs
+++ b/crates/api/src/local_user/notifications/list_mentions.rs
@@ -27,17 +27,17 @@ impl Perform for GetPersonMentions {
     let person_id = Some(local_user_view.person.id);
     let show_bot_accounts = Some(local_user_view.local_user.show_bot_accounts);
 
-    let mentions = PersonMentionQuery::builder()
-      .recipient_id(person_id)
-      .my_person_id(person_id)
-      .sort(sort)
-      .unread_only(unread_only)
-      .show_bot_accounts(show_bot_accounts)
-      .page(page)
-      .limit(limit)
-      .build()
-      .list(&mut context.pool())
-      .await?;
+    let mentions = PersonMentionQuery {
+      recipient_id: person_id,
+      my_person_id: person_id,
+      sort,
+      unread_only,
+      show_bot_accounts,
+      page,
+      limit,
+    }
+    .list(&mut context.pool())
+    .await?;
 
     Ok(GetPersonMentionsResponse { mentions })
   }

--- a/crates/api/src/local_user/notifications/list_mentions.rs
+++ b/crates/api/src/local_user/notifications/list_mentions.rs
@@ -28,7 +28,6 @@ impl Perform for GetPersonMentions {
     let show_bot_accounts = Some(local_user_view.local_user.show_bot_accounts);
 
     let mentions = PersonMentionQuery::builder()
-      .pool(&mut context.pool())
       .recipient_id(person_id)
       .my_person_id(person_id)
       .sort(sort)
@@ -37,7 +36,7 @@ impl Perform for GetPersonMentions {
       .page(page)
       .limit(limit)
       .build()
-      .list()
+      .list(&mut context.pool())
       .await?;
 
     Ok(GetPersonMentionsResponse { mentions })

--- a/crates/api/src/local_user/notifications/list_replies.rs
+++ b/crates/api/src/local_user/notifications/list_replies.rs
@@ -24,17 +24,17 @@ impl Perform for GetReplies {
     let person_id = Some(local_user_view.person.id);
     let show_bot_accounts = Some(local_user_view.local_user.show_bot_accounts);
 
-    let replies = CommentReplyQuery::builder()
-      .recipient_id(person_id)
-      .my_person_id(person_id)
-      .sort(sort)
-      .unread_only(unread_only)
-      .show_bot_accounts(show_bot_accounts)
-      .page(page)
-      .limit(limit)
-      .build()
-      .list(&mut context.pool())
-      .await?;
+    let replies = CommentReplyQuery {
+      recipient_id: person_id,
+      my_person_id: person_id,
+      sort,
+      unread_only,
+      show_bot_accounts,
+      page,
+      limit,
+    }
+    .list(&mut context.pool())
+    .await?;
 
     Ok(GetRepliesResponse { replies })
   }

--- a/crates/api/src/local_user/notifications/list_replies.rs
+++ b/crates/api/src/local_user/notifications/list_replies.rs
@@ -25,7 +25,6 @@ impl Perform for GetReplies {
     let show_bot_accounts = Some(local_user_view.local_user.show_bot_accounts);
 
     let replies = CommentReplyQuery::builder()
-      .pool(&mut context.pool())
       .recipient_id(person_id)
       .my_person_id(person_id)
       .sort(sort)
@@ -34,7 +33,7 @@ impl Perform for GetReplies {
       .page(page)
       .limit(limit)
       .build()
-      .list()
+      .list(&mut context.pool())
       .await?;
 
     Ok(GetRepliesResponse { replies })

--- a/crates/api/src/post_report/list.rs
+++ b/crates/api/src/post_report/list.rs
@@ -22,22 +22,18 @@ impl Perform for ListPostReports {
     let data: &ListPostReports = self;
     let local_user_view = local_user_view_from_jwt(&data.auth, context).await?;
 
-    let person_id = local_user_view.person.id;
-    let admin = local_user_view.person.admin;
     let community_id = data.community_id;
     let unresolved_only = data.unresolved_only;
 
     let page = data.page;
     let limit = data.limit;
     let post_reports = PostReportQuery::builder()
-      .my_person_id(person_id)
-      .admin(admin)
       .community_id(community_id)
       .unresolved_only(unresolved_only)
       .page(page)
       .limit(limit)
       .build()
-      .list(&mut context.pool())
+      .list(&mut context.pool(), &local_user_view.person)
       .await?;
 
     Ok(ListPostReportsResponse { post_reports })

--- a/crates/api/src/post_report/list.rs
+++ b/crates/api/src/post_report/list.rs
@@ -30,7 +30,6 @@ impl Perform for ListPostReports {
     let page = data.page;
     let limit = data.limit;
     let post_reports = PostReportQuery::builder()
-      .pool(&mut context.pool())
       .my_person_id(person_id)
       .admin(admin)
       .community_id(community_id)
@@ -38,7 +37,7 @@ impl Perform for ListPostReports {
       .page(page)
       .limit(limit)
       .build()
-      .list()
+      .list(&mut context.pool())
       .await?;
 
     Ok(ListPostReportsResponse { post_reports })

--- a/crates/api/src/post_report/list.rs
+++ b/crates/api/src/post_report/list.rs
@@ -27,14 +27,14 @@ impl Perform for ListPostReports {
 
     let page = data.page;
     let limit = data.limit;
-    let post_reports = PostReportQuery::builder()
-      .community_id(community_id)
-      .unresolved_only(unresolved_only)
-      .page(page)
-      .limit(limit)
-      .build()
-      .list(&mut context.pool(), &local_user_view.person)
-      .await?;
+    let post_reports = PostReportQuery {
+      community_id,
+      unresolved_only,
+      page,
+      limit,
+    }
+    .list(&mut context.pool(), &local_user_view.person)
+    .await?;
 
     Ok(ListPostReportsResponse { post_reports })
   }

--- a/crates/api/src/private_message_report/list.rs
+++ b/crates/api/src/private_message_report/list.rs
@@ -21,13 +21,13 @@ impl Perform for ListPrivateMessageReports {
     let unresolved_only = self.unresolved_only;
     let page = self.page;
     let limit = self.limit;
-    let private_message_reports = PrivateMessageReportQuery::builder()
-      .unresolved_only(unresolved_only)
-      .page(page)
-      .limit(limit)
-      .build()
-      .list(&mut context.pool())
-      .await?;
+    let private_message_reports = PrivateMessageReportQuery {
+      unresolved_only,
+      page,
+      limit,
+    }
+    .list(&mut context.pool())
+    .await?;
 
     Ok(ListPrivateMessageReportsResponse {
       private_message_reports,

--- a/crates/api/src/private_message_report/list.rs
+++ b/crates/api/src/private_message_report/list.rs
@@ -22,12 +22,11 @@ impl Perform for ListPrivateMessageReports {
     let page = self.page;
     let limit = self.limit;
     let private_message_reports = PrivateMessageReportQuery::builder()
-      .pool(&mut context.pool())
       .unresolved_only(unresolved_only)
       .page(page)
       .limit(limit)
       .build()
-      .list()
+      .list(&mut context.pool())
       .await?;
 
     Ok(ListPrivateMessageReportsResponse {

--- a/crates/api/src/site/registration_applications/list.rs
+++ b/crates/api/src/site/registration_applications/list.rs
@@ -23,18 +23,18 @@ impl Perform for ListRegistrationApplications {
     is_admin(&local_user_view)?;
 
     let unread_only = data.unread_only;
-    let verified_email_only = local_site.require_email_verification;
+    let verified_email_only = Some(local_site.require_email_verification);
 
     let page = data.page;
     let limit = data.limit;
-    let registration_applications = RegistrationApplicationQuery::builder()
-      .unread_only(unread_only)
-      .verified_email_only(Some(verified_email_only))
-      .page(page)
-      .limit(limit)
-      .build()
-      .list(&mut context.pool())
-      .await?;
+    let registration_applications = RegistrationApplicationQuery {
+      unread_only,
+      verified_email_only,
+      page,
+      limit,
+    }
+    .list(&mut context.pool())
+    .await?;
 
     Ok(Self::Response {
       registration_applications,

--- a/crates/api/src/site/registration_applications/list.rs
+++ b/crates/api/src/site/registration_applications/list.rs
@@ -28,13 +28,12 @@ impl Perform for ListRegistrationApplications {
     let page = data.page;
     let limit = data.limit;
     let registration_applications = RegistrationApplicationQuery::builder()
-      .pool(&mut context.pool())
       .unread_only(unread_only)
       .verified_email_only(Some(verified_email_only))
       .page(page)
       .limit(limit)
       .build()
-      .list()
+      .list(&mut context.pool())
       .await?;
 
     Ok(Self::Response {

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -667,12 +667,13 @@ pub async fn remove_user_data_in_community(
 
   // Comments
   // TODO Diesel doesn't allow updates with joins, so this has to be a loop
-  let comments = CommentQuery::builder()
-    .creator_id(Some(banned_person_id))
-    .community_id(Some(community_id))
-    .build()
-    .list(pool)
-    .await?;
+  let comments = CommentQuery {
+    creator_id: Some(banned_person_id),
+    community_id: Some(community_id),
+    ..Default::default()
+  }
+  .list(pool)
+  .await?;
 
   for comment_view in &comments {
     let comment_id = comment_view.comment.id;

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -668,11 +668,10 @@ pub async fn remove_user_data_in_community(
   // Comments
   // TODO Diesel doesn't allow updates with joins, so this has to be a loop
   let comments = CommentQuery::builder()
-    .pool(pool)
     .creator_id(Some(banned_person_id))
     .community_id(Some(community_id))
     .build()
-    .list()
+    .list(pool)
     .await?;
 
   for comment_view in &comments {

--- a/crates/api_crud/src/community/list.rs
+++ b/crates/api_crud/src/community/list.rs
@@ -32,7 +32,6 @@ impl PerformCrud for ListCommunities {
     let limit = data.limit;
     let local_user = local_user_view.map(|l| l.local_user);
     let communities = CommunityQuery::builder()
-      .pool(&mut context.pool())
       .listing_type(listing_type)
       .show_nsfw(show_nsfw)
       .sort(sort)
@@ -41,7 +40,7 @@ impl PerformCrud for ListCommunities {
       .limit(limit)
       .is_mod_or_admin(is_admin)
       .build()
-      .list()
+      .list(&mut context.pool())
       .await?;
 
     // Return the jwt

--- a/crates/api_crud/src/community/list.rs
+++ b/crates/api_crud/src/community/list.rs
@@ -31,17 +31,18 @@ impl PerformCrud for ListCommunities {
     let page = data.page;
     let limit = data.limit;
     let local_user = local_user_view.map(|l| l.local_user);
-    let communities = CommunityQuery::builder()
-      .listing_type(listing_type)
-      .show_nsfw(show_nsfw)
-      .sort(sort)
-      .local_user(local_user.as_ref())
-      .page(page)
-      .limit(limit)
-      .is_mod_or_admin(is_admin)
-      .build()
-      .list(&mut context.pool())
-      .await?;
+    let communities = CommunityQuery {
+      listing_type,
+      show_nsfw,
+      sort,
+      local_user: local_user.as_ref(),
+      page,
+      limit,
+      is_mod_or_admin: is_admin,
+      ..Default::default()
+    }
+    .list(&mut context.pool())
+    .await?;
 
     // Return the jwt
     Ok(ListCommunitiesResponse { communities })

--- a/crates/api_crud/src/post/read.rs
+++ b/crates/api_crud/src/post/read.rs
@@ -100,11 +100,12 @@ impl PerformCrud for GetPost {
 
     // Fetch the cross_posts
     let cross_posts = if let Some(url) = &post_view.post.url {
-      let mut x_posts = PostQuery::builder()
-        .url_search(Some(url.inner().as_str().into()))
-        .build()
-        .list(&mut context.pool())
-        .await?;
+      let mut x_posts = PostQuery {
+        url_search: Some(url.inner().as_str().into()),
+        ..Default::default()
+      }
+      .list(&mut context.pool())
+      .await?;
 
       // Don't return this post as one of the cross_posts
       x_posts.retain(|x| x.post.id != post_id);

--- a/crates/api_crud/src/post/read.rs
+++ b/crates/api_crud/src/post/read.rs
@@ -101,10 +101,9 @@ impl PerformCrud for GetPost {
     // Fetch the cross_posts
     let cross_posts = if let Some(url) = &post_view.post.url {
       let mut x_posts = PostQuery::builder()
-        .pool(&mut context.pool())
         .url_search(Some(url.inner().as_str().into()))
         .build()
-        .list()
+        .list(&mut context.pool())
         .await?;
 
       // Don't return this post as one of the cross_posts

--- a/crates/api_crud/src/private_message/read.rs
+++ b/crates/api_crud/src/private_message/read.rs
@@ -25,13 +25,12 @@ impl PerformCrud for GetPrivateMessages {
     let limit = data.limit;
     let unread_only = data.unread_only;
     let mut messages = PrivateMessageQuery::builder()
-      .pool(&mut context.pool())
       .recipient_id(person_id)
       .page(page)
       .limit(limit)
       .unread_only(unread_only)
       .build()
-      .list()
+      .list(&mut context.pool())
       .await?;
 
     // Messages sent by ourselves should be marked as read. The `read` column in database is only

--- a/crates/api_crud/src/private_message/read.rs
+++ b/crates/api_crud/src/private_message/read.rs
@@ -24,13 +24,13 @@ impl PerformCrud for GetPrivateMessages {
     let page = data.page;
     let limit = data.limit;
     let unread_only = data.unread_only;
-    let mut messages = PrivateMessageQuery::builder()
-      .page(page)
-      .limit(limit)
-      .unread_only(unread_only)
-      .build()
-      .list(&mut context.pool(), person_id)
-      .await?;
+    let mut messages = PrivateMessageQuery {
+      page,
+      limit,
+      unread_only,
+    }
+    .list(&mut context.pool(), person_id)
+    .await?;
 
     // Messages sent by ourselves should be marked as read. The `read` column in database is only
     // for the recipient, and shouldnt be exposed to sender.

--- a/crates/api_crud/src/private_message/read.rs
+++ b/crates/api_crud/src/private_message/read.rs
@@ -25,12 +25,11 @@ impl PerformCrud for GetPrivateMessages {
     let limit = data.limit;
     let unread_only = data.unread_only;
     let mut messages = PrivateMessageQuery::builder()
-      .recipient_id(person_id)
       .page(page)
       .limit(limit)
       .unread_only(unread_only)
       .build()
-      .list(&mut context.pool())
+      .list(&mut context.pool(), person_id)
       .await?;
 
     // Messages sent by ourselves should be marked as read. The `read` column in database is only

--- a/crates/apub/src/api/list_comments.rs
+++ b/crates/apub/src/api/list_comments.rs
@@ -52,7 +52,6 @@ pub async fn list_comments(
   let post_id = data.post_id;
   let local_user = local_user_view.map(|l| l.local_user);
   let comments = CommentQuery::builder()
-    .pool(&mut context.pool())
     .listing_type(Some(listing_type))
     .sort(sort)
     .max_depth(max_depth)
@@ -64,7 +63,7 @@ pub async fn list_comments(
     .page(page)
     .limit(limit)
     .build()
-    .list()
+    .list(&mut context.pool())
     .await
     .with_lemmy_type(LemmyErrorType::CouldntGetComments)?;
 

--- a/crates/apub/src/api/list_comments.rs
+++ b/crates/apub/src/api/list_comments.rs
@@ -39,7 +39,11 @@ pub async fn list_comments(
   let limit = data.limit;
   let parent_id = data.parent_id;
 
-  let listing_type = listing_type_with_default(data.type_, &local_site, community_id)?;
+  let listing_type = Some(listing_type_with_default(
+    data.type_,
+    &local_site,
+    community_id,
+  )?);
 
   // If a parent_id is given, fetch the comment to get the path
   let parent_path = if let Some(parent_id) = parent_id {
@@ -51,21 +55,22 @@ pub async fn list_comments(
   let parent_path_cloned = parent_path.clone();
   let post_id = data.post_id;
   let local_user = local_user_view.map(|l| l.local_user);
-  let comments = CommentQuery::builder()
-    .listing_type(Some(listing_type))
-    .sort(sort)
-    .max_depth(max_depth)
-    .saved_only(saved_only)
-    .community_id(community_id)
-    .parent_path(parent_path_cloned)
-    .post_id(post_id)
-    .local_user(local_user.as_ref())
-    .page(page)
-    .limit(limit)
-    .build()
-    .list(&mut context.pool())
-    .await
-    .with_lemmy_type(LemmyErrorType::CouldntGetComments)?;
+  let comments = CommentQuery {
+    listing_type,
+    sort,
+    max_depth,
+    saved_only,
+    community_id,
+    parent_path: parent_path_cloned,
+    post_id,
+    local_user: local_user.as_ref(),
+    page,
+    limit,
+    ..Default::default()
+  }
+  .list(&mut context.pool())
+  .await
+  .with_lemmy_type(LemmyErrorType::CouldntGetComments)?;
 
   Ok(Json(GetCommentsResponse { comments }))
 }

--- a/crates/apub/src/api/list_posts.rs
+++ b/crates/apub/src/api/list_posts.rs
@@ -36,26 +36,32 @@ pub async fn list_posts(
   };
   let saved_only = data.saved_only;
 
-  let listing_type = listing_type_with_default(data.type_, &local_site, community_id)?;
+  let listing_type = Some(listing_type_with_default(
+    data.type_,
+    &local_site,
+    community_id,
+  )?);
 
-  let is_mod_or_admin =
+  let is_mod_or_admin = Some(
     is_mod_or_admin_opt(&mut context.pool(), local_user_view.as_ref(), community_id)
       .await
-      .is_ok();
+      .is_ok(),
+  );
 
-  let posts = PostQuery::builder()
-    .local_user(local_user_view.map(|l| l.local_user).as_ref())
-    .listing_type(Some(listing_type))
-    .sort(sort)
-    .community_id(community_id)
-    .saved_only(saved_only)
-    .page(page)
-    .limit(limit)
-    .is_mod_or_admin(Some(is_mod_or_admin))
-    .build()
-    .list(&mut context.pool())
-    .await
-    .with_lemmy_type(LemmyErrorType::CouldntGetPosts)?;
+  let posts = PostQuery {
+    local_user: local_user_view.map(|l| l.local_user).as_ref(),
+    listing_type,
+    sort,
+    community_id,
+    saved_only,
+    page,
+    limit,
+    is_mod_or_admin,
+    ..Default::default()
+  }
+  .list(&mut context.pool())
+  .await
+  .with_lemmy_type(LemmyErrorType::CouldntGetPosts)?;
 
   Ok(Json(GetPostsResponse { posts }))
 }

--- a/crates/apub/src/api/list_posts.rs
+++ b/crates/apub/src/api/list_posts.rs
@@ -44,7 +44,6 @@ pub async fn list_posts(
       .is_ok();
 
   let posts = PostQuery::builder()
-    .pool(&mut context.pool())
     .local_user(local_user_view.map(|l| l.local_user).as_ref())
     .listing_type(Some(listing_type))
     .sort(sort)
@@ -54,7 +53,7 @@ pub async fn list_posts(
     .limit(limit)
     .is_mod_or_admin(Some(is_mod_or_admin))
     .build()
-    .list()
+    .list(&mut context.pool())
     .await
     .with_lemmy_type(LemmyErrorType::CouldntGetPosts)?;
 

--- a/crates/apub/src/api/read_person.rs
+++ b/crates/apub/src/api/read_person.rs
@@ -57,7 +57,6 @@ pub async fn read_person(
   let local_user_clone = local_user.clone();
 
   let posts = PostQuery::builder()
-    .pool(&mut context.pool())
     .sort(sort)
     .saved_only(saved_only)
     .local_user(local_user.as_ref())
@@ -75,11 +74,10 @@ pub async fn read_person(
       },
     )
     .build()
-    .list()
+    .list(&mut context.pool())
     .await?;
 
   let comments = CommentQuery::builder()
-    .pool(&mut context.pool())
     .local_user(local_user_clone.as_ref())
     .sort(sort.map(post_to_comment_sort_type))
     .saved_only(saved_only)
@@ -97,7 +95,7 @@ pub async fn read_person(
       },
     )
     .build()
-    .list()
+    .list(&mut context.pool())
     .await?;
 
   let moderates =

--- a/crates/apub/src/api/read_person.rs
+++ b/crates/apub/src/api/read_person.rs
@@ -56,47 +56,49 @@ pub async fn read_person(
   let local_user = local_user_view.map(|l| l.local_user);
   let local_user_clone = local_user.clone();
 
-  let posts = PostQuery::builder()
-    .sort(sort)
-    .saved_only(saved_only)
-    .local_user(local_user.as_ref())
-    .community_id(community_id)
-    .is_mod_or_admin(is_admin)
-    .page(page)
-    .limit(limit)
-    .creator_id(
+  let posts = PostQuery {
+    sort,
+    saved_only,
+    local_user:local_user.as_ref(),
+    community_id,
+    is_mod_or_admin: is_admin,
+    page,
+    limit,
+    creator_id:
       // If its saved only, you don't care what creator it was
       // Or, if its not saved, then you only want it for that specific creator
       if !saved_only.unwrap_or(false) {
         Some(person_details_id)
       } else {
         None
-      },
-    )
-    .build()
-    .list(&mut context.pool())
-    .await?;
+      }
+    ,
+    ..Default::default()
+  }
+  .list(&mut context.pool())
+  .await?;
 
-  let comments = CommentQuery::builder()
-    .local_user(local_user_clone.as_ref())
-    .sort(sort.map(post_to_comment_sort_type))
-    .saved_only(saved_only)
-    .show_deleted_and_removed(Some(false))
-    .community_id(community_id)
-    .page(page)
-    .limit(limit)
-    .creator_id(
+  let comments = CommentQuery {
+    local_user: (local_user_clone.as_ref()),
+    sort: (sort.map(post_to_comment_sort_type)),
+    saved_only: (saved_only),
+    show_deleted_and_removed: (Some(false)),
+    community_id: (community_id),
+    page: (page),
+    limit: (limit),
+    creator_id: (
       // If its saved only, you don't care what creator it was
       // Or, if its not saved, then you only want it for that specific creator
       if !saved_only.unwrap_or(false) {
         Some(person_details_id)
       } else {
         None
-      },
-    )
-    .build()
-    .list(&mut context.pool())
-    .await?;
+      }
+    ),
+    ..Default::default()
+  }
+  .list(&mut context.pool())
+  .await?;
 
   let moderates =
     CommunityModeratorView::for_person(&mut context.pool(), person_details_id).await?;

--- a/crates/apub/src/api/search.rs
+++ b/crates/apub/src/api/search.rs
@@ -53,56 +53,59 @@ pub async fn search(
   let local_user = local_user_view.map(|l| l.local_user);
   match search_type {
     SearchType::Posts => {
-      posts = PostQuery::builder()
-        .sort(sort)
-        .listing_type(listing_type)
-        .community_id(community_id)
-        .creator_id(creator_id)
-        .local_user(local_user.as_ref())
-        .search_term(Some(q))
-        .is_mod_or_admin(is_admin)
-        .page(page)
-        .limit(limit)
-        .build()
-        .list(&mut context.pool())
-        .await?;
+      posts = PostQuery {
+        sort: (sort),
+        listing_type: (listing_type),
+        community_id: (community_id),
+        creator_id: (creator_id),
+        local_user: (local_user.as_ref()),
+        search_term: (Some(q)),
+        is_mod_or_admin: (is_admin),
+        page: (page),
+        limit: (limit),
+        ..Default::default()
+      }
+      .list(&mut context.pool())
+      .await?;
     }
     SearchType::Comments => {
-      comments = CommentQuery::builder()
-        .sort(sort.map(post_to_comment_sort_type))
-        .listing_type(listing_type)
-        .search_term(Some(q))
-        .community_id(community_id)
-        .creator_id(creator_id)
-        .local_user(local_user.as_ref())
-        .page(page)
-        .limit(limit)
-        .build()
-        .list(&mut context.pool())
-        .await?;
+      comments = CommentQuery {
+        sort: (sort.map(post_to_comment_sort_type)),
+        listing_type: (listing_type),
+        search_term: (Some(q)),
+        community_id: (community_id),
+        creator_id: (creator_id),
+        local_user: (local_user.as_ref()),
+        page: (page),
+        limit: (limit),
+        ..Default::default()
+      }
+      .list(&mut context.pool())
+      .await?;
     }
     SearchType::Communities => {
-      communities = CommunityQuery::builder()
-        .sort(sort)
-        .listing_type(listing_type)
-        .search_term(Some(q))
-        .local_user(local_user.as_ref())
-        .is_mod_or_admin(is_admin)
-        .page(page)
-        .limit(limit)
-        .build()
-        .list(&mut context.pool())
-        .await?;
+      communities = CommunityQuery {
+        sort: (sort),
+        listing_type: (listing_type),
+        search_term: (Some(q)),
+        local_user: (local_user.as_ref()),
+        is_mod_or_admin: (is_admin),
+        page: (page),
+        limit: (limit),
+        ..Default::default()
+      }
+      .list(&mut context.pool())
+      .await?;
     }
     SearchType::Users => {
-      users = PersonQuery::builder()
-        .sort(sort)
-        .search_term(Some(q))
-        .page(page)
-        .limit(limit)
-        .build()
-        .list(&mut context.pool())
-        .await?;
+      users = PersonQuery {
+        sort: (sort),
+        search_term: (Some(q)),
+        page: (page),
+        limit: (limit),
+      }
+      .list(&mut context.pool())
+      .await?;
     }
     SearchType::All => {
       // If the community or creator is included, dont search communities or users
@@ -110,52 +113,55 @@ pub async fn search(
         data.community_id.is_some() || data.community_name.is_some() || data.creator_id.is_some();
 
       let local_user_ = local_user.clone();
-      posts = PostQuery::builder()
-        .sort(sort)
-        .listing_type(listing_type)
-        .community_id(community_id)
-        .creator_id(creator_id)
-        .local_user(local_user_.as_ref())
-        .search_term(Some(q))
-        .is_mod_or_admin(is_admin)
-        .page(page)
-        .limit(limit)
-        .build()
-        .list(&mut context.pool())
-        .await?;
+      posts = PostQuery {
+        sort: (sort),
+        listing_type: (listing_type),
+        community_id: (community_id),
+        creator_id: (creator_id),
+        local_user: (local_user_.as_ref()),
+        search_term: (Some(q)),
+        is_mod_or_admin: (is_admin),
+        page: (page),
+        limit: (limit),
+        ..Default::default()
+      }
+      .list(&mut context.pool())
+      .await?;
 
       let q = data.q.clone();
 
       let local_user_ = local_user.clone();
-      comments = CommentQuery::builder()
-        .sort(sort.map(post_to_comment_sort_type))
-        .listing_type(listing_type)
-        .search_term(Some(q))
-        .community_id(community_id)
-        .creator_id(creator_id)
-        .local_user(local_user_.as_ref())
-        .page(page)
-        .limit(limit)
-        .build()
-        .list(&mut context.pool())
-        .await?;
+      comments = CommentQuery {
+        sort: (sort.map(post_to_comment_sort_type)),
+        listing_type: (listing_type),
+        search_term: (Some(q)),
+        community_id: (community_id),
+        creator_id: (creator_id),
+        local_user: (local_user_.as_ref()),
+        page: (page),
+        limit: (limit),
+        ..Default::default()
+      }
+      .list(&mut context.pool())
+      .await?;
 
       let q = data.q.clone();
 
       communities = if community_or_creator_included {
         vec![]
       } else {
-        CommunityQuery::builder()
-          .sort(sort)
-          .listing_type(listing_type)
-          .search_term(Some(q))
-          .local_user(local_user.as_ref())
-          .is_mod_or_admin(is_admin)
-          .page(page)
-          .limit(limit)
-          .build()
-          .list(&mut context.pool())
-          .await?
+        CommunityQuery {
+          sort: (sort),
+          listing_type: (listing_type),
+          search_term: (Some(q)),
+          local_user: (local_user.as_ref()),
+          is_mod_or_admin: (is_admin),
+          page: (page),
+          limit: (limit),
+          ..Default::default()
+        }
+        .list(&mut context.pool())
+        .await?
       };
 
       let q = data.q.clone();
@@ -163,29 +169,30 @@ pub async fn search(
       users = if community_or_creator_included {
         vec![]
       } else {
-        PersonQuery::builder()
-          .sort(sort)
-          .search_term(Some(q))
-          .page(page)
-          .limit(limit)
-          .build()
-          .list(&mut context.pool())
-          .await?
+        PersonQuery {
+          sort: (sort),
+          search_term: (Some(q)),
+          page: (page),
+          limit: (limit),
+        }
+        .list(&mut context.pool())
+        .await?
       };
     }
     SearchType::Url => {
-      posts = PostQuery::builder()
-        .sort(sort)
-        .listing_type(listing_type)
-        .community_id(community_id)
-        .creator_id(creator_id)
-        .url_search(Some(q))
-        .is_mod_or_admin(is_admin)
-        .page(page)
-        .limit(limit)
-        .build()
-        .list(&mut context.pool())
-        .await?;
+      posts = PostQuery {
+        sort: (sort),
+        listing_type: (listing_type),
+        community_id: (community_id),
+        creator_id: (creator_id),
+        url_search: (Some(q)),
+        is_mod_or_admin: (is_admin),
+        page: (page),
+        limit: (limit),
+        ..Default::default()
+      }
+      .list(&mut context.pool())
+      .await?;
     }
   };
 

--- a/crates/apub/src/api/search.rs
+++ b/crates/apub/src/api/search.rs
@@ -54,7 +54,6 @@ pub async fn search(
   match search_type {
     SearchType::Posts => {
       posts = PostQuery::builder()
-        .pool(&mut context.pool())
         .sort(sort)
         .listing_type(listing_type)
         .community_id(community_id)
@@ -65,12 +64,11 @@ pub async fn search(
         .page(page)
         .limit(limit)
         .build()
-        .list()
+        .list(&mut context.pool())
         .await?;
     }
     SearchType::Comments => {
       comments = CommentQuery::builder()
-        .pool(&mut context.pool())
         .sort(sort.map(post_to_comment_sort_type))
         .listing_type(listing_type)
         .search_term(Some(q))
@@ -80,12 +78,11 @@ pub async fn search(
         .page(page)
         .limit(limit)
         .build()
-        .list()
+        .list(&mut context.pool())
         .await?;
     }
     SearchType::Communities => {
       communities = CommunityQuery::builder()
-        .pool(&mut context.pool())
         .sort(sort)
         .listing_type(listing_type)
         .search_term(Some(q))
@@ -94,18 +91,17 @@ pub async fn search(
         .page(page)
         .limit(limit)
         .build()
-        .list()
+        .list(&mut context.pool())
         .await?;
     }
     SearchType::Users => {
       users = PersonQuery::builder()
-        .pool(&mut context.pool())
         .sort(sort)
         .search_term(Some(q))
         .page(page)
         .limit(limit)
         .build()
-        .list()
+        .list(&mut context.pool())
         .await?;
     }
     SearchType::All => {
@@ -115,7 +111,6 @@ pub async fn search(
 
       let local_user_ = local_user.clone();
       posts = PostQuery::builder()
-        .pool(&mut context.pool())
         .sort(sort)
         .listing_type(listing_type)
         .community_id(community_id)
@@ -126,14 +121,13 @@ pub async fn search(
         .page(page)
         .limit(limit)
         .build()
-        .list()
+        .list(&mut context.pool())
         .await?;
 
       let q = data.q.clone();
 
       let local_user_ = local_user.clone();
       comments = CommentQuery::builder()
-        .pool(&mut context.pool())
         .sort(sort.map(post_to_comment_sort_type))
         .listing_type(listing_type)
         .search_term(Some(q))
@@ -143,7 +137,7 @@ pub async fn search(
         .page(page)
         .limit(limit)
         .build()
-        .list()
+        .list(&mut context.pool())
         .await?;
 
       let q = data.q.clone();
@@ -152,7 +146,6 @@ pub async fn search(
         vec![]
       } else {
         CommunityQuery::builder()
-          .pool(&mut context.pool())
           .sort(sort)
           .listing_type(listing_type)
           .search_term(Some(q))
@@ -161,7 +154,7 @@ pub async fn search(
           .page(page)
           .limit(limit)
           .build()
-          .list()
+          .list(&mut context.pool())
           .await?
       };
 
@@ -171,19 +164,17 @@ pub async fn search(
         vec![]
       } else {
         PersonQuery::builder()
-          .pool(&mut context.pool())
           .sort(sort)
           .search_term(Some(q))
           .page(page)
           .limit(limit)
           .build()
-          .list()
+          .list(&mut context.pool())
           .await?
       };
     }
     SearchType::Url => {
       posts = PostQuery::builder()
-        .pool(&mut context.pool())
         .sort(sort)
         .listing_type(listing_type)
         .community_id(community_id)
@@ -193,7 +184,7 @@ pub async fn search(
         .page(page)
         .limit(limit)
         .build()
-        .list()
+        .list(&mut context.pool())
         .await?;
     }
   };

--- a/crates/db_views/Cargo.toml
+++ b/crates/db_views/Cargo.toml
@@ -29,7 +29,6 @@ diesel_ltree = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_with = { workspace = true }
 tracing = { workspace = true, optional = true }
-typed-builder = { workspace = true }
 ts-rs = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/db_views/src/comment_report_view.rs
+++ b/crates/db_views/src/comment_report_view.rs
@@ -140,10 +140,6 @@ impl CommentReportView {
 #[derive(TypedBuilder)]
 #[builder(field_defaults(default))]
 pub struct CommentReportQuery {
-  #[builder(!default)]
-  my_person_id: PersonId,
-  #[builder(!default)]
-  admin: bool,
   community_id: Option<CommunityId>,
   page: Option<i64>,
   limit: Option<i64>,
@@ -151,7 +147,11 @@ pub struct CommentReportQuery {
 }
 
 impl CommentReportQuery {
-  pub async fn list(self, pool: &mut DbPool<'_>) -> Result<Vec<CommentReportView>, Error> {
+  pub async fn list(
+    self,
+    pool: &mut DbPool<'_>,
+    my_person: &Person,
+  ) -> Result<Vec<CommentReportView>, Error> {
     let conn = &mut get_conn(pool).await?;
 
     let (person_alias_1, person_alias_2) = diesel::alias!(person as person1, person as person2);
@@ -181,7 +181,7 @@ impl CommentReportQuery {
         comment_like::table.on(
           comment::id
             .eq(comment_like::comment_id)
-            .and(comment_like::person_id.eq(self.my_person_id)),
+            .and(comment_like::person_id.eq(my_person.id)),
         ),
       )
       .left_join(
@@ -218,13 +218,13 @@ impl CommentReportQuery {
       .offset(offset);
 
     // If its not an admin, get only the ones you mod
-    let res = if !self.admin {
+    let res = if !my_person.admin {
       query
         .inner_join(
           community_moderator::table.on(
             community_moderator::community_id
               .eq(post::community_id)
-              .and(community_moderator::person_id.eq(self.my_person_id)),
+              .and(community_moderator::person_id.eq(my_person.id)),
           ),
         )
         .load::<<CommentReportView as JoinView>::JoinTuple>(conn)
@@ -513,10 +513,8 @@ mod tests {
 
     // Do a batch read of timmys reports
     let reports = CommentReportQuery::builder()
-      .my_person_id(inserted_timmy.id)
-      .admin(false)
       .build()
-      .list(pool)
+      .list(pool, &inserted_timmy)
       .await
       .unwrap();
 
@@ -588,11 +586,9 @@ mod tests {
     // Do a batch read of timmys reports
     // It should only show saras, which is unresolved
     let reports_after_resolve = CommentReportQuery::builder()
-      .my_person_id(inserted_timmy.id)
-      .admin(false)
       .unresolved_only(Some(true))
       .build()
-      .list(pool)
+      .list(pool, &inserted_timmy)
       .await
       .unwrap();
     assert_eq!(reports_after_resolve[0], expected_sara_report_view);

--- a/crates/db_views/src/comment_report_view.rs
+++ b/crates/db_views/src/comment_report_view.rs
@@ -33,7 +33,6 @@ use lemmy_db_schema::{
   traits::JoinView,
   utils::{get_conn, limit_and_offset, DbPool},
 };
-use typed_builder::TypedBuilder;
 
 impl CommentReportView {
   /// returns the CommentReportView for the provided report_id
@@ -137,13 +136,12 @@ impl CommentReportView {
   }
 }
 
-#[derive(TypedBuilder)]
-#[builder(field_defaults(default))]
+#[derive(Default)]
 pub struct CommentReportQuery {
-  community_id: Option<CommunityId>,
-  page: Option<i64>,
-  limit: Option<i64>,
-  unresolved_only: Option<bool>,
+  pub community_id: Option<CommunityId>,
+  pub page: Option<i64>,
+  pub limit: Option<i64>,
+  pub unresolved_only: Option<bool>,
 }
 
 impl CommentReportQuery {
@@ -512,8 +510,7 @@ mod tests {
     };
 
     // Do a batch read of timmys reports
-    let reports = CommentReportQuery::builder()
-      .build()
+    let reports = CommentReportQuery::default()
       .list(pool, &inserted_timmy)
       .await
       .unwrap();
@@ -585,12 +582,13 @@ mod tests {
 
     // Do a batch read of timmys reports
     // It should only show saras, which is unresolved
-    let reports_after_resolve = CommentReportQuery::builder()
-      .unresolved_only(Some(true))
-      .build()
-      .list(pool, &inserted_timmy)
-      .await
-      .unwrap();
+    let reports_after_resolve = CommentReportQuery {
+      unresolved_only: (Some(true)),
+      ..Default::default()
+    }
+    .list(pool, &inserted_timmy)
+    .await
+    .unwrap();
     assert_eq!(reports_after_resolve[0], expected_sara_report_view);
     assert_eq!(reports_after_resolve.len(), 1);
 

--- a/crates/db_views/src/post_report_view.rs
+++ b/crates/db_views/src/post_report_view.rs
@@ -30,7 +30,6 @@ use lemmy_db_schema::{
   traits::JoinView,
   utils::{get_conn, limit_and_offset, DbPool},
 };
-use typed_builder::TypedBuilder;
 
 type PostReportViewTuple = (
   PostReport,
@@ -159,13 +158,12 @@ impl PostReportView {
   }
 }
 
-#[derive(TypedBuilder)]
-#[builder(field_defaults(default))]
+#[derive(Default)]
 pub struct PostReportQuery {
-  community_id: Option<CommunityId>,
-  page: Option<i64>,
-  limit: Option<i64>,
-  unresolved_only: Option<bool>,
+  pub community_id: Option<CommunityId>,
+  pub page: Option<i64>,
+  pub limit: Option<i64>,
+  pub unresolved_only: Option<bool>,
 }
 
 impl PostReportQuery {
@@ -504,8 +502,7 @@ mod tests {
     };
 
     // Do a batch read of timmys reports
-    let reports = PostReportQuery::builder()
-      .build()
+    let reports = PostReportQuery::default()
       .list(pool, &inserted_timmy)
       .await
       .unwrap();
@@ -575,12 +572,13 @@ mod tests {
 
     // Do a batch read of timmys reports
     // It should only show saras, which is unresolved
-    let reports_after_resolve = PostReportQuery::builder()
-      .unresolved_only(Some(true))
-      .build()
-      .list(pool, &inserted_timmy)
-      .await
-      .unwrap();
+    let reports_after_resolve = PostReportQuery {
+      unresolved_only: (Some(true)),
+      ..Default::default()
+    }
+    .list(pool, &inserted_timmy)
+    .await
+    .unwrap();
     assert_eq!(reports_after_resolve[0], expected_sara_report_view);
 
     // Make sure the counts are correct

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -45,7 +45,6 @@ use lemmy_db_schema::{
   SortType,
 };
 use tracing::debug;
-use typed_builder::TypedBuilder;
 
 type PostViewTuple = (
   Post,
@@ -193,21 +192,20 @@ impl PostView {
   }
 }
 
-#[derive(TypedBuilder)]
-#[builder(field_defaults(default))]
+#[derive(Default)]
 pub struct PostQuery<'a> {
-  listing_type: Option<ListingType>,
-  sort: Option<SortType>,
-  creator_id: Option<PersonId>,
-  community_id: Option<CommunityId>,
-  local_user: Option<&'a LocalUser>,
-  search_term: Option<String>,
-  url_search: Option<String>,
-  saved_only: Option<bool>,
+  pub listing_type: Option<ListingType>,
+  pub sort: Option<SortType>,
+  pub creator_id: Option<PersonId>,
+  pub community_id: Option<CommunityId>,
+  pub local_user: Option<&'a LocalUser>,
+  pub search_term: Option<String>,
+  pub url_search: Option<String>,
+  pub saved_only: Option<bool>,
   /// Used to show deleted or removed posts for admins
-  is_mod_or_admin: Option<bool>,
-  page: Option<i64>,
-  limit: Option<i64>,
+  pub is_mod_or_admin: Option<bool>,
+  pub page: Option<i64>,
+  pub limit: Option<i64>,
 }
 
 impl<'a> PostQuery<'a> {
@@ -617,14 +615,15 @@ mod tests {
         .await
         .unwrap();
 
-    let read_post_listing = PostQuery::builder()
-      .sort(Some(SortType::New))
-      .community_id(Some(data.inserted_community.id))
-      .local_user(Some(&inserted_local_user))
-      .build()
-      .list(pool)
-      .await
-      .unwrap();
+    let read_post_listing = PostQuery {
+      sort: (Some(SortType::New)),
+      community_id: (Some(data.inserted_community.id)),
+      local_user: (Some(&inserted_local_user)),
+      ..Default::default()
+    }
+    .list(pool)
+    .await
+    .unwrap();
 
     let post_listing_single_with_person = PostView::read(
       pool,
@@ -655,14 +654,15 @@ mod tests {
         .await
         .unwrap();
 
-    let post_listings_with_bots = PostQuery::builder()
-      .sort(Some(SortType::New))
-      .community_id(Some(data.inserted_community.id))
-      .local_user(Some(&inserted_local_user))
-      .build()
-      .list(pool)
-      .await
-      .unwrap();
+    let post_listings_with_bots = PostQuery {
+      sort: (Some(SortType::New)),
+      community_id: (Some(data.inserted_community.id)),
+      local_user: (Some(&inserted_local_user)),
+      ..Default::default()
+    }
+    .list(pool)
+    .await
+    .unwrap();
     // should include bot post which has "undetermined" language
     assert_eq!(2, post_listings_with_bots.len());
 
@@ -676,13 +676,14 @@ mod tests {
     let pool = &mut pool.into();
     let data = init_data(pool).await;
 
-    let read_post_listing_multiple_no_person = PostQuery::builder()
-      .sort(Some(SortType::New))
-      .community_id(Some(data.inserted_community.id))
-      .build()
-      .list(pool)
-      .await
-      .unwrap();
+    let read_post_listing_multiple_no_person = PostQuery {
+      sort: (Some(SortType::New)),
+      community_id: (Some(data.inserted_community.id)),
+      ..Default::default()
+    }
+    .list(pool)
+    .await
+    .unwrap();
 
     let read_post_listing_single_no_person =
       PostView::read(pool, data.inserted_post.id, None, None)
@@ -719,14 +720,15 @@ mod tests {
     };
     CommunityBlock::block(pool, &community_block).await.unwrap();
 
-    let read_post_listings_with_person_after_block = PostQuery::builder()
-      .sort(Some(SortType::New))
-      .community_id(Some(data.inserted_community.id))
-      .local_user(Some(&data.inserted_local_user))
-      .build()
-      .list(pool)
-      .await
-      .unwrap();
+    let read_post_listings_with_person_after_block = PostQuery {
+      sort: (Some(SortType::New)),
+      community_id: (Some(data.inserted_community.id)),
+      local_user: (Some(&data.inserted_local_user)),
+      ..Default::default()
+    }
+    .list(pool)
+    .await
+    .unwrap();
     // Should be 0 posts after the community block
     assert_eq!(0, read_post_listings_with_person_after_block.len());
 
@@ -783,14 +785,15 @@ mod tests {
         .await
         .unwrap();
 
-    let read_post_listing = PostQuery::builder()
-      .sort(Some(SortType::New))
-      .community_id(Some(data.inserted_community.id))
-      .local_user(Some(&inserted_local_user))
-      .build()
-      .list(pool)
-      .await
-      .unwrap();
+    let read_post_listing = PostQuery {
+      sort: (Some(SortType::New)),
+      community_id: (Some(data.inserted_community.id)),
+      local_user: (Some(&inserted_local_user)),
+      ..Default::default()
+    }
+    .list(pool)
+    .await
+    .unwrap();
     assert_eq!(1, read_post_listing.len());
 
     assert_eq!(expected_post_with_upvote, read_post_listing[0]);
@@ -822,13 +825,14 @@ mod tests {
 
     Post::create(pool, &post_spanish).await.unwrap();
 
-    let post_listings_all = PostQuery::builder()
-      .sort(Some(SortType::New))
-      .local_user(Some(&data.inserted_local_user))
-      .build()
-      .list(pool)
-      .await
-      .unwrap();
+    let post_listings_all = PostQuery {
+      sort: (Some(SortType::New)),
+      local_user: (Some(&data.inserted_local_user)),
+      ..Default::default()
+    }
+    .list(pool)
+    .await
+    .unwrap();
 
     // no language filters specified, all posts should be returned
     assert_eq!(3, post_listings_all.len());
@@ -841,13 +845,14 @@ mod tests {
       .await
       .unwrap();
 
-    let post_listing_french = PostQuery::builder()
-      .sort(Some(SortType::New))
-      .local_user(Some(&data.inserted_local_user))
-      .build()
-      .list(pool)
-      .await
-      .unwrap();
+    let post_listing_french = PostQuery {
+      sort: (Some(SortType::New)),
+      local_user: (Some(&data.inserted_local_user)),
+      ..Default::default()
+    }
+    .list(pool)
+    .await
+    .unwrap();
 
     // only one post in french and one undetermined should be returned
     assert_eq!(2, post_listing_french.len());
@@ -862,13 +867,14 @@ mod tests {
     )
     .await
     .unwrap();
-    let post_listings_french_und = PostQuery::builder()
-      .sort(Some(SortType::New))
-      .local_user(Some(&data.inserted_local_user))
-      .build()
-      .list(pool)
-      .await
-      .unwrap();
+    let post_listings_french_und = PostQuery {
+      sort: (Some(SortType::New)),
+      local_user: (Some(&data.inserted_local_user)),
+      ..Default::default()
+    }
+    .list(pool)
+    .await
+    .unwrap();
 
     // french post and undetermined language post should be returned
     assert_eq!(2, post_listings_french_und.len());
@@ -898,26 +904,28 @@ mod tests {
     .unwrap();
 
     // Make sure you don't see the deleted post in the results
-    let post_listings_no_admin = PostQuery::builder()
-      .sort(Some(SortType::New))
-      .local_user(Some(&data.inserted_local_user))
-      .is_mod_or_admin(Some(false))
-      .build()
-      .list(pool)
-      .await
-      .unwrap();
+    let post_listings_no_admin = PostQuery {
+      sort: (Some(SortType::New)),
+      local_user: (Some(&data.inserted_local_user)),
+      is_mod_or_admin: (Some(false)),
+      ..Default::default()
+    }
+    .list(pool)
+    .await
+    .unwrap();
 
     assert_eq!(1, post_listings_no_admin.len());
 
     // Make sure they see both
-    let post_listings_is_admin = PostQuery::builder()
-      .sort(Some(SortType::New))
-      .local_user(Some(&data.inserted_local_user))
-      .is_mod_or_admin(Some(true))
-      .build()
-      .list(pool)
-      .await
-      .unwrap();
+    let post_listings_is_admin = PostQuery {
+      sort: (Some(SortType::New)),
+      local_user: (Some(&data.inserted_local_user)),
+      is_mod_or_admin: (Some(true)),
+      ..Default::default()
+    }
+    .list(pool)
+    .await
+    .unwrap();
 
     assert_eq!(2, post_listings_is_admin.len());
 

--- a/crates/db_views/src/private_message_report_view.rs
+++ b/crates/db_views/src/private_message_report_view.rs
@@ -83,17 +83,15 @@ impl PrivateMessageReportView {
 
 #[derive(TypedBuilder)]
 #[builder(field_defaults(default))]
-pub struct PrivateMessageReportQuery<'a, 'b: 'a> {
-  #[builder(!default)]
-  pool: &'a mut DbPool<'b>,
+pub struct PrivateMessageReportQuery {
   page: Option<i64>,
   limit: Option<i64>,
   unresolved_only: Option<bool>,
 }
 
-impl<'a, 'b: 'a> PrivateMessageReportQuery<'a, 'b> {
-  pub async fn list(self) -> Result<Vec<PrivateMessageReportView>, Error> {
-    let conn = &mut get_conn(self.pool).await?;
+impl PrivateMessageReportQuery {
+  pub async fn list(self, pool: &mut DbPool<'_>) -> Result<Vec<PrivateMessageReportView>, Error> {
+    let conn = &mut get_conn(pool).await?;
     let (person_alias_1, person_alias_2) = diesel::alias!(person as person1, person as person2);
 
     let mut query = private_message_report::table
@@ -209,9 +207,8 @@ mod tests {
       .unwrap();
 
     let reports = PrivateMessageReportQuery::builder()
-      .pool(pool)
       .build()
-      .list()
+      .list(pool)
       .await
       .unwrap();
     assert_eq!(1, reports.len());
@@ -234,10 +231,9 @@ mod tests {
       .unwrap();
 
     let reports = PrivateMessageReportQuery::builder()
-      .pool(pool)
       .unresolved_only(Some(false))
       .build()
-      .list()
+      .list(pool)
       .await
       .unwrap();
     assert_eq!(1, reports.len());

--- a/crates/db_views/src/private_message_report_view.rs
+++ b/crates/db_views/src/private_message_report_view.rs
@@ -12,7 +12,6 @@ use lemmy_db_schema::{
   traits::JoinView,
   utils::{get_conn, limit_and_offset, DbPool},
 };
-use typed_builder::TypedBuilder;
 
 type PrivateMessageReportViewTuple = (
   PrivateMessageReport,
@@ -81,12 +80,11 @@ impl PrivateMessageReportView {
   }
 }
 
-#[derive(TypedBuilder)]
-#[builder(field_defaults(default))]
+#[derive(Default)]
 pub struct PrivateMessageReportQuery {
-  page: Option<i64>,
-  limit: Option<i64>,
-  unresolved_only: Option<bool>,
+  pub page: Option<i64>,
+  pub limit: Option<i64>,
+  pub unresolved_only: Option<bool>,
 }
 
 impl PrivateMessageReportQuery {
@@ -206,8 +204,7 @@ mod tests {
       .await
       .unwrap();
 
-    let reports = PrivateMessageReportQuery::builder()
-      .build()
+    let reports = PrivateMessageReportQuery::default()
       .list(pool)
       .await
       .unwrap();
@@ -230,12 +227,13 @@ mod tests {
       .await
       .unwrap();
 
-    let reports = PrivateMessageReportQuery::builder()
-      .unresolved_only(Some(false))
-      .build()
-      .list(pool)
-      .await
-      .unwrap();
+    let reports = PrivateMessageReportQuery {
+      unresolved_only: (Some(false)),
+      ..Default::default()
+    }
+    .list(pool)
+    .await
+    .unwrap();
     assert_eq!(1, reports.len());
     assert!(reports[0].private_message_report.resolved);
     assert!(reports[0].resolver.is_some());

--- a/crates/db_views/src/private_message_view.rs
+++ b/crates/db_views/src/private_message_view.rs
@@ -17,7 +17,6 @@ use lemmy_db_schema::{
   utils::{get_conn, limit_and_offset, DbPool},
 };
 use tracing::debug;
-use typed_builder::TypedBuilder;
 
 type PrivateMessageViewTuple = (PrivateMessage, Person, Person);
 
@@ -68,12 +67,11 @@ impl PrivateMessageView {
   }
 }
 
-#[derive(TypedBuilder)]
-#[builder(field_defaults(default))]
+#[derive(Default)]
 pub struct PrivateMessageQuery {
-  unread_only: Option<bool>,
-  page: Option<i64>,
-  limit: Option<i64>,
+  pub unread_only: Option<bool>,
+  pub page: Option<i64>,
+  pub limit: Option<i64>,
 }
 
 impl PrivateMessageQuery {

--- a/crates/db_views/src/private_message_view.rs
+++ b/crates/db_views/src/private_message_view.rs
@@ -70,9 +70,7 @@ impl PrivateMessageView {
 
 #[derive(TypedBuilder)]
 #[builder(field_defaults(default))]
-pub struct PrivateMessageQuery<'a, 'b: 'a> {
-  #[builder(!default)]
-  pool: &'a mut DbPool<'b>,
+pub struct PrivateMessageQuery {
   #[builder(!default)]
   recipient_id: PersonId,
   unread_only: Option<bool>,
@@ -80,9 +78,9 @@ pub struct PrivateMessageQuery<'a, 'b: 'a> {
   limit: Option<i64>,
 }
 
-impl<'a, 'b: 'a> PrivateMessageQuery<'a, 'b> {
-  pub async fn list(self) -> Result<Vec<PrivateMessageView>, Error> {
-    let conn = &mut get_conn(self.pool).await?;
+impl PrivateMessageQuery {
+  pub async fn list(self, pool: &mut DbPool<'_>) -> Result<Vec<PrivateMessageView>, Error> {
+    let conn = &mut get_conn(pool).await?;
     let person_alias_1 = diesel::alias!(person as person1);
 
     let mut query = private_message::table

--- a/crates/db_views/src/registration_application_view.rs
+++ b/crates/db_views/src/registration_application_view.rs
@@ -91,18 +91,19 @@ impl RegistrationApplicationView {
 
 #[derive(TypedBuilder)]
 #[builder(field_defaults(default))]
-pub struct RegistrationApplicationQuery<'a, 'b: 'a> {
-  #[builder(!default)]
-  pool: &'a mut DbPool<'b>,
+pub struct RegistrationApplicationQuery {
   unread_only: Option<bool>,
   verified_email_only: Option<bool>,
   page: Option<i64>,
   limit: Option<i64>,
 }
 
-impl<'a, 'b: 'a> RegistrationApplicationQuery<'a, 'b> {
-  pub async fn list(self) -> Result<Vec<RegistrationApplicationView>, Error> {
-    let conn = &mut get_conn(self.pool).await?;
+impl RegistrationApplicationQuery {
+  pub async fn list(
+    self,
+    pool: &mut DbPool<'_>,
+  ) -> Result<Vec<RegistrationApplicationView>, Error> {
+    let conn = &mut get_conn(pool).await?;
     let person_alias_1 = diesel::alias!(person as person1);
 
     let mut query = registration_application::table
@@ -328,10 +329,9 @@ mod tests {
 
     // Do a batch read of the applications
     let apps = RegistrationApplicationQuery::builder()
-      .pool(pool)
       .unread_only(Some(true))
       .build()
-      .list()
+      .list(pool)
       .await
       .unwrap();
 
@@ -404,10 +404,9 @@ mod tests {
     // Do a batch read of apps again
     // It should show only jessicas which is unresolved
     let apps_after_resolve = RegistrationApplicationQuery::builder()
-      .pool(pool)
       .unread_only(Some(true))
       .build()
-      .list()
+      .list(pool)
       .await
       .unwrap();
     assert_eq!(apps_after_resolve, vec![read_jess_app_view]);
@@ -420,9 +419,8 @@ mod tests {
 
     // Make sure the not undenied_only has all the apps
     let all_apps = RegistrationApplicationQuery::builder()
-      .pool(pool)
       .build()
-      .list()
+      .list(pool)
       .await
       .unwrap();
     assert_eq!(all_apps.len(), 2);

--- a/crates/db_views/src/registration_application_view.rs
+++ b/crates/db_views/src/registration_application_view.rs
@@ -18,7 +18,6 @@ use lemmy_db_schema::{
   traits::JoinView,
   utils::{get_conn, limit_and_offset, DbPool},
 };
-use typed_builder::TypedBuilder;
 
 type RegistrationApplicationViewTuple =
   (RegistrationApplication, LocalUser, Person, Option<Person>);
@@ -89,13 +88,12 @@ impl RegistrationApplicationView {
   }
 }
 
-#[derive(TypedBuilder)]
-#[builder(field_defaults(default))]
+#[derive(Default)]
 pub struct RegistrationApplicationQuery {
-  unread_only: Option<bool>,
-  verified_email_only: Option<bool>,
-  page: Option<i64>,
-  limit: Option<i64>,
+  pub unread_only: Option<bool>,
+  pub verified_email_only: Option<bool>,
+  pub page: Option<i64>,
+  pub limit: Option<i64>,
 }
 
 impl RegistrationApplicationQuery {
@@ -328,12 +326,13 @@ mod tests {
     assert_eq!(read_sara_app_view, expected_sara_app_view);
 
     // Do a batch read of the applications
-    let apps = RegistrationApplicationQuery::builder()
-      .unread_only(Some(true))
-      .build()
-      .list(pool)
-      .await
-      .unwrap();
+    let apps = RegistrationApplicationQuery {
+      unread_only: (Some(true)),
+      ..Default::default()
+    }
+    .list(pool)
+    .await
+    .unwrap();
 
     assert_eq!(
       apps,
@@ -403,12 +402,13 @@ mod tests {
 
     // Do a batch read of apps again
     // It should show only jessicas which is unresolved
-    let apps_after_resolve = RegistrationApplicationQuery::builder()
-      .unread_only(Some(true))
-      .build()
-      .list(pool)
-      .await
-      .unwrap();
+    let apps_after_resolve = RegistrationApplicationQuery {
+      unread_only: (Some(true)),
+      ..Default::default()
+    }
+    .list(pool)
+    .await
+    .unwrap();
     assert_eq!(apps_after_resolve, vec![read_jess_app_view]);
 
     // Make sure the counts are correct
@@ -418,8 +418,7 @@ mod tests {
     assert_eq!(unread_count_after_approve, 1);
 
     // Make sure the not undenied_only has all the apps
-    let all_apps = RegistrationApplicationQuery::builder()
-      .build()
+    let all_apps = RegistrationApplicationQuery::default()
       .list(pool)
       .await
       .unwrap();

--- a/crates/db_views_actor/Cargo.toml
+++ b/crates/db_views_actor/Cargo.toml
@@ -27,5 +27,4 @@ diesel-async = { workspace = true, features = [
 ], optional = true }
 serde = { workspace = true }
 serde_with = { workspace = true }
-typed-builder = { workspace = true }
 ts-rs = { workspace = true, optional = true }

--- a/crates/db_views_actor/src/comment_reply_view.rs
+++ b/crates/db_views_actor/src/comment_reply_view.rs
@@ -177,9 +177,7 @@ impl CommentReplyView {
 
 #[derive(TypedBuilder)]
 #[builder(field_defaults(default))]
-pub struct CommentReplyQuery<'a, 'b: 'a> {
-  #[builder(!default)]
-  pool: &'a mut DbPool<'b>,
+pub struct CommentReplyQuery {
   my_person_id: Option<PersonId>,
   recipient_id: Option<PersonId>,
   sort: Option<CommentSortType>,
@@ -189,9 +187,9 @@ pub struct CommentReplyQuery<'a, 'b: 'a> {
   limit: Option<i64>,
 }
 
-impl<'a, 'b: 'a> CommentReplyQuery<'a, 'b> {
-  pub async fn list(self) -> Result<Vec<CommentReplyView>, Error> {
-    let conn = &mut get_conn(self.pool).await?;
+impl CommentReplyQuery {
+  pub async fn list(self, pool: &mut DbPool<'_>) -> Result<Vec<CommentReplyView>, Error> {
+    let conn = &mut get_conn(pool).await?;
 
     let person_alias_1 = diesel::alias!(person as person1);
 

--- a/crates/db_views_actor/src/comment_reply_view.rs
+++ b/crates/db_views_actor/src/comment_reply_view.rs
@@ -36,7 +36,6 @@ use lemmy_db_schema::{
   utils::{get_conn, limit_and_offset, DbPool},
   CommentSortType,
 };
-use typed_builder::TypedBuilder;
 
 type CommentReplyViewTuple = (
   CommentReply,
@@ -175,16 +174,15 @@ impl CommentReplyView {
   }
 }
 
-#[derive(TypedBuilder)]
-#[builder(field_defaults(default))]
+#[derive(Default)]
 pub struct CommentReplyQuery {
-  my_person_id: Option<PersonId>,
-  recipient_id: Option<PersonId>,
-  sort: Option<CommentSortType>,
-  unread_only: Option<bool>,
-  show_bot_accounts: Option<bool>,
-  page: Option<i64>,
-  limit: Option<i64>,
+  pub my_person_id: Option<PersonId>,
+  pub recipient_id: Option<PersonId>,
+  pub sort: Option<CommentSortType>,
+  pub unread_only: Option<bool>,
+  pub show_bot_accounts: Option<bool>,
+  pub page: Option<i64>,
+  pub limit: Option<i64>,
 }
 
 impl CommentReplyQuery {

--- a/crates/db_views_actor/src/community_view.rs
+++ b/crates/db_views_actor/src/community_view.rs
@@ -23,7 +23,6 @@ use lemmy_db_schema::{
   ListingType,
   SortType,
 };
-use typed_builder::TypedBuilder;
 
 type CommunityViewTuple = (
   Community,
@@ -100,17 +99,16 @@ impl CommunityView {
   }
 }
 
-#[derive(TypedBuilder)]
-#[builder(field_defaults(default))]
+#[derive(Default)]
 pub struct CommunityQuery<'a> {
-  listing_type: Option<ListingType>,
-  sort: Option<SortType>,
-  local_user: Option<&'a LocalUser>,
-  search_term: Option<String>,
-  is_mod_or_admin: Option<bool>,
-  show_nsfw: Option<bool>,
-  page: Option<i64>,
-  limit: Option<i64>,
+  pub listing_type: Option<ListingType>,
+  pub sort: Option<SortType>,
+  pub local_user: Option<&'a LocalUser>,
+  pub search_term: Option<String>,
+  pub is_mod_or_admin: Option<bool>,
+  pub show_nsfw: Option<bool>,
+  pub page: Option<i64>,
+  pub limit: Option<i64>,
 }
 
 impl<'a> CommunityQuery<'a> {

--- a/crates/db_views_actor/src/community_view.rs
+++ b/crates/db_views_actor/src/community_view.rs
@@ -102,9 +102,7 @@ impl CommunityView {
 
 #[derive(TypedBuilder)]
 #[builder(field_defaults(default))]
-pub struct CommunityQuery<'a, 'b: 'a> {
-  #[builder(!default)]
-  pool: &'a mut DbPool<'b>,
+pub struct CommunityQuery<'a> {
   listing_type: Option<ListingType>,
   sort: Option<SortType>,
   local_user: Option<&'a LocalUser>,
@@ -115,11 +113,11 @@ pub struct CommunityQuery<'a, 'b: 'a> {
   limit: Option<i64>,
 }
 
-impl<'a, 'b: 'a> CommunityQuery<'a, 'b> {
-  pub async fn list(self) -> Result<Vec<CommunityView>, Error> {
+impl<'a> CommunityQuery<'a> {
+  pub async fn list(self, pool: &mut DbPool<'_>) -> Result<Vec<CommunityView>, Error> {
     use SortType::*;
 
-    let conn = &mut get_conn(self.pool).await?;
+    let conn = &mut get_conn(pool).await?;
 
     // The left join below will return None in this case
     let person_id_join = self.local_user.map(|l| l.person_id).unwrap_or(PersonId(-1));

--- a/crates/db_views_actor/src/person_mention_view.rs
+++ b/crates/db_views_actor/src/person_mention_view.rs
@@ -37,7 +37,6 @@ use lemmy_db_schema::{
   utils::{get_conn, limit_and_offset, DbPool},
   CommentSortType,
 };
-use typed_builder::TypedBuilder;
 
 type PersonMentionViewTuple = (
   PersonMention,
@@ -175,16 +174,15 @@ impl PersonMentionView {
   }
 }
 
-#[derive(TypedBuilder)]
-#[builder(field_defaults(default))]
+#[derive(Default)]
 pub struct PersonMentionQuery {
-  my_person_id: Option<PersonId>,
-  recipient_id: Option<PersonId>,
-  sort: Option<CommentSortType>,
-  unread_only: Option<bool>,
-  show_bot_accounts: Option<bool>,
-  page: Option<i64>,
-  limit: Option<i64>,
+  pub my_person_id: Option<PersonId>,
+  pub recipient_id: Option<PersonId>,
+  pub sort: Option<CommentSortType>,
+  pub unread_only: Option<bool>,
+  pub show_bot_accounts: Option<bool>,
+  pub page: Option<i64>,
+  pub limit: Option<i64>,
 }
 
 impl PersonMentionQuery {

--- a/crates/db_views_actor/src/person_mention_view.rs
+++ b/crates/db_views_actor/src/person_mention_view.rs
@@ -177,9 +177,7 @@ impl PersonMentionView {
 
 #[derive(TypedBuilder)]
 #[builder(field_defaults(default))]
-pub struct PersonMentionQuery<'a, 'b: 'a> {
-  #[builder(!default)]
-  pool: &'a mut DbPool<'b>,
+pub struct PersonMentionQuery {
   my_person_id: Option<PersonId>,
   recipient_id: Option<PersonId>,
   sort: Option<CommentSortType>,
@@ -189,9 +187,9 @@ pub struct PersonMentionQuery<'a, 'b: 'a> {
   limit: Option<i64>,
 }
 
-impl<'a, 'b: 'a> PersonMentionQuery<'a, 'b> {
-  pub async fn list(self) -> Result<Vec<PersonMentionView>, Error> {
-    let conn = &mut get_conn(self.pool).await?;
+impl PersonMentionQuery {
+  pub async fn list(self, pool: &mut DbPool<'_>) -> Result<Vec<PersonMentionView>, Error> {
+    let conn = &mut get_conn(pool).await?;
 
     let person_alias_1 = diesel::alias!(person as person1);
 

--- a/crates/db_views_actor/src/person_view.rs
+++ b/crates/db_views_actor/src/person_view.rs
@@ -81,18 +81,16 @@ impl PersonView {
 
 #[derive(TypedBuilder)]
 #[builder(field_defaults(default))]
-pub struct PersonQuery<'a, 'b: 'a> {
-  #[builder(!default)]
-  pool: &'a mut DbPool<'b>,
+pub struct PersonQuery {
   sort: Option<SortType>,
   search_term: Option<String>,
   page: Option<i64>,
   limit: Option<i64>,
 }
 
-impl<'a, 'b: 'a> PersonQuery<'a, 'b> {
-  pub async fn list(self) -> Result<Vec<PersonView>, Error> {
-    let conn = &mut get_conn(self.pool).await?;
+impl PersonQuery {
+  pub async fn list(self, pool: &mut DbPool<'_>) -> Result<Vec<PersonView>, Error> {
+    let conn = &mut get_conn(pool).await?;
     let mut query = person::table
       .inner_join(person_aggregates::table)
       .select((person::all_columns, person_aggregates::all_columns))

--- a/crates/db_views_actor/src/person_view.rs
+++ b/crates/db_views_actor/src/person_view.rs
@@ -19,7 +19,6 @@ use lemmy_db_schema::{
   SortType,
 };
 use std::iter::Iterator;
-use typed_builder::TypedBuilder;
 
 type PersonViewTuple = (Person, PersonAggregates);
 
@@ -79,13 +78,12 @@ impl PersonView {
   }
 }
 
-#[derive(TypedBuilder)]
-#[builder(field_defaults(default))]
+#[derive(Default)]
 pub struct PersonQuery {
-  sort: Option<SortType>,
-  search_term: Option<String>,
-  page: Option<i64>,
-  limit: Option<i64>,
+  pub sort: Option<SortType>,
+  pub search_term: Option<String>,
+  pub page: Option<i64>,
+  pub limit: Option<i64>,
 }
 
 impl PersonQuery {

--- a/crates/routes/src/feeds.rs
+++ b/crates/routes/src/feeds.rs
@@ -124,14 +124,15 @@ async fn get_feed_data(
 ) -> Result<HttpResponse, LemmyError> {
   let site_view = SiteView::read_local(&mut context.pool()).await?;
 
-  let posts = PostQuery::builder()
-    .listing_type(Some(listing_type))
-    .sort(Some(sort_type))
-    .limit(Some(limit))
-    .page(Some(page))
-    .build()
-    .list(&mut context.pool())
-    .await?;
+  let posts = PostQuery {
+    listing_type: (Some(listing_type)),
+    sort: (Some(sort_type)),
+    limit: (Some(limit)),
+    page: (Some(page)),
+    ..Default::default()
+  }
+  .list(&mut context.pool())
+  .await?;
 
   let items = create_post_items(posts, &context.settings().get_protocol_and_hostname())?;
 
@@ -242,15 +243,16 @@ async fn get_feed_user(
   let site_view = SiteView::read_local(pool).await?;
   let person = Person::read_from_name(pool, user_name, false).await?;
 
-  let posts = PostQuery::builder()
-    .listing_type(Some(ListingType::All))
-    .sort(Some(*sort_type))
-    .creator_id(Some(person.id))
-    .limit(Some(*limit))
-    .page(Some(*page))
-    .build()
-    .list(pool)
-    .await?;
+  let posts = PostQuery {
+    listing_type: (Some(ListingType::All)),
+    sort: (Some(*sort_type)),
+    creator_id: (Some(person.id)),
+    limit: (Some(*limit)),
+    page: (Some(*page)),
+    ..Default::default()
+  }
+  .list(pool)
+  .await?;
 
   let items = create_post_items(posts, protocol_and_hostname)?;
 
@@ -276,14 +278,15 @@ async fn get_feed_community(
   let site_view = SiteView::read_local(pool).await?;
   let community = Community::read_from_name(pool, community_name, false).await?;
 
-  let posts = PostQuery::builder()
-    .sort(Some(*sort_type))
-    .community_id(Some(community.id))
-    .limit(Some(*limit))
-    .page(Some(*page))
-    .build()
-    .list(pool)
-    .await?;
+  let posts = PostQuery {
+    sort: (Some(*sort_type)),
+    community_id: (Some(community.id)),
+    limit: (Some(*limit)),
+    page: (Some(*page)),
+    ..Default::default()
+  }
+  .list(pool)
+  .await?;
 
   let items = create_post_items(posts, protocol_and_hostname)?;
 
@@ -315,15 +318,16 @@ async fn get_feed_front(
   let local_user_id = LocalUserId(Claims::decode(jwt, jwt_secret)?.claims.sub);
   let local_user = LocalUser::read(pool, local_user_id).await?;
 
-  let posts = PostQuery::builder()
-    .listing_type(Some(ListingType::Subscribed))
-    .local_user(Some(&local_user))
-    .sort(Some(*sort_type))
-    .limit(Some(*limit))
-    .page(Some(*page))
-    .build()
-    .list(pool)
-    .await?;
+  let posts = PostQuery {
+    listing_type: (Some(ListingType::Subscribed)),
+    local_user: (Some(&local_user)),
+    sort: (Some(*sort_type)),
+    limit: (Some(*limit)),
+    page: (Some(*page)),
+    ..Default::default()
+  }
+  .list(pool)
+  .await?;
 
   let items = create_post_items(posts, protocol_and_hostname)?;
 
@@ -356,25 +360,27 @@ async fn get_feed_inbox(
 
   let sort = CommentSortType::New;
 
-  let replies = CommentReplyQuery::builder()
-    .recipient_id(Some(person_id))
-    .my_person_id(Some(person_id))
-    .show_bot_accounts(Some(show_bot_accounts))
-    .sort(Some(sort))
-    .limit(Some(RSS_FETCH_LIMIT))
-    .build()
-    .list(pool)
-    .await?;
+  let replies = CommentReplyQuery {
+    recipient_id: (Some(person_id)),
+    my_person_id: (Some(person_id)),
+    show_bot_accounts: (Some(show_bot_accounts)),
+    sort: (Some(sort)),
+    limit: (Some(RSS_FETCH_LIMIT)),
+    ..Default::default()
+  }
+  .list(pool)
+  .await?;
 
-  let mentions = PersonMentionQuery::builder()
-    .recipient_id(Some(person_id))
-    .my_person_id(Some(person_id))
-    .show_bot_accounts(Some(show_bot_accounts))
-    .sort(Some(sort))
-    .limit(Some(RSS_FETCH_LIMIT))
-    .build()
-    .list(pool)
-    .await?;
+  let mentions = PersonMentionQuery {
+    recipient_id: (Some(person_id)),
+    my_person_id: (Some(person_id)),
+    show_bot_accounts: (Some(show_bot_accounts)),
+    sort: (Some(sort)),
+    limit: (Some(RSS_FETCH_LIMIT)),
+    ..Default::default()
+  }
+  .list(pool)
+  .await?;
 
   let items = create_reply_and_mention_items(replies, mentions, protocol_and_hostname)?;
 

--- a/crates/routes/src/feeds.rs
+++ b/crates/routes/src/feeds.rs
@@ -125,13 +125,12 @@ async fn get_feed_data(
   let site_view = SiteView::read_local(&mut context.pool()).await?;
 
   let posts = PostQuery::builder()
-    .pool(&mut context.pool())
     .listing_type(Some(listing_type))
     .sort(Some(sort_type))
     .limit(Some(limit))
     .page(Some(page))
     .build()
-    .list()
+    .list(&mut context.pool())
     .await?;
 
   let items = create_post_items(posts, &context.settings().get_protocol_and_hostname())?;
@@ -244,14 +243,13 @@ async fn get_feed_user(
   let person = Person::read_from_name(pool, user_name, false).await?;
 
   let posts = PostQuery::builder()
-    .pool(pool)
     .listing_type(Some(ListingType::All))
     .sort(Some(*sort_type))
     .creator_id(Some(person.id))
     .limit(Some(*limit))
     .page(Some(*page))
     .build()
-    .list()
+    .list(pool)
     .await?;
 
   let items = create_post_items(posts, protocol_and_hostname)?;
@@ -279,13 +277,12 @@ async fn get_feed_community(
   let community = Community::read_from_name(pool, community_name, false).await?;
 
   let posts = PostQuery::builder()
-    .pool(pool)
     .sort(Some(*sort_type))
     .community_id(Some(community.id))
     .limit(Some(*limit))
     .page(Some(*page))
     .build()
-    .list()
+    .list(pool)
     .await?;
 
   let items = create_post_items(posts, protocol_and_hostname)?;
@@ -319,14 +316,13 @@ async fn get_feed_front(
   let local_user = LocalUser::read(pool, local_user_id).await?;
 
   let posts = PostQuery::builder()
-    .pool(pool)
     .listing_type(Some(ListingType::Subscribed))
     .local_user(Some(&local_user))
     .sort(Some(*sort_type))
     .limit(Some(*limit))
     .page(Some(*page))
     .build()
-    .list()
+    .list(pool)
     .await?;
 
   let items = create_post_items(posts, protocol_and_hostname)?;
@@ -361,25 +357,23 @@ async fn get_feed_inbox(
   let sort = CommentSortType::New;
 
   let replies = CommentReplyQuery::builder()
-    .pool(pool)
     .recipient_id(Some(person_id))
     .my_person_id(Some(person_id))
     .show_bot_accounts(Some(show_bot_accounts))
     .sort(Some(sort))
     .limit(Some(RSS_FETCH_LIMIT))
     .build()
-    .list()
+    .list(pool)
     .await?;
 
   let mentions = PersonMentionQuery::builder()
-    .pool(pool)
     .recipient_id(Some(person_id))
     .my_person_id(Some(person_id))
     .show_bot_accounts(Some(show_bot_accounts))
     .sort(Some(sort))
     .limit(Some(RSS_FETCH_LIMIT))
     .build()
-    .list()
+    .list(pool)
     .await?;
 
   let items = create_reply_and_mention_items(replies, mentions, protocol_and_hostname)?;


### PR DESCRIPTION
When re-running the first cargo clippy command in fix-clippy.sh, the build time of db_views is now 311.1s instead of 1281.9s

Helps with #3610