### PR TITLE
Federation tests replication round0 - demonstrate absent replication of comment deletes

### DIFF
--- a/api_tests/src/comment.spec.ts
+++ b/api_tests/src/comment.spec.ts
@@ -289,7 +289,7 @@ test("Unlike a comment", async () => {
 
   // Lemmy automatically creates 1 like (vote) by author of comment.
   // Make sure that comment is unliked on gamma, downstream peer
-  // This is testing replication from remote-home-remoet (alpha-beta-gamma)
+  // This is testing replication from remote-home-remote (alpha-beta-gamma)
   let gammaComment = (
     await resolveComment(gamma, commentRes.comment_view.comment)
   ).comment;

--- a/api_tests/src/comment.spec.ts
+++ b/api_tests/src/comment.spec.ts
@@ -227,10 +227,21 @@ test("Remove a comment from admin and community on different instance", async ()
 
 test("Unlike a comment", async () => {
   let commentRes = await createComment(alpha, postRes.post_view.post.id);
+
+  // Make sure that comment is liked (voted up) on gamma, downstream peer
+  // This is testing replication from remote-home-remoet (alpha-beta-gamma)
+  let gammaComment1 = (
+    await resolveComment(gamma, commentRes.comment_view.comment)
+  ).comment;
+  expect(gammaComment1).toBeDefined();
+  expect(gammaComment1?.community.local).toBe(false);
+  expect(gammaComment1?.creator.local).toBe(false);
+  expect(gammaComment1?.counts.score).toBe(1);
+
   let unlike = await likeComment(alpha, 0, commentRes.comment_view.comment);
   expect(unlike.comment_view.counts.score).toBe(0);
 
-  // Make sure that post is unliked on beta
+  // Make sure that comment is unliked on beta
   let betaComment = (
     await resolveComment(beta, commentRes.comment_view.comment)
   ).comment;
@@ -238,6 +249,17 @@ test("Unlike a comment", async () => {
   expect(betaComment?.community.local).toBe(true);
   expect(betaComment?.creator.local).toBe(false);
   expect(betaComment?.counts.score).toBe(0);
+
+  // Lemmy automatically creates 1 like (vote) by author of comment.
+  // Make sure that comment is unliked on gamma, downstream peer
+  // This is testing replication from remote-home-remoet (alpha-beta-gamma)
+  let gammaComment = (
+    await resolveComment(gamma, commentRes.comment_view.comment)
+  ).comment;
+  expect(gammaComment).toBeDefined();
+  expect(gammaComment?.community.local).toBe(false);
+  expect(gammaComment?.creator.local).toBe(false);
+  expect(gammaComment?.counts.score).toBe(0);
 });
 
 test("Federated comment like", async () => {


### PR DESCRIPTION
This is an urgent situation to highlight the problem with comment deletes not replicating when a remote-server creates the comment, the home server has no code to replicate delete of comment to all the downstream subscribe servers. Gamma serves as an example of the downstream servers subscribed who are not getting the delete in 0.18.2 version.

The intention here is to put more developer eyes on https://github.com/LemmyNet/lemmy/issues/3588