### PR TITLE
Include Prometheus in default build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,14 +314,15 @@ dependencies = [
 
 [[package]]
 name = "actix-web-prom"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df3127d20a5d01c9fc9aceb969a38d31a6767e1b48a54d55a8f56c769a84923"
+checksum = "f23f332a652836b8f3a6876103c70c9ed436d0e69fa779ab5d7f57b1d5c8d488"
 dependencies = [
  "actix-web",
  "futures-core",
  "pin-project-lite",
  "prometheus",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ console = [
   "reqwest-tracing/opentelemetry_0_16",
 ]
 json-log = ["tracing-subscriber/json"]
-prometheus-metrics = ["prometheus", "actix-web-prom"]
 default = []
 
 [workspace]
@@ -166,5 +165,5 @@ futures-util = { workspace = true }
 tokio-postgres = { workspace = true }
 tokio-postgres-rustls = { workspace = true }
 chrono = { workspace = true }
-prometheus = { version = "0.13.3", features = ["process"], optional = true }
-actix-web-prom = { version = "0.6.0", optional = true }
+prometheus = { version = "0.13.3", features = ["process"] }
+actix-web-prom = "0.7.0"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - RUST_BACKTRACE=full
     ports:
       # prometheus metrics available at the path /metrics on port 10002 by default
-      # enable prometheus metrics by setting the CARGO_BUILD_FEATURES build arg above to "prometheus-metrics"
+      # see https://join-lemmy.org/docs/administration/prometheus.html
       - "10002:10002"
     volumes:
       - ./lemmy.hjson:/config/config.hjson:Z

--- a/docker/lemmy.hjson
+++ b/docker/lemmy.hjson
@@ -23,5 +23,10 @@
     # api_key: "API_KEY"
   }
 
+  # prometheus: {
+  #   bind: "0.0.0.0"
+  #   port: 10002
+  # }
+
   #opentelemetry_url: "http://otel:4137"
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ use url::Url;
 use {
   actix_web_prom::PrometheusMetricsBuilder,
   prometheus::default_registry,
-  prometheus_metrics::serve_prometheus,
+  prometheus_metrics::serve_prometheus_metrics,
 };
 
 /// Max timeout for http requests
@@ -145,7 +145,7 @@ pub async fn start_lemmy_server() -> Result<(), LemmyError> {
   }
 
   #[cfg(feature = "prometheus-metrics")]
-  serve_prometheus(settings.prometheus.as_ref(), context.clone());
+  serve_prometheus_metrics(settings.prometheus.as_ref(), context.clone());
 
   let settings_bind = settings.clone();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ use reqwest::Client;
 use reqwest_middleware::ClientBuilder;
 use reqwest_tracing::TracingMiddleware;
 use std::{env, thread, time::Duration};
-use tracing::subscriber::set_global_default;
+use tracing::{info, subscriber::set_global_default};
 use tracing_actix_web::TracingLogger;
 use tracing_error::ErrorLayer;
 use tracing_log::LogTracer;
@@ -140,7 +140,10 @@ pub async fn start_lemmy_server() -> Result<(), LemmyError> {
     });
   }
 
-  serve_prometheus_metrics(settings.prometheus.as_ref(), context.clone());
+  match settings.prometheus.is_some() {
+    true => serve_prometheus_metrics(settings.prometheus.as_ref(), context.clone()),
+    false => info!("No Prometheus config provided, will not start Prometheus server"),
+  }
 
   let settings_bind = settings.clone();
 

--- a/src/prometheus_metrics.rs
+++ b/src/prometheus_metrics.rs
@@ -23,12 +23,6 @@ static DEFAULT_BIND: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
 static DEFAULT_PORT: i32 = 10002;
 
 pub fn serve_prometheus_metrics(config: Option<&PrometheusConfig>, lemmy_context: LemmyContext) {
-  // if there is no prometheus config block, disable the server
-  if config.is_none() {
-    eprintln!("No Prometheus config provided, will not start Prometheus server");
-    return;
-  }
-
   let context = Arc::new(PromContext {
     lemmy: lemmy_context,
   });


### PR DESCRIPTION
- Remove `prometheus-metrics` feature flag
- Refactor `prometheus_metrics.rs` to implement the `Collector` trait
- Bumped `actix-web-prom` to the latest version
- Replaced `unwrap()` calls with error handling or at least `expect()`

https://github.com/LemmyNet/lemmy/issues/3558