### PR TITLE
add trigram index to search

### DIFF
--- a/migrations/2023-07-24-232635_trigram-index/down.sql
+++ b/migrations/2023-07-24-232635_trigram-index/down.sql
@@ -4,3 +4,5 @@ DROP INDEX idx_post_trigram;
 
 DROP INDEX idx_person_trigram;
 
+DROP INDEX idx_community_trigram;
+

--- a/migrations/2023-07-24-232635_trigram-index/down.sql
+++ b/migrations/2023-07-24-232635_trigram-index/down.sql
@@ -1,0 +1,6 @@
+DROP INDEX idx_comment_content_trigram;
+
+DROP INDEX idx_post_trigram;
+
+DROP INDEX idx_person_trigram;
+

--- a/migrations/2023-07-24-232635_trigram-index/up.sql
+++ b/migrations/2023-07-24-232635_trigram-index/up.sql
@@ -1,0 +1,8 @@
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX idx_comment_content_trigram ON comment USING gin(content gin_trgm_ops);
+
+CREATE INDEX idx_post_trigram ON post USING gin(name gin_trgm_ops, body gin_trgm_ops);
+
+CREATE INDEX idx_person_trigram ON person USING gin(name gin_trgm_ops, display_name gin_trgm_ops);
+

--- a/migrations/2023-07-24-232635_trigram-index/up.sql
+++ b/migrations/2023-07-24-232635_trigram-index/up.sql
@@ -1,8 +1,10 @@
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
 
-CREATE INDEX idx_comment_content_trigram ON comment USING gin(content gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_comment_content_trigram ON comment USING gin(content gin_trgm_ops);
 
-CREATE INDEX idx_post_trigram ON post USING gin(name gin_trgm_ops, body gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_post_trigram ON post USING gin(name gin_trgm_ops, body gin_trgm_ops);
 
-CREATE INDEX idx_person_trigram ON person USING gin(name gin_trgm_ops, display_name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_person_trigram ON person USING gin(name gin_trgm_ops, display_name gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS idx_community_trigram ON community USING gin(name gin_trgm_ops, title gin_trgm_ops);
 


### PR DESCRIPTION
Search currently does ILIKE '%x%y%' queries on person, post, comment tables. These cause seq scans because they can't be indexed with a normal BTREE index.

This PR adds trigram indexes to all three tables. This should speed up most of those searches to < 100ms. The cost is slightly higher cost for updating/creating rows in those tables.

One limitation is that this index is suboptimal when other filters are present and important, for example searching in one community.

This migration should really run in the background with CREATE INDEX CONCURRENTLY since it will take a while but I don't think there's a way to do that from within diesel.