### PR TITLE
PostgreSQL EXPLAIN shows faster performance listing posts for community

### DIFF
--- a/migrations/2023-08-07-131300_add_post_index/down.sql
+++ b/migrations/2023-08-07-131300_add_post_index/down.sql
@@ -1,0 +1,2 @@
+-- Drop the new indexes
+DROP INDEX idx_post_aggregates_community;

--- a/migrations/2023-08-07-131300_add_post_index/down.sql
+++ b/migrations/2023-08-07-131300_add_post_index/down.sql
@@ -1,2 +1,3 @@
 -- Drop the new indexes
 DROP INDEX idx_post_aggregates_community;
+

--- a/migrations/2023-08-07-131300_add_post_index/up.sql
+++ b/migrations/2023-08-07-131300_add_post_index/up.sql
@@ -1,0 +1,3 @@
+-- explain of Diesel generated SELECT queries shows improvement with this index
+-- used both when listing posts for a specific community and in cross-reference for block lists
+CREATE INDEX idx_post_aggregates_community ON post_aggregates (community_id DESC);

--- a/migrations/2023-08-07-131300_add_post_index/up.sql
+++ b/migrations/2023-08-07-131300_add_post_index/up.sql
@@ -1,3 +1,4 @@
 -- explain of Diesel generated SELECT queries shows improvement with this index
 -- used both when listing posts for a specific community and in cross-reference for block lists
 CREATE INDEX idx_post_aggregates_community ON post_aggregates (community_id DESC);
+


### PR DESCRIPTION
with added INDEX on post_aggregates field community_id. Even when it is not part of the compound indexes, PostgreSQL 15.3 seems to utilize it with significant improvement.

There may be a benefit to adding another INDEX on post_aggregates creator_id - when listing a profile?