### PR TITLE
WIP: Local only communities

### DIFF
--- a/crates/api_common/src/community.rs
+++ b/crates/api_common/src/community.rs
@@ -55,6 +55,8 @@ pub struct CreateCommunity {
   pub nsfw: Option<bool>,
   /// Whether to restrict posting only to moderators.
   pub posting_restricted_to_mods: Option<bool>,
+  /// Whether to restrict posting only to local users.
+  pub posting_restricted_to_local: Option<bool>,
   pub discussion_languages: Option<Vec<LanguageId>>,
   pub auth: Sensitive<String>,
 }
@@ -152,6 +154,8 @@ pub struct EditCommunity {
   pub nsfw: Option<bool>,
   /// Whether to restrict posting only to moderators.
   pub posting_restricted_to_mods: Option<bool>,
+  /// Whether to restrict posting only to local users.
+  pub posting_restricted_to_local: Option<bool>,
   pub discussion_languages: Option<Vec<LanguageId>>,
   pub auth: Sensitive<String>,
 }

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -209,6 +209,22 @@ pub async fn check_community_ban(
 }
 
 #[tracing::instrument(skip_all)]
+pub async fn check_can_post_to_local_only_community(
+  person: &Person,
+  community_id: CommunityId,
+  pool: &mut DbPool<'_>,
+) -> Result<(), LemmyError> {
+  let community = Community::read(pool, community_id)
+    .await
+    .with_lemmy_type(LemmyErrorType::CouldntFindCommunity)?;
+  if community.local && person.local {
+    Ok(())
+  } else {
+    Err(LemmyErrorType::OnlyLocalCanPostInCommunity)?
+  }
+}
+
+#[tracing::instrument(skip_all)]
 pub async fn check_community_deleted_or_removed(
   community_id: CommunityId,
   pool: &mut DbPool<'_>,

--- a/crates/api_crud/src/comment/create.rs
+++ b/crates/api_crud/src/comment/create.rs
@@ -6,6 +6,7 @@ use lemmy_api_common::{
   context::LemmyContext,
   send_activity::{ActivityChannel, SendActivityData},
   utils::{
+    check_can_post_to_local_only_community,
     check_community_ban,
     check_community_deleted_or_removed,
     check_post_deleted_or_removed,
@@ -62,6 +63,12 @@ pub async fn create_comment(
   check_community_ban(local_user_view.person.id, community_id, &mut context.pool()).await?;
   check_community_deleted_or_removed(community_id, &mut context.pool()).await?;
   check_post_deleted_or_removed(&post)?;
+  check_can_post_to_local_only_community(
+    &local_user_view.person,
+    community_id,
+    &mut context.pool(),
+  )
+  .await?;
 
   // Check if post is locked, no new comments
   if post.locked {

--- a/crates/api_crud/src/community/create.rs
+++ b/crates/api_crud/src/community/create.rs
@@ -99,6 +99,7 @@ pub async fn create_community(
     .inbox_url(Some(generate_inbox_url(&community_actor_id)?))
     .shared_inbox_url(Some(generate_shared_inbox_url(&community_actor_id)?))
     .posting_restricted_to_mods(data.posting_restricted_to_mods)
+    .posting_restricted_to_local(data.posting_restricted_to_local)
     .instance_id(site_view.site.instance_id)
     .build();
 

--- a/crates/api_crud/src/community/update.rs
+++ b/crates/api_crud/src/community/update.rs
@@ -72,6 +72,7 @@ pub async fn update_community(
     banner,
     nsfw: data.nsfw,
     posting_restricted_to_mods: data.posting_restricted_to_mods,
+    posting_restricted_to_local: data.posting_restricted_to_local,
     updated: Some(Some(naive_now())),
     ..Default::default()
   };

--- a/crates/api_crud/src/post/create.rs
+++ b/crates/api_crud/src/post/create.rs
@@ -86,6 +86,12 @@ pub async fn create_post(
     }
   }
 
+  if community.posting_restricted_to_local {
+    if !local_user_view.person.local {
+      return Err(LemmyErrorType::OnlyLocalCanPostInCommunity)?;
+    }
+  }
+
   // Fetch post links and pictrs cached image
   let (metadata_res, thumbnail_url) =
     fetch_site_data(context.client(), context.settings(), data_url, true).await;

--- a/crates/apub/src/objects/comment.rs
+++ b/crates/apub/src/objects/comment.rs
@@ -138,11 +138,6 @@ impl Object for ApubComment {
     verify_is_public(&note.to, &note.cc)?;
     let community = note.community(context).await?;
 
-    // assuming everything hitting this code path is remote
-    if community.posting_restricted_to_local {
-      return Err(LemmyErrorType::OnlyLocalCanPostInCommunity)?;
-    }
-
     check_apub_id_valid_with_strictness(note.id.inner(), community.local, context).await?;
     verify_is_remote_object(note.id.inner(), context.settings())?;
     verify_person_in_community(&note.attributed_to, &community, context).await?;

--- a/crates/apub/src/objects/comment.rs
+++ b/crates/apub/src/objects/comment.rs
@@ -138,6 +138,11 @@ impl Object for ApubComment {
     verify_is_public(&note.to, &note.cc)?;
     let community = note.community(context).await?;
 
+    // assuming everything hitting this code path is remote
+    if community.posting_restricted_to_local {
+      return Err(LemmyErrorType::OnlyLocalCanPostInCommunity)?;
+    }
+
     check_apub_id_valid_with_strictness(note.id.inner(), community.local, context).await?;
     verify_is_remote_object(note.id.inner(), context.settings())?;
     verify_person_in_community(&note.attributed_to, &community, context).await?;

--- a/crates/apub/src/objects/community.rs
+++ b/crates/apub/src/objects/community.rs
@@ -110,6 +110,7 @@ impl Object for ApubCommunity {
       published: Some(convert_datetime(self.published)),
       updated: self.updated.map(convert_datetime),
       posting_restricted_to_mods: Some(self.posting_restricted_to_mods),
+      posting_restricted_to_local: Some(self.posting_restricted_to_local),
       attributed_to: Some(generate_moderators_url(&self.actor_id)?.into()),
     };
     Ok(group)

--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -45,7 +45,7 @@ use lemmy_db_schema::{
   traits::Crud,
 };
 use lemmy_utils::{
-  error::LemmyError,
+  error::{LemmyError, LemmyErrorType},
   utils::{
     markdown::markdown_to_html,
     slurs::{check_slurs_opt, remove_slurs},
@@ -172,6 +172,11 @@ impl Object for ApubPost {
     let community = page.community(context).await?;
     if community.posting_restricted_to_mods {
       is_mod_or_admin(&mut context.pool(), creator.id, community.id).await?;
+    }
+    if community.posting_restricted_to_local {
+      if !creator.local {
+        return Err(LemmyErrorType::OnlyLocalCanPostInCommunity)?;
+      }
     }
     let mut name = page
       .name

--- a/crates/apub/src/protocol/objects/group.rs
+++ b/crates/apub/src/protocol/objects/group.rs
@@ -68,6 +68,7 @@ pub struct Group {
   pub(crate) attributed_to: Option<CollectionId<ApubCommunityModerators>>,
   // lemmy extension
   pub(crate) posting_restricted_to_mods: Option<bool>,
+  pub(crate) posting_restricted_to_local: Option<bool>,
   pub(crate) outbox: CollectionId<ApubCommunityOutbox>,
   pub(crate) endpoints: Option<Endpoints>,
   pub(crate) featured: Option<CollectionId<ApubCommunityFeatured>>,
@@ -124,6 +125,7 @@ impl Group {
       shared_inbox_url: self.endpoints.map(|e| e.shared_inbox.into()),
       moderators_url: self.attributed_to.map(Into::into),
       posting_restricted_to_mods: self.posting_restricted_to_mods,
+      posting_restricted_to_local: self.posting_restricted_to_local,
       instance_id,
       featured_url: self.featured.map(Into::into),
     }
@@ -155,6 +157,7 @@ impl Group {
       shared_inbox_url: Some(self.endpoints.map(|e| e.shared_inbox.into())),
       moderators_url: self.attributed_to.map(Into::into),
       posting_restricted_to_mods: self.posting_restricted_to_mods,
+      posting_restricted_to_local: self.posting_restricted_to_local,
       featured_url: self.featured.map(Into::into),
     }
   }

--- a/crates/db_schema/src/impls/community.rs
+++ b/crates/db_schema/src/impls/community.rs
@@ -418,6 +418,7 @@ mod tests {
       featured_url: None,
       hidden: false,
       posting_restricted_to_mods: false,
+      posting_restricted_to_local: false,
       instance_id: inserted_instance.id,
     };
 

--- a/crates/db_schema/src/schema.rs
+++ b/crates/db_schema/src/schema.rs
@@ -175,6 +175,7 @@ diesel::table! {
         moderators_url -> Nullable<Varchar>,
         #[max_length = 255]
         featured_url -> Nullable<Varchar>,
+        posting_restricted_to_local -> Bool,
     }
 }
 

--- a/crates/db_schema/src/source/community.rs
+++ b/crates/db_schema/src/source/community.rs
@@ -62,6 +62,8 @@ pub struct Community {
   /// Url where featured posts collection is served over Activitypub
   #[serde(skip)]
   pub featured_url: Option<DbUrl>,
+  /// Whether posting is restricted to local users only.
+  pub posting_restricted_to_local: bool,
 }
 
 #[derive(Debug, Clone, TypedBuilder)]
@@ -93,6 +95,7 @@ pub struct CommunityInsertForm {
   pub featured_url: Option<DbUrl>,
   pub hidden: Option<bool>,
   pub posting_restricted_to_mods: Option<bool>,
+  pub posting_restricted_to_local: Option<bool>,
   #[builder(!default)]
   pub instance_id: InstanceId,
 }
@@ -122,6 +125,7 @@ pub struct CommunityUpdateForm {
   pub featured_url: Option<DbUrl>,
   pub hidden: Option<bool>,
   pub posting_restricted_to_mods: Option<bool>,
+  pub posting_restricted_to_local: Option<bool>,
 }
 
 #[derive(PartialEq, Eq, Debug)]

--- a/crates/db_views/src/comment_report_view.rs
+++ b/crates/db_views/src/comment_report_view.rs
@@ -391,6 +391,7 @@ mod tests {
         banner: None,
         hidden: false,
         posting_restricted_to_mods: false,
+        posting_restricted_to_local: false,
         published: inserted_community.published,
         private_key: inserted_community.private_key,
         public_key: inserted_community.public_key,

--- a/crates/db_views/src/comment_view.rs
+++ b/crates/db_views/src/comment_view.rs
@@ -899,6 +899,7 @@ mod tests {
         banner: None,
         hidden: false,
         posting_restricted_to_mods: false,
+        posting_restricted_to_local: false,
         published: data.inserted_community.published,
         instance_id: data.inserted_instance.id,
         private_key: data.inserted_community.private_key.clone(),

--- a/crates/db_views/src/post_report_view.rs
+++ b/crates/db_views/src/post_report_view.rs
@@ -348,6 +348,7 @@ mod tests {
         banner: None,
         hidden: false,
         posting_restricted_to_mods: false,
+        posting_restricted_to_local: false,
         published: inserted_community.published,
         instance_id: inserted_instance.id,
         private_key: inserted_community.private_key.clone(),

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -1103,6 +1103,7 @@ mod tests {
         banner: None,
         hidden: false,
         posting_restricted_to_mods: false,
+        posting_restricted_to_local: false,
         published: inserted_community.published,
         instance_id: data.inserted_instance.id,
         private_key: inserted_community.private_key.clone(),

--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -118,6 +118,7 @@ pub enum LemmyErrorType {
   CommunityAlreadyExists,
   LanguageNotAllowed,
   OnlyModsCanPostInCommunity,
+  OnlyLocalCanPostInCommunity,
   CouldntUpdatePost,
   NoPostEditAllowed,
   CouldntFindPost,

--- a/migrations/2023-08-19-082311_local_only_communities/down.sql
+++ b/migrations/2023-08-19-082311_local_only_communities/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE community
+    DROP COLUMN posting_restricted_to_local;

--- a/migrations/2023-08-19-082311_local_only_communities/up.sql
+++ b/migrations/2023-08-19-082311_local_only_communities/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE community
+    ADD COLUMN posting_restricted_to_local boolean DEFAULT FALSE NOT NULL;


### PR DESCRIPTION
Adds a new flag to communities to mark them as "local only".

Unlike other fediverse software these communities will still federate, but posts will be effectively locked to those who are not in the same instance as the community.

This is an untested proof of concept hacked together in a few hours. I'm sending it just to get feedback on my overall approach. (And of course asking if upstream even wants this functionality in the first place)

Use lemmy-ui from https://github.com/ShittyKopper/lemmy-ui/tree/feat/local_only_communities, requires TS binding regeneration.