### PR TITLE
Fix sanitize_html whitespaces

### DIFF
--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -797,12 +797,14 @@ pub fn generate_moderators_url(community_id: &DbUrl) -> Result<DbUrl, LemmyError
 /// Sanitize HTML with default options. Additionally, dont allow bypassing markdown
 /// links and images
 pub fn sanitize_html(data: &str) -> String {
-  let sanitized = ammonia::Builder::default()
+  ammonia::Builder::default()
     .rm_tags(&["a", "img"])
     .clean(data)
-    .to_string();
-  // restore markdown quotes
-  sanitized.replace("&gt;", ">")
+    .to_string()
+    // restore markdown quotes
+    .replace("&gt;", ">")
+    // restore white space
+    .replace("&nbsp;", " ")
 }
 
 pub fn sanitize_html_opt(data: &Option<String>) -> Option<String> {
@@ -839,5 +841,7 @@ mod tests {
     assert_eq!(sanitized, " hello");
     let sanitized = sanitize_html("<img src='http://example.com'> test");
     assert_eq!(sanitized, " test");
+    let sanitized = sanitize_html("Hello&nbsp;World");
+    assert_eq!(sanitized, "Hello World");
   }
 }


### PR DESCRIPTION
ammonia is not replacing `&nbsp;` to spaces when sanitizing html.

Example url for new post testing
https://www.20min.ch/fr/story/espace-mise-en-orbite-reussie-pour-une-mission-lunaire-indienne-905291103206

![image](https://github.com/LemmyNet/lemmy/assets/226090/9d0aeae8-e045-4cf0-ab02-766cec0d3eb9)
