### PR TITLE
Fix 2FA bypass via password reset

### DIFF
--- a/crates/api/src/local_user/change_password_after_reset.rs
+++ b/crates/api/src/local_user/change_password_after_reset.rs
@@ -5,15 +5,11 @@ use lemmy_api_common::{
   person::{LoginResponse, PasswordChangeAfterReset},
   utils::password_length_check,
 };
-use lemmy_db_schema::{
-  source::{local_user::LocalUser, password_reset_request::PasswordResetRequest},
-  RegistrationMode,
+use lemmy_db_schema::source::{
+  local_user::LocalUser,
+  password_reset_request::PasswordResetRequest,
 };
-use lemmy_db_views::structs::SiteView;
-use lemmy_utils::{
-  claims::Claims,
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
-};
+use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 #[async_trait::async_trait(?Send)]
 impl Perform for PasswordChangeAfterReset {
@@ -38,30 +34,12 @@ impl Perform for PasswordChangeAfterReset {
 
     // Update the user with the new password
     let password = data.password.clone();
-    let updated_local_user =
-      LocalUser::update_password(&mut context.pool(), local_user_id, &password)
-        .await
-        .with_lemmy_type(LemmyErrorType::CouldntUpdateUser)?;
-
-    // Return the jwt if login is allowed
-    let site_view = SiteView::read_local(&mut context.pool()).await?;
-    let jwt = if site_view.local_site.registration_mode == RegistrationMode::RequireApplication
-      && !updated_local_user.accepted_application
-    {
-      None
-    } else {
-      Some(
-        Claims::jwt(
-          updated_local_user.id.0,
-          &context.secret().jwt_secret,
-          &context.settings().hostname,
-        )?
-        .into(),
-      )
-    };
+    LocalUser::update_password(&mut context.pool(), local_user_id, &password)
+      .await
+      .with_lemmy_type(LemmyErrorType::CouldntUpdateUser)?;
 
     Ok(LoginResponse {
-      jwt,
+      jwt: None,
       verify_email_sent: false,
       registration_created: false,
     })


### PR DESCRIPTION
Fixes #3714

This PR changes the behavior of the password reset endpoint, so that it wont authenticate the user after a successful password reset.

In order to not introduce braking changes, the password reset endpoint will still return a Login Response but now without a JWT. That way Lemmy UI will just redirect to unauthenticated home after a successful password reset.