### PR TITLE
Add logging for pictrs uploads

### DIFF
--- a/crates/db_schema/src/impls/image_upload.rs
+++ b/crates/db_schema/src/impls/image_upload.rs
@@ -1,0 +1,47 @@
+use crate::{
+  newtypes::{ImageUploadId, LocalUserId},
+  schema::image_upload::dsl::{image_upload, local_user_id, pictrs_alias},
+  source::image_upload::{ImageUpload, ImageUploadForm},
+  utils::{get_conn, DbPool},
+};
+use diesel::{insert_into, result::Error, ExpressionMethods, QueryDsl, Table};
+use diesel_async::RunQueryDsl;
+
+impl ImageUpload {
+  pub async fn create(pool: &mut DbPool<'_>, form: &ImageUploadForm) -> Result<Self, Error> {
+    let conn = &mut get_conn(pool).await?;
+    insert_into(image_upload)
+      .values(form)
+      .get_result::<Self>(conn)
+      .await
+  }
+
+  pub async fn get_all_by_local_user_id(
+    pool: &mut DbPool<'_>,
+    user_id: &LocalUserId,
+  ) -> Result<Vec<Self>, Error> {
+    let conn = &mut get_conn(pool).await?;
+    image_upload
+      .filter(local_user_id.eq(user_id))
+      .select(image_upload::all_columns())
+      .load::<ImageUpload>(conn)
+      .await
+  }
+
+  pub async fn delete(
+    pool: &mut DbPool<'_>,
+    image_upload_id: ImageUploadId,
+  ) -> Result<usize, Error> {
+    let conn = &mut get_conn(pool).await?;
+    diesel::delete(image_upload.find(image_upload_id))
+      .execute(conn)
+      .await
+  }
+
+  pub async fn delete_by_alias(pool: &mut DbPool<'_>, alias: &str) -> Result<usize, Error> {
+    let conn = &mut get_conn(pool).await?;
+    diesel::delete(image_upload.filter(pictrs_alias.eq(alias)))
+      .execute(conn)
+      .await
+  }
+}

--- a/crates/db_schema/src/impls/local_user.rs
+++ b/crates/db_schema/src/impls/local_user.rs
@@ -1,11 +1,12 @@
 use crate::{
-  newtypes::LocalUserId,
+  newtypes::{LocalUserId, PersonId},
   schema::local_user::dsl::{
     accepted_application,
     email,
     email_verified,
     local_user,
     password_encrypted,
+    person_id,
     validator_time,
   },
   source::{
@@ -16,7 +17,7 @@ use crate::{
   utils::{get_conn, naive_now, DbPool},
 };
 use bcrypt::{hash, DEFAULT_COST};
-use diesel::{dsl::insert_into, result::Error, ExpressionMethods, QueryDsl};
+use diesel::{dsl::insert_into, result::Error, ExpressionMethods, QueryDsl, Table};
 use diesel_async::RunQueryDsl;
 
 impl LocalUser {
@@ -60,6 +61,15 @@ impl LocalUser {
     let conn = &mut get_conn(pool).await?;
     select(exists(local_user.filter(email.eq(email_))))
       .get_result(conn)
+      .await
+  }
+
+  pub async fn get_by_person_id(pool: &mut DbPool<'_>, id: &PersonId) -> Result<Self, Error> {
+    let conn = &mut get_conn(pool).await?;
+    local_user
+      .filter(person_id.eq(id))
+      .select(local_user::all_columns())
+      .first::<LocalUser>(conn)
       .await
   }
 }

--- a/crates/db_schema/src/impls/local_user.rs
+++ b/crates/db_schema/src/impls/local_user.rs
@@ -1,12 +1,11 @@
 use crate::{
-  newtypes::{LocalUserId, PersonId},
+  newtypes::LocalUserId,
   schema::local_user::dsl::{
     accepted_application,
     email,
     email_verified,
     local_user,
     password_encrypted,
-    person_id,
     validator_time,
   },
   source::{
@@ -17,7 +16,7 @@ use crate::{
   utils::{get_conn, naive_now, DbPool},
 };
 use bcrypt::{hash, DEFAULT_COST};
-use diesel::{dsl::insert_into, result::Error, ExpressionMethods, QueryDsl, Table};
+use diesel::{dsl::insert_into, result::Error, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 
 impl LocalUser {
@@ -61,15 +60,6 @@ impl LocalUser {
     let conn = &mut get_conn(pool).await?;
     select(exists(local_user.filter(email.eq(email_))))
       .get_result(conn)
-      .await
-  }
-
-  pub async fn get_by_person_id(pool: &mut DbPool<'_>, id: &PersonId) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    local_user
-      .filter(person_id.eq(id))
-      .select(local_user::all_columns())
-      .first::<LocalUser>(conn)
       .await
   }
 }

--- a/crates/db_schema/src/impls/mod.rs
+++ b/crates/db_schema/src/impls/mod.rs
@@ -10,6 +10,7 @@ pub mod custom_emoji;
 pub mod email_verification;
 pub mod federation_allowlist;
 pub mod federation_blocklist;
+pub mod image_upload;
 pub mod instance;
 pub mod language;
 pub mod local_site;

--- a/crates/db_schema/src/newtypes.rs
+++ b/crates/db_schema/src/newtypes.rs
@@ -140,6 +140,12 @@ pub struct CommentReplyId(i32);
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[cfg_attr(feature = "full", derive(DieselNewType, TS))]
 #[cfg_attr(feature = "full", ts(export))]
+/// The Image Upload id.
+pub struct ImageUploadId(i32);
+
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize, Default)]
+#[cfg_attr(feature = "full", derive(DieselNewType, TS))]
+#[cfg_attr(feature = "full", ts(export))]
 /// The instance id.
 pub struct InstanceId(i32);
 

--- a/crates/db_schema/src/schema.rs
+++ b/crates/db_schema/src/schema.rs
@@ -300,6 +300,16 @@ diesel::table! {
 }
 
 diesel::table! {
+    image_upload (id) {
+        id -> Int4,
+        local_user_id -> Int4,
+        pictrs_alias -> Text,
+        pictrs_delete_token -> Text,
+        published -> Timestamptz,
+    }
+}
+
+diesel::table! {
     instance (id) {
         id -> Int4,
         #[max_length = 255]
@@ -405,9 +415,9 @@ diesel::table! {
         totp_2fa_secret -> Nullable<Text>,
         totp_2fa_url -> Nullable<Text>,
         open_links_in_new_tab -> Bool,
+        infinite_scroll_enabled -> Bool,
         blur_nsfw -> Bool,
         auto_expand -> Bool,
-        infinite_scroll_enabled -> Bool,
         admin -> Bool,
         post_listing_mode -> PostListingModeEnum,
     }
@@ -893,6 +903,7 @@ diesel::joinable!(custom_emoji_keyword -> custom_emoji (custom_emoji_id));
 diesel::joinable!(email_verification -> local_user (local_user_id));
 diesel::joinable!(federation_allowlist -> instance (instance_id));
 diesel::joinable!(federation_blocklist -> instance (instance_id));
+diesel::joinable!(image_upload -> local_user (local_user_id));
 diesel::joinable!(local_site -> site (site_id));
 diesel::joinable!(local_site_rate_limit -> local_site (local_site_id));
 diesel::joinable!(local_user -> person (person_id));
@@ -967,6 +978,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     email_verification,
     federation_allowlist,
     federation_blocklist,
+    image_upload,
     instance,
     language,
     local_site,

--- a/crates/db_schema/src/source/image_upload.rs
+++ b/crates/db_schema/src/source/image_upload.rs
@@ -1,0 +1,36 @@
+use crate::newtypes::{ImageUploadId, LocalUserId};
+#[cfg(feature = "full")]
+use crate::schema::image_upload;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+use std::fmt::Debug;
+#[cfg(feature = "full")]
+use ts_rs::TS;
+use typed_builder::TypedBuilder;
+
+#[skip_serializing_none]
+#[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "full", derive(Queryable, Associations, Identifiable, TS))]
+#[cfg_attr(feature = "full", diesel(table_name = image_upload))]
+#[cfg_attr(feature = "full", ts(export))]
+#[cfg_attr(
+  feature = "full",
+  diesel(belongs_to(crate::source::local_user::LocalUser))
+)]
+pub struct ImageUpload {
+  pub id: ImageUploadId,
+  pub local_user_id: LocalUserId,
+  pub pictrs_alias: String,
+  pub pictrs_delete_token: String,
+  pub published: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, TypedBuilder)]
+#[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
+#[cfg_attr(feature = "full", diesel(table_name = image_upload))]
+pub struct ImageUploadForm {
+  pub local_user_id: LocalUserId,
+  pub pictrs_alias: String,
+  pub pictrs_delete_token: String,
+}

--- a/crates/db_schema/src/source/mod.rs
+++ b/crates/db_schema/src/source/mod.rs
@@ -15,6 +15,7 @@ pub mod custom_emoji_keyword;
 pub mod email_verification;
 pub mod federation_allowlist;
 pub mod federation_blocklist;
+pub mod image_upload;
 pub mod instance;
 pub mod language;
 pub mod local_site;

--- a/migrations/2023-08-31-205559_add_image_upload/down.sql
+++ b/migrations/2023-08-31-205559_add_image_upload/down.sql
@@ -1,0 +1,2 @@
+DROP TABLE image_upload;
+

--- a/migrations/2023-08-31-205559_add_image_upload/up.sql
+++ b/migrations/2023-08-31-205559_add_image_upload/up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE image_upload (
+    id serial PRIMARY KEY,
+    local_user_id int REFERENCES local_user ON UPDATE CASCADE ON DELETE CASCADE NOT NULL,
+    pictrs_alias text NOT NULL UNIQUE,
+    pictrs_delete_token text NOT NULL,
+    published timestamptz DEFAULT now() NOT NULL
+);
+
+CREATE INDEX idx_image_upload_local_user_id ON image_upload (local_user_id);
+
+CREATE INDEX idx_image_upload_alias ON image_upload (pictrs_alias);
+

--- a/migrations/2023-08-31-205559_add_image_upload/up.sql
+++ b/migrations/2023-08-31-205559_add_image_upload/up.sql
@@ -8,5 +8,3 @@ CREATE TABLE image_upload (
 
 CREATE INDEX idx_image_upload_local_user_id ON image_upload (local_user_id);
 
-CREATE INDEX idx_image_upload_alias ON image_upload (pictrs_alias);
-

--- a/scripts/sql_format_check.sh
+++ b/scripts/sql_format_check.sh
@@ -11,5 +11,5 @@ find migrations -type f -name "*.sql" -print0 | while read -d $'\0' FILE
 do
   TMP_FILE="/tmp/tmp_pg_format.sql"
   pg_format $FILE > $TMP_FILE
-  diff $FILE $TMP_FILE
+  diff -u $FILE $TMP_FILE
 done


### PR DESCRIPTION
Add new table, image_upload to store link between local_user_id and a pictrs image alias. Also update PurgeUser to take this into account.

Also fixed a bug in the url to the pictrs purge that was causing it to always fail.

Should allow for admins to keep track of who is uploading what and when.