### PR TITLE
Remove unused db view options

### DIFF
--- a/crates/apub/src/api/read_person.rs
+++ b/crates/apub/src/api/read_person.rs
@@ -65,7 +65,7 @@ pub async fn read_person(
     saved_only,
     local_user: local_user_view.as_ref(),
     community_id,
-    is_profile_view: Some(true),
+    is_profile_view: true,
     page,
     limit,
     creator_id,
@@ -75,14 +75,13 @@ pub async fn read_person(
   .await?;
 
   let comments = CommentQuery {
-    local_user: (local_user_view.as_ref()),
-    sort: (sort.map(post_to_comment_sort_type)),
-    saved_only: (saved_only),
-    show_deleted_and_removed: (Some(false)),
-    community_id: (community_id),
-    is_profile_view: Some(true),
-    page: (page),
-    limit: (limit),
+    local_user: local_user_view.as_ref(),
+    sort: sort.map(post_to_comment_sort_type),
+    saved_only,
+    community_id,
+    is_profile_view: true,
+    page,
+    limit,
     creator_id,
     ..Default::default()
   }

--- a/crates/db_views/src/comment_view.rs
+++ b/crates/db_views/src/comment_view.rs
@@ -195,7 +195,6 @@ fn queries<'a>() -> Queries<
       query = query.filter(comment_saved::comment_id.is_not_null());
     }
 
-    let is_profile_view = options.is_profile_view.unwrap_or(false);
     let is_creator = options.creator_id == options.local_user.map(|l| l.person.id);
     // only show deleted comments to creator
     if !is_creator {
@@ -204,7 +203,7 @@ fn queries<'a>() -> Queries<
 
     let is_admin = options.local_user.map(|l| l.person.admin).unwrap_or(false);
     // only show removed comments to admin when viewing user profile
-    if !(is_profile_view && is_admin) {
+    if !(options.is_profile_view && is_admin) {
       query = query.filter(comment::removed.eq(false));
     }
 
@@ -310,8 +309,7 @@ pub struct CommentQuery<'a> {
   pub local_user: Option<&'a LocalUserView>,
   pub search_term: Option<String>,
   pub saved_only: Option<bool>,
-  pub is_profile_view: Option<bool>,
-  pub show_deleted_and_removed: Option<bool>,
+  pub is_profile_view: bool,
   pub page: Option<i64>,
   pub limit: Option<i64>,
   pub max_depth: Option<i32>,

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -212,7 +212,6 @@ fn queries<'a>() -> Queries<
       )
       .select(selection);
 
-    let is_profile_view = options.is_profile_view.unwrap_or(false);
     let is_creator = options.creator_id == options.local_user.map(|l| l.person.id);
     // only show deleted posts to creator
     if is_creator {
@@ -223,7 +222,7 @@ fn queries<'a>() -> Queries<
 
     let is_admin = options.local_user.map(|l| l.person.admin).unwrap_or(false);
     // only show removed posts to admin when viewing user profile
-    if !(is_profile_view && is_admin) {
+    if !(options.is_profile_view && is_admin) {
       query = query
         .filter(community::removed.eq(false))
         .filter(post::removed.eq(false));
@@ -425,7 +424,7 @@ pub struct PostQuery<'a> {
   pub url_search: Option<String>,
   pub saved_only: Option<bool>,
   pub moderator_view: Option<bool>,
-  pub is_profile_view: Option<bool>,
+  pub is_profile_view: bool,
   pub page: Option<i64>,
   pub limit: Option<i64>,
 }

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -915,7 +915,7 @@ mod tests {
     let post_listings_is_admin = PostQuery {
       sort: Some(SortType::New),
       local_user: Some(&data.local_user_view),
-      is_profile_view: Some(true),
+      is_profile_view: true,
       ..Default::default()
     }
     .list(pool)


### PR DESCRIPTION
- `show_deleted_and_removed` option is unused, and leftover from https://github.com/LemmyNet/lemmy/pull/3286
- `is_profile_view` doesnt need to be an option