### PR TITLE
Use local_site.default_post_listing_type as the initial listing type for new users

### DIFF
--- a/crates/api_crud/src/user/create.rs
+++ b/crates/api_crud/src/user/create.rs
@@ -138,6 +138,7 @@ impl PerformCrud for Register {
       .password_encrypted(data.password.to_string())
       .show_nsfw(Some(data.show_nsfw))
       .accepted_application(accepted_application)
+      .default_listing_type(Some(local_site.default_post_listing_type))
       .build();
 
     let inserted_local_user = LocalUser::create(&mut context.pool(), &local_user_form).await?;


### PR DESCRIPTION
Currently, new users always start on "Local". It seems to make more sense to apply the site's configured default listing type for new users as well.