### PR TITLE
Update .woodpecker.yml use steps instead

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -29,7 +29,7 @@ variables:
 #       recursive: true
 #       submodule_update_remote: true
 
-pipeline:
+steps:
   prepare_repo:
     image: alpine:3
     commands:


### PR DESCRIPTION
Pipeline syntax changed in V1 it now is steps instead of pipeline see https://woodpecker-ci.org/docs/usage/pipeline-syntax