### PR TITLE
Sitemap - use UTC time

### DIFF
--- a/crates/db_schema/src/impls/post.rs
+++ b/crates/db_schema/src/impls/post.rs
@@ -105,7 +105,7 @@ impl Post {
     let conn = &mut get_conn(pool).await?;
     post
       .select((ap_id, coalesce(updated, published)))
-      .filter(local)
+      .filter(local.eq(true))
       .filter(deleted.eq(false))
       .filter(removed.eq(false))
       .filter(published.ge(Utc::now().naive_utc() - Duration::days(1)))

--- a/crates/db_schema/src/impls/post.rs
+++ b/crates/db_schema/src/impls/post.rs
@@ -101,7 +101,7 @@ impl Post {
 
   pub async fn list_for_sitemap(
     pool: &mut DbPool<'_>,
-  ) -> Result<Vec<(DbUrl, chrono::NaiveDateTime)>, Error> {
+  ) -> Result<Vec<(DbUrl, chrono::DateTime<Utc>)>, Error> {
     let conn = &mut get_conn(pool).await?;
     post
       .select((ap_id, coalesce(updated, published)))
@@ -110,7 +110,7 @@ impl Post {
       .filter(removed.eq(false))
       .filter(published.ge(Utc::now().naive_utc() - Duration::days(1)))
       .order(published.desc())
-      .load::<(DbUrl, chrono::NaiveDateTime)>(conn)
+      .load::<(DbUrl, chrono::DateTime<Utc>)>(conn)
       .await
   }
 


### PR DESCRIPTION
This PR changes the sitemap generation to use UTC time now that https://github.com/LemmyNet/lemmy/pull/3496 has been merged.

I have also included a small change in 28b65e1ec7e7d9789774c2d097cc1be4d91f8df0 to change the filter statement to use the built-in `eq` function. I can take it out and create a separate PR for it if you want me to.