### PR TITLE
remove performance-problematic and buggy duplicate site aggregates

### DIFF
--- a/migrations/2023-07-26-222023_site-aggregates-one/down.sql
+++ b/migrations/2023-07-26-222023_site-aggregates-one/down.sql
@@ -1,0 +1,11 @@
+create or replace function site_aggregates_site()
+returns trigger language plpgsql
+as $$
+begin
+  IF (TG_OP = 'INSERT') THEN
+    insert into site_aggregates (site_id) values (NEW.id);
+  ELSIF (TG_OP = 'DELETE') THEN
+    delete from site_aggregates where site_id = OLD.id;
+  END IF;
+  return null;
+end $$;

--- a/migrations/2023-07-26-222023_site-aggregates-one/up.sql
+++ b/migrations/2023-07-26-222023_site-aggregates-one/up.sql
@@ -1,0 +1,15 @@
+create or replace function site_aggregates_site()
+returns trigger language plpgsql
+as $$
+begin
+  -- we only ever want to have a single value in site_aggregate because the site_aggregate triggers update all rows in that table.
+  -- a cleaner check would be to insert it for the local_site but that would break assumptions at least in the tests
+  IF (TG_OP = 'INSERT') AND NOT EXISTS (select id from site_aggregates limit 1) THEN
+    insert into site_aggregates (site_id) values (NEW.id);
+  ELSIF (TG_OP = 'DELETE') THEN
+    delete from site_aggregates where site_id = OLD.id;
+  END IF;
+  return null;
+end $$;
+
+delete from site_aggregates a where not exists (select id from local_site s where s.site_id = a.site_id);


### PR DESCRIPTION
site_aggregates currently contains an entry for every site. But all the triggers as well as the rust code assume there is only one row in site_aggregates.

This SQL migration removes all site_aggregates apart from the one belonging to local_site as well as prevents insertion of more than one row.

This should have the same performance effect as  https://github.com/LemmyNet/lemmy/pull/3704, that is, it should significantly speed up deletes of posts and comments (https://github.com/LemmyNet/lemmy/issues/3165), but it's a simpler change and based on what dessalines commented there.

It is part of the solution to #3528 