### PR TITLE
Add internal id lookup API

### DIFF
--- a/crates/api_common/src/internal_lookup.rs
+++ b/crates/api_common/src/internal_lookup.rs
@@ -1,33 +1,32 @@
 
+use crate::sensitive::Sensitive;
 use lemmy_db_schema::newtypes::DbUrl;
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
-
-use crate::sensitive::Sensitive;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "full", derive(TS))]
 #[cfg_attr(feature = "full", ts(export))]
 pub struct InternalLookupRequest {
-    // The actor_id to lookup.  This can be a Post or Comment actor_id based on the value of `lookup_type`.
-    pub actor_id : DbUrl,
-    // The type of the actor_id to lookup.
-    pub lookup_type : InternalLookupType,
-    pub auth: Option<Sensitive<String>>
+  // The actor_id to lookup.  This can be a Post or Comment actor_id based on the value of `lookup_type`.
+  pub actor_id : DbUrl,
+  // The type of the actor_id to lookup.
+  pub lookup_type : InternalLookupType,
+  pub auth: Option<Sensitive<String>>
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "full", derive(TS))]
 #[cfg_attr(feature = "full", ts(export))]
 pub struct InternalLookupResponse {
-    // Not sure how to abstract PostId and CommentId here without splitting this into two endpoints.
-    pub internal_id : Option<i32>
+  // Not sure how to abstract PostId and CommentId here without splitting this into two endpoints.
+  pub internal_id : Option<i32>
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "full", derive(TS))]
 #[cfg_attr(feature = "full", ts(export))]
 pub enum InternalLookupType {
-    Post,
-    Comment
+  Post,
+  Comment
 }

--- a/crates/api_common/src/internal_lookup.rs
+++ b/crates/api_common/src/internal_lookup.rs
@@ -1,4 +1,3 @@
-
 use crate::sensitive::Sensitive;
 use lemmy_db_schema::newtypes::DbUrl;
 use serde::{Deserialize, Serialize};

--- a/crates/api_common/src/internal_lookup.rs
+++ b/crates/api_common/src/internal_lookup.rs
@@ -9,10 +9,10 @@ use ts_rs::TS;
 #[cfg_attr(feature = "full", ts(export))]
 pub struct InternalLookupRequest {
   // The actor_id to lookup.  This can be a Post or Comment actor_id based on the value of `lookup_type`.
-  pub actor_id : DbUrl,
+  pub actor_id: DbUrl,
   // The type of the actor_id to lookup.
-  pub lookup_type : InternalLookupType,
-  pub auth: Option<Sensitive<String>>
+  pub lookup_type: InternalLookupType,
+  pub auth: Option<Sensitive<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -20,7 +20,7 @@ pub struct InternalLookupRequest {
 #[cfg_attr(feature = "full", ts(export))]
 pub struct InternalLookupResponse {
   // Not sure how to abstract PostId and CommentId here without splitting this into two endpoints.
-  pub internal_id : Option<i32>
+  pub internal_id : Option<i32>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -28,5 +28,5 @@ pub struct InternalLookupResponse {
 #[cfg_attr(feature = "full", ts(export))]
 pub enum InternalLookupType {
   Post,
-  Comment
+  Comment,
 }

--- a/crates/api_common/src/internal_lookup.rs
+++ b/crates/api_common/src/internal_lookup.rs
@@ -20,7 +20,7 @@ pub struct InternalLookupRequest {
 #[cfg_attr(feature = "full", derive(TS))]
 #[cfg_attr(feature = "full", ts(export))]
 pub struct InternalLookupResponse {
-    // not sure how to abstract PostId and CommentId here
+    // Not sure how to abstract PostId and CommentId here without splitting this into two endpoints.
     pub internal_id : Option<i32>
 }
 

--- a/crates/api_common/src/internal_lookup.rs
+++ b/crates/api_common/src/internal_lookup.rs
@@ -1,6 +1,7 @@
 use crate::sensitive::Sensitive;
 use lemmy_db_schema::newtypes::DbUrl;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "full")]
 use ts_rs::TS;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/crates/api_common/src/internal_lookup.rs
+++ b/crates/api_common/src/internal_lookup.rs
@@ -1,0 +1,33 @@
+
+use lemmy_db_schema::newtypes::DbUrl;
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+
+use crate::sensitive::Sensitive;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "full", derive(TS))]
+#[cfg_attr(feature = "full", ts(export))]
+pub struct InternalLookupRequest {
+    // The actor_id to lookup.  This can be a Post or Comment actor_id based on the value of `lookup_type`.
+    pub actor_id : DbUrl,
+    // The type of the actor_id to lookup.
+    pub lookup_type : InternalLookupType,
+    pub auth: Option<Sensitive<String>>
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "full", derive(TS))]
+#[cfg_attr(feature = "full", ts(export))]
+pub struct InternalLookupResponse {
+    // not sure how to abstract PostId and CommentId here
+    pub internal_id : Option<i32>
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "full", derive(TS))]
+#[cfg_attr(feature = "full", ts(export))]
+pub enum InternalLookupType {
+    Post,
+    Comment
+}

--- a/crates/api_common/src/internal_lookup.rs
+++ b/crates/api_common/src/internal_lookup.rs
@@ -20,7 +20,7 @@ pub struct InternalLookupRequest {
 #[cfg_attr(feature = "full", ts(export))]
 pub struct InternalLookupResponse {
   // Not sure how to abstract PostId and CommentId here without splitting this into two endpoints.
-  pub internal_id : Option<i32>,
+  pub internal_id: Option<i32>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/crates/api_common/src/lib.rs
+++ b/crates/api_common/src/lib.rs
@@ -5,6 +5,7 @@ pub mod community;
 #[cfg(feature = "full")]
 pub mod context;
 pub mod custom_emoji;
+pub mod internal_lookup;
 pub mod person;
 pub mod post;
 pub mod private_message;
@@ -14,7 +15,6 @@ pub mod request;
 pub mod send_activity;
 pub mod sensitive;
 pub mod site;
-pub mod internal_lookup;
 #[cfg(feature = "full")]
 pub mod utils;
 

--- a/crates/api_common/src/lib.rs
+++ b/crates/api_common/src/lib.rs
@@ -14,6 +14,7 @@ pub mod request;
 pub mod send_activity;
 pub mod sensitive;
 pub mod site;
+pub mod internal_lookup;
 #[cfg(feature = "full")]
 pub mod utils;
 

--- a/crates/apub/src/api/internal_lookup.rs
+++ b/crates/apub/src/api/internal_lookup.rs
@@ -13,7 +13,6 @@ pub async fn internal_lookup(
   data: Query<InternalLookupRequest>,
   context: Data<LemmyContext>,
 ) -> Result<Json<InternalLookupResponse>, LemmyError> {
-
   let local_user_view = local_user_view_from_jwt_opt(data.auth.as_ref(), &context).await;
   let local_site = LocalSite::read(&mut context.pool()).await?;
 
@@ -35,14 +34,12 @@ pub async fn internal_lookup(
           // This requires that both Posts and Comments have the same type for their Ids.
           // I'm not sure how to best solve this though other than to create two separate
           // endpoints, one for looking up a comment and other for lookup up posts.
-          c.id.0 
+          c.id.0
         })
     },
     InternalLookupType::Post => Post::read_from_apub_id(&mut context.pool(), actor_id)
       .await?
-      .map(|p| {
-        p.id.0
-      })
+      .map(|p| p.id.0)
   };
 
   // Do we still want to return the internal_ids for deleted posts?

--- a/crates/apub/src/api/internal_lookup.rs
+++ b/crates/apub/src/api/internal_lookup.rs
@@ -36,10 +36,10 @@ pub async fn internal_lookup(
           // endpoints, one for looking up a comment and other for lookup up posts.
           c.id.0
         })
-    },
+    }
     InternalLookupType::Post => Post::read_from_apub_id(&mut context.pool(), actor_id)
       .await?
-      .map(|p| p.id.0)
+      .map(|p| p.id.0),
   };
 
   // Do we still want to return the internal_ids for deleted posts?

--- a/crates/apub/src/api/internal_lookup.rs
+++ b/crates/apub/src/api/internal_lookup.rs
@@ -1,22 +1,11 @@
 use activitypub_federation::config::Data;
-use lemmy_api_common::{
-    internal_lookup::{
-        InternalLookupRequest, 
-        InternalLookupResponse, 
-        InternalLookupType
-    }, 
-    context::LemmyContext, 
-    utils::{
-        local_user_view_from_jwt_opt, 
-        check_private_instance
-    }
-};
 use actix_web::web::{Json, Query};
-use lemmy_db_schema::source::{
-    comment::Comment,
-    post::Post, 
-    local_site::LocalSite
+use lemmy_api_common::{
+  context::LemmyContext,
+  internal_lookup::{InternalLookupRequest, InternalLookupResponse, InternalLookupType}, 
+  utils::{check_private_instance, local_user_view_from_jwt_opt}
 };
+use lemmy_db_schema::source::{comment::Comment,post::Post, local_site::LocalSite};
 use lemmy_utils::error::LemmyError;
 
 #[tracing::instrument(skip(context))]
@@ -25,40 +14,40 @@ pub async fn internal_lookup(
   context: Data<LemmyContext>,
 ) -> Result<Json<InternalLookupResponse>, LemmyError> {
 
-    let local_user_view = local_user_view_from_jwt_opt(data.auth.as_ref(), &context).await;
-    let local_site = LocalSite::read(&mut context.pool()).await?;
+  let local_user_view = local_user_view_from_jwt_opt(data.auth.as_ref(), &context).await;
+  let local_site = LocalSite::read(&mut context.pool()).await?;
 
-    check_private_instance(&local_user_view, &local_site)?;
+  check_private_instance(&local_user_view, &local_site)?;
 
-    let actor_id = (*data.actor_id).to_owned();
-    let lookup_type = data.lookup_type.to_owned();
+  let actor_id = (*data.actor_id).to_owned();
+  let lookup_type = data.lookup_type.to_owned();
 
-    // In theory we could use the URL itself to determine the actor's type, but the client should already
-    // know this before making the request.  Also, as different software comes online that each have their
-    // own unique ids for posts and comments, those would have to  be added here.
-    let internal_id = match lookup_type {
-        InternalLookupType::Comment => {
-            // Is there a better way to do this?  I assume there's an index on the `actor_id` column, but
-            // do we store this in RAM anywhere that would be faster to read?
-            Comment::read_from_apub_id(&mut context.pool(), actor_id)
-                .await?
-                .map(|c| {
-                    // This requires that both Posts and Comments have the same type for their Ids.
-                    // I'm not sure how to best solve this though other than to create two separate
-                    // endpoints, one for looking up a comment and other for lookup up posts.
-                    c.id.0 
-                })
-        },
-        InternalLookupType::Post => {
-            Post::read_from_apub_id(&mut context.pool(), actor_id)
-                .await?
-                .map(|p| {
-                    p.id.0
-                })
-        }
-    };
+  // In theory we could use the URL itself to determine the actor's type, but the client should already
+  // know this before making the request.  Also, as different software comes online that each have their
+  // own unique ids for posts and comments, those would have to  be added here.
+  let internal_id = match lookup_type {
+    InternalLookupType::Comment => {
+      // Is there a better way to do this?  I assume there's an index on the `actor_id` column, but
+      // do we store this in RAM anywhere that would be faster to read?
+      Comment::read_from_apub_id(&mut context.pool(), actor_id)
+        .await?
+        .map(|c| {
+            // This requires that both Posts and Comments have the same type for their Ids.
+            // I'm not sure how to best solve this though other than to create two separate
+            // endpoints, one for looking up a comment and other for lookup up posts.
+            c.id.0 
+        })
+    },
+    InternalLookupType::Post => {
+      Post::read_from_apub_id(&mut context.pool(), actor_id)
+        .await?
+        .map(|p| {
+            p.id.0
+        })
+    }
+  };
 
-    // Do we still want to return the internal_ids for deleted posts?
+  // Do we still want to return the internal_ids for deleted posts?
 
-    Ok(Json(InternalLookupResponse { internal_id }))
+  Ok(Json(InternalLookupResponse { internal_id }))
 }

--- a/crates/apub/src/api/internal_lookup.rs
+++ b/crates/apub/src/api/internal_lookup.rs
@@ -1,0 +1,60 @@
+use activitypub_federation::config::Data;
+use lemmy_api_common::{
+    internal_lookup::{
+        InternalLookupRequest, 
+        InternalLookupResponse, 
+        InternalLookupType
+    }, 
+    context::LemmyContext, 
+    utils::{
+        local_user_view_from_jwt_opt, 
+        check_private_instance
+    }
+};
+use actix_web::web::{Json, Query};
+use lemmy_db_schema::source::{
+    comment::Comment,
+    post::Post, 
+    local_site::LocalSite
+};
+use lemmy_utils::error::LemmyError;
+
+#[tracing::instrument(skip(context))]
+pub async fn internal_lookup(
+  data: Query<InternalLookupRequest>,
+  context: Data<LemmyContext>,
+) -> Result<Json<InternalLookupResponse>, LemmyError> {
+
+    let local_user_view = local_user_view_from_jwt_opt(data.auth.as_ref(), &context).await;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
+
+    check_private_instance(&local_user_view, &local_site)?;
+
+    let actor_id = (*data.actor_id).to_owned();
+    let lookup_type = data.lookup_type.to_owned();
+
+    // In theory we could use the URL itself to determine the actor's type, but the client should already
+    // know this before making the request.  Also, as different software comes online that each have their
+    // own unique ids for posts and comments, those would have to  be added here.
+    let internal_id = match lookup_type {
+        InternalLookupType::Comment => {
+            // Is there a better way to do this?
+            Comment::read_from_apub_id(&mut context.pool(), actor_id)
+                .await?
+                .map(|c| {
+                    c.id.0
+                })
+        },
+        InternalLookupType::Post => {
+            Post::read_from_apub_id(&mut context.pool(), actor_id)
+                .await?
+                .map(|p| {
+                    p.id.0
+                })
+        }
+    };
+
+    // Do we still want to return the internal_ids for deleted posts?
+
+    Ok(Json(InternalLookupResponse { internal_id }))
+}

--- a/crates/apub/src/api/internal_lookup.rs
+++ b/crates/apub/src/api/internal_lookup.rs
@@ -2,10 +2,10 @@ use activitypub_federation::config::Data;
 use actix_web::web::{Json, Query};
 use lemmy_api_common::{
   context::LemmyContext,
-  internal_lookup::{InternalLookupRequest, InternalLookupResponse, InternalLookupType}, 
-  utils::{check_private_instance, local_user_view_from_jwt_opt}
+  internal_lookup::{InternalLookupRequest, InternalLookupResponse, InternalLookupType},
+  utils::{check_private_instance, local_user_view_from_jwt_opt},
 };
-use lemmy_db_schema::source::{comment::Comment,post::Post, local_site::LocalSite};
+use lemmy_db_schema::source::{comment::Comment, local_site::LocalSite, post::Post};
 use lemmy_utils::error::LemmyError;
 
 #[tracing::instrument(skip(context))]
@@ -32,19 +32,17 @@ pub async fn internal_lookup(
       Comment::read_from_apub_id(&mut context.pool(), actor_id)
         .await?
         .map(|c| {
-            // This requires that both Posts and Comments have the same type for their Ids.
-            // I'm not sure how to best solve this though other than to create two separate
-            // endpoints, one for looking up a comment and other for lookup up posts.
-            c.id.0 
+          // This requires that both Posts and Comments have the same type for their Ids.
+          // I'm not sure how to best solve this though other than to create two separate
+          // endpoints, one for looking up a comment and other for lookup up posts.
+          c.id.0 
         })
     },
-    InternalLookupType::Post => {
-      Post::read_from_apub_id(&mut context.pool(), actor_id)
-        .await?
-        .map(|p| {
-            p.id.0
-        })
-    }
+    InternalLookupType::Post => Post::read_from_apub_id(&mut context.pool(), actor_id)
+      .await?
+      .map(|p| {
+        p.id.0
+      })
   };
 
   // Do we still want to return the internal_ids for deleted posts?

--- a/crates/apub/src/api/internal_lookup.rs
+++ b/crates/apub/src/api/internal_lookup.rs
@@ -38,11 +38,15 @@ pub async fn internal_lookup(
     // own unique ids for posts and comments, those would have to  be added here.
     let internal_id = match lookup_type {
         InternalLookupType::Comment => {
-            // Is there a better way to do this?
+            // Is there a better way to do this?  I assume there's an index on the `actor_id` column, but
+            // do we store this in RAM anywhere that would be faster to read?
             Comment::read_from_apub_id(&mut context.pool(), actor_id)
                 .await?
                 .map(|c| {
-                    c.id.0
+                    // This requires that both Posts and Comments have the same type for their Ids.
+                    // I'm not sure how to best solve this though other than to create two separate
+                    // endpoints, one for looking up a comment and other for lookup up posts.
+                    c.id.0 
                 })
         },
         InternalLookupType::Post => {

--- a/crates/apub/src/api/mod.rs
+++ b/crates/apub/src/api/mod.rs
@@ -1,6 +1,7 @@
 use lemmy_db_schema::{newtypes::CommunityId, source::local_site::LocalSite, ListingType};
 use lemmy_utils::error::LemmyError;
 
+pub mod internal_lookup;
 pub mod list_comments;
 pub mod list_posts;
 pub mod read_community;

--- a/src/api_routes_http.rs
+++ b/src/api_routes_http.rs
@@ -95,13 +95,13 @@ use lemmy_api_common::{
 use lemmy_api_crud::{post::create::create_post, PerformCrud};
 use lemmy_apub::{
   api::{
+    internal_lookup::internal_lookup,
     list_comments::list_comments,
     list_posts::list_posts,
     read_community::read_community,
     read_person::read_person,
     resolve_object::resolve_object,
-    search::search, 
-    internal_lookup::internal_lookup,
+    search::search,
   },
   SendActivity,
 };

--- a/src/api_routes_http.rs
+++ b/src/api_routes_http.rs
@@ -100,7 +100,8 @@ use lemmy_apub::{
     read_community::read_community,
     read_person::read_person,
     resolve_object::resolve_object,
-    search::search, internal_lookup::internal_lookup,
+    search::search, 
+    internal_lookup::internal_lookup,
   },
   SendActivity,
 };

--- a/src/api_routes_http.rs
+++ b/src/api_routes_http.rs
@@ -100,7 +100,7 @@ use lemmy_apub::{
     read_community::read_community,
     read_person::read_person,
     resolve_object::resolve_object,
-    search::search,
+    search::search, internal_lookup::internal_lookup,
   },
   SendActivity,
 };
@@ -133,6 +133,11 @@ pub fn config(cfg: &mut web::ServiceConfig, rate_limit: &RateLimitCell) {
         web::resource("/resolve_object")
           .wrap(rate_limit.message())
           .route(web::get().to(resolve_object)),
+      )
+      .service(
+        web::resource("/internal_lookup")
+          .wrap(rate_limit.message())
+          .route(web::get().to(internal_lookup)),
       )
       // Community
       .service(


### PR DESCRIPTION
In order to solve an issue I'm running into with my own project (https://www.github.com/marsara9/lemmy-search) I opened an issue to see if resolve_object could be made to not require auth.  As part of the conversation that transpired there, it was raised that it might be better to expose a explicit API to just do the `ap_id -> local id` lookup instead of using `resolve_object`.

See: #3685 for more details.