### PR TITLE
Change AddAdmin to use person_id instead of local_user_id

### DIFF
--- a/crates/api_common/src/person.rs
+++ b/crates/api_common/src/person.rs
@@ -1,6 +1,6 @@
 use crate::sensitive::Sensitive;
 use lemmy_db_schema::{
-  newtypes::{CommentReplyId, CommunityId, LanguageId, LocalUserId, PersonId, PersonMentionId},
+  newtypes::{CommentReplyId, CommunityId, LanguageId, PersonId, PersonMentionId},
   CommentSortType,
   ListingType,
   SortType,
@@ -198,7 +198,7 @@ pub struct MarkAllAsRead {
 #[cfg_attr(feature = "full", ts(export))]
 /// Adds an admin to a site.
 pub struct AddAdmin {
-  pub local_user_id: LocalUserId,
+  pub person_id: PersonId,
   pub added: bool,
   pub auth: Sensitive<String>,
 }


### PR DESCRIPTION
- Front ends don't have easy access to local_user_id on moddable items like comments and posts.

context: https://github.com/LemmyNet/lemmy-ui/pull/1993#issuecomment-1705666704