### PR TITLE
feat: Use yt-dl to resolve direct video URLs

### DIFF
--- a/crates/api_common/Cargo.toml
+++ b/crates/api_common/Cargo.toml
@@ -66,3 +66,4 @@ once_cell = { workspace = true, optional = true }
 actix-web = { workspace = true, optional = true }
 # necessary for wasmt compilation
 getrandom = { version = "0.2.10", features = ["js"] }
+youtube_dl = { version = "0.8.1", features = ["tokio"] }

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -396,7 +396,7 @@ mod tests {
       )
     );
     assert_eq!(
-      meta.title,
+      meta.embed_video_url,
       Some(Url::parse("https://example.com/video.mp4").unwrap().into())
     );
   }


### PR DESCRIPTION
This is a first pass at implementing https://github.com/LemmyNet/lemmy/issues/3633. The backend will now attempt to use the `youtube_dl` library to directly resolve video URLs submitted by users for better video embedding.

Considerations:

1. It's important to keep the `yt-dlp` binary up-to-date. The library I used has a built-in downloader that can download the binary to a path. Is that something we want to pursue? If so, where should we store the binary?
1. The test case I added is lackluster at best, and doesn't hit any real URLs. Should I add a test that hits a real URL?
2. Should errors from `yt-dlp` be logged?
3. I am not a Rust developer, so hopefully everything makes sense!