### PR TITLE
Adding a clippy needless_return lint.

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -170,6 +170,7 @@ steps:
         -D clippy::needless_collect
         -D clippy::unwrap_used
         -D clippy::indexing_slicing
+        -D clippy::needless_return
     when: *slow_check_paths
 
   cargo_build:

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -19,7 +19,8 @@ cargo clippy --workspace --fix --allow-staged --allow-dirty --tests --all-target
   -D clippy::explicit_iter_loop \
   -D clippy::needless_collect \
   -D clippy::unwrap_used \
-  -D clippy::indexing_slicing
+  -D clippy::indexing_slicing \
+  -D clippy::needless_return
 
 # Format rust files
 cargo +nightly fmt


### PR DESCRIPTION
Described here: https://rust-lang.github.io/rust-clippy/stable/index.html#needless_return

I checked and we already should pass this one, but its good to have a deny, just in case.