### PR TITLE
Speedup CI

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -53,6 +53,8 @@ pipeline:
       # store cargo data in repo folder so that it gets cached between steps
       CARGO_HOME: .cargo
     commands:
+      # need make existing toolchain available
+      - cp -n ~/.cargo . -r
       - rustup toolchain install nightly-2023-07-10 --profile minimal --component rustfmt
       - cargo +nightly-2023-07-10 fmt -- --check
 

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -227,7 +227,7 @@ pipeline:
       [MINIO_ENDPOINT, MINIO_WRITE_USER, MINIO_WRITE_PASSWORD, MINIO_BUCKET]
     when:
       - event: push
-      - branch: main
+        branch: main
 
   publish_release_docker:
     image: woodpeckerci/plugin-docker-buildx

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -55,7 +55,7 @@ pipeline:
     commands:
       # need make existing toolchain available
       - cp -n ~/.cargo . -r
-      - rustup toolchain install nightly-2023-07-10 --profile minimal --component rustfmt
+      - rustup toolchain install nightly-2023-07-10 --no-self-update --profile minimal --component rustfmt
       - cargo +nightly-2023-07-10 fmt -- --check
 
   sql_fmt:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -38,16 +38,25 @@ pipeline:
       - git submodule update
 
   prettier_check:
+    group: format
     image: tmknom/prettier:3.0.0
     commands:
       - prettier -c . '!**/volumes' '!**/dist' '!target' '!**/translations'
 
   toml_fmt:
+    group: format
     image: tamasfe/taplo:0.8.1
     commands:
       - taplo format --check
 
+  sql_fmt:
+    group: format
+    image: backplane/pgformatter:latest
+    commands:
+      - ./scripts/sql_format_check.sh
+
   cargo_fmt:
+    group: format
     image: *muslrust_image
     environment:
       # store cargo data in repo folder so that it gets cached between steps
@@ -57,11 +66,6 @@ pipeline:
       - cp -n ~/.cargo . -r
       - rustup toolchain install nightly-2023-07-10 --no-self-update --profile minimal --component rustfmt
       - cargo +nightly-2023-07-10 fmt -- --check
-
-  sql_fmt:
-    image: backplane/pgformatter:latest
-    commands:
-      - ./scripts/sql_format_check.sh
 
   restore-cache:
     image: meltwater/drone-cache:v1

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -166,7 +166,17 @@ pipeline:
         -D clippy::indexing_slicing
     when: *slow_check_paths
 
+  cargo_build:
+    image: *muslrust_image
+    environment:
+      CARGO_HOME: .cargo
+    commands:
+      - cargo build
+      - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server
+    when: *slow_check_paths
+
   cargo_test:
+    group: tests
     image: *muslrust_image
     environment:
       LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
@@ -177,16 +187,8 @@ pipeline:
       - cargo test --workspace --no-fail-fast
     when: *slow_check_paths
 
-  cargo_build:
-    image: *muslrust_image
-    environment:
-      CARGO_HOME: .cargo
-    commands:
-      - cargo build
-      - mv target/x86_64-unknown-linux-musl/debug/lemmy_server target/lemmy_server
-    when: *slow_check_paths
-
   run_federation_tests:
+    group: tests
     image: node:alpine
     environment:
       LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -53,23 +53,13 @@ pipeline:
       # store cargo data in repo folder so that it gets cached between steps
       CARGO_HOME: .cargo
     commands:
-      # need make existing toolchain available
-      - cp -n ~/.cargo . -r
-      - rustup toolchain install nightly-2023-07-10
-      - rustup component add rustfmt --toolchain nightly-2023-07-10
+      - rustup toolchain install nightly-2023-07-10 --profile minimal --component rustfmt
       - cargo +nightly-2023-07-10 fmt -- --check
 
   sql_fmt:
-    image: alpine:3
+    image: backplane/pgformatter:latest
     commands:
-      - apk add bash wget perl make git
-      - wget https://github.com/darold/pgFormatter/archive/refs/tags/v5.5.tar.gz
-      - tar xzf v5.5.tar.gz
-      - cd pgFormatter-5.5
-      - perl Makefile.PL
-      - make && make install
-      - cd ..
-      - ./scripts/./sql_format_check.sh
+      - ./scripts/sql_format_check.sh
 
   restore-cache:
     image: meltwater/drone-cache:v1
@@ -231,7 +221,9 @@ pipeline:
         - "api_tests/node_modules"
     secrets:
       [MINIO_ENDPOINT, MINIO_WRITE_USER, MINIO_WRITE_PASSWORD, MINIO_BUCKET]
-    when: *slow_check_paths
+    when:
+      - event: push
+      - branch: main
 
   publish_release_docker:
     image: woodpeckerci/plugin-docker-buildx


### PR DESCRIPTION
- only install minimal nightly toolchain, dont do self-update
- use prebuilt pgformatter image
- only update cache on main branch, not after every pr build
- run unit tests and api tests in parallel