### PR TITLE
Fix ordering when doing a comment_parent type `list_comments`

### DIFF
--- a/crates/db_views/src/comment_view.rs
+++ b/crates/db_views/src/comment_view.rs
@@ -237,8 +237,8 @@ fn queries<'a>() -> Queries<
 
       query = query.filter(nlevel(comment::path).le(depth_limit));
 
-      // only order if filtering by a post id. DOS potential otherwise and max_depth + !post_id isn't used anyways (afaik)
-      if options.post_id.is_some() {
+      // only order if filtering by a post id, or parent_path. DOS potential otherwise and max_depth + !post_id isn't used anyways (afaik)
+      if options.post_id.is_some() || options.parent_path.is_some() {
         // Always order by the parent path first
         query = query.order_by(subpath(comment::path, 0, -1));
       }

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -308,7 +308,7 @@ fn queries<'a>() -> Queries<
       .unwrap_or(true)
     {
       // Do not hide read posts when it is a user profile view
-      if !is_profile_view {
+      if !options.is_profile_view {
         query = query.filter(post_read::post_id.is_null());
       }
     }


### PR DESCRIPTION
#3717 introduced a regression when fetching `list_comments`, and using the `parent_path`, but not the post_id (which might be missing for pages like `/comment/id`. )

The tree-builders in jerboa and lemmy-ui aren't resilient enough to build comment trees without the correct path order.

https://github.com/LemmyNet/lemmy-ui/issues/1999
https://github.com/LemmyNet/lemmy-ui/pull/2022
Fixes https://github.com/LemmyNet/lemmy/issues/3767
https://github.com/dessalines/jerboa/issues/1109