### PR TITLE
Change logic for determining comment default language (fixes #3451)

### DIFF
--- a/crates/api_crud/src/post/create.rs
+++ b/crates/api_crud/src/post/create.rs
@@ -91,6 +91,16 @@ pub async fn create_post(
     .map(|u| (u.title, u.description, u.embed_video_url))
     .unwrap_or_default();
 
+  // Only need to check if language is allowed in case user set it explicitly. When using default
+  // language, it already only returns allowed languages.
+  CommunityLanguage::is_allowed_community_language(
+    &mut context.pool(),
+    data.language_id,
+    community_id,
+  )
+  .await?;
+
+  // attempt to set default language if none was provided
   let language_id = match data.language_id {
     Some(lid) => Some(lid),
     None => {
@@ -102,8 +112,6 @@ pub async fn create_post(
       .await?
     }
   };
-  CommunityLanguage::is_allowed_community_language(&mut context.pool(), language_id, community_id)
-    .await?;
 
   let post_form = PostInsertForm::builder()
     .name(data.name.trim().to_owned())


### PR DESCRIPTION
When submitting a comment without explicit language id, it would currently always use the post language. Users have reported many problems with this recently. One case is if the post language was previously allowed in the community, but later disallowed. Then all replies to that post without explicit language will throw an error.

The logic for default post language (based on overlap of user languages and community languages) seems to be working much more reliably, so we can use it for comments as well.

This change might allow us to get rid of the workaround in https://github.com/LemmyNet/lemmy/pull/2851 in the future.