### PR TITLE
Denormalize community_id into post_aggregates for a 1000x speed-up when loading posts

### DIFF
--- a/crates/db_schema/src/aggregates/structs.rs
+++ b/crates/db_schema/src/aggregates/structs.rs
@@ -96,6 +96,7 @@ pub struct PostAggregates {
   pub featured_local: bool,
   pub hot_rank: i32,
   pub hot_rank_active: i32,
+  pub community_id: CommunityId,
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]

--- a/crates/db_schema/src/aggregates/structs.rs
+++ b/crates/db_schema/src/aggregates/structs.rs
@@ -97,6 +97,7 @@ pub struct PostAggregates {
   pub hot_rank: i32,
   pub hot_rank_active: i32,
   pub community_id: CommunityId,
+  pub creator_id: PersonId,
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]

--- a/crates/db_schema/src/schema.rs
+++ b/crates/db_schema/src/schema.rs
@@ -672,6 +672,7 @@ diesel::table! {
         featured_local -> Bool,
         hot_rank -> Int4,
         hot_rank_active -> Int4,
+        community_id -> Int4,
     }
 }
 
@@ -908,6 +909,7 @@ diesel::joinable!(person_post_aggregates -> post (post_id));
 diesel::joinable!(post -> community (community_id));
 diesel::joinable!(post -> language (language_id));
 diesel::joinable!(post -> person (creator_id));
+diesel::joinable!(post_aggregates -> community (community_id));
 diesel::joinable!(post_aggregates -> post (post_id));
 diesel::joinable!(post_like -> person (person_id));
 diesel::joinable!(post_like -> post (post_id));

--- a/crates/db_schema/src/schema.rs
+++ b/crates/db_schema/src/schema.rs
@@ -673,6 +673,7 @@ diesel::table! {
         hot_rank -> Int4,
         hot_rank_active -> Int4,
         community_id -> Int4,
+        creator_id -> Int4,
     }
 }
 
@@ -910,6 +911,7 @@ diesel::joinable!(post -> community (community_id));
 diesel::joinable!(post -> language (language_id));
 diesel::joinable!(post -> person (creator_id));
 diesel::joinable!(post_aggregates -> community (community_id));
+diesel::joinable!(post_aggregates -> person (creator_id));
 diesel::joinable!(post_aggregates -> post (post_id));
 diesel::joinable!(post_like -> person (person_id));
 diesel::joinable!(post_like -> post (post_id));

--- a/crates/db_views/src/post_report_view.rs
+++ b/crates/db_views/src/post_report_view.rs
@@ -471,6 +471,7 @@ mod tests {
         hot_rank: 1728,
         hot_rank_active: 1728,
         community_id: inserted_post.community_id,
+        creator_id: inserted_post.creator_id,
       },
       resolver: None,
     };

--- a/crates/db_views/src/post_report_view.rs
+++ b/crates/db_views/src/post_report_view.rs
@@ -470,6 +470,7 @@ mod tests {
         featured_local: false,
         hot_rank: 1728,
         hot_rank_active: 1728,
+        community_id: inserted_post.community_id,
       },
       resolver: None,
     };

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -219,7 +219,8 @@ impl<'a> PostQuery<'a> {
 
     let mut query = post::table
       .inner_join(person::table)
-      .inner_join(community::table)
+      .inner_join(post_aggregates::table)
+      .inner_join(community::table.on(post_aggregates::community_id.eq(community::id)))
       .left_join(
         community_person_ban::table.on(
           post::community_id
@@ -227,7 +228,6 @@ impl<'a> PostQuery<'a> {
             .and(community_person_ban::person_id.eq(post::creator_id)),
         ),
       )
-      .inner_join(post_aggregates::table)
       .left_join(
         community_follower::table.on(
           post::community_id
@@ -1051,6 +1051,7 @@ mod tests {
         featured_local: false,
         hot_rank: 1728,
         hot_rank_active: 1728,
+        community_id: inserted_post.community_id,
       },
       subscribed: SubscribedType::NotSubscribed,
       read: false,

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -217,62 +217,62 @@ impl<'a> PostQuery<'a> {
     let person_id_join = self.local_user.map(|l| l.person_id).unwrap_or(PersonId(-1));
     let local_user_id_join = self.local_user.map(|l| l.id).unwrap_or(LocalUserId(-1));
 
-    let mut query = post::table
+    let mut query = post_aggregates::table
       .inner_join(person::table)
-      .inner_join(post_aggregates::table)
-      .inner_join(community::table.on(post_aggregates::community_id.eq(community::id)))
+      .inner_join(post::table)
+      .inner_join(community::table)
       .left_join(
         community_person_ban::table.on(
-          post::community_id
+          post_aggregates::community_id
             .eq(community_person_ban::community_id)
-            .and(community_person_ban::person_id.eq(post::creator_id)),
+            .and(community_person_ban::person_id.eq(post_aggregates::creator_id)),
         ),
       )
       .left_join(
         community_follower::table.on(
-          post::community_id
+          post_aggregates::community_id
             .eq(community_follower::community_id)
             .and(community_follower::person_id.eq(person_id_join)),
         ),
       )
       .left_join(
         post_saved::table.on(
-          post::id
+          post_aggregates::post_id
             .eq(post_saved::post_id)
             .and(post_saved::person_id.eq(person_id_join)),
         ),
       )
       .left_join(
         post_read::table.on(
-          post::id
+          post_aggregates::post_id
             .eq(post_read::post_id)
             .and(post_read::person_id.eq(person_id_join)),
         ),
       )
       .left_join(
         person_block::table.on(
-          post::creator_id
+          post_aggregates::creator_id
             .eq(person_block::target_id)
             .and(person_block::person_id.eq(person_id_join)),
         ),
       )
       .left_join(
         community_block::table.on(
-          post::community_id
+          post_aggregates::community_id
             .eq(community_block::community_id)
             .and(community_block::person_id.eq(person_id_join)),
         ),
       )
       .left_join(
         post_like::table.on(
-          post::id
+          post_aggregates::post_id
             .eq(post_like::post_id)
             .and(post_like::person_id.eq(person_id_join)),
         ),
       )
       .left_join(
         person_post_aggregates::table.on(
-          post::id
+          post_aggregates::post_id
             .eq(person_post_aggregates::post_id)
             .and(person_post_aggregates::person_id.eq(person_id_join)),
         ),
@@ -316,12 +316,12 @@ impl<'a> PostQuery<'a> {
       query = query.then_order_by(post_aggregates::featured_local.desc());
     } else if let Some(community_id) = self.community_id {
       query = query
-        .filter(post::community_id.eq(community_id))
+        .filter(post_aggregates::community_id.eq(community_id))
         .then_order_by(post_aggregates::featured_community.desc());
     }
 
     if let Some(creator_id) = self.creator_id {
-      query = query.filter(post::creator_id.eq(creator_id));
+      query = query.filter(post_aggregates::creator_id.eq(creator_id));
     }
 
     if let Some(listing_type) = self.listing_type {

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -73,56 +73,56 @@ impl PostView {
 
     // The left join below will return None in this case
     let person_id_join = my_person_id.unwrap_or(PersonId(-1));
-    let mut query = post::table
-      .find(post_id)
+    let mut query = post_aggregates::table
+      .filter(post_aggregates::post_id.eq(post_id))
       .inner_join(person::table)
       .inner_join(community::table)
       .left_join(
         community_person_ban::table.on(
-          post::community_id
+          post_aggregates::community_id
             .eq(community_person_ban::community_id)
-            .and(community_person_ban::person_id.eq(post::creator_id)),
+            .and(community_person_ban::person_id.eq(post_aggregates::creator_id)),
         ),
       )
-      .inner_join(post_aggregates::table)
+      .inner_join(post::table)
       .left_join(
         community_follower::table.on(
-          post::community_id
+          post_aggregates::community_id
             .eq(community_follower::community_id)
             .and(community_follower::person_id.eq(person_id_join)),
         ),
       )
       .left_join(
         post_saved::table.on(
-          post::id
+          post_aggregates::post_id
             .eq(post_saved::post_id)
             .and(post_saved::person_id.eq(person_id_join)),
         ),
       )
       .left_join(
         post_read::table.on(
-          post::id
+          post_aggregates::post_id
             .eq(post_read::post_id)
             .and(post_read::person_id.eq(person_id_join)),
         ),
       )
       .left_join(
         person_block::table.on(
-          post::creator_id
+          post_aggregates::creator_id
             .eq(person_block::target_id)
             .and(person_block::person_id.eq(person_id_join)),
         ),
       )
       .left_join(
         post_like::table.on(
-          post::id
+          post_aggregates::post_id
             .eq(post_like::post_id)
             .and(post_like::person_id.eq(person_id_join)),
         ),
       )
       .left_join(
         person_post_aggregates::table.on(
-          post::id
+          post_aggregates::post_id
             .eq(person_post_aggregates::post_id)
             .and(person_post_aggregates::person_id.eq(person_id_join)),
         ),

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -1052,6 +1052,7 @@ mod tests {
         hot_rank: 1728,
         hot_rank_active: 1728,
         community_id: inserted_post.community_id,
+        creator_id: inserted_post.creator_id,
       },
       subscribed: SubscribedType::NotSubscribed,
       read: false,

--- a/migrations/2023-07-18-082614_post_aggregates_community_id/down.sql
+++ b/migrations/2023-07-18-082614_post_aggregates_community_id/down.sql
@@ -16,7 +16,5 @@ BEGIN
 END
 $$;
 
-DROP INDEX idx_post_aggregates_community;
-
 ALTER TABLE post_aggregates DROP COLUMN community_id;
 

--- a/migrations/2023-07-18-082614_post_aggregates_community_id/down.sql
+++ b/migrations/2023-07-18-082614_post_aggregates_community_id/down.sql
@@ -1,0 +1,22 @@
+-- This file should undo anything in `up.sql`
+
+CREATE OR REPLACE FUNCTION post_aggregates_post()
+    RETURNS trigger
+    LANGUAGE plpgsql
+AS
+$$
+BEGIN
+    IF (TG_OP = 'INSERT') THEN
+        INSERT INTO post_aggregates (post_id, published, newest_comment_time, newest_comment_time_necro)
+        VALUES (NEW.id, NEW.published, NEW.published, NEW.published);
+    ELSIF (TG_OP = 'DELETE') THEN
+        DELETE FROM post_aggregates WHERE post_id = OLD.id;
+    END IF;
+    RETURN NULL;
+END
+$$;
+
+DROP INDEX idx_post_aggregates_community;
+
+ALTER TABLE post_aggregates DROP COLUMN community_id;
+

--- a/migrations/2023-07-18-082614_post_aggregates_community_id/down.sql
+++ b/migrations/2023-07-18-082614_post_aggregates_community_id/down.sql
@@ -16,5 +16,5 @@ BEGIN
 END
 $$;
 
-ALTER TABLE post_aggregates DROP COLUMN community_id;
+ALTER TABLE post_aggregates DROP COLUMN community_id, DROP COLUMN creator_id;
 

--- a/migrations/2023-07-18-082614_post_aggregates_community_id/up.sql
+++ b/migrations/2023-07-18-082614_post_aggregates_community_id/up.sql
@@ -1,0 +1,29 @@
+-- Your SQL goes here
+ALTER TABLE post_aggregates
+    ADD COLUMN community_id integer REFERENCES community ON UPDATE CASCADE ON DELETE CASCADE;
+
+CREATE INDEX idx_post_aggregates_community ON post_aggregates (community_id, featured_local DESC, hot_rank DESC);
+
+CREATE OR REPLACE FUNCTION post_aggregates_post()
+    RETURNS trigger
+    LANGUAGE plpgsql
+AS
+$$
+BEGIN
+    IF (TG_OP = 'INSERT') THEN
+        INSERT INTO post_aggregates (post_id, published, newest_comment_time, newest_comment_time_necro, community_id)
+        VALUES (NEW.id, NEW.published, NEW.published, NEW.published, NEW.community_id);
+    ELSIF (TG_OP = 'DELETE') THEN
+        DELETE FROM post_aggregates WHERE post_id = OLD.id;
+    END IF;
+    RETURN NULL;
+END
+$$;
+
+UPDATE post_aggregates
+SET community_id=post.community_id
+FROM post
+WHERE post.id = post_aggregates.post_id;
+
+ALTER TABLE post_aggregates
+    ALTER COLUMN community_id SET NOT NULL;

--- a/migrations/2023-07-18-082614_post_aggregates_community_id/up.sql
+++ b/migrations/2023-07-18-082614_post_aggregates_community_id/up.sql
@@ -2,8 +2,6 @@
 ALTER TABLE post_aggregates
     ADD COLUMN community_id integer REFERENCES community ON UPDATE CASCADE ON DELETE CASCADE;
 
-CREATE INDEX idx_post_aggregates_community ON post_aggregates (community_id, featured_local DESC, hot_rank DESC);
-
 CREATE OR REPLACE FUNCTION post_aggregates_post()
     RETURNS trigger
     LANGUAGE plpgsql

--- a/migrations/2023-07-18-082614_post_aggregates_community_id/up.sql
+++ b/migrations/2023-07-18-082614_post_aggregates_community_id/up.sql
@@ -10,7 +10,11 @@ AS
 $$
 BEGIN
     IF (TG_OP = 'INSERT') THEN
-        INSERT INTO post_aggregates (post_id, published, newest_comment_time, newest_comment_time_necro, community_id,
+        INSERT INTO post_aggregates (post_id,
+                                     published,
+                                     newest_comment_time,
+                                     newest_comment_time_necro,
+                                     community_id,
                                      creator_id)
         VALUES (NEW.id, NEW.published, NEW.published, NEW.published, NEW.community_id, NEW.creator_id);
     ELSIF (TG_OP = 'DELETE') THEN

--- a/migrations/2023-07-18-082614_post_aggregates_community_id/up.sql
+++ b/migrations/2023-07-18-082614_post_aggregates_community_id/up.sql
@@ -1,6 +1,7 @@
 -- Your SQL goes here
 ALTER TABLE post_aggregates
-    ADD COLUMN community_id integer REFERENCES community ON UPDATE CASCADE ON DELETE CASCADE;
+    ADD COLUMN community_id integer REFERENCES community ON UPDATE CASCADE ON DELETE CASCADE,
+    ADD COLUMN creator_id integer REFERENCES person ON UPDATE CASCADE ON DELETE CASCADE;
 
 CREATE OR REPLACE FUNCTION post_aggregates_post()
     RETURNS trigger
@@ -9,8 +10,9 @@ AS
 $$
 BEGIN
     IF (TG_OP = 'INSERT') THEN
-        INSERT INTO post_aggregates (post_id, published, newest_comment_time, newest_comment_time_necro, community_id)
-        VALUES (NEW.id, NEW.published, NEW.published, NEW.published, NEW.community_id);
+        INSERT INTO post_aggregates (post_id, published, newest_comment_time, newest_comment_time_necro, community_id,
+                                     creator_id)
+        VALUES (NEW.id, NEW.published, NEW.published, NEW.published, NEW.community_id, NEW.creator_id);
     ELSIF (TG_OP = 'DELETE') THEN
         DELETE FROM post_aggregates WHERE post_id = OLD.id;
     END IF;
@@ -19,9 +21,11 @@ END
 $$;
 
 UPDATE post_aggregates
-SET community_id=post.community_id
+SET community_id=post.community_id,
+    creator_id=post.creator_id
 FROM post
 WHERE post.id = post_aggregates.post_id;
 
 ALTER TABLE post_aggregates
-    ALTER COLUMN community_id SET NOT NULL;
+    ALTER COLUMN community_id SET NOT NULL,
+    ALTER COLUMN creator_id SET NOT NULL;


### PR DESCRIPTION
Credit to @phiresky for this idea, originally posted in comments of #2994 

This PR adds `community_id` to `post_aggregates` (& a new index on `post_aggregates`) to enable joining `community` directly to `post_aggregates` when querying posts.

**On lemm.ee, this optimization speeds up the query for front page of subscribed posts ~1000x, from several seconds to to just milliseconds.** You can check a before/after of query plans here: https://gist.github.com/sunaurus/856e03165bb0c0010505afeebde45230