### PR TITLE
Sanitize email notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2628,6 +2628,7 @@ dependencies = [
  "encoding",
  "futures",
  "getrandom 0.2.10",
+ "html-escape",
  "lemmy_db_schema",
  "lemmy_db_views",
  "lemmy_db_views_actor",

--- a/crates/api_common/Cargo.toml
+++ b/crates/api_common/Cargo.toml
@@ -66,3 +66,4 @@ once_cell = { workspace = true, optional = true }
 actix-web = { workspace = true, optional = true }
 # necessary for wasmt compilation
 getrandom = { version = "0.2.10", features = ["js"] }
+html-escape = "0.2.13"

--- a/crates/api_common/src/build_response.rs
+++ b/crates/api_common/src/build_response.rs
@@ -3,7 +3,9 @@ use crate::{
   community::CommunityResponse,
   context::LemmyContext,
   post::PostResponse,
-  utils::{check_person_block, get_interface_language, is_mod_or_admin, send_email_to_user},
+  utils::{
+    check_person_block, escape_html, get_interface_language, is_mod_or_admin, send_email_to_user,
+  },
 };
 use actix_web::web::Data;
 use lemmy_db_schema::{
@@ -126,7 +128,11 @@ pub async fn send_local_notifs(
         send_email_to_user(
           &mention_user_view,
           &lang.notification_mentioned_by_subject(&person.name),
-          &lang.notification_mentioned_by_body(&comment.content, &inbox_link, &person.name),
+          &lang.notification_mentioned_by_body(
+            escape_html(&comment.content),
+            &inbox_link,
+            escape_html(&person.name),
+          ),
           context.settings(),
         )
         .await
@@ -169,7 +175,11 @@ pub async fn send_local_notifs(
           send_email_to_user(
             &parent_user_view,
             &lang.notification_comment_reply_subject(&person.name),
-            &lang.notification_comment_reply_body(&comment.content, &inbox_link, &person.name),
+            &lang.notification_comment_reply_body(
+              escape_html(&comment.content),
+              &inbox_link,
+              escape_html(&person.name),
+            ),
             context.settings(),
           )
           .await
@@ -206,7 +216,11 @@ pub async fn send_local_notifs(
           send_email_to_user(
             &parent_user_view,
             &lang.notification_post_reply_subject(&person.name),
-            &lang.notification_post_reply_body(&comment.content, &inbox_link, &person.name),
+            &lang.notification_post_reply_body(
+              escape_html(&comment.content),
+              &inbox_link,
+              escape_html(&person.name),
+            ),
             context.settings(),
           )
           .await

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -1,11 +1,10 @@
 use crate::{
-  context::LemmyContext,
-  request::purge_image_from_pictrs,
-  sensitive::Sensitive,
+  context::LemmyContext, request::purge_image_from_pictrs, sensitive::Sensitive,
   site::FederatedInstances,
 };
 use anyhow::Context;
 use chrono::NaiveDateTime;
+use html_escape;
 use lemmy_db_schema::{
   impls::person::is_banned,
   newtypes::{CommunityId, DbUrl, LocalUserId, PersonId, PostId},
@@ -28,9 +27,7 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views::{comment_view::CommentQuery, structs::LocalUserView};
 use lemmy_db_views_actor::structs::{
-  CommunityModeratorView,
-  CommunityPersonBanView,
-  CommunityView,
+  CommunityModeratorView, CommunityPersonBanView, CommunityView,
 };
 use lemmy_utils::{
   claims::Claims,
@@ -44,6 +41,7 @@ use lemmy_utils::{
 use regex::Regex;
 use reqwest_middleware::ClientWithMiddleware;
 use rosetta_i18n::{Language, LanguageId};
+use std::borrow::Cow;
 use tracing::warn;
 use url::{ParseError, Url};
 
@@ -818,4 +816,8 @@ pub fn generate_featured_url(actor_id: &DbUrl) -> Result<DbUrl, ParseError> {
 
 pub fn generate_moderators_url(community_id: &DbUrl) -> Result<DbUrl, LemmyError> {
   Ok(Url::parse(&format!("{community_id}/moderators"))?.into())
+}
+
+pub fn escape_html(data: &str) -> Cow<str> {
+  return html_escape::encode_safe(data);
 }

--- a/crates/api_crud/src/private_message/create.rs
+++ b/crates/api_crud/src/private_message/create.rs
@@ -11,6 +11,7 @@ use lemmy_api_common::{
     local_user_view_from_jwt,
     send_email_to_user,
     EndpointType,
+    escape_html,
   },
 };
 use lemmy_db_schema::{
@@ -92,7 +93,11 @@ impl PerformCrud for CreatePrivateMessage {
       send_email_to_user(
         &local_recipient,
         &lang.notification_private_message_subject(sender_name),
-        &lang.notification_private_message_body(inbox_link, &content_slurs_removed, sender_name),
+        &lang.notification_private_message_body(
+          inbox_link,
+          escape_html(&content_slurs_removed),
+          escape_html(sender_name),
+        ),
         context.settings(),
       )
       .await;


### PR DESCRIPTION
Sanitizes email notifications by escaping all special characters (i.e. `<` -> `&lt;`, `>` -> `&gt;` and so on...).
