### PR TITLE
Make sure comments are sorted by hot_rank, then score.

### DIFF
--- a/crates/db_views/src/comment_view.rs
+++ b/crates/db_views/src/comment_view.rs
@@ -345,7 +345,9 @@ impl<'a> CommentQuery<'a> {
     };
 
     query = match self.sort.unwrap_or(CommentSortType::Hot) {
-      CommentSortType::Hot => query.then_order_by(comment_aggregates::hot_rank.desc()),
+      CommentSortType::Hot => query
+        .then_order_by(comment_aggregates::hot_rank.desc())
+        .then_order_by(comment_aggregates::score.desc()),
       CommentSortType::New => query.then_order_by(comment::published.desc()),
       CommentSortType::Old => query.then_order_by(comment::published.asc()),
       CommentSortType::Top => query.order_by(comment_aggregates::score.desc()),

--- a/migrations/2023-07-19-163511_comment_sort_hot_rank_then_score/down.sql
+++ b/migrations/2023-07-19-163511_comment_sort_hot_rank_then_score/down.sql
@@ -1,0 +1,4 @@
+drop index idx_comment_aggregates_hot, idx_comment_aggregates_score;
+
+create index idx_comment_aggregates_hot on comment_aggregates (hot_rank desc, published desc);
+create index idx_comment_aggregates_score on comment_aggregates (score desc, published desc);

--- a/migrations/2023-07-19-163511_comment_sort_hot_rank_then_score/up.sql
+++ b/migrations/2023-07-19-163511_comment_sort_hot_rank_then_score/up.sql
@@ -1,0 +1,10 @@
+-- Alter the comment_aggregates hot sort to sort by score after hot_rank.
+-- Reason being, is that hot_ranks go to zero after a few days, 
+-- and then comments should be sorted by score, not published.
+
+drop index idx_comment_aggregates_hot, idx_comment_aggregates_score;
+
+create index idx_comment_aggregates_hot on comment_aggregates (hot_rank desc, score desc);
+
+-- Remove published from this sort, its pointless
+create index idx_comment_aggregates_score on comment_aggregates (score desc);


### PR DESCRIPTION
Since hot_ranks go to zero after a few days, a secondary sort is necessary. 

I'm changing this from published to score for comment_views, since viewing older comment threads, you want to see the top comments, not the newest ones.

Should be merged after #3618 