### PR TITLE
Move entry from .rgignore to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ bindings
 # Database cluster and sockets for testing
 dev_pgdata/
 *.PGSQL.*
+
+# database dumps
+*.sqldump

--- a/.rgignore
+++ b/.rgignore
@@ -1,1 +1,0 @@
-*.sqldump


### PR DESCRIPTION
rg command respects gitignore, and sql dumps should be ignored by git as well. So theres no reason to have a separate file.