### PR TITLE
disable rustfmt feature on rosetta-build

### DIFF
--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -55,4 +55,4 @@ enum-map = "2.6"
 reqwest = { workspace = true }
 
 [build-dependencies]
-rosetta-build = "0.1.3"
+rosetta-build = { version = "0.1.3", default-features = false }


### PR DESCRIPTION
Disabling the `rustfmt` feature on rosetta-build allows more flexibility with how/where lemmy can be built.
