### PR TITLE
Add nicer CLI via clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,6 +415,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,40 +959,43 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.32"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
+checksum = "6a13b88d2c62ff462f88e4a121f17a82c1af05693a2f192b5c38d14de73c19f6"
 dependencies = [
- "bitflags 1.3.2",
+ "clap_builder",
  "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
+dependencies = [
+ "anstream",
+ "anstyle",
  "clap_lex",
- "is-terminal",
- "once_cell",
  "strsim",
- "termcolor",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.0.21"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 2.0.25",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.3.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "clokwerk"
@@ -997,6 +1048,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "combine"
@@ -2126,15 +2183,6 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
@@ -2468,18 +2516,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
-name = "is-terminal"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
-dependencies = [
- "hermit-abi 0.2.6",
- "io-lifetimes",
- "rustix 0.36.5",
- "windows-sys 0.42.0",
-]
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2810,6 +2846,7 @@ dependencies = [
  "actix-web",
  "actix-web-prom",
  "chrono",
+ "clap",
  "clokwerk",
  "console-subscriber",
  "diesel",
@@ -3519,12 +3556,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "6.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3900,30 +3931,6 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.103",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -5729,6 +5736,12 @@ name = "utf8-width"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 version = "0.18.1"
 edition = "2021"
-description = "A link aggregator for the fediverse"
+description = "A link aggregator for the fediverse."
 license = "AGPL-3.0"
 homepage = "https://join-lemmy.org/"
 documentation = "https://join-lemmy.org/docs/en/index.html"
@@ -31,13 +31,7 @@ debug = 0
 
 [features]
 embed-pictrs = ["pict-rs"]
-console = [
-  "console-subscriber",
-  "opentelemetry",
-  "opentelemetry-otlp",
-  "tracing-opentelemetry",
-  "reqwest-tracing/opentelemetry_0_16",
-]
+console = ["console-subscriber", "opentelemetry", "opentelemetry-otlp", "tracing-opentelemetry", "reqwest-tracing/opentelemetry_0_16"]
 json-log = ["tracing-subscriber/json"]
 prometheus-metrics = ["prometheus", "actix-web-prom"]
 default = []
@@ -167,3 +161,4 @@ tokio-postgres-rustls = { workspace = true }
 chrono = { workspace = true }
 prometheus = { version = "0.13.3", features = ["process"], optional = true }
 actix-web-prom = { version = "0.6.0", optional = true }
+clap = { version = "4.4.2", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,13 @@ debug = 0
 
 [features]
 embed-pictrs = ["pict-rs"]
-console = ["console-subscriber", "opentelemetry", "opentelemetry-otlp", "tracing-opentelemetry", "reqwest-tracing/opentelemetry_0_16"]
+console = [
+  "console-subscriber",
+  "opentelemetry",
+  "opentelemetry-otlp",
+  "tracing-opentelemetry",
+  "reqwest-tracing/opentelemetry_0_16",
+]
 json-log = ["tracing-subscriber/json"]
 prometheus-metrics = ["prometheus", "actix-web-prom"]
 default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,8 @@ pub mod session_middleware;
 pub mod telemetry;
 
 use crate::{
-  code_migrations::run_advanced_migrations, root_span_builder::QuieterRootSpanBuilder,
+  code_migrations::run_advanced_migrations,
+  root_span_builder::QuieterRootSpanBuilder,
   session_middleware::SessionMiddleware,
 };
 use activitypub_federation::config::{FederationConfig, FederationMiddleware};
@@ -17,7 +18,9 @@ use actix_cors::Cors;
 use actix_web::{
   middleware::{self, ErrorHandlers},
   web::Data,
-  App, HttpServer, Result,
+  App,
+  HttpServer,
+  Result,
 };
 use clap::Parser;
 use lemmy_api_common::{
@@ -26,12 +29,14 @@ use lemmy_api_common::{
   request::build_user_agent,
   send_activity::{ActivityChannel, MATCH_OUTGOING_ACTIVITIES},
   utils::{
-    check_private_instance_and_federation_enabled, local_site_rate_limit_to_rate_limit_config,
+    check_private_instance_and_federation_enabled,
+    local_site_rate_limit_to_rate_limit_config,
   },
 };
 use lemmy_apub::{
   activities::{handle_outgoing_activities, match_outgoing_activities},
-  VerifyUrlData, FEDERATION_HTTP_FETCH_LIMIT,
+  VerifyUrlData,
+  FEDERATION_HTTP_FETCH_LIMIT,
 };
 use lemmy_db_schema::{
   source::secret::Secret,
@@ -39,8 +44,11 @@ use lemmy_db_schema::{
 };
 use lemmy_routes::{feeds, images, nodeinfo, webfinger};
 use lemmy_utils::{
-  error::LemmyError, rate_limit::RateLimitCell, response::jsonify_plain_text_errors,
-  settings::SETTINGS, SYNCHRONOUS_FEDERATION,
+  error::LemmyError,
+  rate_limit::RateLimitCell,
+  response::jsonify_plain_text_errors,
+  settings::SETTINGS,
+  SYNCHRONOUS_FEDERATION,
 };
 use reqwest::Client;
 use reqwest_middleware::ClientBuilder;
@@ -54,7 +62,8 @@ use tracing_subscriber::{filter::Targets, layer::SubscriberExt, Layer, Registry}
 use url::Url;
 #[cfg(feature = "prometheus-metrics")]
 use {
-  actix_web_prom::PrometheusMetricsBuilder, prometheus::default_registry,
+  actix_web_prom::PrometheusMetricsBuilder,
+  prometheus::default_registry,
   prometheus_metrics::serve_prometheus,
 };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,41 +1,46 @@
-use lemmy_server::{init_logging, start_lemmy_server};
+use clap::Parser;
+use lemmy_server::{init_logging, start_lemmy_server, Args};
 use lemmy_utils::{error::LemmyError, settings::SETTINGS};
 
 #[tokio::main]
 pub async fn main() -> Result<(), LemmyError> {
   init_logging(&SETTINGS.opentelemetry_url)?;
-  #[cfg(not(feature = "embed-pictrs"))]
-  start_lemmy_server().await?;
-  #[cfg(feature = "embed-pictrs")]
-  {
-    let pictrs_port = &SETTINGS
-      .pictrs_config()
-      .unwrap_or_default()
-      .url
-      .port()
-      .unwrap_or(8080);
-    let pictrs_address = ["127.0.0.1", &pictrs_port.to_string()].join(":");
-    pict_rs::ConfigSource::memory(serde_json::json!({
-        "server": {
-            "address": pictrs_address
-        },
-        "old_db": {
-            "path": "./pictrs/old"
-        },
-        "repo": {
-            "type": "sled",
-            "path": "./pictrs/sled-repo"
-        },
-        "store": {
-            "type": "filesystem",
-            "path": "./pictrs/files"
-        }
-    }))
-    .init::<&str>(None)
-    .expect("initialize pictrs config");
-    let (lemmy, pictrs) = tokio::join!(start_lemmy_server(), pict_rs::run());
-    lemmy?;
-    pictrs.expect("run pictrs");
-  }
-  Ok(())
+  start(Args::parse()).await
+}
+
+#[cfg(not(feature = "embed-pictrs"))]
+async fn start(args: Args) -> Result<(), LemmyError> {
+  start_lemmy_server(args).await
+}
+
+#[cfg(feature = "embed-pictrs")]
+async fn start(args: Args) -> Result<(), LemmyError> {
+  let pictrs_port = &SETTINGS
+    .pictrs_config()
+    .unwrap_or_default()
+    .url
+    .port()
+    .unwrap_or(8080);
+  let pictrs_address = ["127.0.0.1", &pictrs_port.to_string()].join(":");
+  pict_rs::ConfigSource::memory(serde_json::json!({
+      "server": {
+          "address": pictrs_address
+      },
+      "old_db": {
+          "path": "./pictrs/old"
+      },
+      "repo": {
+          "type": "sled",
+          "path": "./pictrs/sled-repo"
+      },
+      "store": {
+          "type": "filesystem",
+          "path": "./pictrs/files"
+      }
+  }))
+  .init::<&str>(None)
+  .expect("initialize pictrs config");
+  let (lemmy, pictrs) = tokio::join!(start_lemmy_server(), pict_rs::run());
+  lemmy?;
+  pictrs.expect("run pictrs");
 }


### PR DESCRIPTION
Improves the CLI ergonomics of the server binary by using the `clap` crate, the de-facto standard Rust CLI argument parser.

This is generally good practice. This makes it so you can use `lemmy_server -h` to get this:

```
A link aggregator for the fediverse

Usage: lemmy_server.exe [OPTIONS]

Options:
      --disable-scheduled-tasks  Disables running scheduled tasks
  -h, --help                     Print help (see more with '--help')
  -V, --version                  Print version
```

Or `lemmy_server --help` to get this:

```
A link aggregator for the fediverse.

This is the Lemmy backend API server. This will connect to a PostgreSQL database, run any pending migrations and start accepting API requests.

Usage: lemmy_server.exe [OPTIONS]

Options:
      --disable-scheduled-tasks
          Disables running scheduled tasks.

          If you are running multiple Lemmy server processes, you probably want to disable scheduled tasks on all but one of the processes, to avoid running the tasks more often than intended.

  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version
```

And `lemmy_server -V` to get `lemmy_server 0.18.1` (unsure why that is the current version but that is unrelated).

Also improves the doc comment on the `start_lemmy_server` function so it makes more sense when viewed from [docs.rs](https://docs.rs/lemmy_server/latest/lemmy_server/fn.start_lemmy_server.html).