### PR TITLE
Post list date ranges - establish post/list API parameters when_before when_after targeted published dates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2738,6 +2738,7 @@ dependencies = [
 name = "lemmy_db_views"
 version = "0.18.1"
 dependencies = [
+ "chrono",
  "diesel",
  "diesel-async",
  "diesel_ltree",

--- a/crates/api_common/src/post.rs
+++ b/crates/api_common/src/post.rs
@@ -78,6 +78,9 @@ pub struct GetPosts {
   pub liked_only: Option<bool>,
   pub disliked_only: Option<bool>,
   pub moderator_view: Option<bool>,
+  // optional when_* parameters are in millioseconds since 00:00:00 UTC on 1 January 1970
+  pub when_before: Option<i64>,
+  pub when_after: Option<i64>,
   pub auth: Option<Sensitive<String>>,
 }
 

--- a/crates/api_common/src/post.rs
+++ b/crates/api_common/src/post.rs
@@ -78,8 +78,9 @@ pub struct GetPosts {
   pub liked_only: Option<bool>,
   pub disliked_only: Option<bool>,
   pub moderator_view: Option<bool>,
-  // optional when_* parameters are in milliseconds since 00:00:00 UTC on 1 January 1970
+  /// optional post <= filtering parameter in milliseconds since 00:00:00 UTC on 1 January 1970 (unix time millis)
   pub when_before: Option<i64>,
+  /// optional post >= filtering parameter in milliseconds since 00:00:00 UTC on 1 January 1970 (unix time millis)
   pub when_after: Option<i64>,
   pub auth: Option<Sensitive<String>>,
 }

--- a/crates/api_common/src/post.rs
+++ b/crates/api_common/src/post.rs
@@ -78,7 +78,7 @@ pub struct GetPosts {
   pub liked_only: Option<bool>,
   pub disliked_only: Option<bool>,
   pub moderator_view: Option<bool>,
-  // optional when_* parameters are in millioseconds since 00:00:00 UTC on 1 January 1970
+  // optional when_* parameters are in milliseconds since 00:00:00 UTC on 1 January 1970
   pub when_before: Option<i64>,
   pub when_after: Option<i64>,
   pub auth: Option<Sensitive<String>>,

--- a/crates/apub/src/api/list_posts.rs
+++ b/crates/apub/src/api/list_posts.rs
@@ -26,6 +26,9 @@ pub async fn list_posts(
 
   let sort = data.sort;
 
+  let when_before = data.when_before;
+  let when_after = data.when_after;
+
   let page = data.page;
   let limit = data.limit;
   let community_id = if let Some(name) = &data.community_name {
@@ -61,6 +64,8 @@ pub async fn list_posts(
     moderator_view,
     page,
     limit,
+    when_before,
+    when_after,
     ..Default::default()
   }
   .list(&mut context.pool())

--- a/crates/db_views/Cargo.toml
+++ b/crates/db_views/Cargo.toml
@@ -30,6 +30,7 @@ serde = { workspace = true }
 serde_with = { workspace = true }
 tracing = { workspace = true, optional = true }
 ts-rs = { workspace = true, optional = true }
+chrono = { workspace = true }
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -449,7 +449,7 @@ pub struct PostQuery<'a> {
   pub is_profile_view: bool,
   pub page: Option<i64>,
   pub limit: Option<i64>,
-  // optional when_* parameters are in millioseconds since 00:00:00 UTC on 1 January 1970
+  // optional when_* parameters are in milliseconds since 00:00:00 UTC on 1 January 1970
   pub when_before: Option<i64>,
   pub when_after: Option<i64>,
 }

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -386,7 +386,7 @@ fn queries<'a>() -> Queries<
 
     let (limit, offset) = limit_and_offset(options.page, options.limit)?;
 
-    // when_before and when_after to filter queries.
+    // when_before and when_after to filter posts by specified published date.
     // ToDo: establish default convention, likley specific to the sort choice picked
     // For "Top*" sorting, this allows custom range, overrides filtering that sort choice previously set
     if let Some(when_before) = options.when_before {

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -433,6 +433,9 @@ pub struct PostQuery<'a> {
   pub is_profile_view: bool,
   pub page: Option<i64>,
   pub limit: Option<i64>,
+  // optional when_* parameters are in millioseconds since 00:00:00 UTC on 1 January 1970
+  pub when_before: Option<i64>,
+  pub when_after: Option<i64>,
 }
 
 impl<'a> PostQuery<'a> {

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -386,6 +386,22 @@ fn queries<'a>() -> Queries<
 
     let (limit, offset) = limit_and_offset(options.page, options.limit)?;
 
+    // when_before and when_after to filter queries.
+    // ToDo: establish default convention, likley specific to the sort choice picked
+    // For "Top*" sorting, this allows custom range, overrides filtering that sort choice previously set
+    if let Some(when_before) = options.when_before {
+      let parsed_when_before = chrono::NaiveDateTime::from_timestamp_millis(when_before);
+      if let Some(when_before_ndt) = parsed_when_before {
+        query = query.filter(post_aggregates::published.le(when_before_ndt));
+      }
+    }
+    if let Some(when_after) = options.when_after {
+      let parsed_when_after = chrono::NaiveDateTime::from_timestamp_millis(when_after);
+      if let Some(when_after_ndt) = parsed_when_after {
+        query = query.filter(post_aggregates::published.ge(when_after_ndt));
+      }
+    }
+
     query = query.limit(limit).offset(offset);
 
     debug!("Post View Query: {:?}", debug_query::<Pg, _>(&query));

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -387,7 +387,8 @@ fn queries<'a>() -> Queries<
     let (limit, offset) = limit_and_offset(options.page, options.limit)?;
 
     // when_before and when_after to filter posts by specified published date.
-    // ToDo: establish default convention, likley specific to the sort choice picked
+    // TODO: establish default convention, likley specific to the sort choice picked
+    // TODO: there is a pending change to eliminate NaiveDateTime https://github.com/LemmyNet/lemmy/pull/3496
     // For "Top*" sorting, this allows custom range, overrides filtering that sort choice previously set
     if let Some(when_before) = options.when_before {
       let parsed_when_before = chrono::NaiveDateTime::from_timestamp_millis(when_before);
@@ -449,8 +450,9 @@ pub struct PostQuery<'a> {
   pub is_profile_view: bool,
   pub page: Option<i64>,
   pub limit: Option<i64>,
-  // optional when_* parameters are in milliseconds since 00:00:00 UTC on 1 January 1970
+  /// optional post <= filtering parameter in milliseconds since 00:00:00 UTC on 1 January 1970 (unix time millis)
   pub when_before: Option<i64>,
+  /// optional post >= filtering parameter in milliseconds since 00:00:00 UTC on 1 January 1970 (unix time millis)
   pub when_after: Option<i64>,
 }
 


### PR DESCRIPTION
This establishes two new API parameters for post/list API. Intention is to facilitate PostgreSQL performance-concerned changes, give front-end apps the ability to focus their requests based on time of content, allow more flexibility than fixed "Top 3 months" to "Top 6 months" choices.

Example AP usage calI:  
`curl 'http://lemmy-alpha:8541/api/v3/post/list?limit=1&when_after=1692181907000&sort=Active' ` 
To specify posts published after Wednesday, August 16, 2023 10:31:47 AM UTC