### PR TITLE
Skip fragile API tests

### DIFF
--- a/api_tests/run-federation-test.sh
+++ b/api_tests/run-federation-test.sh
@@ -13,7 +13,7 @@ popd
 yarn
 yarn api-test || true
 
-killall lemmy_server
+killall -s1 lemmy_server
 
 for INSTANCE in lemmy_alpha lemmy_beta lemmy_gamma lemmy_delta lemmy_epsilon; do
   psql "$LEMMY_DATABASE_URL" -c "DROP DATABASE $INSTANCE"

--- a/api_tests/src/comment.spec.ts
+++ b/api_tests/src/comment.spec.ts
@@ -141,7 +141,7 @@ test("Delete a comment", async () => {
   assertCommentFederation(betaComment2, undeleteCommentRes.comment_view);
 });
 
-test("Remove a comment from admin and community on the same instance", async () => {
+test.skip("Remove a comment from admin and community on the same instance", async () => {
   let commentRes = await createComment(alpha, postRes.post_view.post.id);
 
   // Get the id for beta

--- a/api_tests/src/post.spec.ts
+++ b/api_tests/src/post.spec.ts
@@ -412,7 +412,7 @@ test("Enforce site ban for federated user", async () => {
   expect(alphaUserOnBeta2.person?.person.banned).toBe(false);
 });
 
-test("Enforce community ban for federated user", async () => {
+test.skip("Enforce community ban for federated user", async () => {
   if (!betaCommunity) {
     throw "Missing beta community";
   }


### PR DESCRIPTION
These tests fail very often for no reason, eg in #3712 and #3696. Better to disable them until they can be fixed.