### PR TITLE
Automatically resolve report when post/comment is removed

### DIFF
--- a/crates/api_crud/src/comment/remove.rs
+++ b/crates/api_crud/src/comment/remove.rs
@@ -10,10 +10,11 @@ use lemmy_api_common::{
 use lemmy_db_schema::{
   source::{
     comment::{Comment, CommentUpdateForm},
+    comment_report::CommentReport,
     moderator::{ModRemoveComment, ModRemoveCommentForm},
     post::Post,
   },
-  traits::Crud,
+  traits::{Crud, Reportable},
 };
 use lemmy_db_views::structs::CommentView;
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
@@ -55,6 +56,9 @@ pub async fn remove_comment(
   )
   .await
   .with_lemmy_type(LemmyErrorType::CouldntUpdateComment)?;
+
+  CommentReport::resolve_all_for_object(&mut context.pool(), comment_id, local_user_view.person.id)
+    .await?;
 
   // Mod tables
   let form = ModRemoveCommentForm {

--- a/crates/api_crud/src/post/remove.rs
+++ b/crates/api_crud/src/post/remove.rs
@@ -11,8 +11,9 @@ use lemmy_db_schema::{
   source::{
     moderator::{ModRemovePost, ModRemovePostForm},
     post::{Post, PostUpdateForm},
+    post_report::PostReport,
   },
-  traits::Crud,
+  traits::{Crud, Reportable},
 };
 use lemmy_utils::error::LemmyError;
 
@@ -53,6 +54,9 @@ pub async fn remove_post(
     },
   )
   .await?;
+
+  PostReport::resolve_all_for_object(&mut context.pool(), post_id, local_user_view.person.id)
+    .await?;
 
   // Mod tables
   let form = ModRemovePostForm {

--- a/crates/db_schema/src/impls/post_report.rs
+++ b/crates/db_schema/src/impls/post_report.rs
@@ -1,6 +1,9 @@
 use crate::{
-  newtypes::{PersonId, PostReportId},
-  schema::post_report::dsl::{post_report, resolved, resolver_id, updated},
+  newtypes::{PersonId, PostId, PostReportId},
+  schema::post_report::{
+    dsl::{post_report, resolved, resolver_id, updated},
+    post_id,
+  },
   source::post_report::{PostReport, PostReportForm},
   traits::Reportable,
   utils::{get_conn, naive_now, DbPool},
@@ -17,6 +20,7 @@ use diesel_async::RunQueryDsl;
 impl Reportable for PostReport {
   type Form = PostReportForm;
   type IdType = PostReportId;
+  type ObjectIdType = PostId;
 
   async fn report(pool: &mut DbPool<'_>, post_report_form: &PostReportForm) -> Result<Self, Error> {
     let conn = &mut get_conn(pool).await?;
@@ -42,6 +46,22 @@ impl Reportable for PostReport {
       .await
   }
 
+  async fn resolve_all_for_object(
+    pool: &mut DbPool<'_>,
+    post_id_: PostId,
+    by_resolver_id: PersonId,
+  ) -> Result<usize, Error> {
+    let conn = &mut get_conn(pool).await?;
+    update(post_report.filter(post_id.eq(post_id_)))
+      .set((
+        resolved.eq(true),
+        resolver_id.eq(by_resolver_id),
+        updated.eq(naive_now()),
+      ))
+      .execute(conn)
+      .await
+  }
+
   async fn unresolve(
     pool: &mut DbPool<'_>,
     report_id: Self::IdType,
@@ -56,5 +76,99 @@ impl Reportable for PostReport {
       ))
       .execute(conn)
       .await
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  #![allow(clippy::unwrap_used)]
+  #![allow(clippy::indexing_slicing)]
+
+  use super::*;
+  use crate::{
+    source::{
+      community::{Community, CommunityInsertForm},
+      instance::Instance,
+      person::{Person, PersonInsertForm},
+      post::{Post, PostInsertForm},
+    },
+    traits::Crud,
+    utils::build_db_pool_for_tests,
+  };
+  use serial_test::serial;
+
+  async fn init(pool: &mut DbPool<'_>) -> (Person, PostReport) {
+    let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
+      .await
+      .unwrap();
+    let person_form = PersonInsertForm::builder()
+      .name("jim".into())
+      .public_key("pubkey".to_string())
+      .instance_id(inserted_instance.id)
+      .build();
+    let person = Person::create(pool, &person_form).await.unwrap();
+
+    let community_form = CommunityInsertForm::builder()
+      .name("test community_4".to_string())
+      .title("nada".to_owned())
+      .public_key("pubkey".to_string())
+      .instance_id(inserted_instance.id)
+      .build();
+    let community = Community::create(pool, &community_form).await.unwrap();
+
+    let form = PostInsertForm::builder()
+      .name("A test post".into())
+      .creator_id(person.id)
+      .community_id(community.id)
+      .build();
+    let post = Post::create(pool, &form).await.unwrap();
+
+    let report_form = PostReportForm {
+      post_id: post.id,
+      creator_id: person.id,
+      reason: "my reason".to_string(),
+      ..Default::default()
+    };
+    let report = PostReport::report(pool, &report_form).await.unwrap();
+    (person, report)
+  }
+
+  #[tokio::test]
+  #[serial]
+  async fn test_resolve_post_report() {
+    let pool = &build_db_pool_for_tests().await;
+    let pool = &mut pool.into();
+
+    let (person, report) = init(pool).await;
+
+    let resolved_count = PostReport::resolve(pool, report.id, person.id)
+      .await
+      .unwrap();
+    assert_eq!(resolved_count, 1);
+
+    let unresolved_count = PostReport::unresolve(pool, report.id, person.id)
+      .await
+      .unwrap();
+    assert_eq!(unresolved_count, 1);
+
+    Person::delete(pool, person.id).await.unwrap();
+    Post::delete(pool, report.post_id).await.unwrap();
+  }
+
+  #[tokio::test]
+  #[serial]
+  async fn test_resolve_all_post_reports() {
+    let pool = &build_db_pool_for_tests().await;
+    let pool = &mut pool.into();
+
+    let (person, report) = init(pool).await;
+
+    let resolved_count = PostReport::resolve_all_for_object(pool, report.post_id, person.id)
+      .await
+      .unwrap();
+    assert_eq!(resolved_count, 1);
+
+    Person::delete(pool, person.id).await.unwrap();
+    Post::delete(pool, report.post_id).await.unwrap();
   }
 }

--- a/crates/db_schema/src/impls/private_message_report.rs
+++ b/crates/db_schema/src/impls/private_message_report.rs
@@ -1,9 +1,6 @@
 use crate::{
   newtypes::{PersonId, PrivateMessageId, PrivateMessageReportId},
-  schema::private_message_report::{
-    dsl::{private_message_report, resolved, resolver_id, updated},
-    private_message_id,
-  },
+  schema::private_message_report::dsl::{private_message_report, resolved, resolver_id, updated},
   source::private_message_report::{PrivateMessageReport, PrivateMessageReportForm},
   traits::Reportable,
   utils::{get_conn, naive_now, DbPool},
@@ -51,9 +48,9 @@ impl Reportable for PrivateMessageReport {
 
   // TODO: this is unused because private message doesnt have remove handler
   async fn resolve_all_for_object(
-    pool: &mut DbPool<'_>,
-    pm_id_: PrivateMessageId,
-    by_resolver_id: PersonId,
+    _pool: &mut DbPool<'_>,
+    _pm_id_: PrivateMessageId,
+    _by_resolver_id: PersonId,
   ) -> Result<usize, Error> {
     unimplemented!()
   }

--- a/crates/db_schema/src/impls/private_message_report.rs
+++ b/crates/db_schema/src/impls/private_message_report.rs
@@ -1,6 +1,9 @@
 use crate::{
-  newtypes::{PersonId, PrivateMessageReportId},
-  schema::private_message_report::dsl::{private_message_report, resolved, resolver_id, updated},
+  newtypes::{PersonId, PrivateMessageId, PrivateMessageReportId},
+  schema::private_message_report::{
+    dsl::{private_message_report, resolved, resolver_id, updated},
+    private_message_id,
+  },
   source::private_message_report::{PrivateMessageReport, PrivateMessageReportForm},
   traits::Reportable,
   utils::{get_conn, naive_now, DbPool},
@@ -17,6 +20,7 @@ use diesel_async::RunQueryDsl;
 impl Reportable for PrivateMessageReport {
   type Form = PrivateMessageReportForm;
   type IdType = PrivateMessageReportId;
+  type ObjectIdType = PrivateMessageId;
 
   async fn report(
     pool: &mut DbPool<'_>,
@@ -43,6 +47,15 @@ impl Reportable for PrivateMessageReport {
       ))
       .execute(conn)
       .await
+  }
+
+  // TODO: this is unused because private message doesnt have remove handler
+  async fn resolve_all_for_object(
+    pool: &mut DbPool<'_>,
+    pm_id_: PrivateMessageId,
+    by_resolver_id: PersonId,
+  ) -> Result<usize, Error> {
+    unimplemented!()
   }
 
   async fn unresolve(

--- a/crates/db_schema/src/source/post_report.rs
+++ b/crates/db_schema/src/source/post_report.rs
@@ -30,7 +30,7 @@ pub struct PostReport {
   pub updated: Option<chrono::NaiveDateTime>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = post_report))]
 pub struct PostReportForm {

--- a/crates/db_schema/src/traits.rs
+++ b/crates/db_schema/src/traits.rs
@@ -155,6 +155,7 @@ pub trait Readable {
 pub trait Reportable {
   type Form;
   type IdType;
+  type ObjectIdType;
   async fn report(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<Self, Error>
   where
     Self: Sized;
@@ -162,6 +163,13 @@ pub trait Reportable {
     pool: &mut DbPool<'_>,
     report_id: Self::IdType,
     resolver_id: PersonId,
+  ) -> Result<usize, Error>
+  where
+    Self: Sized;
+  async fn resolve_all_for_object(
+    pool: &mut DbPool<'_>,
+    comment_id_: Self::ObjectIdType,
+    by_resolver_id: PersonId,
   ) -> Result<usize, Error>
   where
     Self: Sized;


### PR DESCRIPTION
At the moment it is necessary to resolve each report separately. This PR simplifies the work of mods by resolving all related reports automatically when a post or comment is removed. It doesnt cover other cases like user ban with "remove content", or removing multiple invalid reports for the same object. Auto-resolve could also be done when the user deletes his own post. But then reports should be restored when the delete is reverted so thats a bit more complicated.