### PR TITLE
Lowercase domain on db query filters (#3849)

### DIFF
--- a/crates/apub/src/lib.rs
+++ b/crates/apub/src/lib.rs
@@ -84,7 +84,7 @@ fn check_apub_id_valid(apub_id: &Url, local_site_data: &LocalSiteData) -> Result
   if local_site_data
     .blocked_instances
     .iter()
-    .any(|i| domain.eq(&i.domain))
+    .any(|i| domain.eq(&i.domain.to_lowercase()))
   {
     Err(LemmyErrorType::DomainBlocked(domain.clone()))?;
   }
@@ -94,7 +94,7 @@ fn check_apub_id_valid(apub_id: &Url, local_site_data: &LocalSiteData) -> Result
     && !local_site_data
       .allowed_instances
       .iter()
-      .any(|i| domain.eq(&i.domain))
+      .any(|i| domain.eq(&i.domain.to_lowercase()))
   {
     Err(LemmyErrorType::DomainNotInAllowList(domain))?;
   }

--- a/crates/db_schema/src/impls/community.rs
+++ b/crates/db_schema/src/impls/community.rs
@@ -334,7 +334,7 @@ impl ApubActor for Community {
     community::table
       .inner_join(instance::table)
       .filter(lower(community::name).eq(community_name.to_lowercase()))
-      .filter(instance::domain.eq(for_domain))
+      .filter(instance::domain.eq(for_domain.to_lowercase()))
       .select(community::all_columns)
       .first::<Self>(conn)
       .await

--- a/crates/db_schema/src/impls/instance.rs
+++ b/crates/db_schema/src/impls/instance.rs
@@ -23,7 +23,7 @@ impl Instance {
 
     // First try to read the instance row and return directly if found
     let instance = instance::table
-      .filter(domain.eq(&domain_))
+      .filter(domain.eq(&domain_.to_lowercase()))
       .first::<Self>(conn)
       .await;
     match instance {

--- a/crates/db_schema/src/impls/person.rs
+++ b/crates/db_schema/src/impls/person.rs
@@ -141,7 +141,7 @@ impl ApubActor for Person {
     person::table
       .inner_join(instance::table)
       .filter(lower(person::name).eq(person_name.to_lowercase()))
-      .filter(instance::domain.eq(for_domain))
+      .filter(instance::domain.eq(for_domain.to_lowercase()))
       .select(person::all_columns)
       .first::<Self>(conn)
       .await


### PR DESCRIPTION
Might fix #3849, which depends whether domains are always stored lowercase or not. 

It seems this is the case for community name, as the query parameter for the community name is always lower-cased on the queries.

Updated all the instances where the `domain` passed as a filter.