### PR TITLE
Use the right JSON element for instance version number

### DIFF
--- a/src/scheduled_tasks.rs
+++ b/src/scheduled_tasks.rs
@@ -392,7 +392,7 @@ fn update_instance_software(conn: &mut PgConnection, user_agent: &str) -> LemmyR
               .domain(instance.domain)
               .updated(Some(naive_now()))
               .software(node_info.software.and_then(|s| s.name))
-              .version(node_info.version.clone())
+              .version(node_info.software.and_then(|s| s.version))
               .build(),
           )
         }


### PR DESCRIPTION
Seems this regression was introduced here https://github.com/LemmyNet/lemmy/commit/7d8cb93b5323eb50bd90afde270685d1ecd07061#diff-004bf329e21663a6e252ebddbfb26242a385ac4dba84352d7ad264c5a2daba23R368

Obviously, this means that instances running 0.18.3 are starting to fill instance version numbers with `2.0` instead of the software version in the JSON. (Which we can see here : https://lemmy.ml/nodeinfo/2.0.json )

This issue can be seen in production here on lemmy.ml (https://lemmy.ml/instances)

Note : This PR has not been tested.