### PR TITLE
Use standard rustfmt

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,5 +1,0 @@
-tab_spaces = 2
-edition = "2021"
-imports_layout = "HorizontalVertical"
-imports_granularity = "Crate"
-group_imports = "One"

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -15,7 +15,6 @@ variables:
         - "api_tests/**"
         # config files and scripts used by ci
         - ".woodpecker.yml"
-        - ".rustfmt.toml"
         - "scripts/update_config_defaults.sh"
         - "diesel.toml"
         - ".gitmodules"

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -62,6 +62,7 @@ steps:
       # store cargo data in repo folder so that it gets cached between steps
       CARGO_HOME: .cargo
     commands:
+      - rustup component add rustfmt
       - cargo fmt --check
 
   restore-cache:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -62,10 +62,7 @@ steps:
       # store cargo data in repo folder so that it gets cached between steps
       CARGO_HOME: .cargo
     commands:
-      # need make existing toolchain available
-      - cp -n ~/.cargo . -r
-      - rustup toolchain install nightly-2023-07-10 --no-self-update --profile minimal --component rustfmt
-      - cargo +nightly-2023-07-10 fmt -- --check
+      - cargo fmt --check
 
   restore-cache:
     image: meltwater/drone-cache:v1

--- a/crates/api/src/comment/distinguish.rs
+++ b/crates/api/src/comment/distinguish.rs
@@ -1,58 +1,58 @@
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  comment::{CommentResponse, DistinguishComment},
-  context::LemmyContext,
-  utils::{check_community_ban, is_mod_or_admin, local_user_view_from_jwt},
+    comment::{CommentResponse, DistinguishComment},
+    context::LemmyContext,
+    utils::{check_community_ban, is_mod_or_admin, local_user_view_from_jwt},
 };
 use lemmy_db_schema::{
-  source::comment::{Comment, CommentUpdateForm},
-  traits::Crud,
+    source::comment::{Comment, CommentUpdateForm},
+    traits::Crud,
 };
 use lemmy_db_views::structs::CommentView;
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn distinguish_comment(
-  data: Json<DistinguishComment>,
-  context: Data<LemmyContext>,
+    data: Json<DistinguishComment>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<CommentResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  let orig_comment = CommentView::read(&mut context.pool(), data.comment_id, None).await?;
+    let orig_comment = CommentView::read(&mut context.pool(), data.comment_id, None).await?;
 
-  check_community_ban(
-    local_user_view.person.id,
-    orig_comment.community.id,
-    &mut context.pool(),
-  )
-  .await?;
+    check_community_ban(
+        local_user_view.person.id,
+        orig_comment.community.id,
+        &mut context.pool(),
+    )
+    .await?;
 
-  // Verify that only a mod or admin can distinguish a comment
-  is_mod_or_admin(
-    &mut context.pool(),
-    local_user_view.person.id,
-    orig_comment.community.id,
-  )
-  .await?;
+    // Verify that only a mod or admin can distinguish a comment
+    is_mod_or_admin(
+        &mut context.pool(),
+        local_user_view.person.id,
+        orig_comment.community.id,
+    )
+    .await?;
 
-  // Update the Comment
-  let form = CommentUpdateForm {
-    distinguished: Some(data.distinguished),
-    ..Default::default()
-  };
-  Comment::update(&mut context.pool(), data.comment_id, &form)
-    .await
-    .with_lemmy_type(LemmyErrorType::CouldntUpdateComment)?;
+    // Update the Comment
+    let form = CommentUpdateForm {
+        distinguished: Some(data.distinguished),
+        ..Default::default()
+    };
+    Comment::update(&mut context.pool(), data.comment_id, &form)
+        .await
+        .with_lemmy_type(LemmyErrorType::CouldntUpdateComment)?;
 
-  let comment_view = CommentView::read(
-    &mut context.pool(),
-    data.comment_id,
-    Some(local_user_view.person.id),
-  )
-  .await?;
+    let comment_view = CommentView::read(
+        &mut context.pool(),
+        data.comment_id,
+        Some(local_user_view.person.id),
+    )
+    .await?;
 
-  Ok(Json(CommentResponse {
-    comment_view,
-    recipient_ids: Vec::new(),
-  }))
+    Ok(Json(CommentResponse {
+        comment_view,
+        recipient_ids: Vec::new(),
+    }))
 }

--- a/crates/api/src/comment/like.rs
+++ b/crates/api/src/comment/like.rs
@@ -1,20 +1,20 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  build_response::build_comment_response,
-  comment::{CommentResponse, CreateCommentLike},
-  context::LemmyContext,
-  send_activity::{ActivityChannel, SendActivityData},
-  utils::{check_community_ban, check_downvotes_enabled, local_user_view_from_jwt},
+    build_response::build_comment_response,
+    comment::{CommentResponse, CreateCommentLike},
+    context::LemmyContext,
+    send_activity::{ActivityChannel, SendActivityData},
+    utils::{check_community_ban, check_downvotes_enabled, local_user_view_from_jwt},
 };
 use lemmy_db_schema::{
-  newtypes::LocalUserId,
-  source::{
-    comment::{CommentLike, CommentLikeForm},
-    comment_reply::CommentReply,
-    local_site::LocalSite,
-  },
-  traits::Likeable,
+    newtypes::LocalUserId,
+    source::{
+        comment::{CommentLike, CommentLikeForm},
+        comment_reply::CommentReply,
+        local_site::LocalSite,
+    },
+    traits::Likeable,
 };
 use lemmy_db_views::structs::{CommentView, LocalUserView};
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
@@ -22,75 +22,76 @@ use std::ops::Deref;
 
 #[tracing::instrument(skip(context))]
 pub async fn like_comment(
-  data: Json<CreateCommentLike>,
-  context: Data<LemmyContext>,
+    data: Json<CreateCommentLike>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<CommentResponse>, LemmyError> {
-  let local_site = LocalSite::read(&mut context.pool()).await?;
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  let mut recipient_ids = Vec::<LocalUserId>::new();
+    let mut recipient_ids = Vec::<LocalUserId>::new();
 
-  // Don't do a downvote if site has downvotes disabled
-  check_downvotes_enabled(data.score, &local_site)?;
+    // Don't do a downvote if site has downvotes disabled
+    check_downvotes_enabled(data.score, &local_site)?;
 
-  let comment_id = data.comment_id;
-  let orig_comment = CommentView::read(&mut context.pool(), comment_id, None).await?;
+    let comment_id = data.comment_id;
+    let orig_comment = CommentView::read(&mut context.pool(), comment_id, None).await?;
 
-  check_community_ban(
-    local_user_view.person.id,
-    orig_comment.community.id,
-    &mut context.pool(),
-  )
-  .await?;
-
-  // Add parent poster or commenter to recipients
-  let comment_reply = CommentReply::read_by_comment(&mut context.pool(), comment_id).await;
-  if let Ok(reply) = comment_reply {
-    let recipient_id = reply.recipient_id;
-    if let Ok(local_recipient) = LocalUserView::read_person(&mut context.pool(), recipient_id).await
-    {
-      recipient_ids.push(local_recipient.local_user.id);
-    }
-  }
-
-  let like_form = CommentLikeForm {
-    comment_id: data.comment_id,
-    post_id: orig_comment.post.id,
-    person_id: local_user_view.person.id,
-    score: data.score,
-  };
-
-  // Remove any likes first
-  let person_id = local_user_view.person.id;
-
-  CommentLike::remove(&mut context.pool(), person_id, comment_id).await?;
-
-  // Only add the like if the score isnt 0
-  let do_add = like_form.score != 0 && (like_form.score == 1 || like_form.score == -1);
-  if do_add {
-    CommentLike::like(&mut context.pool(), &like_form)
-      .await
-      .with_lemmy_type(LemmyErrorType::CouldntLikeComment)?;
-  }
-
-  ActivityChannel::submit_activity(
-    SendActivityData::LikePostOrComment(
-      orig_comment.comment.ap_id,
-      local_user_view.person.clone(),
-      orig_comment.community,
-      data.score,
-    ),
-    &context,
-  )
-  .await?;
-
-  Ok(Json(
-    build_comment_response(
-      context.deref(),
-      comment_id,
-      Some(local_user_view),
-      recipient_ids,
+    check_community_ban(
+        local_user_view.person.id,
+        orig_comment.community.id,
+        &mut context.pool(),
     )
-    .await?,
-  ))
+    .await?;
+
+    // Add parent poster or commenter to recipients
+    let comment_reply = CommentReply::read_by_comment(&mut context.pool(), comment_id).await;
+    if let Ok(reply) = comment_reply {
+        let recipient_id = reply.recipient_id;
+        if let Ok(local_recipient) =
+            LocalUserView::read_person(&mut context.pool(), recipient_id).await
+        {
+            recipient_ids.push(local_recipient.local_user.id);
+        }
+    }
+
+    let like_form = CommentLikeForm {
+        comment_id: data.comment_id,
+        post_id: orig_comment.post.id,
+        person_id: local_user_view.person.id,
+        score: data.score,
+    };
+
+    // Remove any likes first
+    let person_id = local_user_view.person.id;
+
+    CommentLike::remove(&mut context.pool(), person_id, comment_id).await?;
+
+    // Only add the like if the score isnt 0
+    let do_add = like_form.score != 0 && (like_form.score == 1 || like_form.score == -1);
+    if do_add {
+        CommentLike::like(&mut context.pool(), &like_form)
+            .await
+            .with_lemmy_type(LemmyErrorType::CouldntLikeComment)?;
+    }
+
+    ActivityChannel::submit_activity(
+        SendActivityData::LikePostOrComment(
+            orig_comment.comment.ap_id,
+            local_user_view.person.clone(),
+            orig_comment.community,
+            data.score,
+        ),
+        &context,
+    )
+    .await?;
+
+    Ok(Json(
+        build_comment_response(
+            context.deref(),
+            comment_id,
+            Some(local_user_view),
+            recipient_ids,
+        )
+        .await?,
+    ))
 }

--- a/crates/api/src/comment/save.rs
+++ b/crates/api/src/comment/save.rs
@@ -1,44 +1,44 @@
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  comment::{CommentResponse, SaveComment},
-  context::LemmyContext,
-  utils::local_user_view_from_jwt,
+    comment::{CommentResponse, SaveComment},
+    context::LemmyContext,
+    utils::local_user_view_from_jwt,
 };
 use lemmy_db_schema::{
-  source::comment::{CommentSaved, CommentSavedForm},
-  traits::Saveable,
+    source::comment::{CommentSaved, CommentSavedForm},
+    traits::Saveable,
 };
 use lemmy_db_views::structs::CommentView;
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn save_comment(
-  data: Json<SaveComment>,
-  context: Data<LemmyContext>,
+    data: Json<SaveComment>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<CommentResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  let comment_saved_form = CommentSavedForm {
-    comment_id: data.comment_id,
-    person_id: local_user_view.person.id,
-  };
+    let comment_saved_form = CommentSavedForm {
+        comment_id: data.comment_id,
+        person_id: local_user_view.person.id,
+    };
 
-  if data.save {
-    CommentSaved::save(&mut context.pool(), &comment_saved_form)
-      .await
-      .with_lemmy_type(LemmyErrorType::CouldntSaveComment)?;
-  } else {
-    CommentSaved::unsave(&mut context.pool(), &comment_saved_form)
-      .await
-      .with_lemmy_type(LemmyErrorType::CouldntSaveComment)?;
-  }
+    if data.save {
+        CommentSaved::save(&mut context.pool(), &comment_saved_form)
+            .await
+            .with_lemmy_type(LemmyErrorType::CouldntSaveComment)?;
+    } else {
+        CommentSaved::unsave(&mut context.pool(), &comment_saved_form)
+            .await
+            .with_lemmy_type(LemmyErrorType::CouldntSaveComment)?;
+    }
 
-  let comment_id = data.comment_id;
-  let person_id = local_user_view.person.id;
-  let comment_view = CommentView::read(&mut context.pool(), comment_id, Some(person_id)).await?;
+    let comment_id = data.comment_id;
+    let person_id = local_user_view.person.id;
+    let comment_view = CommentView::read(&mut context.pool(), comment_id, Some(person_id)).await?;
 
-  Ok(Json(CommentResponse {
-    comment_view,
-    recipient_ids: Vec::new(),
-  }))
+    Ok(Json(CommentResponse {
+        comment_view,
+        recipient_ids: Vec::new(),
+    }))
 }

--- a/crates/api/src/comment_report/create.rs
+++ b/crates/api/src/comment_report/create.rs
@@ -2,22 +2,20 @@ use crate::check_report_reason;
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  comment::{CommentReportResponse, CreateCommentReport},
-  context::LemmyContext,
-  send_activity::{ActivityChannel, SendActivityData},
-  utils::{
-    check_community_ban,
-    local_user_view_from_jwt,
-    sanitize_html,
-    send_new_report_email_to_admins,
-  },
+    comment::{CommentReportResponse, CreateCommentReport},
+    context::LemmyContext,
+    send_activity::{ActivityChannel, SendActivityData},
+    utils::{
+        check_community_ban, local_user_view_from_jwt, sanitize_html,
+        send_new_report_email_to_admins,
+    },
 };
 use lemmy_db_schema::{
-  source::{
-    comment_report::{CommentReport, CommentReportForm},
-    local_site::LocalSite,
-  },
-  traits::Reportable,
+    source::{
+        comment_report::{CommentReport, CommentReportForm},
+        local_site::LocalSite,
+    },
+    traits::Reportable,
 };
 use lemmy_db_views::structs::{CommentReportView, CommentView};
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
@@ -25,58 +23,58 @@ use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 /// Creates a comment report and notifies the moderators of the community
 #[tracing::instrument(skip(context))]
 pub async fn create_comment_report(
-  data: Json<CreateCommentReport>,
-  context: Data<LemmyContext>,
+    data: Json<CreateCommentReport>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<CommentReportResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
-  let local_site = LocalSite::read(&mut context.pool()).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
 
-  let reason = sanitize_html(data.reason.trim());
-  check_report_reason(&reason, &local_site)?;
+    let reason = sanitize_html(data.reason.trim());
+    check_report_reason(&reason, &local_site)?;
 
-  let person_id = local_user_view.person.id;
-  let comment_id = data.comment_id;
-  let comment_view = CommentView::read(&mut context.pool(), comment_id, None).await?;
+    let person_id = local_user_view.person.id;
+    let comment_id = data.comment_id;
+    let comment_view = CommentView::read(&mut context.pool(), comment_id, None).await?;
 
-  check_community_ban(person_id, comment_view.community.id, &mut context.pool()).await?;
+    check_community_ban(person_id, comment_view.community.id, &mut context.pool()).await?;
 
-  let report_form = CommentReportForm {
-    creator_id: person_id,
-    comment_id,
-    original_comment_text: comment_view.comment.content,
-    reason,
-  };
+    let report_form = CommentReportForm {
+        creator_id: person_id,
+        comment_id,
+        original_comment_text: comment_view.comment.content,
+        reason,
+    };
 
-  let report = CommentReport::report(&mut context.pool(), &report_form)
-    .await
-    .with_lemmy_type(LemmyErrorType::CouldntCreateReport)?;
+    let report = CommentReport::report(&mut context.pool(), &report_form)
+        .await
+        .with_lemmy_type(LemmyErrorType::CouldntCreateReport)?;
 
-  let comment_report_view =
-    CommentReportView::read(&mut context.pool(), report.id, person_id).await?;
+    let comment_report_view =
+        CommentReportView::read(&mut context.pool(), report.id, person_id).await?;
 
-  // Email the admins
-  if local_site.reports_email_admins {
-    send_new_report_email_to_admins(
-      &comment_report_view.creator.name,
-      &comment_report_view.comment_creator.name,
-      &mut context.pool(),
-      context.settings(),
+    // Email the admins
+    if local_site.reports_email_admins {
+        send_new_report_email_to_admins(
+            &comment_report_view.creator.name,
+            &comment_report_view.comment_creator.name,
+            &mut context.pool(),
+            context.settings(),
+        )
+        .await?;
+    }
+
+    ActivityChannel::submit_activity(
+        SendActivityData::CreateReport(
+            comment_view.comment.ap_id.inner().clone(),
+            local_user_view.person,
+            comment_view.community,
+            data.reason.clone(),
+        ),
+        &context,
     )
     .await?;
-  }
 
-  ActivityChannel::submit_activity(
-    SendActivityData::CreateReport(
-      comment_view.comment.ap_id.inner().clone(),
-      local_user_view.person,
-      comment_view.community,
-      data.reason.clone(),
-    ),
-    &context,
-  )
-  .await?;
-
-  Ok(Json(CommentReportResponse {
-    comment_report_view,
-  }))
+    Ok(Json(CommentReportResponse {
+        comment_report_view,
+    }))
 }

--- a/crates/api/src/comment_report/list.rs
+++ b/crates/api/src/comment_report/list.rs
@@ -1,8 +1,8 @@
 use actix_web::web::{Data, Json, Query};
 use lemmy_api_common::{
-  comment::{ListCommentReports, ListCommentReportsResponse},
-  context::LemmyContext,
-  utils::local_user_view_from_jwt,
+    comment::{ListCommentReports, ListCommentReportsResponse},
+    context::LemmyContext,
+    utils::local_user_view_from_jwt,
 };
 use lemmy_db_views::comment_report_view::CommentReportQuery;
 use lemmy_utils::error::LemmyError;
@@ -11,24 +11,24 @@ use lemmy_utils::error::LemmyError;
 /// or returns all comment reports for communities a user moderates
 #[tracing::instrument(skip(context))]
 pub async fn list_comment_reports(
-  data: Query<ListCommentReports>,
-  context: Data<LemmyContext>,
+    data: Query<ListCommentReports>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<ListCommentReportsResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  let community_id = data.community_id;
-  let unresolved_only = data.unresolved_only.unwrap_or_default();
+    let community_id = data.community_id;
+    let unresolved_only = data.unresolved_only.unwrap_or_default();
 
-  let page = data.page;
-  let limit = data.limit;
-  let comment_reports = CommentReportQuery {
-    community_id,
-    unresolved_only,
-    page,
-    limit,
-  }
-  .list(&mut context.pool(), &local_user_view)
-  .await?;
+    let page = data.page;
+    let limit = data.limit;
+    let comment_reports = CommentReportQuery {
+        community_id,
+        unresolved_only,
+        page,
+        limit,
+    }
+    .list(&mut context.pool(), &local_user_view)
+    .await?;
 
-  Ok(Json(ListCommentReportsResponse { comment_reports }))
+    Ok(Json(ListCommentReportsResponse { comment_reports }))
 }

--- a/crates/api/src/comment_report/resolve.rs
+++ b/crates/api/src/comment_report/resolve.rs
@@ -1,8 +1,8 @@
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  comment::{CommentReportResponse, ResolveCommentReport},
-  context::LemmyContext,
-  utils::{is_mod_or_admin, local_user_view_from_jwt},
+    comment::{CommentReportResponse, ResolveCommentReport},
+    context::LemmyContext,
+    utils::{is_mod_or_admin, local_user_view_from_jwt},
 };
 use lemmy_db_schema::{source::comment_report::CommentReport, traits::Reportable};
 use lemmy_db_views::structs::CommentReportView;
@@ -11,33 +11,33 @@ use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 /// Resolves or unresolves a comment report and notifies the moderators of the community
 #[tracing::instrument(skip(context))]
 pub async fn resolve_comment_report(
-  data: Json<ResolveCommentReport>,
-  context: Data<LemmyContext>,
+    data: Json<ResolveCommentReport>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<CommentReportResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  let report_id = data.report_id;
-  let person_id = local_user_view.person.id;
-  let report = CommentReportView::read(&mut context.pool(), report_id, person_id).await?;
+    let report_id = data.report_id;
+    let person_id = local_user_view.person.id;
+    let report = CommentReportView::read(&mut context.pool(), report_id, person_id).await?;
 
-  let person_id = local_user_view.person.id;
-  is_mod_or_admin(&mut context.pool(), person_id, report.community.id).await?;
+    let person_id = local_user_view.person.id;
+    is_mod_or_admin(&mut context.pool(), person_id, report.community.id).await?;
 
-  if data.resolved {
-    CommentReport::resolve(&mut context.pool(), report_id, person_id)
-      .await
-      .with_lemmy_type(LemmyErrorType::CouldntResolveReport)?;
-  } else {
-    CommentReport::unresolve(&mut context.pool(), report_id, person_id)
-      .await
-      .with_lemmy_type(LemmyErrorType::CouldntResolveReport)?;
-  }
+    if data.resolved {
+        CommentReport::resolve(&mut context.pool(), report_id, person_id)
+            .await
+            .with_lemmy_type(LemmyErrorType::CouldntResolveReport)?;
+    } else {
+        CommentReport::unresolve(&mut context.pool(), report_id, person_id)
+            .await
+            .with_lemmy_type(LemmyErrorType::CouldntResolveReport)?;
+    }
 
-  let report_id = data.report_id;
-  let comment_report_view =
-    CommentReportView::read(&mut context.pool(), report_id, person_id).await?;
+    let report_id = data.report_id;
+    let comment_report_view =
+        CommentReportView::read(&mut context.pool(), report_id, person_id).await?;
 
-  Ok(Json(CommentReportResponse {
-    comment_report_view,
-  }))
+    Ok(Json(CommentReportResponse {
+        comment_report_view,
+    }))
 }

--- a/crates/api/src/community/add_mod.rs
+++ b/crates/api/src/community/add_mod.rs
@@ -1,77 +1,78 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  community::{AddModToCommunity, AddModToCommunityResponse},
-  context::LemmyContext,
-  send_activity::{ActivityChannel, SendActivityData},
-  utils::{is_mod_or_admin, local_user_view_from_jwt},
+    community::{AddModToCommunity, AddModToCommunityResponse},
+    context::LemmyContext,
+    send_activity::{ActivityChannel, SendActivityData},
+    utils::{is_mod_or_admin, local_user_view_from_jwt},
 };
 use lemmy_db_schema::{
-  source::{
-    community::{Community, CommunityModerator, CommunityModeratorForm},
-    moderator::{ModAddCommunity, ModAddCommunityForm},
-  },
-  traits::{Crud, Joinable},
+    source::{
+        community::{Community, CommunityModerator, CommunityModeratorForm},
+        moderator::{ModAddCommunity, ModAddCommunityForm},
+    },
+    traits::{Crud, Joinable},
 };
 use lemmy_db_views_actor::structs::CommunityModeratorView;
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn add_mod_to_community(
-  data: Json<AddModToCommunity>,
-  context: Data<LemmyContext>,
+    data: Json<AddModToCommunity>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<AddModToCommunityResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  let community_id = data.community_id;
+    let community_id = data.community_id;
 
-  // Verify that only mods or admins can add mod
-  is_mod_or_admin(&mut context.pool(), local_user_view.person.id, community_id).await?;
-  let community = Community::read(&mut context.pool(), community_id).await?;
-  if local_user_view.local_user.admin && !community.local {
-    Err(LemmyErrorType::NotAModerator)?
-  }
+    // Verify that only mods or admins can add mod
+    is_mod_or_admin(&mut context.pool(), local_user_view.person.id, community_id).await?;
+    let community = Community::read(&mut context.pool(), community_id).await?;
+    if local_user_view.local_user.admin && !community.local {
+        Err(LemmyErrorType::NotAModerator)?
+    }
 
-  // Update in local database
-  let community_moderator_form = CommunityModeratorForm {
-    community_id: data.community_id,
-    person_id: data.person_id,
-  };
-  if data.added {
-    CommunityModerator::join(&mut context.pool(), &community_moderator_form)
-      .await
-      .with_lemmy_type(LemmyErrorType::CommunityModeratorAlreadyExists)?;
-  } else {
-    CommunityModerator::leave(&mut context.pool(), &community_moderator_form)
-      .await
-      .with_lemmy_type(LemmyErrorType::CommunityModeratorAlreadyExists)?;
-  }
+    // Update in local database
+    let community_moderator_form = CommunityModeratorForm {
+        community_id: data.community_id,
+        person_id: data.person_id,
+    };
+    if data.added {
+        CommunityModerator::join(&mut context.pool(), &community_moderator_form)
+            .await
+            .with_lemmy_type(LemmyErrorType::CommunityModeratorAlreadyExists)?;
+    } else {
+        CommunityModerator::leave(&mut context.pool(), &community_moderator_form)
+            .await
+            .with_lemmy_type(LemmyErrorType::CommunityModeratorAlreadyExists)?;
+    }
 
-  // Mod tables
-  let form = ModAddCommunityForm {
-    mod_person_id: local_user_view.person.id,
-    other_person_id: data.person_id,
-    community_id: data.community_id,
-    removed: Some(!data.added),
-  };
+    // Mod tables
+    let form = ModAddCommunityForm {
+        mod_person_id: local_user_view.person.id,
+        other_person_id: data.person_id,
+        community_id: data.community_id,
+        removed: Some(!data.added),
+    };
 
-  ModAddCommunity::create(&mut context.pool(), &form).await?;
+    ModAddCommunity::create(&mut context.pool(), &form).await?;
 
-  // Note: in case a remote mod is added, this returns the old moderators list, it will only get
-  //       updated once we receive an activity from the community (like `Announce/Add/Moderator`)
-  let community_id = data.community_id;
-  let moderators = CommunityModeratorView::for_community(&mut context.pool(), community_id).await?;
+    // Note: in case a remote mod is added, this returns the old moderators list, it will only get
+    //       updated once we receive an activity from the community (like `Announce/Add/Moderator`)
+    let community_id = data.community_id;
+    let moderators =
+        CommunityModeratorView::for_community(&mut context.pool(), community_id).await?;
 
-  ActivityChannel::submit_activity(
-    SendActivityData::AddModToCommunity(
-      local_user_view.person,
-      data.community_id,
-      data.person_id,
-      data.added,
-    ),
-    &context,
-  )
-  .await?;
+    ActivityChannel::submit_activity(
+        SendActivityData::AddModToCommunity(
+            local_user_view.person,
+            data.community_id,
+            data.person_id,
+            data.added,
+        ),
+        &context,
+    )
+    .await?;
 
-  Ok(Json(AddModToCommunityResponse { moderators }))
+    Ok(Json(AddModToCommunityResponse { moderators }))
 }

--- a/crates/api/src/community/ban.rs
+++ b/crates/api/src/community/ban.rs
@@ -1,113 +1,108 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  community::{BanFromCommunity, BanFromCommunityResponse},
-  context::LemmyContext,
-  send_activity::{ActivityChannel, SendActivityData},
-  utils::{
-    is_mod_or_admin,
-    local_user_view_from_jwt,
-    remove_user_data_in_community,
-    sanitize_html_opt,
-  },
+    community::{BanFromCommunity, BanFromCommunityResponse},
+    context::LemmyContext,
+    send_activity::{ActivityChannel, SendActivityData},
+    utils::{
+        is_mod_or_admin, local_user_view_from_jwt, remove_user_data_in_community, sanitize_html_opt,
+    },
 };
 use lemmy_db_schema::{
-  source::{
-    community::{
-      CommunityFollower,
-      CommunityFollowerForm,
-      CommunityPersonBan,
-      CommunityPersonBanForm,
+    source::{
+        community::{
+            CommunityFollower, CommunityFollowerForm, CommunityPersonBan, CommunityPersonBanForm,
+        },
+        moderator::{ModBanFromCommunity, ModBanFromCommunityForm},
     },
-    moderator::{ModBanFromCommunity, ModBanFromCommunityForm},
-  },
-  traits::{Bannable, Crud, Followable},
+    traits::{Bannable, Crud, Followable},
 };
 use lemmy_db_views_actor::structs::PersonView;
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
-  utils::{time::naive_from_unix, validation::is_valid_body_field},
+    error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+    utils::{time::naive_from_unix, validation::is_valid_body_field},
 };
 
 #[tracing::instrument(skip(context))]
 pub async fn ban_from_community(
-  data: Json<BanFromCommunity>,
-  context: Data<LemmyContext>,
+    data: Json<BanFromCommunity>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<BanFromCommunityResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  let banned_person_id = data.person_id;
-  let remove_data = data.remove_data.unwrap_or(false);
-  let expires = data.expires.map(naive_from_unix);
+    let banned_person_id = data.person_id;
+    let remove_data = data.remove_data.unwrap_or(false);
+    let expires = data.expires.map(naive_from_unix);
 
-  // Verify that only mods or admins can ban
-  is_mod_or_admin(
-    &mut context.pool(),
-    local_user_view.person.id,
-    data.community_id,
-  )
-  .await?;
-  is_valid_body_field(&data.reason, false)?;
+    // Verify that only mods or admins can ban
+    is_mod_or_admin(
+        &mut context.pool(),
+        local_user_view.person.id,
+        data.community_id,
+    )
+    .await?;
+    is_valid_body_field(&data.reason, false)?;
 
-  let community_user_ban_form = CommunityPersonBanForm {
-    community_id: data.community_id,
-    person_id: data.person_id,
-    expires: Some(expires),
-  };
-
-  if data.ban {
-    CommunityPersonBan::ban(&mut context.pool(), &community_user_ban_form)
-      .await
-      .with_lemmy_type(LemmyErrorType::CommunityUserAlreadyBanned)?;
-
-    // Also unsubscribe them from the community, if they are subscribed
-    let community_follower_form = CommunityFollowerForm {
-      community_id: data.community_id,
-      person_id: banned_person_id,
-      pending: false,
+    let community_user_ban_form = CommunityPersonBanForm {
+        community_id: data.community_id,
+        person_id: data.person_id,
+        expires: Some(expires),
     };
 
-    CommunityFollower::unfollow(&mut context.pool(), &community_follower_form)
-      .await
-      .ok();
-  } else {
-    CommunityPersonBan::unban(&mut context.pool(), &community_user_ban_form)
-      .await
-      .with_lemmy_type(LemmyErrorType::CommunityUserAlreadyBanned)?;
-  }
+    if data.ban {
+        CommunityPersonBan::ban(&mut context.pool(), &community_user_ban_form)
+            .await
+            .with_lemmy_type(LemmyErrorType::CommunityUserAlreadyBanned)?;
 
-  // Remove/Restore their data if that's desired
-  if remove_data {
-    remove_user_data_in_community(data.community_id, banned_person_id, &mut context.pool()).await?;
-  }
+        // Also unsubscribe them from the community, if they are subscribed
+        let community_follower_form = CommunityFollowerForm {
+            community_id: data.community_id,
+            person_id: banned_person_id,
+            pending: false,
+        };
 
-  // Mod tables
-  let form = ModBanFromCommunityForm {
-    mod_person_id: local_user_view.person.id,
-    other_person_id: data.person_id,
-    community_id: data.community_id,
-    reason: sanitize_html_opt(&data.reason),
-    banned: Some(data.ban),
-    expires,
-  };
+        CommunityFollower::unfollow(&mut context.pool(), &community_follower_form)
+            .await
+            .ok();
+    } else {
+        CommunityPersonBan::unban(&mut context.pool(), &community_user_ban_form)
+            .await
+            .with_lemmy_type(LemmyErrorType::CommunityUserAlreadyBanned)?;
+    }
 
-  ModBanFromCommunity::create(&mut context.pool(), &form).await?;
+    // Remove/Restore their data if that's desired
+    if remove_data {
+        remove_user_data_in_community(data.community_id, banned_person_id, &mut context.pool())
+            .await?;
+    }
 
-  let person_view = PersonView::read(&mut context.pool(), data.person_id).await?;
+    // Mod tables
+    let form = ModBanFromCommunityForm {
+        mod_person_id: local_user_view.person.id,
+        other_person_id: data.person_id,
+        community_id: data.community_id,
+        reason: sanitize_html_opt(&data.reason),
+        banned: Some(data.ban),
+        expires,
+    };
 
-  ActivityChannel::submit_activity(
-    SendActivityData::BanFromCommunity(
-      local_user_view.person,
-      data.community_id,
-      person_view.person.clone(),
-      data.0.clone(),
-    ),
-    &context,
-  )
-  .await?;
+    ModBanFromCommunity::create(&mut context.pool(), &form).await?;
 
-  Ok(Json(BanFromCommunityResponse {
-    person_view,
-    banned: data.ban,
-  }))
+    let person_view = PersonView::read(&mut context.pool(), data.person_id).await?;
+
+    ActivityChannel::submit_activity(
+        SendActivityData::BanFromCommunity(
+            local_user_view.person,
+            data.community_id,
+            person_view.person.clone(),
+            data.0.clone(),
+        ),
+        &context,
+    )
+    .await?;
+
+    Ok(Json(BanFromCommunityResponse {
+        person_view,
+        banned: data.ban,
+    }))
 }

--- a/crates/api/src/community/block.rs
+++ b/crates/api/src/community/block.rs
@@ -1,71 +1,71 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  community::{BlockCommunity, BlockCommunityResponse},
-  context::LemmyContext,
-  send_activity::{ActivityChannel, SendActivityData},
-  utils::local_user_view_from_jwt,
+    community::{BlockCommunity, BlockCommunityResponse},
+    context::LemmyContext,
+    send_activity::{ActivityChannel, SendActivityData},
+    utils::local_user_view_from_jwt,
 };
 use lemmy_db_schema::{
-  source::{
-    community::{CommunityFollower, CommunityFollowerForm},
-    community_block::{CommunityBlock, CommunityBlockForm},
-  },
-  traits::{Blockable, Followable},
+    source::{
+        community::{CommunityFollower, CommunityFollowerForm},
+        community_block::{CommunityBlock, CommunityBlockForm},
+    },
+    traits::{Blockable, Followable},
 };
 use lemmy_db_views_actor::structs::CommunityView;
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn block_community(
-  data: Json<BlockCommunity>,
-  context: Data<LemmyContext>,
+    data: Json<BlockCommunity>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<BlockCommunityResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  let community_id = data.community_id;
-  let person_id = local_user_view.person.id;
-  let community_block_form = CommunityBlockForm {
-    person_id,
-    community_id,
-  };
-
-  if data.block {
-    CommunityBlock::block(&mut context.pool(), &community_block_form)
-      .await
-      .with_lemmy_type(LemmyErrorType::CommunityBlockAlreadyExists)?;
-
-    // Also, unfollow the community, and send a federated unfollow
-    let community_follower_form = CommunityFollowerForm {
-      community_id: data.community_id,
-      person_id,
-      pending: false,
+    let community_id = data.community_id;
+    let person_id = local_user_view.person.id;
+    let community_block_form = CommunityBlockForm {
+        person_id,
+        community_id,
     };
 
-    CommunityFollower::unfollow(&mut context.pool(), &community_follower_form)
-      .await
-      .ok();
-  } else {
-    CommunityBlock::unblock(&mut context.pool(), &community_block_form)
-      .await
-      .with_lemmy_type(LemmyErrorType::CommunityBlockAlreadyExists)?;
-  }
+    if data.block {
+        CommunityBlock::block(&mut context.pool(), &community_block_form)
+            .await
+            .with_lemmy_type(LemmyErrorType::CommunityBlockAlreadyExists)?;
 
-  let community_view =
-    CommunityView::read(&mut context.pool(), community_id, Some(person_id), false).await?;
+        // Also, unfollow the community, and send a federated unfollow
+        let community_follower_form = CommunityFollowerForm {
+            community_id: data.community_id,
+            person_id,
+            pending: false,
+        };
 
-  ActivityChannel::submit_activity(
-    SendActivityData::FollowCommunity(
-      community_view.community.clone(),
-      local_user_view.person.clone(),
-      false,
-    ),
-    &context,
-  )
-  .await?;
+        CommunityFollower::unfollow(&mut context.pool(), &community_follower_form)
+            .await
+            .ok();
+    } else {
+        CommunityBlock::unblock(&mut context.pool(), &community_block_form)
+            .await
+            .with_lemmy_type(LemmyErrorType::CommunityBlockAlreadyExists)?;
+    }
 
-  Ok(Json(BlockCommunityResponse {
-    blocked: data.block,
-    community_view,
-  }))
+    let community_view =
+        CommunityView::read(&mut context.pool(), community_id, Some(person_id), false).await?;
+
+    ActivityChannel::submit_activity(
+        SendActivityData::FollowCommunity(
+            community_view.community.clone(),
+            local_user_view.person.clone(),
+            false,
+        ),
+        &context,
+    )
+    .await?;
+
+    Ok(Json(BlockCommunityResponse {
+        blocked: data.block,
+        community_view,
+    }))
 }

--- a/crates/api/src/community/follow.rs
+++ b/crates/api/src/community/follow.rs
@@ -1,71 +1,72 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  community::{CommunityResponse, FollowCommunity},
-  context::LemmyContext,
-  send_activity::{ActivityChannel, SendActivityData},
-  utils::{check_community_ban, check_community_deleted_or_removed, local_user_view_from_jwt},
+    community::{CommunityResponse, FollowCommunity},
+    context::LemmyContext,
+    send_activity::{ActivityChannel, SendActivityData},
+    utils::{check_community_ban, check_community_deleted_or_removed, local_user_view_from_jwt},
 };
 use lemmy_db_schema::{
-  source::{
-    actor_language::CommunityLanguage,
-    community::{Community, CommunityFollower, CommunityFollowerForm},
-  },
-  traits::{Crud, Followable},
+    source::{
+        actor_language::CommunityLanguage,
+        community::{Community, CommunityFollower, CommunityFollowerForm},
+    },
+    traits::{Crud, Followable},
 };
 use lemmy_db_views_actor::structs::CommunityView;
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn follow_community(
-  data: Json<FollowCommunity>,
-  context: Data<LemmyContext>,
+    data: Json<FollowCommunity>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<CommunityResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  let community = Community::read(&mut context.pool(), data.community_id).await?;
-  let mut community_follower_form = CommunityFollowerForm {
-    community_id: community.id,
-    person_id: local_user_view.person.id,
-    pending: false,
-  };
+    let community = Community::read(&mut context.pool(), data.community_id).await?;
+    let mut community_follower_form = CommunityFollowerForm {
+        community_id: community.id,
+        person_id: local_user_view.person.id,
+        pending: false,
+    };
 
-  if data.follow {
-    if community.local {
-      check_community_ban(local_user_view.person.id, community.id, &mut context.pool()).await?;
-      check_community_deleted_or_removed(community.id, &mut context.pool()).await?;
+    if data.follow {
+        if community.local {
+            check_community_ban(local_user_view.person.id, community.id, &mut context.pool())
+                .await?;
+            check_community_deleted_or_removed(community.id, &mut context.pool()).await?;
 
-      CommunityFollower::follow(&mut context.pool(), &community_follower_form)
-        .await
-        .with_lemmy_type(LemmyErrorType::CommunityFollowerAlreadyExists)?;
-    } else {
-      // Mark as pending, the actual federation activity is sent via `SendActivity` handler
-      community_follower_form.pending = true;
-      CommunityFollower::follow(&mut context.pool(), &community_follower_form)
-        .await
-        .with_lemmy_type(LemmyErrorType::CommunityFollowerAlreadyExists)?;
+            CommunityFollower::follow(&mut context.pool(), &community_follower_form)
+                .await
+                .with_lemmy_type(LemmyErrorType::CommunityFollowerAlreadyExists)?;
+        } else {
+            // Mark as pending, the actual federation activity is sent via `SendActivity` handler
+            community_follower_form.pending = true;
+            CommunityFollower::follow(&mut context.pool(), &community_follower_form)
+                .await
+                .with_lemmy_type(LemmyErrorType::CommunityFollowerAlreadyExists)?;
+        }
     }
-  }
-  if !data.follow {
-    CommunityFollower::unfollow(&mut context.pool(), &community_follower_form)
-      .await
-      .with_lemmy_type(LemmyErrorType::CommunityFollowerAlreadyExists)?;
-  }
+    if !data.follow {
+        CommunityFollower::unfollow(&mut context.pool(), &community_follower_form)
+            .await
+            .with_lemmy_type(LemmyErrorType::CommunityFollowerAlreadyExists)?;
+    }
 
-  ActivityChannel::submit_activity(
-    SendActivityData::FollowCommunity(community, local_user_view.person.clone(), data.follow),
-    &context,
-  )
-  .await?;
+    ActivityChannel::submit_activity(
+        SendActivityData::FollowCommunity(community, local_user_view.person.clone(), data.follow),
+        &context,
+    )
+    .await?;
 
-  let community_id = data.community_id;
-  let person_id = local_user_view.person.id;
-  let community_view =
-    CommunityView::read(&mut context.pool(), community_id, Some(person_id), false).await?;
-  let discussion_languages = CommunityLanguage::read(&mut context.pool(), community_id).await?;
+    let community_id = data.community_id;
+    let person_id = local_user_view.person.id;
+    let community_view =
+        CommunityView::read(&mut context.pool(), community_id, Some(person_id), false).await?;
+    let discussion_languages = CommunityLanguage::read(&mut context.pool(), community_id).await?;
 
-  Ok(Json(CommunityResponse {
-    community_view,
-    discussion_languages,
-  }))
+    Ok(Json(CommunityResponse {
+        community_view,
+        discussion_languages,
+    }))
 }

--- a/crates/api/src/community/hide.rs
+++ b/crates/api/src/community/hide.rs
@@ -1,54 +1,54 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  build_response::build_community_response,
-  community::{CommunityResponse, HideCommunity},
-  context::LemmyContext,
-  send_activity::{ActivityChannel, SendActivityData},
-  utils::{is_admin, local_user_view_from_jwt, sanitize_html_opt},
+    build_response::build_community_response,
+    community::{CommunityResponse, HideCommunity},
+    context::LemmyContext,
+    send_activity::{ActivityChannel, SendActivityData},
+    utils::{is_admin, local_user_view_from_jwt, sanitize_html_opt},
 };
 use lemmy_db_schema::{
-  source::{
-    community::{Community, CommunityUpdateForm},
-    moderator::{ModHideCommunity, ModHideCommunityForm},
-  },
-  traits::Crud,
+    source::{
+        community::{Community, CommunityUpdateForm},
+        moderator::{ModHideCommunity, ModHideCommunityForm},
+    },
+    traits::Crud,
 };
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn hide_community(
-  data: Json<HideCommunity>,
-  context: Data<LemmyContext>,
+    data: Json<HideCommunity>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<CommunityResponse>, LemmyError> {
-  // Verify its a admin (only admin can hide or unhide it)
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
-  is_admin(&local_user_view)?;
+    // Verify its a admin (only admin can hide or unhide it)
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    is_admin(&local_user_view)?;
 
-  let community_form = CommunityUpdateForm {
-    hidden: Some(data.hidden),
-    ..Default::default()
-  };
+    let community_form = CommunityUpdateForm {
+        hidden: Some(data.hidden),
+        ..Default::default()
+    };
 
-  let mod_hide_community_form = ModHideCommunityForm {
-    community_id: data.community_id,
-    mod_person_id: local_user_view.person.id,
-    reason: sanitize_html_opt(&data.reason),
-    hidden: Some(data.hidden),
-  };
+    let mod_hide_community_form = ModHideCommunityForm {
+        community_id: data.community_id,
+        mod_person_id: local_user_view.person.id,
+        reason: sanitize_html_opt(&data.reason),
+        hidden: Some(data.hidden),
+    };
 
-  let community_id = data.community_id;
-  let community = Community::update(&mut context.pool(), community_id, &community_form)
-    .await
-    .with_lemmy_type(LemmyErrorType::CouldntUpdateCommunityHiddenStatus)?;
+    let community_id = data.community_id;
+    let community = Community::update(&mut context.pool(), community_id, &community_form)
+        .await
+        .with_lemmy_type(LemmyErrorType::CouldntUpdateCommunityHiddenStatus)?;
 
-  ModHideCommunity::create(&mut context.pool(), &mod_hide_community_form).await?;
+    ModHideCommunity::create(&mut context.pool(), &mod_hide_community_form).await?;
 
-  ActivityChannel::submit_activity(
-    SendActivityData::UpdateCommunity(local_user_view.person.clone(), community),
-    &context,
-  )
-  .await?;
+    ActivityChannel::submit_activity(
+        SendActivityData::UpdateCommunity(local_user_view.person.clone(), community),
+        &context,
+    )
+    .await?;
 
-  build_community_response(&context, local_user_view, community_id).await
+    build_community_response(&context, local_user_view, community_id).await
 }

--- a/crates/api/src/community/transfer.rs
+++ b/crates/api/src/community/transfer.rs
@@ -1,96 +1,97 @@
 use actix_web::web::{Data, Json};
 use anyhow::Context;
 use lemmy_api_common::{
-  community::{GetCommunityResponse, TransferCommunity},
-  context::LemmyContext,
-  utils::{is_admin, is_top_mod, local_user_view_from_jwt},
+    community::{GetCommunityResponse, TransferCommunity},
+    context::LemmyContext,
+    utils::{is_admin, is_top_mod, local_user_view_from_jwt},
 };
 use lemmy_db_schema::{
-  source::{
-    community::{CommunityModerator, CommunityModeratorForm},
-    moderator::{ModTransferCommunity, ModTransferCommunityForm},
-  },
-  traits::{Crud, Joinable},
+    source::{
+        community::{CommunityModerator, CommunityModeratorForm},
+        moderator::{ModTransferCommunity, ModTransferCommunityForm},
+    },
+    traits::{Crud, Joinable},
 };
 use lemmy_db_views_actor::structs::{CommunityModeratorView, CommunityView};
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
-  location_info,
+    error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+    location_info,
 };
 
 // TODO: we dont do anything for federation here, it should be updated the next time the community
 //       gets fetched. i hope we can get rid of the community creator role soon.
 #[tracing::instrument(skip(context))]
 pub async fn transfer_community(
-  data: Json<TransferCommunity>,
-  context: Data<LemmyContext>,
+    data: Json<TransferCommunity>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<GetCommunityResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  // Fetch the community mods
-  let community_id = data.community_id;
-  let mut community_mods =
-    CommunityModeratorView::for_community(&mut context.pool(), community_id).await?;
+    // Fetch the community mods
+    let community_id = data.community_id;
+    let mut community_mods =
+        CommunityModeratorView::for_community(&mut context.pool(), community_id).await?;
 
-  // Make sure transferrer is either the top community mod, or an admin
-  if !(is_top_mod(&local_user_view, &community_mods).is_ok() || is_admin(&local_user_view).is_ok())
-  {
-    Err(LemmyErrorType::NotAnAdmin)?
-  }
+    // Make sure transferrer is either the top community mod, or an admin
+    if !(is_top_mod(&local_user_view, &community_mods).is_ok()
+        || is_admin(&local_user_view).is_ok())
+    {
+        Err(LemmyErrorType::NotAnAdmin)?
+    }
 
-  // You have to re-do the community_moderator table, reordering it.
-  // Add the transferee to the top
-  let creator_index = community_mods
-    .iter()
-    .position(|r| r.moderator.id == data.person_id)
-    .context(location_info!())?;
-  let creator_person = community_mods.remove(creator_index);
-  community_mods.insert(0, creator_person);
+    // You have to re-do the community_moderator table, reordering it.
+    // Add the transferee to the top
+    let creator_index = community_mods
+        .iter()
+        .position(|r| r.moderator.id == data.person_id)
+        .context(location_info!())?;
+    let creator_person = community_mods.remove(creator_index);
+    community_mods.insert(0, creator_person);
 
-  // Delete all the mods
-  let community_id = data.community_id;
+    // Delete all the mods
+    let community_id = data.community_id;
 
-  CommunityModerator::delete_for_community(&mut context.pool(), community_id).await?;
+    CommunityModerator::delete_for_community(&mut context.pool(), community_id).await?;
 
-  // TODO: this should probably be a bulk operation
-  // Re-add the mods, in the new order
-  for cmod in &community_mods {
-    let community_moderator_form = CommunityModeratorForm {
-      community_id: cmod.community.id,
-      person_id: cmod.moderator.id,
+    // TODO: this should probably be a bulk operation
+    // Re-add the mods, in the new order
+    for cmod in &community_mods {
+        let community_moderator_form = CommunityModeratorForm {
+            community_id: cmod.community.id,
+            person_id: cmod.moderator.id,
+        };
+
+        CommunityModerator::join(&mut context.pool(), &community_moderator_form)
+            .await
+            .with_lemmy_type(LemmyErrorType::CommunityModeratorAlreadyExists)?;
+    }
+
+    // Mod tables
+    let form = ModTransferCommunityForm {
+        mod_person_id: local_user_view.person.id,
+        other_person_id: data.person_id,
+        community_id: data.community_id,
     };
 
-    CommunityModerator::join(&mut context.pool(), &community_moderator_form)
-      .await
-      .with_lemmy_type(LemmyErrorType::CommunityModeratorAlreadyExists)?;
-  }
+    ModTransferCommunity::create(&mut context.pool(), &form).await?;
 
-  // Mod tables
-  let form = ModTransferCommunityForm {
-    mod_person_id: local_user_view.person.id,
-    other_person_id: data.person_id,
-    community_id: data.community_id,
-  };
+    let community_id = data.community_id;
+    let person_id = local_user_view.person.id;
+    let community_view =
+        CommunityView::read(&mut context.pool(), community_id, Some(person_id), false)
+            .await
+            .with_lemmy_type(LemmyErrorType::CouldntFindCommunity)?;
 
-  ModTransferCommunity::create(&mut context.pool(), &form).await?;
+    let community_id = data.community_id;
+    let moderators = CommunityModeratorView::for_community(&mut context.pool(), community_id)
+        .await
+        .with_lemmy_type(LemmyErrorType::CouldntFindCommunity)?;
 
-  let community_id = data.community_id;
-  let person_id = local_user_view.person.id;
-  let community_view =
-    CommunityView::read(&mut context.pool(), community_id, Some(person_id), false)
-      .await
-      .with_lemmy_type(LemmyErrorType::CouldntFindCommunity)?;
-
-  let community_id = data.community_id;
-  let moderators = CommunityModeratorView::for_community(&mut context.pool(), community_id)
-    .await
-    .with_lemmy_type(LemmyErrorType::CouldntFindCommunity)?;
-
-  // Return the jwt
-  Ok(Json(GetCommunityResponse {
-    community_view,
-    site: None,
-    moderators,
-    discussion_languages: vec![],
-  }))
+    // Return the jwt
+    Ok(Json(GetCommunityResponse {
+        community_view,
+        site: None,
+        moderators,
+        discussion_languages: vec![],
+    }))
 }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -3,8 +3,8 @@ use captcha::Captcha;
 use lemmy_api_common::utils::local_site_to_slur_regex;
 use lemmy_db_schema::source::local_site::LocalSite;
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
-  utils::slurs::check_slurs,
+    error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+    utils::slurs::check_slurs,
 };
 use std::io::Cursor;
 
@@ -21,117 +21,117 @@ pub mod sitemap;
 
 /// Converts the captcha to a base64 encoded wav audio file
 pub(crate) fn captcha_as_wav_base64(captcha: &Captcha) -> Result<String, LemmyError> {
-  let letters = captcha.as_wav();
+    let letters = captcha.as_wav();
 
-  // Decode each wav file, concatenate the samples
-  let mut concat_samples: Vec<i16> = Vec::new();
-  let mut any_header: Option<wav::Header> = None;
-  for letter in letters {
-    let mut cursor = Cursor::new(letter.unwrap_or_default());
-    let (header, samples) = wav::read(&mut cursor)?;
-    any_header = Some(header);
-    if let Some(samples16) = samples.as_sixteen() {
-      concat_samples.extend(samples16);
-    } else {
-      Err(LemmyErrorType::CouldntCreateAudioCaptcha)?
+    // Decode each wav file, concatenate the samples
+    let mut concat_samples: Vec<i16> = Vec::new();
+    let mut any_header: Option<wav::Header> = None;
+    for letter in letters {
+        let mut cursor = Cursor::new(letter.unwrap_or_default());
+        let (header, samples) = wav::read(&mut cursor)?;
+        any_header = Some(header);
+        if let Some(samples16) = samples.as_sixteen() {
+            concat_samples.extend(samples16);
+        } else {
+            Err(LemmyErrorType::CouldntCreateAudioCaptcha)?
+        }
     }
-  }
 
-  // Encode the concatenated result as a wav file
-  let mut output_buffer = Cursor::new(vec![]);
-  if let Some(header) = any_header {
-    wav::write(
-      header,
-      &wav::BitDepth::Sixteen(concat_samples),
-      &mut output_buffer,
-    )
-    .with_lemmy_type(LemmyErrorType::CouldntCreateAudioCaptcha)?;
+    // Encode the concatenated result as a wav file
+    let mut output_buffer = Cursor::new(vec![]);
+    if let Some(header) = any_header {
+        wav::write(
+            header,
+            &wav::BitDepth::Sixteen(concat_samples),
+            &mut output_buffer,
+        )
+        .with_lemmy_type(LemmyErrorType::CouldntCreateAudioCaptcha)?;
 
-    Ok(base64.encode(output_buffer.into_inner()))
-  } else {
-    Err(LemmyErrorType::CouldntCreateAudioCaptcha)?
-  }
+        Ok(base64.encode(output_buffer.into_inner()))
+    } else {
+        Err(LemmyErrorType::CouldntCreateAudioCaptcha)?
+    }
 }
 
 /// Check size of report
 pub(crate) fn check_report_reason(reason: &str, local_site: &LocalSite) -> Result<(), LemmyError> {
-  let slur_regex = &local_site_to_slur_regex(local_site);
+    let slur_regex = &local_site_to_slur_regex(local_site);
 
-  check_slurs(reason, slur_regex)?;
-  if reason.is_empty() {
-    Err(LemmyErrorType::ReportReasonRequired)?
-  } else if reason.chars().count() > 1000 {
-    Err(LemmyErrorType::ReportTooLong)?
-  } else {
-    Ok(())
-  }
+    check_slurs(reason, slur_regex)?;
+    if reason.is_empty() {
+        Err(LemmyErrorType::ReportReasonRequired)?
+    } else if reason.chars().count() > 1000 {
+        Err(LemmyErrorType::ReportTooLong)?
+    } else {
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use lemmy_api_common::utils::check_validator_time;
-  use lemmy_db_schema::{
-    source::{
-      instance::Instance,
-      local_user::{LocalUser, LocalUserInsertForm},
-      person::{Person, PersonInsertForm},
-      secret::Secret,
-    },
-    traits::Crud,
-    utils::build_db_pool_for_tests,
-  };
-  use lemmy_utils::{claims::Claims, settings::SETTINGS};
-  use serial_test::serial;
+    use lemmy_api_common::utils::check_validator_time;
+    use lemmy_db_schema::{
+        source::{
+            instance::Instance,
+            local_user::{LocalUser, LocalUserInsertForm},
+            person::{Person, PersonInsertForm},
+            secret::Secret,
+        },
+        traits::Crud,
+        utils::build_db_pool_for_tests,
+    };
+    use lemmy_utils::{claims::Claims, settings::SETTINGS};
+    use serial_test::serial;
 
-  #[tokio::test]
-  #[serial]
-  async fn test_should_not_validate_user_token_after_password_change() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-    let secret = Secret::init(pool).await.unwrap();
-    let settings = &SETTINGS.to_owned();
+    #[tokio::test]
+    #[serial]
+    async fn test_should_not_validate_user_token_after_password_change() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
+        let secret = Secret::init(pool).await.unwrap();
+        let settings = &SETTINGS.to_owned();
 
-    let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
-      .await
-      .unwrap();
+        let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
+            .await
+            .unwrap();
 
-    let new_person = PersonInsertForm::builder()
-      .name("Gerry9812".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
+        let new_person = PersonInsertForm::builder()
+            .name("Gerry9812".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let inserted_person = Person::create(pool, &new_person).await.unwrap();
+        let inserted_person = Person::create(pool, &new_person).await.unwrap();
 
-    let local_user_form = LocalUserInsertForm::builder()
-      .person_id(inserted_person.id)
-      .password_encrypted("123456".to_string())
-      .build();
+        let local_user_form = LocalUserInsertForm::builder()
+            .person_id(inserted_person.id)
+            .password_encrypted("123456".to_string())
+            .build();
 
-    let inserted_local_user = LocalUser::create(pool, &local_user_form).await.unwrap();
+        let inserted_local_user = LocalUser::create(pool, &local_user_form).await.unwrap();
 
-    let jwt = Claims::jwt(
-      inserted_local_user.id.0,
-      &secret.jwt_secret,
-      &settings.hostname,
-    )
-    .unwrap();
-    let claims = Claims::decode(&jwt, &secret.jwt_secret).unwrap().claims;
-    let check = check_validator_time(&inserted_local_user.validator_time, &claims);
-    assert!(check.is_ok());
-
-    // The check should fail, since the validator time is now newer than the jwt issue time
-    let updated_local_user =
-      LocalUser::update_password(pool, inserted_local_user.id, "password111")
-        .await
+        let jwt = Claims::jwt(
+            inserted_local_user.id.0,
+            &secret.jwt_secret,
+            &settings.hostname,
+        )
         .unwrap();
-    let check_after = check_validator_time(&updated_local_user.validator_time, &claims);
-    assert!(check_after.is_err());
+        let claims = Claims::decode(&jwt, &secret.jwt_secret).unwrap().claims;
+        let check = check_validator_time(&inserted_local_user.validator_time, &claims);
+        assert!(check.is_ok());
 
-    let num_deleted = Person::delete(pool, inserted_person.id).await.unwrap();
-    assert_eq!(1, num_deleted);
-  }
+        // The check should fail, since the validator time is now newer than the jwt issue time
+        let updated_local_user =
+            LocalUser::update_password(pool, inserted_local_user.id, "password111")
+                .await
+                .unwrap();
+        let check_after = check_validator_time(&updated_local_user.validator_time, &claims);
+        assert!(check_after.is_err());
+
+        let num_deleted = Person::delete(pool, inserted_person.id).await.unwrap();
+        assert_eq!(1, num_deleted);
+    }
 }

--- a/crates/api/src/local_user/add_admin.rs
+++ b/crates/api/src/local_user/add_admin.rs
@@ -1,50 +1,50 @@
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  context::LemmyContext,
-  person::{AddAdmin, AddAdminResponse},
-  utils::{is_admin, local_user_view_from_jwt},
+    context::LemmyContext,
+    person::{AddAdmin, AddAdminResponse},
+    utils::{is_admin, local_user_view_from_jwt},
 };
 use lemmy_db_schema::{
-  source::{
-    local_user::{LocalUser, LocalUserUpdateForm},
-    moderator::{ModAdd, ModAddForm},
-  },
-  traits::Crud,
+    source::{
+        local_user::{LocalUser, LocalUserUpdateForm},
+        moderator::{ModAdd, ModAddForm},
+    },
+    traits::Crud,
 };
 use lemmy_db_views_actor::structs::PersonView;
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn add_admin(
-  data: Json<AddAdmin>,
-  context: Data<LemmyContext>,
+    data: Json<AddAdmin>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<AddAdminResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  // Make sure user is an admin
-  is_admin(&local_user_view)?;
+    // Make sure user is an admin
+    is_admin(&local_user_view)?;
 
-  let added_admin = LocalUser::update(
-    &mut context.pool(),
-    data.local_user_id,
-    &LocalUserUpdateForm {
-      admin: Some(data.added),
-      ..Default::default()
-    },
-  )
-  .await
-  .with_lemmy_type(LemmyErrorType::CouldntUpdateUser)?;
+    let added_admin = LocalUser::update(
+        &mut context.pool(),
+        data.local_user_id,
+        &LocalUserUpdateForm {
+            admin: Some(data.added),
+            ..Default::default()
+        },
+    )
+    .await
+    .with_lemmy_type(LemmyErrorType::CouldntUpdateUser)?;
 
-  // Mod tables
-  let form = ModAddForm {
-    mod_person_id: local_user_view.person.id,
-    other_person_id: added_admin.person_id,
-    removed: Some(!data.added),
-  };
+    // Mod tables
+    let form = ModAddForm {
+        mod_person_id: local_user_view.person.id,
+        other_person_id: added_admin.person_id,
+        removed: Some(!data.added),
+    };
 
-  ModAdd::create(&mut context.pool(), &form).await?;
+    ModAdd::create(&mut context.pool(), &form).await?;
 
-  let admins = PersonView::admins(&mut context.pool()).await?;
+    let admins = PersonView::admins(&mut context.pool()).await?;
 
-  Ok(Json(AddAdminResponse { admins }))
+    Ok(Json(AddAdminResponse { admins }))
 }

--- a/crates/api/src/local_user/ban_person.rs
+++ b/crates/api/src/local_user/ban_person.rs
@@ -1,80 +1,80 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  context::LemmyContext,
-  person::{BanPerson, BanPersonResponse},
-  send_activity::{ActivityChannel, SendActivityData},
-  utils::{is_admin, local_user_view_from_jwt, remove_user_data, sanitize_html_opt},
+    context::LemmyContext,
+    person::{BanPerson, BanPersonResponse},
+    send_activity::{ActivityChannel, SendActivityData},
+    utils::{is_admin, local_user_view_from_jwt, remove_user_data, sanitize_html_opt},
 };
 use lemmy_db_schema::{
-  source::{
-    moderator::{ModBan, ModBanForm},
-    person::{Person, PersonUpdateForm},
-  },
-  traits::Crud,
+    source::{
+        moderator::{ModBan, ModBanForm},
+        person::{Person, PersonUpdateForm},
+    },
+    traits::Crud,
 };
 use lemmy_db_views_actor::structs::PersonView;
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
-  utils::{time::naive_from_unix, validation::is_valid_body_field},
+    error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+    utils::{time::naive_from_unix, validation::is_valid_body_field},
 };
 #[tracing::instrument(skip(context))]
 pub async fn ban_from_site(
-  data: Json<BanPerson>,
-  context: Data<LemmyContext>,
+    data: Json<BanPerson>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<BanPersonResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  // Make sure user is an admin
-  is_admin(&local_user_view)?;
+    // Make sure user is an admin
+    is_admin(&local_user_view)?;
 
-  is_valid_body_field(&data.reason, false)?;
+    is_valid_body_field(&data.reason, false)?;
 
-  let expires = data.expires.map(naive_from_unix);
+    let expires = data.expires.map(naive_from_unix);
 
-  let person = Person::update(
-    &mut context.pool(),
-    data.person_id,
-    &PersonUpdateForm {
-      banned: Some(data.ban),
-      ban_expires: Some(expires),
-      ..Default::default()
-    },
-  )
-  .await
-  .with_lemmy_type(LemmyErrorType::CouldntUpdateUser)?;
+    let person = Person::update(
+        &mut context.pool(),
+        data.person_id,
+        &PersonUpdateForm {
+            banned: Some(data.ban),
+            ban_expires: Some(expires),
+            ..Default::default()
+        },
+    )
+    .await
+    .with_lemmy_type(LemmyErrorType::CouldntUpdateUser)?;
 
-  // Remove their data if that's desired
-  let remove_data = data.remove_data.unwrap_or(false);
-  if remove_data {
-    remove_user_data(person.id, &context).await?;
-  }
+    // Remove their data if that's desired
+    let remove_data = data.remove_data.unwrap_or(false);
+    if remove_data {
+        remove_user_data(person.id, &context).await?;
+    }
 
-  // Mod tables
-  let form = ModBanForm {
-    mod_person_id: local_user_view.person.id,
-    other_person_id: data.person_id,
-    reason: sanitize_html_opt(&data.reason),
-    banned: Some(data.ban),
-    expires,
-  };
+    // Mod tables
+    let form = ModBanForm {
+        mod_person_id: local_user_view.person.id,
+        other_person_id: data.person_id,
+        reason: sanitize_html_opt(&data.reason),
+        banned: Some(data.ban),
+        expires,
+    };
 
-  ModBan::create(&mut context.pool(), &form).await?;
+    ModBan::create(&mut context.pool(), &form).await?;
 
-  let person_view = PersonView::read(&mut context.pool(), data.person_id).await?;
+    let person_view = PersonView::read(&mut context.pool(), data.person_id).await?;
 
-  ActivityChannel::submit_activity(
-    SendActivityData::BanFromSite(
-      local_user_view.person,
-      person_view.person.clone(),
-      data.0.clone(),
-    ),
-    &context,
-  )
-  .await?;
+    ActivityChannel::submit_activity(
+        SendActivityData::BanFromSite(
+            local_user_view.person,
+            person_view.person.clone(),
+            data.0.clone(),
+        ),
+        &context,
+    )
+    .await?;
 
-  Ok(Json(BanPersonResponse {
-    person_view,
-    banned: data.ban,
-  }))
+    Ok(Json(BanPersonResponse {
+        person_view,
+        banned: data.ban,
+    }))
 }

--- a/crates/api/src/local_user/block.rs
+++ b/crates/api/src/local_user/block.rs
@@ -1,12 +1,12 @@
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  context::LemmyContext,
-  person::{BlockPerson, BlockPersonResponse},
-  utils::local_user_view_from_jwt,
+    context::LemmyContext,
+    person::{BlockPerson, BlockPersonResponse},
+    utils::local_user_view_from_jwt,
 };
 use lemmy_db_schema::{
-  source::person_block::{PersonBlock, PersonBlockForm},
-  traits::Blockable,
+    source::person_block::{PersonBlock, PersonBlockForm},
+    traits::Blockable,
 };
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_db_views_actor::structs::PersonView;
@@ -14,42 +14,42 @@ use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn block_person(
-  data: Json<BlockPerson>,
-  context: Data<LemmyContext>,
+    data: Json<BlockPerson>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<BlockPersonResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  let target_id = data.person_id;
-  let person_id = local_user_view.person.id;
+    let target_id = data.person_id;
+    let person_id = local_user_view.person.id;
 
-  // Don't let a person block themselves
-  if target_id == person_id {
-    Err(LemmyErrorType::CantBlockYourself)?
-  }
+    // Don't let a person block themselves
+    if target_id == person_id {
+        Err(LemmyErrorType::CantBlockYourself)?
+    }
 
-  let person_block_form = PersonBlockForm {
-    person_id,
-    target_id,
-  };
+    let person_block_form = PersonBlockForm {
+        person_id,
+        target_id,
+    };
 
-  let target_user = LocalUserView::read_person(&mut context.pool(), target_id).await;
-  if target_user.map(|t| t.local_user.admin) == Ok(true) {
-    Err(LemmyErrorType::CantBlockAdmin)?
-  }
+    let target_user = LocalUserView::read_person(&mut context.pool(), target_id).await;
+    if target_user.map(|t| t.local_user.admin) == Ok(true) {
+        Err(LemmyErrorType::CantBlockAdmin)?
+    }
 
-  if data.block {
-    PersonBlock::block(&mut context.pool(), &person_block_form)
-      .await
-      .with_lemmy_type(LemmyErrorType::PersonBlockAlreadyExists)?;
-  } else {
-    PersonBlock::unblock(&mut context.pool(), &person_block_form)
-      .await
-      .with_lemmy_type(LemmyErrorType::PersonBlockAlreadyExists)?;
-  }
+    if data.block {
+        PersonBlock::block(&mut context.pool(), &person_block_form)
+            .await
+            .with_lemmy_type(LemmyErrorType::PersonBlockAlreadyExists)?;
+    } else {
+        PersonBlock::unblock(&mut context.pool(), &person_block_form)
+            .await
+            .with_lemmy_type(LemmyErrorType::PersonBlockAlreadyExists)?;
+    }
 
-  let person_view = PersonView::read(&mut context.pool(), target_id).await?;
-  Ok(Json(BlockPersonResponse {
-    person_view,
-    blocked: data.block,
-  }))
+    let person_view = PersonView::read(&mut context.pool(), target_id).await?;
+    Ok(Json(BlockPersonResponse {
+        person_view,
+        blocked: data.block,
+    }))
 }

--- a/crates/api/src/local_user/change_password.rs
+++ b/crates/api/src/local_user/change_password.rs
@@ -1,56 +1,56 @@
 use actix_web::web::{Data, Json};
 use bcrypt::verify;
 use lemmy_api_common::{
-  context::LemmyContext,
-  person::{ChangePassword, LoginResponse},
-  utils::{local_user_view_from_jwt, password_length_check},
+    context::LemmyContext,
+    person::{ChangePassword, LoginResponse},
+    utils::{local_user_view_from_jwt, password_length_check},
 };
 use lemmy_db_schema::source::local_user::LocalUser;
 use lemmy_utils::{
-  claims::Claims,
-  error::{LemmyError, LemmyErrorType},
+    claims::Claims,
+    error::{LemmyError, LemmyErrorType},
 };
 
 #[tracing::instrument(skip(context))]
 pub async fn change_password(
-  data: Json<ChangePassword>,
-  context: Data<LemmyContext>,
+    data: Json<ChangePassword>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<LoginResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(data.auth.as_ref(), &context).await?;
+    let local_user_view = local_user_view_from_jwt(data.auth.as_ref(), &context).await?;
 
-  password_length_check(&data.new_password)?;
+    password_length_check(&data.new_password)?;
 
-  // Make sure passwords match
-  if data.new_password != data.new_password_verify {
-    Err(LemmyErrorType::PasswordsDoNotMatch)?
-  }
+    // Make sure passwords match
+    if data.new_password != data.new_password_verify {
+        Err(LemmyErrorType::PasswordsDoNotMatch)?
+    }
 
-  // Check the old password
-  let valid: bool = verify(
-    &data.old_password,
-    &local_user_view.local_user.password_encrypted,
-  )
-  .unwrap_or(false);
-  if !valid {
-    Err(LemmyErrorType::IncorrectLogin)?
-  }
+    // Check the old password
+    let valid: bool = verify(
+        &data.old_password,
+        &local_user_view.local_user.password_encrypted,
+    )
+    .unwrap_or(false);
+    if !valid {
+        Err(LemmyErrorType::IncorrectLogin)?
+    }
 
-  let local_user_id = local_user_view.local_user.id;
-  let new_password = data.new_password.clone();
-  let updated_local_user =
-    LocalUser::update_password(&mut context.pool(), local_user_id, &new_password).await?;
+    let local_user_id = local_user_view.local_user.id;
+    let new_password = data.new_password.clone();
+    let updated_local_user =
+        LocalUser::update_password(&mut context.pool(), local_user_id, &new_password).await?;
 
-  // Return the jwt
-  Ok(Json(LoginResponse {
-    jwt: Some(
-      Claims::jwt(
-        updated_local_user.id.0,
-        &context.secret().jwt_secret,
-        &context.settings().hostname,
-      )?
-      .into(),
-    ),
-    verify_email_sent: false,
-    registration_created: false,
-  }))
+    // Return the jwt
+    Ok(Json(LoginResponse {
+        jwt: Some(
+            Claims::jwt(
+                updated_local_user.id.0,
+                &context.secret().jwt_secret,
+                &context.settings().hostname,
+            )?
+            .into(),
+        ),
+        verify_email_sent: false,
+        registration_created: false,
+    }))
 }

--- a/crates/api/src/local_user/change_password_after_reset.rs
+++ b/crates/api/src/local_user/change_password_after_reset.rs
@@ -1,42 +1,41 @@
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  context::LemmyContext,
-  person::{LoginResponse, PasswordChangeAfterReset},
-  utils::password_length_check,
+    context::LemmyContext,
+    person::{LoginResponse, PasswordChangeAfterReset},
+    utils::password_length_check,
 };
 use lemmy_db_schema::source::{
-  local_user::LocalUser,
-  password_reset_request::PasswordResetRequest,
+    local_user::LocalUser, password_reset_request::PasswordResetRequest,
 };
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn change_password_after_reset(
-  data: Json<PasswordChangeAfterReset>,
-  context: Data<LemmyContext>,
+    data: Json<PasswordChangeAfterReset>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<LoginResponse>, LemmyError> {
-  // Fetch the user_id from the token
-  let token = data.token.clone();
-  let local_user_id = PasswordResetRequest::read_from_token(&mut context.pool(), &token)
-    .await
-    .map(|p| p.local_user_id)?;
+    // Fetch the user_id from the token
+    let token = data.token.clone();
+    let local_user_id = PasswordResetRequest::read_from_token(&mut context.pool(), &token)
+        .await
+        .map(|p| p.local_user_id)?;
 
-  password_length_check(&data.password)?;
+    password_length_check(&data.password)?;
 
-  // Make sure passwords match
-  if data.password != data.password_verify {
-    Err(LemmyErrorType::PasswordsDoNotMatch)?
-  }
+    // Make sure passwords match
+    if data.password != data.password_verify {
+        Err(LemmyErrorType::PasswordsDoNotMatch)?
+    }
 
-  // Update the user with the new password
-  let password = data.password.clone();
-  LocalUser::update_password(&mut context.pool(), local_user_id, &password)
-    .await
-    .with_lemmy_type(LemmyErrorType::CouldntUpdateUser)?;
+    // Update the user with the new password
+    let password = data.password.clone();
+    LocalUser::update_password(&mut context.pool(), local_user_id, &password)
+        .await
+        .with_lemmy_type(LemmyErrorType::CouldntUpdateUser)?;
 
-  Ok(Json(LoginResponse {
-    jwt: None,
-    verify_email_sent: false,
-    registration_created: false,
-  }))
+    Ok(Json(LoginResponse {
+        jwt: None,
+        verify_email_sent: false,
+        registration_created: false,
+    }))
 }

--- a/crates/api/src/local_user/get_captcha.rs
+++ b/crates/api/src/local_user/get_captcha.rs
@@ -2,46 +2,46 @@ use crate::captcha_as_wav_base64;
 use actix_web::web::{Data, Json};
 use captcha::{gen, Difficulty};
 use lemmy_api_common::{
-  context::LemmyContext,
-  person::{CaptchaResponse, GetCaptchaResponse},
+    context::LemmyContext,
+    person::{CaptchaResponse, GetCaptchaResponse},
 };
 use lemmy_db_schema::source::{
-  captcha_answer::{CaptchaAnswer, CaptchaAnswerForm},
-  local_site::LocalSite,
+    captcha_answer::{CaptchaAnswer, CaptchaAnswerForm},
+    local_site::LocalSite,
 };
 use lemmy_utils::error::LemmyError;
 
 #[tracing::instrument(skip(context))]
 pub async fn get_captcha(
-  context: Data<LemmyContext>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<GetCaptchaResponse>, LemmyError> {
-  let local_site = LocalSite::read(&mut context.pool()).await?;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
 
-  if !local_site.captcha_enabled {
-    return Ok(Json(GetCaptchaResponse { ok: None }));
-  }
+    if !local_site.captcha_enabled {
+        return Ok(Json(GetCaptchaResponse { ok: None }));
+    }
 
-  let captcha = gen(match local_site.captcha_difficulty.as_str() {
-    "easy" => Difficulty::Easy,
-    "hard" => Difficulty::Hard,
-    _ => Difficulty::Medium,
-  });
+    let captcha = gen(match local_site.captcha_difficulty.as_str() {
+        "easy" => Difficulty::Easy,
+        "hard" => Difficulty::Hard,
+        _ => Difficulty::Medium,
+    });
 
-  let answer = captcha.chars_as_string();
+    let answer = captcha.chars_as_string();
 
-  let png = captcha.as_base64().expect("failed to generate captcha");
+    let png = captcha.as_base64().expect("failed to generate captcha");
 
-  let wav = captcha_as_wav_base64(&captcha)?;
+    let wav = captcha_as_wav_base64(&captcha)?;
 
-  let captcha_form: CaptchaAnswerForm = CaptchaAnswerForm { answer };
-  // Stores the captcha item in the db
-  let captcha = CaptchaAnswer::insert(&mut context.pool(), &captcha_form).await?;
+    let captcha_form: CaptchaAnswerForm = CaptchaAnswerForm { answer };
+    // Stores the captcha item in the db
+    let captcha = CaptchaAnswer::insert(&mut context.pool(), &captcha_form).await?;
 
-  Ok(Json(GetCaptchaResponse {
-    ok: Some(CaptchaResponse {
-      png,
-      wav,
-      uuid: captcha.uuid.to_string(),
-    }),
-  }))
+    Ok(Json(GetCaptchaResponse {
+        ok: Some(CaptchaResponse {
+            png,
+            wav,
+            uuid: captcha.uuid.to_string(),
+        }),
+    }))
 }

--- a/crates/api/src/local_user/list_banned.rs
+++ b/crates/api/src/local_user/list_banned.rs
@@ -1,22 +1,22 @@
 use actix_web::web::{Data, Json, Query};
 use lemmy_api_common::{
-  context::LemmyContext,
-  person::{BannedPersonsResponse, GetBannedPersons},
-  utils::{is_admin, local_user_view_from_jwt},
+    context::LemmyContext,
+    person::{BannedPersonsResponse, GetBannedPersons},
+    utils::{is_admin, local_user_view_from_jwt},
 };
 use lemmy_db_views_actor::structs::PersonView;
 use lemmy_utils::error::LemmyError;
 
 pub async fn list_banned_users(
-  data: Query<GetBannedPersons>,
-  context: Data<LemmyContext>,
+    data: Query<GetBannedPersons>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<BannedPersonsResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  // Make sure user is an admin
-  is_admin(&local_user_view)?;
+    // Make sure user is an admin
+    is_admin(&local_user_view)?;
 
-  let banned = PersonView::banned(&mut context.pool()).await?;
+    let banned = PersonView::banned(&mut context.pool()).await?;
 
-  Ok(Json(BannedPersonsResponse { banned }))
+    Ok(Json(BannedPersonsResponse { banned }))
 }

--- a/crates/api/src/local_user/login.rs
+++ b/crates/api/src/local_user/login.rs
@@ -1,77 +1,77 @@
 use actix_web::web::{Data, Json};
 use bcrypt::verify;
 use lemmy_api_common::{
-  context::LemmyContext,
-  person::{Login, LoginResponse},
-  utils::{check_registration_application, check_user_valid},
+    context::LemmyContext,
+    person::{Login, LoginResponse},
+    utils::{check_registration_application, check_user_valid},
 };
 use lemmy_db_views::structs::{LocalUserView, SiteView};
 use lemmy_utils::{
-  claims::Claims,
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
-  utils::validation::check_totp_2fa_valid,
+    claims::Claims,
+    error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+    utils::validation::check_totp_2fa_valid,
 };
 
 #[tracing::instrument(skip(context))]
 pub async fn login(
-  data: Json<Login>,
-  context: Data<LemmyContext>,
+    data: Json<Login>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<LoginResponse>, LemmyError> {
-  let site_view = SiteView::read_local(&mut context.pool()).await?;
+    let site_view = SiteView::read_local(&mut context.pool()).await?;
 
-  // Fetch that username / email
-  let username_or_email = data.username_or_email.clone();
-  let local_user_view =
-    LocalUserView::find_by_email_or_name(&mut context.pool(), &username_or_email)
-      .await
-      .with_lemmy_type(LemmyErrorType::IncorrectLogin)?;
+    // Fetch that username / email
+    let username_or_email = data.username_or_email.clone();
+    let local_user_view =
+        LocalUserView::find_by_email_or_name(&mut context.pool(), &username_or_email)
+            .await
+            .with_lemmy_type(LemmyErrorType::IncorrectLogin)?;
 
-  // Verify the password
-  let valid: bool = verify(
-    &data.password,
-    &local_user_view.local_user.password_encrypted,
-  )
-  .unwrap_or(false);
-  if !valid {
-    Err(LemmyErrorType::IncorrectLogin)?
-  }
-  check_user_valid(
-    local_user_view.person.banned,
-    local_user_view.person.ban_expires,
-    local_user_view.person.deleted,
-  )?;
+    // Verify the password
+    let valid: bool = verify(
+        &data.password,
+        &local_user_view.local_user.password_encrypted,
+    )
+    .unwrap_or(false);
+    if !valid {
+        Err(LemmyErrorType::IncorrectLogin)?
+    }
+    check_user_valid(
+        local_user_view.person.banned,
+        local_user_view.person.ban_expires,
+        local_user_view.person.deleted,
+    )?;
 
-  // Check if the user's email is verified if email verification is turned on
-  // However, skip checking verification if the user is an admin
-  if !local_user_view.local_user.admin
-    && site_view.local_site.require_email_verification
-    && !local_user_view.local_user.email_verified
-  {
-    Err(LemmyErrorType::EmailNotVerified)?
-  }
+    // Check if the user's email is verified if email verification is turned on
+    // However, skip checking verification if the user is an admin
+    if !local_user_view.local_user.admin
+        && site_view.local_site.require_email_verification
+        && !local_user_view.local_user.email_verified
+    {
+        Err(LemmyErrorType::EmailNotVerified)?
+    }
 
-  check_registration_application(&local_user_view, &site_view.local_site, &mut context.pool())
-    .await?;
+    check_registration_application(&local_user_view, &site_view.local_site, &mut context.pool())
+        .await?;
 
-  // Check the totp
-  check_totp_2fa_valid(
-    &local_user_view.local_user.totp_2fa_secret,
-    &data.totp_2fa_token,
-    &site_view.site.name,
-    &local_user_view.person.name,
-  )?;
+    // Check the totp
+    check_totp_2fa_valid(
+        &local_user_view.local_user.totp_2fa_secret,
+        &data.totp_2fa_token,
+        &site_view.site.name,
+        &local_user_view.person.name,
+    )?;
 
-  // Return the jwt
-  Ok(Json(LoginResponse {
-    jwt: Some(
-      Claims::jwt(
-        local_user_view.local_user.id.0,
-        &context.secret().jwt_secret,
-        &context.settings().hostname,
-      )?
-      .into(),
-    ),
-    verify_email_sent: false,
-    registration_created: false,
-  }))
+    // Return the jwt
+    Ok(Json(LoginResponse {
+        jwt: Some(
+            Claims::jwt(
+                local_user_view.local_user.id.0,
+                &context.secret().jwt_secret,
+                &context.settings().hostname,
+            )?
+            .into(),
+        ),
+        verify_email_sent: false,
+        registration_created: false,
+    }))
 }

--- a/crates/api/src/local_user/notifications/list_mentions.rs
+++ b/crates/api/src/local_user/notifications/list_mentions.rs
@@ -1,37 +1,37 @@
 use actix_web::web::{Data, Json, Query};
 use lemmy_api_common::{
-  context::LemmyContext,
-  person::{GetPersonMentions, GetPersonMentionsResponse},
-  utils::local_user_view_from_jwt,
+    context::LemmyContext,
+    person::{GetPersonMentions, GetPersonMentionsResponse},
+    utils::local_user_view_from_jwt,
 };
 use lemmy_db_views_actor::person_mention_view::PersonMentionQuery;
 use lemmy_utils::error::LemmyError;
 
 #[tracing::instrument(skip(context))]
 pub async fn list_mentions(
-  data: Query<GetPersonMentions>,
-  context: Data<LemmyContext>,
+    data: Query<GetPersonMentions>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<GetPersonMentionsResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  let sort = data.sort;
-  let page = data.page;
-  let limit = data.limit;
-  let unread_only = data.unread_only.unwrap_or_default();
-  let person_id = Some(local_user_view.person.id);
-  let show_bot_accounts = local_user_view.local_user.show_bot_accounts;
+    let sort = data.sort;
+    let page = data.page;
+    let limit = data.limit;
+    let unread_only = data.unread_only.unwrap_or_default();
+    let person_id = Some(local_user_view.person.id);
+    let show_bot_accounts = local_user_view.local_user.show_bot_accounts;
 
-  let mentions = PersonMentionQuery {
-    recipient_id: person_id,
-    my_person_id: person_id,
-    sort,
-    unread_only,
-    show_bot_accounts,
-    page,
-    limit,
-  }
-  .list(&mut context.pool())
-  .await?;
+    let mentions = PersonMentionQuery {
+        recipient_id: person_id,
+        my_person_id: person_id,
+        sort,
+        unread_only,
+        show_bot_accounts,
+        page,
+        limit,
+    }
+    .list(&mut context.pool())
+    .await?;
 
-  Ok(Json(GetPersonMentionsResponse { mentions }))
+    Ok(Json(GetPersonMentionsResponse { mentions }))
 }

--- a/crates/api/src/local_user/notifications/list_replies.rs
+++ b/crates/api/src/local_user/notifications/list_replies.rs
@@ -1,37 +1,37 @@
 use actix_web::web::{Data, Json, Query};
 use lemmy_api_common::{
-  context::LemmyContext,
-  person::{GetReplies, GetRepliesResponse},
-  utils::local_user_view_from_jwt,
+    context::LemmyContext,
+    person::{GetReplies, GetRepliesResponse},
+    utils::local_user_view_from_jwt,
 };
 use lemmy_db_views_actor::comment_reply_view::CommentReplyQuery;
 use lemmy_utils::error::LemmyError;
 
 #[tracing::instrument(skip(context))]
 pub async fn list_replies(
-  data: Query<GetReplies>,
-  context: Data<LemmyContext>,
+    data: Query<GetReplies>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<GetRepliesResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  let sort = data.sort;
-  let page = data.page;
-  let limit = data.limit;
-  let unread_only = data.unread_only.unwrap_or_default();
-  let person_id = Some(local_user_view.person.id);
-  let show_bot_accounts = local_user_view.local_user.show_bot_accounts;
+    let sort = data.sort;
+    let page = data.page;
+    let limit = data.limit;
+    let unread_only = data.unread_only.unwrap_or_default();
+    let person_id = Some(local_user_view.person.id);
+    let show_bot_accounts = local_user_view.local_user.show_bot_accounts;
 
-  let replies = CommentReplyQuery {
-    recipient_id: person_id,
-    my_person_id: person_id,
-    sort,
-    unread_only,
-    show_bot_accounts,
-    page,
-    limit,
-  }
-  .list(&mut context.pool())
-  .await?;
+    let replies = CommentReplyQuery {
+        recipient_id: person_id,
+        my_person_id: person_id,
+        sort,
+        unread_only,
+        show_bot_accounts,
+        page,
+        limit,
+    }
+    .list(&mut context.pool())
+    .await?;
 
-  Ok(Json(GetRepliesResponse { replies }))
+    Ok(Json(GetRepliesResponse { replies }))
 }

--- a/crates/api/src/local_user/notifications/mark_all_read.rs
+++ b/crates/api/src/local_user/notifications/mark_all_read.rs
@@ -1,38 +1,36 @@
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  context::LemmyContext,
-  person::{GetRepliesResponse, MarkAllAsRead},
-  utils::local_user_view_from_jwt,
+    context::LemmyContext,
+    person::{GetRepliesResponse, MarkAllAsRead},
+    utils::local_user_view_from_jwt,
 };
 use lemmy_db_schema::source::{
-  comment_reply::CommentReply,
-  person_mention::PersonMention,
-  private_message::PrivateMessage,
+    comment_reply::CommentReply, person_mention::PersonMention, private_message::PrivateMessage,
 };
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn mark_all_notifications_read(
-  data: Json<MarkAllAsRead>,
-  context: Data<LemmyContext>,
+    data: Json<MarkAllAsRead>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<GetRepliesResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
-  let person_id = local_user_view.person.id;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let person_id = local_user_view.person.id;
 
-  // Mark all comment_replies as read
-  CommentReply::mark_all_as_read(&mut context.pool(), person_id)
-    .await
-    .with_lemmy_type(LemmyErrorType::CouldntUpdateComment)?;
+    // Mark all comment_replies as read
+    CommentReply::mark_all_as_read(&mut context.pool(), person_id)
+        .await
+        .with_lemmy_type(LemmyErrorType::CouldntUpdateComment)?;
 
-  // Mark all user mentions as read
-  PersonMention::mark_all_as_read(&mut context.pool(), person_id)
-    .await
-    .with_lemmy_type(LemmyErrorType::CouldntUpdateComment)?;
+    // Mark all user mentions as read
+    PersonMention::mark_all_as_read(&mut context.pool(), person_id)
+        .await
+        .with_lemmy_type(LemmyErrorType::CouldntUpdateComment)?;
 
-  // Mark all private_messages as read
-  PrivateMessage::mark_all_as_read(&mut context.pool(), person_id)
-    .await
-    .with_lemmy_type(LemmyErrorType::CouldntUpdatePrivateMessage)?;
+    // Mark all private_messages as read
+    PrivateMessage::mark_all_as_read(&mut context.pool(), person_id)
+        .await
+        .with_lemmy_type(LemmyErrorType::CouldntUpdatePrivateMessage)?;
 
-  Ok(Json(GetRepliesResponse { replies: vec![] }))
+    Ok(Json(GetRepliesResponse { replies: vec![] }))
 }

--- a/crates/api/src/local_user/notifications/mark_mention_read.rs
+++ b/crates/api/src/local_user/notifications/mark_mention_read.rs
@@ -1,46 +1,46 @@
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  context::LemmyContext,
-  person::{MarkPersonMentionAsRead, PersonMentionResponse},
-  utils::local_user_view_from_jwt,
+    context::LemmyContext,
+    person::{MarkPersonMentionAsRead, PersonMentionResponse},
+    utils::local_user_view_from_jwt,
 };
 use lemmy_db_schema::{
-  source::person_mention::{PersonMention, PersonMentionUpdateForm},
-  traits::Crud,
+    source::person_mention::{PersonMention, PersonMentionUpdateForm},
+    traits::Crud,
 };
 use lemmy_db_views_actor::structs::PersonMentionView;
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn mark_person_mention_as_read(
-  data: Json<MarkPersonMentionAsRead>,
-  context: Data<LemmyContext>,
+    data: Json<MarkPersonMentionAsRead>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<PersonMentionResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  let person_mention_id = data.person_mention_id;
-  let read_person_mention = PersonMention::read(&mut context.pool(), person_mention_id).await?;
+    let person_mention_id = data.person_mention_id;
+    let read_person_mention = PersonMention::read(&mut context.pool(), person_mention_id).await?;
 
-  if local_user_view.person.id != read_person_mention.recipient_id {
-    Err(LemmyErrorType::CouldntUpdateComment)?
-  }
+    if local_user_view.person.id != read_person_mention.recipient_id {
+        Err(LemmyErrorType::CouldntUpdateComment)?
+    }
 
-  let person_mention_id = read_person_mention.id;
-  let read = Some(data.read);
-  PersonMention::update(
-    &mut context.pool(),
-    person_mention_id,
-    &PersonMentionUpdateForm { read },
-  )
-  .await
-  .with_lemmy_type(LemmyErrorType::CouldntUpdateComment)?;
+    let person_mention_id = read_person_mention.id;
+    let read = Some(data.read);
+    PersonMention::update(
+        &mut context.pool(),
+        person_mention_id,
+        &PersonMentionUpdateForm { read },
+    )
+    .await
+    .with_lemmy_type(LemmyErrorType::CouldntUpdateComment)?;
 
-  let person_mention_id = read_person_mention.id;
-  let person_id = local_user_view.person.id;
-  let person_mention_view =
-    PersonMentionView::read(&mut context.pool(), person_mention_id, Some(person_id)).await?;
+    let person_mention_id = read_person_mention.id;
+    let person_id = local_user_view.person.id;
+    let person_mention_view =
+        PersonMentionView::read(&mut context.pool(), person_mention_id, Some(person_id)).await?;
 
-  Ok(Json(PersonMentionResponse {
-    person_mention_view,
-  }))
+    Ok(Json(PersonMentionResponse {
+        person_mention_view,
+    }))
 }

--- a/crates/api/src/local_user/notifications/mark_reply_read.rs
+++ b/crates/api/src/local_user/notifications/mark_reply_read.rs
@@ -1,45 +1,45 @@
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  context::LemmyContext,
-  person::{CommentReplyResponse, MarkCommentReplyAsRead},
-  utils::local_user_view_from_jwt,
+    context::LemmyContext,
+    person::{CommentReplyResponse, MarkCommentReplyAsRead},
+    utils::local_user_view_from_jwt,
 };
 use lemmy_db_schema::{
-  source::comment_reply::{CommentReply, CommentReplyUpdateForm},
-  traits::Crud,
+    source::comment_reply::{CommentReply, CommentReplyUpdateForm},
+    traits::Crud,
 };
 use lemmy_db_views_actor::structs::CommentReplyView;
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn mark_reply_as_read(
-  data: Json<MarkCommentReplyAsRead>,
-  context: Data<LemmyContext>,
+    data: Json<MarkCommentReplyAsRead>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<CommentReplyResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  let comment_reply_id = data.comment_reply_id;
-  let read_comment_reply = CommentReply::read(&mut context.pool(), comment_reply_id).await?;
+    let comment_reply_id = data.comment_reply_id;
+    let read_comment_reply = CommentReply::read(&mut context.pool(), comment_reply_id).await?;
 
-  if local_user_view.person.id != read_comment_reply.recipient_id {
-    Err(LemmyErrorType::CouldntUpdateComment)?
-  }
+    if local_user_view.person.id != read_comment_reply.recipient_id {
+        Err(LemmyErrorType::CouldntUpdateComment)?
+    }
 
-  let comment_reply_id = read_comment_reply.id;
-  let read = Some(data.read);
+    let comment_reply_id = read_comment_reply.id;
+    let read = Some(data.read);
 
-  CommentReply::update(
-    &mut context.pool(),
-    comment_reply_id,
-    &CommentReplyUpdateForm { read },
-  )
-  .await
-  .with_lemmy_type(LemmyErrorType::CouldntUpdateComment)?;
+    CommentReply::update(
+        &mut context.pool(),
+        comment_reply_id,
+        &CommentReplyUpdateForm { read },
+    )
+    .await
+    .with_lemmy_type(LemmyErrorType::CouldntUpdateComment)?;
 
-  let comment_reply_id = read_comment_reply.id;
-  let person_id = local_user_view.person.id;
-  let comment_reply_view =
-    CommentReplyView::read(&mut context.pool(), comment_reply_id, Some(person_id)).await?;
+    let comment_reply_id = read_comment_reply.id;
+    let person_id = local_user_view.person.id;
+    let comment_reply_view =
+        CommentReplyView::read(&mut context.pool(), comment_reply_id, Some(person_id)).await?;
 
-  Ok(Json(CommentReplyResponse { comment_reply_view }))
+    Ok(Json(CommentReplyResponse { comment_reply_view }))
 }

--- a/crates/api/src/local_user/notifications/unread_count.rs
+++ b/crates/api/src/local_user/notifications/unread_count.rs
@@ -1,8 +1,8 @@
 use actix_web::web::{Data, Json, Query};
 use lemmy_api_common::{
-  context::LemmyContext,
-  person::{GetUnreadCount, GetUnreadCountResponse},
-  utils::local_user_view_from_jwt,
+    context::LemmyContext,
+    person::{GetUnreadCount, GetUnreadCountResponse},
+    utils::local_user_view_from_jwt,
 };
 use lemmy_db_views::structs::PrivateMessageView;
 use lemmy_db_views_actor::structs::{CommentReplyView, PersonMentionView};
@@ -10,23 +10,23 @@ use lemmy_utils::error::LemmyError;
 
 #[tracing::instrument(skip(context))]
 pub async fn unread_count(
-  data: Query<GetUnreadCount>,
-  context: Data<LemmyContext>,
+    data: Query<GetUnreadCount>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<GetUnreadCountResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  let person_id = local_user_view.person.id;
+    let person_id = local_user_view.person.id;
 
-  let replies = CommentReplyView::get_unread_replies(&mut context.pool(), person_id).await?;
+    let replies = CommentReplyView::get_unread_replies(&mut context.pool(), person_id).await?;
 
-  let mentions = PersonMentionView::get_unread_mentions(&mut context.pool(), person_id).await?;
+    let mentions = PersonMentionView::get_unread_mentions(&mut context.pool(), person_id).await?;
 
-  let private_messages =
-    PrivateMessageView::get_unread_messages(&mut context.pool(), person_id).await?;
+    let private_messages =
+        PrivateMessageView::get_unread_messages(&mut context.pool(), person_id).await?;
 
-  Ok(Json(GetUnreadCountResponse {
-    replies,
-    mentions,
-    private_messages,
-  }))
+    Ok(Json(GetUnreadCountResponse {
+        replies,
+        mentions,
+        private_messages,
+    }))
 }

--- a/crates/api/src/local_user/report_count.rs
+++ b/crates/api/src/local_user/report_count.rs
@@ -1,40 +1,41 @@
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  context::LemmyContext,
-  person::{GetReportCount, GetReportCountResponse},
-  utils::local_user_view_from_jwt,
+    context::LemmyContext,
+    person::{GetReportCount, GetReportCountResponse},
+    utils::local_user_view_from_jwt,
 };
 use lemmy_db_views::structs::{CommentReportView, PostReportView, PrivateMessageReportView};
 use lemmy_utils::error::LemmyError;
 
 #[tracing::instrument(skip(context))]
 pub async fn report_count(
-  data: Json<GetReportCount>,
-  context: Data<LemmyContext>,
+    data: Json<GetReportCount>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<GetReportCountResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  let person_id = local_user_view.person.id;
-  let admin = local_user_view.local_user.admin;
-  let community_id = data.community_id;
+    let person_id = local_user_view.person.id;
+    let admin = local_user_view.local_user.admin;
+    let community_id = data.community_id;
 
-  let comment_reports =
-    CommentReportView::get_report_count(&mut context.pool(), person_id, admin, community_id)
-      .await?;
+    let comment_reports =
+        CommentReportView::get_report_count(&mut context.pool(), person_id, admin, community_id)
+            .await?;
 
-  let post_reports =
-    PostReportView::get_report_count(&mut context.pool(), person_id, admin, community_id).await?;
+    let post_reports =
+        PostReportView::get_report_count(&mut context.pool(), person_id, admin, community_id)
+            .await?;
 
-  let private_message_reports = if admin && community_id.is_none() {
-    Some(PrivateMessageReportView::get_report_count(&mut context.pool()).await?)
-  } else {
-    None
-  };
+    let private_message_reports = if admin && community_id.is_none() {
+        Some(PrivateMessageReportView::get_report_count(&mut context.pool()).await?)
+    } else {
+        None
+    };
 
-  Ok(Json(GetReportCountResponse {
-    community_id,
-    comment_reports,
-    post_reports,
-    private_message_reports,
-  }))
+    Ok(Json(GetReportCountResponse {
+        community_id,
+        comment_reports,
+        post_reports,
+        private_message_reports,
+    }))
 }

--- a/crates/api/src/local_user/reset_password.rs
+++ b/crates/api/src/local_user/reset_password.rs
@@ -1,8 +1,8 @@
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  context::LemmyContext,
-  person::{PasswordReset, PasswordResetResponse},
-  utils::send_password_reset_email,
+    context::LemmyContext,
+    person::{PasswordReset, PasswordResetResponse},
+    utils::send_password_reset_email,
 };
 use lemmy_db_schema::source::password_reset_request::PasswordResetRequest;
 use lemmy_db_views::structs::LocalUserView;
@@ -10,26 +10,26 @@ use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn reset_password(
-  data: Json<PasswordReset>,
-  context: Data<LemmyContext>,
+    data: Json<PasswordReset>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<PasswordResetResponse>, LemmyError> {
-  // Fetch that email
-  let email = data.email.to_lowercase();
-  let local_user_view = LocalUserView::find_by_email(&mut context.pool(), &email)
-    .await
-    .with_lemmy_type(LemmyErrorType::IncorrectLogin)?;
+    // Fetch that email
+    let email = data.email.to_lowercase();
+    let local_user_view = LocalUserView::find_by_email(&mut context.pool(), &email)
+        .await
+        .with_lemmy_type(LemmyErrorType::IncorrectLogin)?;
 
-  // Check for too many attempts (to limit potential abuse)
-  let recent_resets_count = PasswordResetRequest::get_recent_password_resets_count(
-    &mut context.pool(),
-    local_user_view.local_user.id,
-  )
-  .await?;
-  if recent_resets_count >= 3 {
-    Err(LemmyErrorType::PasswordResetLimitReached)?
-  }
+    // Check for too many attempts (to limit potential abuse)
+    let recent_resets_count = PasswordResetRequest::get_recent_password_resets_count(
+        &mut context.pool(),
+        local_user_view.local_user.id,
+    )
+    .await?;
+    if recent_resets_count >= 3 {
+        Err(LemmyErrorType::PasswordResetLimitReached)?
+    }
 
-  // Email the pure token to the user.
-  send_password_reset_email(&local_user_view, &mut context.pool(), context.settings()).await?;
-  Ok(Json(PasswordResetResponse {}))
+    // Email the pure token to the user.
+    send_password_reset_email(&local_user_view, &mut context.pool(), context.settings()).await?;
+    Ok(Json(PasswordResetResponse {}))
 }

--- a/crates/api/src/local_user/save_settings.rs
+++ b/crates/api/src/local_user/save_settings.rs
@@ -1,174 +1,171 @@
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  context::LemmyContext,
-  person::{LoginResponse, SaveUserSettings},
-  utils::{local_user_view_from_jwt, sanitize_html_opt, send_verification_email},
+    context::LemmyContext,
+    person::{LoginResponse, SaveUserSettings},
+    utils::{local_user_view_from_jwt, sanitize_html_opt, send_verification_email},
 };
 use lemmy_db_schema::{
-  source::{
-    actor_language::LocalUserLanguage,
-    local_user::{LocalUser, LocalUserUpdateForm},
-    person::{Person, PersonUpdateForm},
-  },
-  traits::Crud,
-  utils::{diesel_option_overwrite, diesel_option_overwrite_to_url},
+    source::{
+        actor_language::LocalUserLanguage,
+        local_user::{LocalUser, LocalUserUpdateForm},
+        person::{Person, PersonUpdateForm},
+    },
+    traits::Crud,
+    utils::{diesel_option_overwrite, diesel_option_overwrite_to_url},
 };
 use lemmy_db_views::structs::SiteView;
 use lemmy_utils::{
-  claims::Claims,
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
-  utils::validation::{
-    build_totp_2fa,
-    generate_totp_2fa_secret,
-    is_valid_bio_field,
-    is_valid_display_name,
-    is_valid_matrix_id,
-  },
+    claims::Claims,
+    error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+    utils::validation::{
+        build_totp_2fa, generate_totp_2fa_secret, is_valid_bio_field, is_valid_display_name,
+        is_valid_matrix_id,
+    },
 };
 
 #[tracing::instrument(skip(context))]
 pub async fn save_user_settings(
-  data: Json<SaveUserSettings>,
-  context: Data<LemmyContext>,
+    data: Json<SaveUserSettings>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<LoginResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
-  let site_view = SiteView::read_local(&mut context.pool()).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let site_view = SiteView::read_local(&mut context.pool()).await?;
 
-  let bio = sanitize_html_opt(&data.bio);
-  let display_name = sanitize_html_opt(&data.display_name);
+    let bio = sanitize_html_opt(&data.bio);
+    let display_name = sanitize_html_opt(&data.display_name);
 
-  let avatar = diesel_option_overwrite_to_url(&data.avatar)?;
-  let banner = diesel_option_overwrite_to_url(&data.banner)?;
-  let bio = diesel_option_overwrite(bio);
-  let display_name = diesel_option_overwrite(display_name);
-  let matrix_user_id = diesel_option_overwrite(data.matrix_user_id.clone());
-  let email_deref = data.email.as_deref().map(str::to_lowercase);
-  let email = diesel_option_overwrite(email_deref.clone());
+    let avatar = diesel_option_overwrite_to_url(&data.avatar)?;
+    let banner = diesel_option_overwrite_to_url(&data.banner)?;
+    let bio = diesel_option_overwrite(bio);
+    let display_name = diesel_option_overwrite(display_name);
+    let matrix_user_id = diesel_option_overwrite(data.matrix_user_id.clone());
+    let email_deref = data.email.as_deref().map(str::to_lowercase);
+    let email = diesel_option_overwrite(email_deref.clone());
 
-  if let Some(Some(email)) = &email {
-    let previous_email = local_user_view.local_user.email.clone().unwrap_or_default();
-    // Only send the verification email if there was an email change
-    if previous_email.ne(email) {
-      send_verification_email(
-        &local_user_view,
-        email,
-        &mut context.pool(),
-        context.settings(),
-      )
-      .await?;
+    if let Some(Some(email)) = &email {
+        let previous_email = local_user_view.local_user.email.clone().unwrap_or_default();
+        // Only send the verification email if there was an email change
+        if previous_email.ne(email) {
+            send_verification_email(
+                &local_user_view,
+                email,
+                &mut context.pool(),
+                context.settings(),
+            )
+            .await?;
+        }
     }
-  }
 
-  // When the site requires email, make sure email is not Some(None). IE, an overwrite to a None value
-  if let Some(email) = &email {
-    if email.is_none() && site_view.local_site.require_email_verification {
-      Err(LemmyErrorType::EmailRequired)?
+    // When the site requires email, make sure email is not Some(None). IE, an overwrite to a None value
+    if let Some(email) = &email {
+        if email.is_none() && site_view.local_site.require_email_verification {
+            Err(LemmyErrorType::EmailRequired)?
+        }
     }
-  }
 
-  if let Some(Some(bio)) = &bio {
-    is_valid_bio_field(bio)?;
-  }
+    if let Some(Some(bio)) = &bio {
+        is_valid_bio_field(bio)?;
+    }
 
-  if let Some(Some(display_name)) = &display_name {
-    is_valid_display_name(
-      display_name.trim(),
-      site_view.local_site.actor_name_max_length as usize,
-    )?;
-  }
+    if let Some(Some(display_name)) = &display_name {
+        is_valid_display_name(
+            display_name.trim(),
+            site_view.local_site.actor_name_max_length as usize,
+        )?;
+    }
 
-  if let Some(Some(matrix_user_id)) = &matrix_user_id {
-    is_valid_matrix_id(matrix_user_id)?;
-  }
+    if let Some(Some(matrix_user_id)) = &matrix_user_id {
+        is_valid_matrix_id(matrix_user_id)?;
+    }
 
-  let local_user_id = local_user_view.local_user.id;
-  let person_id = local_user_view.person.id;
-  let default_listing_type = data.default_listing_type;
-  let default_sort_type = data.default_sort_type;
-  let theme = sanitize_html_opt(&data.theme);
+    let local_user_id = local_user_view.local_user.id;
+    let person_id = local_user_view.person.id;
+    let default_listing_type = data.default_listing_type;
+    let default_sort_type = data.default_sort_type;
+    let theme = sanitize_html_opt(&data.theme);
 
-  let person_form = PersonUpdateForm {
-    display_name,
-    bio,
-    matrix_user_id,
-    bot_account: data.bot_account,
-    avatar,
-    banner,
-    ..Default::default()
-  };
+    let person_form = PersonUpdateForm {
+        display_name,
+        bio,
+        matrix_user_id,
+        bot_account: data.bot_account,
+        avatar,
+        banner,
+        ..Default::default()
+    };
 
-  Person::update(&mut context.pool(), person_id, &person_form)
-    .await
-    .with_lemmy_type(LemmyErrorType::UserAlreadyExists)?;
+    Person::update(&mut context.pool(), person_id, &person_form)
+        .await
+        .with_lemmy_type(LemmyErrorType::UserAlreadyExists)?;
 
-  if let Some(discussion_languages) = data.discussion_languages.clone() {
-    LocalUserLanguage::update(&mut context.pool(), discussion_languages, local_user_id).await?;
-  }
+    if let Some(discussion_languages) = data.discussion_languages.clone() {
+        LocalUserLanguage::update(&mut context.pool(), discussion_languages, local_user_id).await?;
+    }
 
-  // If generate_totp is Some(false), this will clear it out from the database.
-  let (totp_2fa_secret, totp_2fa_url) = if let Some(generate) = data.generate_totp_2fa {
-    if generate {
-      let secret = generate_totp_2fa_secret();
-      let url =
-        build_totp_2fa(&site_view.site.name, &local_user_view.person.name, &secret)?.get_url();
-      (Some(Some(secret)), Some(Some(url)))
+    // If generate_totp is Some(false), this will clear it out from the database.
+    let (totp_2fa_secret, totp_2fa_url) = if let Some(generate) = data.generate_totp_2fa {
+        if generate {
+            let secret = generate_totp_2fa_secret();
+            let url = build_totp_2fa(&site_view.site.name, &local_user_view.person.name, &secret)?
+                .get_url();
+            (Some(Some(secret)), Some(Some(url)))
+        } else {
+            (Some(None), Some(None))
+        }
     } else {
-      (Some(None), Some(None))
-    }
-  } else {
-    (None, None)
-  };
+        (None, None)
+    };
 
-  let local_user_form = LocalUserUpdateForm {
-    email,
-    show_avatars: data.show_avatars,
-    show_read_posts: data.show_read_posts,
-    show_new_post_notifs: data.show_new_post_notifs,
-    send_notifications_to_email: data.send_notifications_to_email,
-    show_nsfw: data.show_nsfw,
-    blur_nsfw: data.blur_nsfw,
-    auto_expand: data.auto_expand,
-    show_bot_accounts: data.show_bot_accounts,
-    show_scores: data.show_scores,
-    default_sort_type,
-    default_listing_type,
-    theme,
-    interface_language: data.interface_language.clone(),
-    totp_2fa_secret,
-    totp_2fa_url,
-    open_links_in_new_tab: data.open_links_in_new_tab,
-    infinite_scroll_enabled: data.infinite_scroll_enabled,
-    ..Default::default()
-  };
+    let local_user_form = LocalUserUpdateForm {
+        email,
+        show_avatars: data.show_avatars,
+        show_read_posts: data.show_read_posts,
+        show_new_post_notifs: data.show_new_post_notifs,
+        send_notifications_to_email: data.send_notifications_to_email,
+        show_nsfw: data.show_nsfw,
+        blur_nsfw: data.blur_nsfw,
+        auto_expand: data.auto_expand,
+        show_bot_accounts: data.show_bot_accounts,
+        show_scores: data.show_scores,
+        default_sort_type,
+        default_listing_type,
+        theme,
+        interface_language: data.interface_language.clone(),
+        totp_2fa_secret,
+        totp_2fa_url,
+        open_links_in_new_tab: data.open_links_in_new_tab,
+        infinite_scroll_enabled: data.infinite_scroll_enabled,
+        ..Default::default()
+    };
 
-  let local_user_res =
-    LocalUser::update(&mut context.pool(), local_user_id, &local_user_form).await;
-  let updated_local_user = match local_user_res {
-    Ok(u) => u,
-    Err(e) => {
-      let err_type = if e.to_string()
-        == "duplicate key value violates unique constraint \"local_user_email_key\""
-      {
-        LemmyErrorType::EmailAlreadyExists
-      } else {
-        LemmyErrorType::UserAlreadyExists
-      };
+    let local_user_res =
+        LocalUser::update(&mut context.pool(), local_user_id, &local_user_form).await;
+    let updated_local_user = match local_user_res {
+        Ok(u) => u,
+        Err(e) => {
+            let err_type = if e.to_string()
+                == "duplicate key value violates unique constraint \"local_user_email_key\""
+            {
+                LemmyErrorType::EmailAlreadyExists
+            } else {
+                LemmyErrorType::UserAlreadyExists
+            };
 
-      return Err(e).with_lemmy_type(err_type);
-    }
-  };
+            return Err(e).with_lemmy_type(err_type);
+        }
+    };
 
-  // Return the jwt
-  Ok(Json(LoginResponse {
-    jwt: Some(
-      Claims::jwt(
-        updated_local_user.id.0,
-        &context.secret().jwt_secret,
-        &context.settings().hostname,
-      )?
-      .into(),
-    ),
-    verify_email_sent: false,
-    registration_created: false,
-  }))
+    // Return the jwt
+    Ok(Json(LoginResponse {
+        jwt: Some(
+            Claims::jwt(
+                updated_local_user.id.0,
+                &context.secret().jwt_secret,
+                &context.settings().hostname,
+            )?
+            .into(),
+        ),
+        verify_email_sent: false,
+        registration_created: false,
+    }))
 }

--- a/crates/api/src/local_user/verify_email.rs
+++ b/crates/api/src/local_user/verify_email.rs
@@ -1,38 +1,38 @@
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  context::LemmyContext,
-  person::{VerifyEmail, VerifyEmailResponse},
+    context::LemmyContext,
+    person::{VerifyEmail, VerifyEmailResponse},
 };
 use lemmy_db_schema::{
-  source::{
-    email_verification::EmailVerification,
-    local_user::{LocalUser, LocalUserUpdateForm},
-  },
-  traits::Crud,
+    source::{
+        email_verification::EmailVerification,
+        local_user::{LocalUser, LocalUserUpdateForm},
+    },
+    traits::Crud,
 };
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 pub async fn verify_email(
-  data: Json<VerifyEmail>,
-  context: Data<LemmyContext>,
+    data: Json<VerifyEmail>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<VerifyEmailResponse>, LemmyError> {
-  let token = data.token.clone();
-  let verification = EmailVerification::read_for_token(&mut context.pool(), &token)
-    .await
-    .with_lemmy_type(LemmyErrorType::TokenNotFound)?;
+    let token = data.token.clone();
+    let verification = EmailVerification::read_for_token(&mut context.pool(), &token)
+        .await
+        .with_lemmy_type(LemmyErrorType::TokenNotFound)?;
 
-  let form = LocalUserUpdateForm {
-    // necessary in case this is a new signup
-    email_verified: Some(true),
-    // necessary in case email of an existing user was changed
-    email: Some(Some(verification.email)),
-    ..Default::default()
-  };
-  let local_user_id = verification.local_user_id;
+    let form = LocalUserUpdateForm {
+        // necessary in case this is a new signup
+        email_verified: Some(true),
+        // necessary in case email of an existing user was changed
+        email: Some(Some(verification.email)),
+        ..Default::default()
+    };
+    let local_user_id = verification.local_user_id;
 
-  LocalUser::update(&mut context.pool(), local_user_id, &form).await?;
+    LocalUser::update(&mut context.pool(), local_user_id, &form).await?;
 
-  EmailVerification::delete_old_tokens_for_local_user(&mut context.pool(), local_user_id).await?;
+    EmailVerification::delete_old_tokens_for_local_user(&mut context.pool(), local_user_id).await?;
 
-  Ok(Json(VerifyEmailResponse {}))
+    Ok(Json(VerifyEmailResponse {}))
 }

--- a/crates/api/src/post/feature.rs
+++ b/crates/api/src/post/feature.rs
@@ -1,89 +1,86 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  build_response::build_post_response,
-  context::LemmyContext,
-  post::{FeaturePost, PostResponse},
-  send_activity::{ActivityChannel, SendActivityData},
-  utils::{
-    check_community_ban,
-    check_community_deleted_or_removed,
-    is_admin,
-    is_mod_or_admin,
-    local_user_view_from_jwt,
-  },
+    build_response::build_post_response,
+    context::LemmyContext,
+    post::{FeaturePost, PostResponse},
+    send_activity::{ActivityChannel, SendActivityData},
+    utils::{
+        check_community_ban, check_community_deleted_or_removed, is_admin, is_mod_or_admin,
+        local_user_view_from_jwt,
+    },
 };
 use lemmy_db_schema::{
-  source::{
-    moderator::{ModFeaturePost, ModFeaturePostForm},
-    post::{Post, PostUpdateForm},
-  },
-  traits::Crud,
-  PostFeatureType,
+    source::{
+        moderator::{ModFeaturePost, ModFeaturePostForm},
+        post::{Post, PostUpdateForm},
+    },
+    traits::Crud,
+    PostFeatureType,
 };
 use lemmy_utils::error::LemmyError;
 
 #[tracing::instrument(skip(context))]
 pub async fn feature_post(
-  data: Json<FeaturePost>,
-  context: Data<LemmyContext>,
+    data: Json<FeaturePost>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<PostResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  let post_id = data.post_id;
-  let orig_post = Post::read(&mut context.pool(), post_id).await?;
+    let post_id = data.post_id;
+    let orig_post = Post::read(&mut context.pool(), post_id).await?;
 
-  check_community_ban(
-    local_user_view.person.id,
-    orig_post.community_id,
-    &mut context.pool(),
-  )
-  .await?;
-  check_community_deleted_or_removed(orig_post.community_id, &mut context.pool()).await?;
-
-  if data.feature_type == PostFeatureType::Community {
-    // Verify that only the mods can feature in community
-    is_mod_or_admin(
-      &mut context.pool(),
-      local_user_view.person.id,
-      orig_post.community_id,
+    check_community_ban(
+        local_user_view.person.id,
+        orig_post.community_id,
+        &mut context.pool(),
     )
     .await?;
-  } else {
-    is_admin(&local_user_view)?;
-  }
+    check_community_deleted_or_removed(orig_post.community_id, &mut context.pool()).await?;
 
-  // Update the post
-  let post_id = data.post_id;
-  let new_post: PostUpdateForm = if data.feature_type == PostFeatureType::Community {
-    PostUpdateForm {
-      featured_community: Some(data.featured),
-      ..Default::default()
+    if data.feature_type == PostFeatureType::Community {
+        // Verify that only the mods can feature in community
+        is_mod_or_admin(
+            &mut context.pool(),
+            local_user_view.person.id,
+            orig_post.community_id,
+        )
+        .await?;
+    } else {
+        is_admin(&local_user_view)?;
     }
-  } else {
-    PostUpdateForm {
-      featured_local: Some(data.featured),
-      ..Default::default()
-    }
-  };
-  let post = Post::update(&mut context.pool(), post_id, &new_post).await?;
 
-  // Mod tables
-  let form = ModFeaturePostForm {
-    mod_person_id: local_user_view.person.id,
-    post_id: data.post_id,
-    featured: data.featured,
-    is_featured_community: data.feature_type == PostFeatureType::Community,
-  };
+    // Update the post
+    let post_id = data.post_id;
+    let new_post: PostUpdateForm = if data.feature_type == PostFeatureType::Community {
+        PostUpdateForm {
+            featured_community: Some(data.featured),
+            ..Default::default()
+        }
+    } else {
+        PostUpdateForm {
+            featured_local: Some(data.featured),
+            ..Default::default()
+        }
+    };
+    let post = Post::update(&mut context.pool(), post_id, &new_post).await?;
 
-  ModFeaturePost::create(&mut context.pool(), &form).await?;
+    // Mod tables
+    let form = ModFeaturePostForm {
+        mod_person_id: local_user_view.person.id,
+        post_id: data.post_id,
+        featured: data.featured,
+        is_featured_community: data.feature_type == PostFeatureType::Community,
+    };
 
-  let person_id = local_user_view.person.id;
-  ActivityChannel::submit_activity(
-    SendActivityData::FeaturePost(post, local_user_view.person, data.featured),
-    &context,
-  )
-  .await?;
+    ModFeaturePost::create(&mut context.pool(), &form).await?;
 
-  build_post_response(&context, orig_post.community_id, person_id, post_id).await
+    let person_id = local_user_view.person.id;
+    ActivityChannel::submit_activity(
+        SendActivityData::FeaturePost(post, local_user_view.person, data.featured),
+        &context,
+    )
+    .await?;
+
+    build_post_response(&context, orig_post.community_id, person_id, post_id).await
 }

--- a/crates/api/src/post/get_link_metadata.rs
+++ b/crates/api/src/post/get_link_metadata.rs
@@ -1,17 +1,17 @@
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  context::LemmyContext,
-  post::{GetSiteMetadata, GetSiteMetadataResponse},
-  request::fetch_site_metadata,
+    context::LemmyContext,
+    post::{GetSiteMetadata, GetSiteMetadataResponse},
+    request::fetch_site_metadata,
 };
 use lemmy_utils::error::LemmyError;
 
 #[tracing::instrument(skip(context))]
 pub async fn get_link_metadata(
-  data: Json<GetSiteMetadata>,
-  context: Data<LemmyContext>,
+    data: Json<GetSiteMetadata>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<GetSiteMetadataResponse>, LemmyError> {
-  let metadata = fetch_site_metadata(context.client(), &data.url).await?;
+    let metadata = fetch_site_metadata(context.client(), &data.url).await?;
 
-  Ok(Json(GetSiteMetadataResponse { metadata }))
+    Ok(Json(GetSiteMetadataResponse { metadata }))
 }

--- a/crates/api/src/post/like.rs
+++ b/crates/api/src/post/like.rs
@@ -1,90 +1,87 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  build_response::build_post_response,
-  context::LemmyContext,
-  post::{CreatePostLike, PostResponse},
-  send_activity::{ActivityChannel, SendActivityData},
-  utils::{
-    check_community_ban,
-    check_community_deleted_or_removed,
-    check_downvotes_enabled,
-    local_user_view_from_jwt,
-    mark_post_as_read,
-  },
+    build_response::build_post_response,
+    context::LemmyContext,
+    post::{CreatePostLike, PostResponse},
+    send_activity::{ActivityChannel, SendActivityData},
+    utils::{
+        check_community_ban, check_community_deleted_or_removed, check_downvotes_enabled,
+        local_user_view_from_jwt, mark_post_as_read,
+    },
 };
 use lemmy_db_schema::{
-  source::{
-    community::Community,
-    local_site::LocalSite,
-    post::{Post, PostLike, PostLikeForm},
-  },
-  traits::{Crud, Likeable},
+    source::{
+        community::Community,
+        local_site::LocalSite,
+        post::{Post, PostLike, PostLikeForm},
+    },
+    traits::{Crud, Likeable},
 };
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 use std::ops::Deref;
 
 #[tracing::instrument(skip(context))]
 pub async fn like_post(
-  data: Json<CreatePostLike>,
-  context: Data<LemmyContext>,
+    data: Json<CreatePostLike>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<PostResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
-  let local_site = LocalSite::read(&mut context.pool()).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
 
-  // Don't do a downvote if site has downvotes disabled
-  check_downvotes_enabled(data.score, &local_site)?;
+    // Don't do a downvote if site has downvotes disabled
+    check_downvotes_enabled(data.score, &local_site)?;
 
-  // Check for a community ban
-  let post_id = data.post_id;
-  let post = Post::read(&mut context.pool(), post_id).await?;
+    // Check for a community ban
+    let post_id = data.post_id;
+    let post = Post::read(&mut context.pool(), post_id).await?;
 
-  check_community_ban(
-    local_user_view.person.id,
-    post.community_id,
-    &mut context.pool(),
-  )
-  .await?;
-  check_community_deleted_or_removed(post.community_id, &mut context.pool()).await?;
+    check_community_ban(
+        local_user_view.person.id,
+        post.community_id,
+        &mut context.pool(),
+    )
+    .await?;
+    check_community_deleted_or_removed(post.community_id, &mut context.pool()).await?;
 
-  let like_form = PostLikeForm {
-    post_id: data.post_id,
-    person_id: local_user_view.person.id,
-    score: data.score,
-  };
+    let like_form = PostLikeForm {
+        post_id: data.post_id,
+        person_id: local_user_view.person.id,
+        score: data.score,
+    };
 
-  // Remove any likes first
-  let person_id = local_user_view.person.id;
+    // Remove any likes first
+    let person_id = local_user_view.person.id;
 
-  PostLike::remove(&mut context.pool(), person_id, post_id).await?;
+    PostLike::remove(&mut context.pool(), person_id, post_id).await?;
 
-  // Only add the like if the score isnt 0
-  let do_add = like_form.score != 0 && (like_form.score == 1 || like_form.score == -1);
-  if do_add {
-    PostLike::like(&mut context.pool(), &like_form)
-      .await
-      .with_lemmy_type(LemmyErrorType::CouldntLikePost)?;
-  }
+    // Only add the like if the score isnt 0
+    let do_add = like_form.score != 0 && (like_form.score == 1 || like_form.score == -1);
+    if do_add {
+        PostLike::like(&mut context.pool(), &like_form)
+            .await
+            .with_lemmy_type(LemmyErrorType::CouldntLikePost)?;
+    }
 
-  // Mark the post as read
-  mark_post_as_read(person_id, post_id, &mut context.pool()).await?;
+    // Mark the post as read
+    mark_post_as_read(person_id, post_id, &mut context.pool()).await?;
 
-  ActivityChannel::submit_activity(
-    SendActivityData::LikePostOrComment(
-      post.ap_id,
-      local_user_view.person.clone(),
-      Community::read(&mut context.pool(), post.community_id).await?,
-      data.score,
-    ),
-    &context,
-  )
-  .await?;
+    ActivityChannel::submit_activity(
+        SendActivityData::LikePostOrComment(
+            post.ap_id,
+            local_user_view.person.clone(),
+            Community::read(&mut context.pool(), post.community_id).await?,
+            data.score,
+        ),
+        &context,
+    )
+    .await?;
 
-  build_post_response(
-    context.deref(),
-    post.community_id,
-    local_user_view.person.id,
-    post_id,
-  )
-  .await
+    build_post_response(
+        context.deref(),
+        post.community_id,
+        local_user_view.person.id,
+        post_id,
+    )
+    .await
 }

--- a/crates/api/src/post/lock.rs
+++ b/crates/api/src/post/lock.rs
@@ -1,79 +1,77 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  build_response::build_post_response,
-  context::LemmyContext,
-  post::{LockPost, PostResponse},
-  send_activity::{ActivityChannel, SendActivityData},
-  utils::{
-    check_community_ban,
-    check_community_deleted_or_removed,
-    is_mod_or_admin,
-    local_user_view_from_jwt,
-  },
+    build_response::build_post_response,
+    context::LemmyContext,
+    post::{LockPost, PostResponse},
+    send_activity::{ActivityChannel, SendActivityData},
+    utils::{
+        check_community_ban, check_community_deleted_or_removed, is_mod_or_admin,
+        local_user_view_from_jwt,
+    },
 };
 use lemmy_db_schema::{
-  source::{
-    moderator::{ModLockPost, ModLockPostForm},
-    post::{Post, PostUpdateForm},
-  },
-  traits::Crud,
+    source::{
+        moderator::{ModLockPost, ModLockPostForm},
+        post::{Post, PostUpdateForm},
+    },
+    traits::Crud,
 };
 use lemmy_utils::error::LemmyError;
 
 #[tracing::instrument(skip(context))]
 pub async fn lock_post(
-  data: Json<LockPost>,
-  context: Data<LemmyContext>,
+    data: Json<LockPost>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<PostResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  let post_id = data.post_id;
-  let orig_post = Post::read(&mut context.pool(), post_id).await?;
+    let post_id = data.post_id;
+    let orig_post = Post::read(&mut context.pool(), post_id).await?;
 
-  check_community_ban(
-    local_user_view.person.id,
-    orig_post.community_id,
-    &mut context.pool(),
-  )
-  .await?;
-  check_community_deleted_or_removed(orig_post.community_id, &mut context.pool()).await?;
+    check_community_ban(
+        local_user_view.person.id,
+        orig_post.community_id,
+        &mut context.pool(),
+    )
+    .await?;
+    check_community_deleted_or_removed(orig_post.community_id, &mut context.pool()).await?;
 
-  // Verify that only the mods can lock
-  is_mod_or_admin(
-    &mut context.pool(),
-    local_user_view.person.id,
-    orig_post.community_id,
-  )
-  .await?;
+    // Verify that only the mods can lock
+    is_mod_or_admin(
+        &mut context.pool(),
+        local_user_view.person.id,
+        orig_post.community_id,
+    )
+    .await?;
 
-  // Update the post
-  let post_id = data.post_id;
-  let locked = data.locked;
-  let post = Post::update(
-    &mut context.pool(),
-    post_id,
-    &PostUpdateForm {
-      locked: Some(locked),
-      ..Default::default()
-    },
-  )
-  .await?;
+    // Update the post
+    let post_id = data.post_id;
+    let locked = data.locked;
+    let post = Post::update(
+        &mut context.pool(),
+        post_id,
+        &PostUpdateForm {
+            locked: Some(locked),
+            ..Default::default()
+        },
+    )
+    .await?;
 
-  // Mod tables
-  let form = ModLockPostForm {
-    mod_person_id: local_user_view.person.id,
-    post_id: data.post_id,
-    locked: Some(locked),
-  };
-  ModLockPost::create(&mut context.pool(), &form).await?;
+    // Mod tables
+    let form = ModLockPostForm {
+        mod_person_id: local_user_view.person.id,
+        post_id: data.post_id,
+        locked: Some(locked),
+    };
+    ModLockPost::create(&mut context.pool(), &form).await?;
 
-  let person_id = local_user_view.person.id;
-  ActivityChannel::submit_activity(
-    SendActivityData::LockPost(post, local_user_view.person, data.locked),
-    &context,
-  )
-  .await?;
+    let person_id = local_user_view.person.id;
+    ActivityChannel::submit_activity(
+        SendActivityData::LockPost(post, local_user_view.person, data.locked),
+        &context,
+    )
+    .await?;
 
-  build_post_response(&context, orig_post.community_id, person_id, post_id).await
+    build_post_response(&context, orig_post.community_id, person_id, post_id).await
 }

--- a/crates/api/src/post/mark_read.rs
+++ b/crates/api/src/post/mark_read.rs
@@ -1,32 +1,32 @@
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  context::LemmyContext,
-  post::{MarkPostAsRead, PostResponse},
-  utils,
-  utils::local_user_view_from_jwt,
+    context::LemmyContext,
+    post::{MarkPostAsRead, PostResponse},
+    utils,
+    utils::local_user_view_from_jwt,
 };
 use lemmy_db_views::structs::PostView;
 use lemmy_utils::error::LemmyError;
 
 #[tracing::instrument(skip(context))]
 pub async fn mark_post_as_read(
-  data: Json<MarkPostAsRead>,
-  context: Data<LemmyContext>,
+    data: Json<MarkPostAsRead>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<PostResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  let post_id = data.post_id;
-  let person_id = local_user_view.person.id;
+    let post_id = data.post_id;
+    let person_id = local_user_view.person.id;
 
-  // Mark the post as read / unread
-  if data.read {
-    utils::mark_post_as_read(person_id, post_id, &mut context.pool()).await?;
-  } else {
-    utils::mark_post_as_unread(person_id, post_id, &mut context.pool()).await?;
-  }
+    // Mark the post as read / unread
+    if data.read {
+        utils::mark_post_as_read(person_id, post_id, &mut context.pool()).await?;
+    } else {
+        utils::mark_post_as_unread(person_id, post_id, &mut context.pool()).await?;
+    }
 
-  // Fetch it
-  let post_view = PostView::read(&mut context.pool(), post_id, Some(person_id), false).await?;
+    // Fetch it
+    let post_view = PostView::read(&mut context.pool(), post_id, Some(person_id), false).await?;
 
-  Ok(Json(PostResponse { post_view }))
+    Ok(Json(PostResponse { post_view }))
 }

--- a/crates/api/src/post_report/create.rs
+++ b/crates/api/src/post_report/create.rs
@@ -2,22 +2,20 @@ use crate::check_report_reason;
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  context::LemmyContext,
-  post::{CreatePostReport, PostReportResponse},
-  send_activity::{ActivityChannel, SendActivityData},
-  utils::{
-    check_community_ban,
-    local_user_view_from_jwt,
-    sanitize_html,
-    send_new_report_email_to_admins,
-  },
+    context::LemmyContext,
+    post::{CreatePostReport, PostReportResponse},
+    send_activity::{ActivityChannel, SendActivityData},
+    utils::{
+        check_community_ban, local_user_view_from_jwt, sanitize_html,
+        send_new_report_email_to_admins,
+    },
 };
 use lemmy_db_schema::{
-  source::{
-    local_site::LocalSite,
-    post_report::{PostReport, PostReportForm},
-  },
-  traits::Reportable,
+    source::{
+        local_site::LocalSite,
+        post_report::{PostReport, PostReportForm},
+    },
+    traits::Reportable,
 };
 use lemmy_db_views::structs::{PostReportView, PostView};
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
@@ -25,57 +23,57 @@ use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 /// Creates a post report and notifies the moderators of the community
 #[tracing::instrument(skip(context))]
 pub async fn create_post_report(
-  data: Json<CreatePostReport>,
-  context: Data<LemmyContext>,
+    data: Json<CreatePostReport>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<PostReportResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
-  let local_site = LocalSite::read(&mut context.pool()).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
 
-  let reason = sanitize_html(data.reason.trim());
-  check_report_reason(&reason, &local_site)?;
+    let reason = sanitize_html(data.reason.trim());
+    check_report_reason(&reason, &local_site)?;
 
-  let person_id = local_user_view.person.id;
-  let post_id = data.post_id;
-  let post_view = PostView::read(&mut context.pool(), post_id, None, false).await?;
+    let person_id = local_user_view.person.id;
+    let post_id = data.post_id;
+    let post_view = PostView::read(&mut context.pool(), post_id, None, false).await?;
 
-  check_community_ban(person_id, post_view.community.id, &mut context.pool()).await?;
+    check_community_ban(person_id, post_view.community.id, &mut context.pool()).await?;
 
-  let report_form = PostReportForm {
-    creator_id: person_id,
-    post_id,
-    original_post_name: post_view.post.name,
-    original_post_url: post_view.post.url,
-    original_post_body: post_view.post.body,
-    reason,
-  };
+    let report_form = PostReportForm {
+        creator_id: person_id,
+        post_id,
+        original_post_name: post_view.post.name,
+        original_post_url: post_view.post.url,
+        original_post_body: post_view.post.body,
+        reason,
+    };
 
-  let report = PostReport::report(&mut context.pool(), &report_form)
-    .await
-    .with_lemmy_type(LemmyErrorType::CouldntCreateReport)?;
+    let report = PostReport::report(&mut context.pool(), &report_form)
+        .await
+        .with_lemmy_type(LemmyErrorType::CouldntCreateReport)?;
 
-  let post_report_view = PostReportView::read(&mut context.pool(), report.id, person_id).await?;
+    let post_report_view = PostReportView::read(&mut context.pool(), report.id, person_id).await?;
 
-  // Email the admins
-  if local_site.reports_email_admins {
-    send_new_report_email_to_admins(
-      &post_report_view.creator.name,
-      &post_report_view.post_creator.name,
-      &mut context.pool(),
-      context.settings(),
+    // Email the admins
+    if local_site.reports_email_admins {
+        send_new_report_email_to_admins(
+            &post_report_view.creator.name,
+            &post_report_view.post_creator.name,
+            &mut context.pool(),
+            context.settings(),
+        )
+        .await?;
+    }
+
+    ActivityChannel::submit_activity(
+        SendActivityData::CreateReport(
+            post_view.post.ap_id.inner().clone(),
+            local_user_view.person,
+            post_view.community,
+            data.reason.clone(),
+        ),
+        &context,
     )
     .await?;
-  }
 
-  ActivityChannel::submit_activity(
-    SendActivityData::CreateReport(
-      post_view.post.ap_id.inner().clone(),
-      local_user_view.person,
-      post_view.community,
-      data.reason.clone(),
-    ),
-    &context,
-  )
-  .await?;
-
-  Ok(Json(PostReportResponse { post_report_view }))
+    Ok(Json(PostReportResponse { post_report_view }))
 }

--- a/crates/api/src/post_report/list.rs
+++ b/crates/api/src/post_report/list.rs
@@ -1,8 +1,8 @@
 use actix_web::web::{Data, Json, Query};
 use lemmy_api_common::{
-  context::LemmyContext,
-  post::{ListPostReports, ListPostReportsResponse},
-  utils::local_user_view_from_jwt,
+    context::LemmyContext,
+    post::{ListPostReports, ListPostReportsResponse},
+    utils::local_user_view_from_jwt,
 };
 use lemmy_db_views::post_report_view::PostReportQuery;
 use lemmy_utils::error::LemmyError;
@@ -11,24 +11,24 @@ use lemmy_utils::error::LemmyError;
 /// or returns all post reports for communities a user moderates
 #[tracing::instrument(skip(context))]
 pub async fn list_post_reports(
-  data: Query<ListPostReports>,
-  context: Data<LemmyContext>,
+    data: Query<ListPostReports>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<ListPostReportsResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  let community_id = data.community_id;
-  let unresolved_only = data.unresolved_only.unwrap_or_default();
+    let community_id = data.community_id;
+    let unresolved_only = data.unresolved_only.unwrap_or_default();
 
-  let page = data.page;
-  let limit = data.limit;
-  let post_reports = PostReportQuery {
-    community_id,
-    unresolved_only,
-    page,
-    limit,
-  }
-  .list(&mut context.pool(), &local_user_view)
-  .await?;
+    let page = data.page;
+    let limit = data.limit;
+    let post_reports = PostReportQuery {
+        community_id,
+        unresolved_only,
+        page,
+        limit,
+    }
+    .list(&mut context.pool(), &local_user_view)
+    .await?;
 
-  Ok(Json(ListPostReportsResponse { post_reports }))
+    Ok(Json(ListPostReportsResponse { post_reports }))
 }

--- a/crates/api/src/post_report/resolve.rs
+++ b/crates/api/src/post_report/resolve.rs
@@ -1,8 +1,8 @@
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  context::LemmyContext,
-  post::{PostReportResponse, ResolvePostReport},
-  utils::{is_mod_or_admin, local_user_view_from_jwt},
+    context::LemmyContext,
+    post::{PostReportResponse, ResolvePostReport},
+    utils::{is_mod_or_admin, local_user_view_from_jwt},
 };
 use lemmy_db_schema::{source::post_report::PostReport, traits::Reportable};
 use lemmy_db_views::structs::PostReportView;
@@ -11,29 +11,29 @@ use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 /// Resolves or unresolves a post report and notifies the moderators of the community
 #[tracing::instrument(skip(context))]
 pub async fn resolve_post_report(
-  data: Json<ResolvePostReport>,
-  context: Data<LemmyContext>,
+    data: Json<ResolvePostReport>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<PostReportResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  let report_id = data.report_id;
-  let person_id = local_user_view.person.id;
-  let report = PostReportView::read(&mut context.pool(), report_id, person_id).await?;
+    let report_id = data.report_id;
+    let person_id = local_user_view.person.id;
+    let report = PostReportView::read(&mut context.pool(), report_id, person_id).await?;
 
-  let person_id = local_user_view.person.id;
-  is_mod_or_admin(&mut context.pool(), person_id, report.community.id).await?;
+    let person_id = local_user_view.person.id;
+    is_mod_or_admin(&mut context.pool(), person_id, report.community.id).await?;
 
-  if data.resolved {
-    PostReport::resolve(&mut context.pool(), report_id, person_id)
-      .await
-      .with_lemmy_type(LemmyErrorType::CouldntResolveReport)?;
-  } else {
-    PostReport::unresolve(&mut context.pool(), report_id, person_id)
-      .await
-      .with_lemmy_type(LemmyErrorType::CouldntResolveReport)?;
-  }
+    if data.resolved {
+        PostReport::resolve(&mut context.pool(), report_id, person_id)
+            .await
+            .with_lemmy_type(LemmyErrorType::CouldntResolveReport)?;
+    } else {
+        PostReport::unresolve(&mut context.pool(), report_id, person_id)
+            .await
+            .with_lemmy_type(LemmyErrorType::CouldntResolveReport)?;
+    }
 
-  let post_report_view = PostReportView::read(&mut context.pool(), report_id, person_id).await?;
+    let post_report_view = PostReportView::read(&mut context.pool(), report_id, person_id).await?;
 
-  Ok(Json(PostReportResponse { post_report_view }))
+    Ok(Json(PostReportResponse { post_report_view }))
 }

--- a/crates/api/src/private_message/mark_read.rs
+++ b/crates/api/src/private_message/mark_read.rs
@@ -1,46 +1,47 @@
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  context::LemmyContext,
-  private_message::{MarkPrivateMessageAsRead, PrivateMessageResponse},
-  utils::local_user_view_from_jwt,
+    context::LemmyContext,
+    private_message::{MarkPrivateMessageAsRead, PrivateMessageResponse},
+    utils::local_user_view_from_jwt,
 };
 use lemmy_db_schema::{
-  source::private_message::{PrivateMessage, PrivateMessageUpdateForm},
-  traits::Crud,
+    source::private_message::{PrivateMessage, PrivateMessageUpdateForm},
+    traits::Crud,
 };
 use lemmy_db_views::structs::PrivateMessageView;
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn mark_pm_as_read(
-  data: Json<MarkPrivateMessageAsRead>,
-  context: Data<LemmyContext>,
+    data: Json<MarkPrivateMessageAsRead>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<PrivateMessageResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  // Checking permissions
-  let private_message_id = data.private_message_id;
-  let orig_private_message = PrivateMessage::read(&mut context.pool(), private_message_id).await?;
-  if local_user_view.person.id != orig_private_message.recipient_id {
-    Err(LemmyErrorType::CouldntUpdatePrivateMessage)?
-  }
+    // Checking permissions
+    let private_message_id = data.private_message_id;
+    let orig_private_message =
+        PrivateMessage::read(&mut context.pool(), private_message_id).await?;
+    if local_user_view.person.id != orig_private_message.recipient_id {
+        Err(LemmyErrorType::CouldntUpdatePrivateMessage)?
+    }
 
-  // Doing the update
-  let private_message_id = data.private_message_id;
-  let read = data.read;
-  PrivateMessage::update(
-    &mut context.pool(),
-    private_message_id,
-    &PrivateMessageUpdateForm {
-      read: Some(read),
-      ..Default::default()
-    },
-  )
-  .await
-  .with_lemmy_type(LemmyErrorType::CouldntUpdatePrivateMessage)?;
+    // Doing the update
+    let private_message_id = data.private_message_id;
+    let read = data.read;
+    PrivateMessage::update(
+        &mut context.pool(),
+        private_message_id,
+        &PrivateMessageUpdateForm {
+            read: Some(read),
+            ..Default::default()
+        },
+    )
+    .await
+    .with_lemmy_type(LemmyErrorType::CouldntUpdatePrivateMessage)?;
 
-  let view = PrivateMessageView::read(&mut context.pool(), private_message_id).await?;
-  Ok(Json(PrivateMessageResponse {
-    private_message_view: view,
-  }))
+    let view = PrivateMessageView::read(&mut context.pool(), private_message_id).await?;
+    Ok(Json(PrivateMessageResponse {
+        private_message_view: view,
+    }))
 }

--- a/crates/api/src/private_message_report/create.rs
+++ b/crates/api/src/private_message_report/create.rs
@@ -1,64 +1,64 @@
 use crate::check_report_reason;
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  context::LemmyContext,
-  private_message::{CreatePrivateMessageReport, PrivateMessageReportResponse},
-  utils::{local_user_view_from_jwt, sanitize_html, send_new_report_email_to_admins},
+    context::LemmyContext,
+    private_message::{CreatePrivateMessageReport, PrivateMessageReportResponse},
+    utils::{local_user_view_from_jwt, sanitize_html, send_new_report_email_to_admins},
 };
 use lemmy_db_schema::{
-  source::{
-    local_site::LocalSite,
-    private_message::PrivateMessage,
-    private_message_report::{PrivateMessageReport, PrivateMessageReportForm},
-  },
-  traits::{Crud, Reportable},
+    source::{
+        local_site::LocalSite,
+        private_message::PrivateMessage,
+        private_message_report::{PrivateMessageReport, PrivateMessageReportForm},
+    },
+    traits::{Crud, Reportable},
 };
 use lemmy_db_views::structs::PrivateMessageReportView;
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn create_pm_report(
-  data: Json<CreatePrivateMessageReport>,
-  context: Data<LemmyContext>,
+    data: Json<CreatePrivateMessageReport>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<PrivateMessageReportResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
-  let local_site = LocalSite::read(&mut context.pool()).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
 
-  let reason = sanitize_html(data.reason.trim());
-  check_report_reason(&reason, &local_site)?;
+    let reason = sanitize_html(data.reason.trim());
+    check_report_reason(&reason, &local_site)?;
 
-  let person_id = local_user_view.person.id;
-  let private_message_id = data.private_message_id;
-  let private_message = PrivateMessage::read(&mut context.pool(), private_message_id).await?;
+    let person_id = local_user_view.person.id;
+    let private_message_id = data.private_message_id;
+    let private_message = PrivateMessage::read(&mut context.pool(), private_message_id).await?;
 
-  let report_form = PrivateMessageReportForm {
-    creator_id: person_id,
-    private_message_id,
-    original_pm_text: private_message.content,
-    reason: reason.clone(),
-  };
+    let report_form = PrivateMessageReportForm {
+        creator_id: person_id,
+        private_message_id,
+        original_pm_text: private_message.content,
+        reason: reason.clone(),
+    };
 
-  let report = PrivateMessageReport::report(&mut context.pool(), &report_form)
-    .await
-    .with_lemmy_type(LemmyErrorType::CouldntCreateReport)?;
+    let report = PrivateMessageReport::report(&mut context.pool(), &report_form)
+        .await
+        .with_lemmy_type(LemmyErrorType::CouldntCreateReport)?;
 
-  let private_message_report_view =
-    PrivateMessageReportView::read(&mut context.pool(), report.id).await?;
+    let private_message_report_view =
+        PrivateMessageReportView::read(&mut context.pool(), report.id).await?;
 
-  // Email the admins
-  if local_site.reports_email_admins {
-    send_new_report_email_to_admins(
-      &private_message_report_view.creator.name,
-      &private_message_report_view.private_message_creator.name,
-      &mut context.pool(),
-      context.settings(),
-    )
-    .await?;
-  }
+    // Email the admins
+    if local_site.reports_email_admins {
+        send_new_report_email_to_admins(
+            &private_message_report_view.creator.name,
+            &private_message_report_view.private_message_creator.name,
+            &mut context.pool(),
+            context.settings(),
+        )
+        .await?;
+    }
 
-  // TODO: consider federating this
+    // TODO: consider federating this
 
-  Ok(Json(PrivateMessageReportResponse {
-    private_message_report_view,
-  }))
+    Ok(Json(PrivateMessageReportResponse {
+        private_message_report_view,
+    }))
 }

--- a/crates/api/src/private_message_report/list.rs
+++ b/crates/api/src/private_message_report/list.rs
@@ -1,33 +1,33 @@
 use actix_web::web::{Data, Json, Query};
 use lemmy_api_common::{
-  context::LemmyContext,
-  private_message::{ListPrivateMessageReports, ListPrivateMessageReportsResponse},
-  utils::{is_admin, local_user_view_from_jwt},
+    context::LemmyContext,
+    private_message::{ListPrivateMessageReports, ListPrivateMessageReportsResponse},
+    utils::{is_admin, local_user_view_from_jwt},
 };
 use lemmy_db_views::private_message_report_view::PrivateMessageReportQuery;
 use lemmy_utils::error::LemmyError;
 
 #[tracing::instrument(skip(context))]
 pub async fn list_pm_reports(
-  data: Query<ListPrivateMessageReports>,
-  context: Data<LemmyContext>,
+    data: Query<ListPrivateMessageReports>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<ListPrivateMessageReportsResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  is_admin(&local_user_view)?;
+    is_admin(&local_user_view)?;
 
-  let unresolved_only = data.unresolved_only.unwrap_or_default();
-  let page = data.page;
-  let limit = data.limit;
-  let private_message_reports = PrivateMessageReportQuery {
-    unresolved_only,
-    page,
-    limit,
-  }
-  .list(&mut context.pool())
-  .await?;
+    let unresolved_only = data.unresolved_only.unwrap_or_default();
+    let page = data.page;
+    let limit = data.limit;
+    let private_message_reports = PrivateMessageReportQuery {
+        unresolved_only,
+        page,
+        limit,
+    }
+    .list(&mut context.pool())
+    .await?;
 
-  Ok(Json(ListPrivateMessageReportsResponse {
-    private_message_reports,
-  }))
+    Ok(Json(ListPrivateMessageReportsResponse {
+        private_message_reports,
+    }))
 }

--- a/crates/api/src/private_message_report/resolve.rs
+++ b/crates/api/src/private_message_report/resolve.rs
@@ -1,8 +1,8 @@
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  context::LemmyContext,
-  private_message::{PrivateMessageReportResponse, ResolvePrivateMessageReport},
-  utils::{is_admin, local_user_view_from_jwt},
+    context::LemmyContext,
+    private_message::{PrivateMessageReportResponse, ResolvePrivateMessageReport},
+    utils::{is_admin, local_user_view_from_jwt},
 };
 use lemmy_db_schema::{source::private_message_report::PrivateMessageReport, traits::Reportable};
 use lemmy_db_views::structs::PrivateMessageReportView;
@@ -10,29 +10,29 @@ use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn resolve_pm_report(
-  data: Json<ResolvePrivateMessageReport>,
-  context: Data<LemmyContext>,
+    data: Json<ResolvePrivateMessageReport>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<PrivateMessageReportResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  is_admin(&local_user_view)?;
+    is_admin(&local_user_view)?;
 
-  let report_id = data.report_id;
-  let person_id = local_user_view.person.id;
-  if data.resolved {
-    PrivateMessageReport::resolve(&mut context.pool(), report_id, person_id)
-      .await
-      .with_lemmy_type(LemmyErrorType::CouldntResolveReport)?;
-  } else {
-    PrivateMessageReport::unresolve(&mut context.pool(), report_id, person_id)
-      .await
-      .with_lemmy_type(LemmyErrorType::CouldntResolveReport)?;
-  }
+    let report_id = data.report_id;
+    let person_id = local_user_view.person.id;
+    if data.resolved {
+        PrivateMessageReport::resolve(&mut context.pool(), report_id, person_id)
+            .await
+            .with_lemmy_type(LemmyErrorType::CouldntResolveReport)?;
+    } else {
+        PrivateMessageReport::unresolve(&mut context.pool(), report_id, person_id)
+            .await
+            .with_lemmy_type(LemmyErrorType::CouldntResolveReport)?;
+    }
 
-  let private_message_report_view =
-    PrivateMessageReportView::read(&mut context.pool(), report_id).await?;
+    let private_message_report_view =
+        PrivateMessageReportView::read(&mut context.pool(), report_id).await?;
 
-  Ok(Json(PrivateMessageReportResponse {
-    private_message_report_view,
-  }))
+    Ok(Json(PrivateMessageReportResponse {
+        private_message_report_view,
+    }))
 }

--- a/crates/api/src/site/federated_instances.rs
+++ b/crates/api/src/site/federated_instances.rs
@@ -1,21 +1,19 @@
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  context::LemmyContext,
-  site::GetFederatedInstancesResponse,
-  utils::build_federated_instances,
+    context::LemmyContext, site::GetFederatedInstancesResponse, utils::build_federated_instances,
 };
 use lemmy_db_views::structs::SiteView;
 use lemmy_utils::error::LemmyError;
 
 #[tracing::instrument(skip(context))]
 pub async fn get_federated_instances(
-  context: Data<LemmyContext>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<GetFederatedInstancesResponse>, LemmyError> {
-  let site_view = SiteView::read_local(&mut context.pool()).await?;
-  let federated_instances =
-    build_federated_instances(&site_view.local_site, &mut context.pool()).await?;
+    let site_view = SiteView::read_local(&mut context.pool()).await?;
+    let federated_instances =
+        build_federated_instances(&site_view.local_site, &mut context.pool()).await?;
 
-  Ok(Json(GetFederatedInstancesResponse {
-    federated_instances,
-  }))
+    Ok(Json(GetFederatedInstancesResponse {
+        federated_instances,
+    }))
 }

--- a/crates/api/src/site/leave_admin.rs
+++ b/crates/api/src/site/leave_admin.rs
@@ -1,79 +1,79 @@
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  context::LemmyContext,
-  site::{GetSiteResponse, LeaveAdmin},
-  utils::{is_admin, local_user_view_from_jwt},
+    context::LemmyContext,
+    site::{GetSiteResponse, LeaveAdmin},
+    utils::{is_admin, local_user_view_from_jwt},
 };
 use lemmy_db_schema::{
-  source::{
-    actor_language::SiteLanguage,
-    language::Language,
-    local_user::{LocalUser, LocalUserUpdateForm},
-    moderator::{ModAdd, ModAddForm},
-    tagline::Tagline,
-  },
-  traits::Crud,
+    source::{
+        actor_language::SiteLanguage,
+        language::Language,
+        local_user::{LocalUser, LocalUserUpdateForm},
+        moderator::{ModAdd, ModAddForm},
+        tagline::Tagline,
+    },
+    traits::Crud,
 };
 use lemmy_db_views::structs::{CustomEmojiView, SiteView};
 use lemmy_db_views_actor::structs::PersonView;
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorType},
-  version,
+    error::{LemmyError, LemmyErrorType},
+    version,
 };
 
 #[tracing::instrument(skip(context))]
 pub async fn leave_admin(
-  data: Json<LeaveAdmin>,
-  context: Data<LemmyContext>,
+    data: Json<LeaveAdmin>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<GetSiteResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  is_admin(&local_user_view)?;
+    is_admin(&local_user_view)?;
 
-  // Make sure there isn't just one admin (so if one leaves, there will still be one left)
-  let admins = PersonView::admins(&mut context.pool()).await?;
-  if admins.len() == 1 {
-    Err(LemmyErrorType::CannotLeaveAdmin)?
-  }
+    // Make sure there isn't just one admin (so if one leaves, there will still be one left)
+    let admins = PersonView::admins(&mut context.pool()).await?;
+    if admins.len() == 1 {
+        Err(LemmyErrorType::CannotLeaveAdmin)?
+    }
 
-  LocalUser::update(
-    &mut context.pool(),
-    local_user_view.local_user.id,
-    &LocalUserUpdateForm {
-      admin: Some(false),
-      ..Default::default()
-    },
-  )
-  .await?;
+    LocalUser::update(
+        &mut context.pool(),
+        local_user_view.local_user.id,
+        &LocalUserUpdateForm {
+            admin: Some(false),
+            ..Default::default()
+        },
+    )
+    .await?;
 
-  // Mod tables
-  let person_id = local_user_view.person.id;
-  let form = ModAddForm {
-    mod_person_id: person_id,
-    other_person_id: person_id,
-    removed: Some(true),
-  };
+    // Mod tables
+    let person_id = local_user_view.person.id;
+    let form = ModAddForm {
+        mod_person_id: person_id,
+        other_person_id: person_id,
+        removed: Some(true),
+    };
 
-  ModAdd::create(&mut context.pool(), &form).await?;
+    ModAdd::create(&mut context.pool(), &form).await?;
 
-  // Reread site and admins
-  let site_view = SiteView::read_local(&mut context.pool()).await?;
-  let admins = PersonView::admins(&mut context.pool()).await?;
+    // Reread site and admins
+    let site_view = SiteView::read_local(&mut context.pool()).await?;
+    let admins = PersonView::admins(&mut context.pool()).await?;
 
-  let all_languages = Language::read_all(&mut context.pool()).await?;
-  let discussion_languages = SiteLanguage::read_local_raw(&mut context.pool()).await?;
-  let taglines = Tagline::get_all(&mut context.pool(), site_view.local_site.id).await?;
-  let custom_emojis =
-    CustomEmojiView::get_all(&mut context.pool(), site_view.local_site.id).await?;
+    let all_languages = Language::read_all(&mut context.pool()).await?;
+    let discussion_languages = SiteLanguage::read_local_raw(&mut context.pool()).await?;
+    let taglines = Tagline::get_all(&mut context.pool(), site_view.local_site.id).await?;
+    let custom_emojis =
+        CustomEmojiView::get_all(&mut context.pool(), site_view.local_site.id).await?;
 
-  Ok(Json(GetSiteResponse {
-    site_view,
-    admins,
-    version: version::VERSION.to_string(),
-    my_user: None,
-    all_languages,
-    discussion_languages,
-    taglines,
-    custom_emojis,
-  }))
+    Ok(Json(GetSiteResponse {
+        site_view,
+        admins,
+        version: version::VERSION.to_string(),
+        my_user: None,
+        all_languages,
+        discussion_languages,
+        taglines,
+        custom_emojis,
+    }))
 }

--- a/crates/api/src/site/mod_log.rs
+++ b/crates/api/src/site/mod_log.rs
@@ -1,190 +1,180 @@
 use actix_web::web::{Data, Json, Query};
 use lemmy_api_common::{
-  context::LemmyContext,
-  site::{GetModlog, GetModlogResponse},
-  utils::{check_private_instance, is_admin, is_mod_or_admin, local_user_view_from_jwt_opt},
+    context::LemmyContext,
+    site::{GetModlog, GetModlogResponse},
+    utils::{check_private_instance, is_admin, is_mod_or_admin, local_user_view_from_jwt_opt},
 };
 use lemmy_db_schema::{
-  newtypes::{CommunityId, PersonId},
-  source::local_site::LocalSite,
-  ModlogActionType,
+    newtypes::{CommunityId, PersonId},
+    source::local_site::LocalSite,
+    ModlogActionType,
 };
 use lemmy_db_views_moderator::structs::{
-  AdminPurgeCommentView,
-  AdminPurgeCommunityView,
-  AdminPurgePersonView,
-  AdminPurgePostView,
-  ModAddCommunityView,
-  ModAddView,
-  ModBanFromCommunityView,
-  ModBanView,
-  ModFeaturePostView,
-  ModHideCommunityView,
-  ModLockPostView,
-  ModRemoveCommentView,
-  ModRemoveCommunityView,
-  ModRemovePostView,
-  ModTransferCommunityView,
-  ModlogListParams,
+    AdminPurgeCommentView, AdminPurgeCommunityView, AdminPurgePersonView, AdminPurgePostView,
+    ModAddCommunityView, ModAddView, ModBanFromCommunityView, ModBanView, ModFeaturePostView,
+    ModHideCommunityView, ModLockPostView, ModRemoveCommentView, ModRemoveCommunityView,
+    ModRemovePostView, ModTransferCommunityView, ModlogListParams,
 };
 use lemmy_utils::error::LemmyError;
 use ModlogActionType::*;
 
 #[tracing::instrument(skip(context))]
 pub async fn get_mod_log(
-  data: Query<GetModlog>,
-  context: Data<LemmyContext>,
+    data: Query<GetModlog>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<GetModlogResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt_opt(data.auth.as_ref(), &context).await;
-  let local_site = LocalSite::read(&mut context.pool()).await?;
+    let local_user_view = local_user_view_from_jwt_opt(data.auth.as_ref(), &context).await;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
 
-  check_private_instance(&local_user_view, &local_site)?;
+    check_private_instance(&local_user_view, &local_site)?;
 
-  let type_ = data.type_.unwrap_or(All);
-  let community_id = data.community_id;
+    let type_ = data.type_.unwrap_or(All);
+    let community_id = data.community_id;
 
-  let (local_person_id, is_admin) = match local_user_view {
-    Some(s) => (s.person.id, is_admin(&s).is_ok()),
-    None => (PersonId(-1), false),
-  };
-  let community_id_value = match community_id {
-    Some(s) => s,
-    None => CommunityId(-1),
-  };
-  let is_mod_of_community = data.community_id.is_some()
-    && is_mod_or_admin(&mut context.pool(), local_person_id, community_id_value)
-      .await
-      .is_ok();
-  let hide_modlog_names = local_site.hide_modlog_mod_names && !is_mod_of_community && !is_admin;
+    let (local_person_id, is_admin) = match local_user_view {
+        Some(s) => (s.person.id, is_admin(&s).is_ok()),
+        None => (PersonId(-1), false),
+    };
+    let community_id_value = match community_id {
+        Some(s) => s,
+        None => CommunityId(-1),
+    };
+    let is_mod_of_community = data.community_id.is_some()
+        && is_mod_or_admin(&mut context.pool(), local_person_id, community_id_value)
+            .await
+            .is_ok();
+    let hide_modlog_names = local_site.hide_modlog_mod_names && !is_mod_of_community && !is_admin;
 
-  let mod_person_id = if hide_modlog_names {
-    None
-  } else {
-    data.mod_person_id
-  };
-  let other_person_id = data.other_person_id;
-  let params = ModlogListParams {
-    community_id,
-    mod_person_id,
-    other_person_id,
-    page: data.page,
-    limit: data.limit,
-    hide_modlog_names,
-  };
-  let removed_posts = match type_ {
-    All | ModRemovePost => ModRemovePostView::list(&mut context.pool(), params).await?,
-    _ => Default::default(),
-  };
-
-  let locked_posts = match type_ {
-    All | ModLockPost => ModLockPostView::list(&mut context.pool(), params).await?,
-    _ => Default::default(),
-  };
-
-  let featured_posts = match type_ {
-    All | ModFeaturePost => ModFeaturePostView::list(&mut context.pool(), params).await?,
-    _ => Default::default(),
-  };
-
-  let removed_comments = match type_ {
-    All | ModRemoveComment => ModRemoveCommentView::list(&mut context.pool(), params).await?,
-    _ => Default::default(),
-  };
-
-  let banned_from_community = match type_ {
-    All | ModBanFromCommunity => ModBanFromCommunityView::list(&mut context.pool(), params).await?,
-    _ => Default::default(),
-  };
-
-  let added_to_community = match type_ {
-    All | ModAddCommunity => ModAddCommunityView::list(&mut context.pool(), params).await?,
-    _ => Default::default(),
-  };
-
-  let transferred_to_community = match type_ {
-    All | ModTransferCommunity => {
-      ModTransferCommunityView::list(&mut context.pool(), params).await?
-    }
-    _ => Default::default(),
-  };
-
-  let hidden_communities = match type_ {
-    All | ModHideCommunity if other_person_id.is_none() => {
-      ModHideCommunityView::list(&mut context.pool(), params).await?
-    }
-    _ => Default::default(),
-  };
-
-  // These arrays are only for the full modlog, when a community isn't given
-  let (
-    banned,
-    added,
-    removed_communities,
-    admin_purged_persons,
-    admin_purged_communities,
-    admin_purged_posts,
-    admin_purged_comments,
-  ) = if data.community_id.is_none() {
-    (
-      match type_ {
-        All | ModBan => ModBanView::list(&mut context.pool(), params).await?,
+    let mod_person_id = if hide_modlog_names {
+        None
+    } else {
+        data.mod_person_id
+    };
+    let other_person_id = data.other_person_id;
+    let params = ModlogListParams {
+        community_id,
+        mod_person_id,
+        other_person_id,
+        page: data.page,
+        limit: data.limit,
+        hide_modlog_names,
+    };
+    let removed_posts = match type_ {
+        All | ModRemovePost => ModRemovePostView::list(&mut context.pool(), params).await?,
         _ => Default::default(),
-      },
-      match type_ {
-        All | ModAdd => ModAddView::list(&mut context.pool(), params).await?,
+    };
+
+    let locked_posts = match type_ {
+        All | ModLockPost => ModLockPostView::list(&mut context.pool(), params).await?,
         _ => Default::default(),
-      },
-      match type_ {
-        All | ModRemoveCommunity if other_person_id.is_none() => {
-          ModRemoveCommunityView::list(&mut context.pool(), params).await?
+    };
+
+    let featured_posts = match type_ {
+        All | ModFeaturePost => ModFeaturePostView::list(&mut context.pool(), params).await?,
+        _ => Default::default(),
+    };
+
+    let removed_comments = match type_ {
+        All | ModRemoveComment => ModRemoveCommentView::list(&mut context.pool(), params).await?,
+        _ => Default::default(),
+    };
+
+    let banned_from_community = match type_ {
+        All | ModBanFromCommunity => {
+            ModBanFromCommunityView::list(&mut context.pool(), params).await?
         }
         _ => Default::default(),
-      },
-      match type_ {
-        All | AdminPurgePerson if other_person_id.is_none() => {
-          AdminPurgePersonView::list(&mut context.pool(), params).await?
-        }
-        _ => Default::default(),
-      },
-      match type_ {
-        All | AdminPurgeCommunity if other_person_id.is_none() => {
-          AdminPurgeCommunityView::list(&mut context.pool(), params).await?
-        }
-        _ => Default::default(),
-      },
-      match type_ {
-        All | AdminPurgePost if other_person_id.is_none() => {
-          AdminPurgePostView::list(&mut context.pool(), params).await?
-        }
-        _ => Default::default(),
-      },
-      match type_ {
-        All | AdminPurgeComment if other_person_id.is_none() => {
-          AdminPurgeCommentView::list(&mut context.pool(), params).await?
-        }
-        _ => Default::default(),
-      },
-    )
-  } else {
-    Default::default()
-  };
+    };
 
-  // Return the jwt
-  Ok(Json(GetModlogResponse {
-    removed_posts,
-    locked_posts,
-    featured_posts,
-    removed_comments,
-    removed_communities,
-    banned_from_community,
-    banned,
-    added_to_community,
-    added,
-    transferred_to_community,
-    admin_purged_persons,
-    admin_purged_communities,
-    admin_purged_posts,
-    admin_purged_comments,
-    hidden_communities,
-  }))
+    let added_to_community = match type_ {
+        All | ModAddCommunity => ModAddCommunityView::list(&mut context.pool(), params).await?,
+        _ => Default::default(),
+    };
+
+    let transferred_to_community = match type_ {
+        All | ModTransferCommunity => {
+            ModTransferCommunityView::list(&mut context.pool(), params).await?
+        }
+        _ => Default::default(),
+    };
+
+    let hidden_communities = match type_ {
+        All | ModHideCommunity if other_person_id.is_none() => {
+            ModHideCommunityView::list(&mut context.pool(), params).await?
+        }
+        _ => Default::default(),
+    };
+
+    // These arrays are only for the full modlog, when a community isn't given
+    let (
+        banned,
+        added,
+        removed_communities,
+        admin_purged_persons,
+        admin_purged_communities,
+        admin_purged_posts,
+        admin_purged_comments,
+    ) = if data.community_id.is_none() {
+        (
+            match type_ {
+                All | ModBan => ModBanView::list(&mut context.pool(), params).await?,
+                _ => Default::default(),
+            },
+            match type_ {
+                All | ModAdd => ModAddView::list(&mut context.pool(), params).await?,
+                _ => Default::default(),
+            },
+            match type_ {
+                All | ModRemoveCommunity if other_person_id.is_none() => {
+                    ModRemoveCommunityView::list(&mut context.pool(), params).await?
+                }
+                _ => Default::default(),
+            },
+            match type_ {
+                All | AdminPurgePerson if other_person_id.is_none() => {
+                    AdminPurgePersonView::list(&mut context.pool(), params).await?
+                }
+                _ => Default::default(),
+            },
+            match type_ {
+                All | AdminPurgeCommunity if other_person_id.is_none() => {
+                    AdminPurgeCommunityView::list(&mut context.pool(), params).await?
+                }
+                _ => Default::default(),
+            },
+            match type_ {
+                All | AdminPurgePost if other_person_id.is_none() => {
+                    AdminPurgePostView::list(&mut context.pool(), params).await?
+                }
+                _ => Default::default(),
+            },
+            match type_ {
+                All | AdminPurgeComment if other_person_id.is_none() => {
+                    AdminPurgeCommentView::list(&mut context.pool(), params).await?
+                }
+                _ => Default::default(),
+            },
+        )
+    } else {
+        Default::default()
+    };
+
+    // Return the jwt
+    Ok(Json(GetModlogResponse {
+        removed_posts,
+        locked_posts,
+        featured_posts,
+        removed_comments,
+        removed_communities,
+        banned_from_community,
+        banned,
+        added_to_community,
+        added,
+        transferred_to_community,
+        admin_purged_persons,
+        admin_purged_communities,
+        admin_purged_posts,
+        admin_purged_comments,
+        hidden_communities,
+    }))
 }

--- a/crates/api/src/site/purge/comment.rs
+++ b/crates/api/src/site/purge/comment.rs
@@ -1,48 +1,48 @@
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  context::LemmyContext,
-  site::{PurgeComment, PurgeItemResponse},
-  utils::{is_admin, local_user_view_from_jwt, sanitize_html_opt},
+    context::LemmyContext,
+    site::{PurgeComment, PurgeItemResponse},
+    utils::{is_admin, local_user_view_from_jwt, sanitize_html_opt},
 };
 use lemmy_db_schema::{
-  source::{
-    comment::Comment,
-    moderator::{AdminPurgeComment, AdminPurgeCommentForm},
-  },
-  traits::Crud,
+    source::{
+        comment::Comment,
+        moderator::{AdminPurgeComment, AdminPurgeCommentForm},
+    },
+    traits::Crud,
 };
 use lemmy_utils::error::LemmyError;
 
 #[tracing::instrument(skip(context))]
 pub async fn purge_comment(
-  data: Json<PurgeComment>,
-  context: Data<LemmyContext>,
+    data: Json<PurgeComment>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<PurgeItemResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  // Only let admin purge an item
-  is_admin(&local_user_view)?;
+    // Only let admin purge an item
+    is_admin(&local_user_view)?;
 
-  let comment_id = data.comment_id;
+    let comment_id = data.comment_id;
 
-  // Read the comment to get the post_id
-  let comment = Comment::read(&mut context.pool(), comment_id).await?;
+    // Read the comment to get the post_id
+    let comment = Comment::read(&mut context.pool(), comment_id).await?;
 
-  let post_id = comment.post_id;
+    let post_id = comment.post_id;
 
-  // TODO read comments for pictrs images and purge them
+    // TODO read comments for pictrs images and purge them
 
-  Comment::delete(&mut context.pool(), comment_id).await?;
+    Comment::delete(&mut context.pool(), comment_id).await?;
 
-  // Mod tables
-  let reason = sanitize_html_opt(&data.reason);
-  let form = AdminPurgeCommentForm {
-    admin_person_id: local_user_view.person.id,
-    reason,
-    post_id,
-  };
+    // Mod tables
+    let reason = sanitize_html_opt(&data.reason);
+    let form = AdminPurgeCommentForm {
+        admin_person_id: local_user_view.person.id,
+        reason,
+        post_id,
+    };
 
-  AdminPurgeComment::create(&mut context.pool(), &form).await?;
+    AdminPurgeComment::create(&mut context.pool(), &form).await?;
 
-  Ok(Json(PurgeItemResponse { success: true }))
+    Ok(Json(PurgeItemResponse { success: true }))
 }

--- a/crates/api/src/site/purge/person.rs
+++ b/crates/api/src/site/purge/person.rs
@@ -1,53 +1,53 @@
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  context::LemmyContext,
-  request::purge_image_from_pictrs,
-  site::{PurgeItemResponse, PurgePerson},
-  utils::{is_admin, local_user_view_from_jwt, purge_image_posts_for_person, sanitize_html_opt},
+    context::LemmyContext,
+    request::purge_image_from_pictrs,
+    site::{PurgeItemResponse, PurgePerson},
+    utils::{is_admin, local_user_view_from_jwt, purge_image_posts_for_person, sanitize_html_opt},
 };
 use lemmy_db_schema::{
-  source::{
-    moderator::{AdminPurgePerson, AdminPurgePersonForm},
-    person::Person,
-  },
-  traits::Crud,
+    source::{
+        moderator::{AdminPurgePerson, AdminPurgePersonForm},
+        person::Person,
+    },
+    traits::Crud,
 };
 use lemmy_utils::error::LemmyError;
 
 #[tracing::instrument(skip(context))]
 pub async fn purge_person(
-  data: Json<PurgePerson>,
-  context: Data<LemmyContext>,
+    data: Json<PurgePerson>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<PurgeItemResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  // Only let admin purge an item
-  is_admin(&local_user_view)?;
+    // Only let admin purge an item
+    is_admin(&local_user_view)?;
 
-  // Read the person to get their images
-  let person_id = data.person_id;
-  let person = Person::read(&mut context.pool(), person_id).await?;
+    // Read the person to get their images
+    let person_id = data.person_id;
+    let person = Person::read(&mut context.pool(), person_id).await?;
 
-  if let Some(banner) = person.banner {
-    purge_image_from_pictrs(&banner, &context).await.ok();
-  }
+    if let Some(banner) = person.banner {
+        purge_image_from_pictrs(&banner, &context).await.ok();
+    }
 
-  if let Some(avatar) = person.avatar {
-    purge_image_from_pictrs(&avatar, &context).await.ok();
-  }
+    if let Some(avatar) = person.avatar {
+        purge_image_from_pictrs(&avatar, &context).await.ok();
+    }
 
-  purge_image_posts_for_person(person_id, &context).await?;
+    purge_image_posts_for_person(person_id, &context).await?;
 
-  Person::delete(&mut context.pool(), person_id).await?;
+    Person::delete(&mut context.pool(), person_id).await?;
 
-  // Mod tables
-  let reason = sanitize_html_opt(&data.reason);
-  let form = AdminPurgePersonForm {
-    admin_person_id: local_user_view.person.id,
-    reason,
-  };
+    // Mod tables
+    let reason = sanitize_html_opt(&data.reason);
+    let form = AdminPurgePersonForm {
+        admin_person_id: local_user_view.person.id,
+        reason,
+    };
 
-  AdminPurgePerson::create(&mut context.pool(), &form).await?;
+    AdminPurgePerson::create(&mut context.pool(), &form).await?;
 
-  Ok(Json(PurgeItemResponse { success: true }))
+    Ok(Json(PurgeItemResponse { success: true }))
 }

--- a/crates/api/src/site/purge/post.rs
+++ b/crates/api/src/site/purge/post.rs
@@ -1,56 +1,56 @@
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  context::LemmyContext,
-  request::purge_image_from_pictrs,
-  site::{PurgeItemResponse, PurgePost},
-  utils::{is_admin, local_user_view_from_jwt, sanitize_html_opt},
+    context::LemmyContext,
+    request::purge_image_from_pictrs,
+    site::{PurgeItemResponse, PurgePost},
+    utils::{is_admin, local_user_view_from_jwt, sanitize_html_opt},
 };
 use lemmy_db_schema::{
-  source::{
-    moderator::{AdminPurgePost, AdminPurgePostForm},
-    post::Post,
-  },
-  traits::Crud,
+    source::{
+        moderator::{AdminPurgePost, AdminPurgePostForm},
+        post::Post,
+    },
+    traits::Crud,
 };
 use lemmy_utils::error::LemmyError;
 
 #[tracing::instrument(skip(context))]
 pub async fn purge_post(
-  data: Json<PurgePost>,
-  context: Data<LemmyContext>,
+    data: Json<PurgePost>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<PurgeItemResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  // Only let admin purge an item
-  is_admin(&local_user_view)?;
+    // Only let admin purge an item
+    is_admin(&local_user_view)?;
 
-  let post_id = data.post_id;
+    let post_id = data.post_id;
 
-  // Read the post to get the community_id
-  let post = Post::read(&mut context.pool(), post_id).await?;
+    // Read the post to get the community_id
+    let post = Post::read(&mut context.pool(), post_id).await?;
 
-  // Purge image
-  if let Some(url) = post.url {
-    purge_image_from_pictrs(&url, &context).await.ok();
-  }
-  // Purge thumbnail
-  if let Some(thumbnail_url) = post.thumbnail_url {
-    purge_image_from_pictrs(&thumbnail_url, &context).await.ok();
-  }
+    // Purge image
+    if let Some(url) = post.url {
+        purge_image_from_pictrs(&url, &context).await.ok();
+    }
+    // Purge thumbnail
+    if let Some(thumbnail_url) = post.thumbnail_url {
+        purge_image_from_pictrs(&thumbnail_url, &context).await.ok();
+    }
 
-  let community_id = post.community_id;
+    let community_id = post.community_id;
 
-  Post::delete(&mut context.pool(), post_id).await?;
+    Post::delete(&mut context.pool(), post_id).await?;
 
-  // Mod tables
-  let reason = sanitize_html_opt(&data.reason);
-  let form = AdminPurgePostForm {
-    admin_person_id: local_user_view.person.id,
-    reason,
-    community_id,
-  };
+    // Mod tables
+    let reason = sanitize_html_opt(&data.reason);
+    let form = AdminPurgePostForm {
+        admin_person_id: local_user_view.person.id,
+        reason,
+        community_id,
+    };
 
-  AdminPurgePost::create(&mut context.pool(), &form).await?;
+    AdminPurgePost::create(&mut context.pool(), &form).await?;
 
-  Ok(Json(PurgeItemResponse { success: true }))
+    Ok(Json(PurgeItemResponse { success: true }))
 }

--- a/crates/api/src/site/registration_applications/approve.rs
+++ b/crates/api/src/site/registration_applications/approve.rs
@@ -1,64 +1,64 @@
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  context::LemmyContext,
-  site::{ApproveRegistrationApplication, RegistrationApplicationResponse},
-  utils::{is_admin, local_user_view_from_jwt, send_application_approved_email},
+    context::LemmyContext,
+    site::{ApproveRegistrationApplication, RegistrationApplicationResponse},
+    utils::{is_admin, local_user_view_from_jwt, send_application_approved_email},
 };
 use lemmy_db_schema::{
-  source::{
-    local_user::{LocalUser, LocalUserUpdateForm},
-    registration_application::{RegistrationApplication, RegistrationApplicationUpdateForm},
-  },
-  traits::Crud,
-  utils::diesel_option_overwrite,
+    source::{
+        local_user::{LocalUser, LocalUserUpdateForm},
+        registration_application::{RegistrationApplication, RegistrationApplicationUpdateForm},
+    },
+    traits::Crud,
+    utils::diesel_option_overwrite,
 };
 use lemmy_db_views::structs::{LocalUserView, RegistrationApplicationView};
 use lemmy_utils::error::LemmyError;
 
 pub async fn approve_registration_application(
-  data: Json<ApproveRegistrationApplication>,
-  context: Data<LemmyContext>,
+    data: Json<ApproveRegistrationApplication>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<RegistrationApplicationResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  let app_id = data.id;
+    let app_id = data.id;
 
-  // Only let admins do this
-  is_admin(&local_user_view)?;
+    // Only let admins do this
+    is_admin(&local_user_view)?;
 
-  // Update the registration with reason, admin_id
-  let deny_reason = diesel_option_overwrite(data.deny_reason.clone());
-  let app_form = RegistrationApplicationUpdateForm {
-    admin_id: Some(Some(local_user_view.person.id)),
-    deny_reason,
-  };
+    // Update the registration with reason, admin_id
+    let deny_reason = diesel_option_overwrite(data.deny_reason.clone());
+    let app_form = RegistrationApplicationUpdateForm {
+        admin_id: Some(Some(local_user_view.person.id)),
+        deny_reason,
+    };
 
-  let registration_application =
-    RegistrationApplication::update(&mut context.pool(), app_id, &app_form).await?;
+    let registration_application =
+        RegistrationApplication::update(&mut context.pool(), app_id, &app_form).await?;
 
-  // Update the local_user row
-  let local_user_form = LocalUserUpdateForm {
-    accepted_application: Some(data.approve),
-    ..Default::default()
-  };
+    // Update the local_user row
+    let local_user_form = LocalUserUpdateForm {
+        accepted_application: Some(data.approve),
+        ..Default::default()
+    };
 
-  let approved_user_id = registration_application.local_user_id;
-  LocalUser::update(&mut context.pool(), approved_user_id, &local_user_form).await?;
+    let approved_user_id = registration_application.local_user_id;
+    LocalUser::update(&mut context.pool(), approved_user_id, &local_user_form).await?;
 
-  if data.approve {
-    let approved_local_user_view =
-      LocalUserView::read(&mut context.pool(), approved_user_id).await?;
+    if data.approve {
+        let approved_local_user_view =
+            LocalUserView::read(&mut context.pool(), approved_user_id).await?;
 
-    if approved_local_user_view.local_user.email.is_some() {
-      send_application_approved_email(&approved_local_user_view, context.settings()).await?;
+        if approved_local_user_view.local_user.email.is_some() {
+            send_application_approved_email(&approved_local_user_view, context.settings()).await?;
+        }
     }
-  }
 
-  // Read the view
-  let registration_application =
-    RegistrationApplicationView::read(&mut context.pool(), app_id).await?;
+    // Read the view
+    let registration_application =
+        RegistrationApplicationView::read(&mut context.pool(), app_id).await?;
 
-  Ok(Json(RegistrationApplicationResponse {
-    registration_application,
-  }))
+    Ok(Json(RegistrationApplicationResponse {
+        registration_application,
+    }))
 }

--- a/crates/api/src/site/registration_applications/list.rs
+++ b/crates/api/src/site/registration_applications/list.rs
@@ -1,8 +1,8 @@
 use actix_web::web::{Data, Json, Query};
 use lemmy_api_common::{
-  context::LemmyContext,
-  site::{ListRegistrationApplications, ListRegistrationApplicationsResponse},
-  utils::{is_admin, local_user_view_from_jwt},
+    context::LemmyContext,
+    site::{ListRegistrationApplications, ListRegistrationApplicationsResponse},
+    utils::{is_admin, local_user_view_from_jwt},
 };
 use lemmy_db_schema::source::local_site::LocalSite;
 use lemmy_db_views::registration_application_view::RegistrationApplicationQuery;
@@ -10,30 +10,30 @@ use lemmy_utils::error::LemmyError;
 
 /// Lists registration applications, filterable by undenied only.
 pub async fn list_registration_applications(
-  data: Query<ListRegistrationApplications>,
-  context: Data<LemmyContext>,
+    data: Query<ListRegistrationApplications>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<ListRegistrationApplicationsResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
-  let local_site = LocalSite::read(&mut context.pool()).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
 
-  // Make sure user is an admin
-  is_admin(&local_user_view)?;
+    // Make sure user is an admin
+    is_admin(&local_user_view)?;
 
-  let unread_only = data.unread_only.unwrap_or_default();
-  let verified_email_only = local_site.require_email_verification;
+    let unread_only = data.unread_only.unwrap_or_default();
+    let verified_email_only = local_site.require_email_verification;
 
-  let page = data.page;
-  let limit = data.limit;
-  let registration_applications = RegistrationApplicationQuery {
-    unread_only,
-    verified_email_only,
-    page,
-    limit,
-  }
-  .list(&mut context.pool())
-  .await?;
+    let page = data.page;
+    let limit = data.limit;
+    let registration_applications = RegistrationApplicationQuery {
+        unread_only,
+        verified_email_only,
+        page,
+        limit,
+    }
+    .list(&mut context.pool())
+    .await?;
 
-  Ok(Json(ListRegistrationApplicationsResponse {
-    registration_applications,
-  }))
+    Ok(Json(ListRegistrationApplicationsResponse {
+        registration_applications,
+    }))
 }

--- a/crates/api/src/site/registration_applications/unread_count.rs
+++ b/crates/api/src/site/registration_applications/unread_count.rs
@@ -1,29 +1,30 @@
 use actix_web::web::{Data, Json, Query};
 use lemmy_api_common::{
-  context::LemmyContext,
-  site::{GetUnreadRegistrationApplicationCount, GetUnreadRegistrationApplicationCountResponse},
-  utils::{is_admin, local_user_view_from_jwt},
+    context::LemmyContext,
+    site::{GetUnreadRegistrationApplicationCount, GetUnreadRegistrationApplicationCountResponse},
+    utils::{is_admin, local_user_view_from_jwt},
 };
 use lemmy_db_schema::source::local_site::LocalSite;
 use lemmy_db_views::structs::RegistrationApplicationView;
 use lemmy_utils::error::LemmyError;
 
 pub async fn get_unread_registration_application_count(
-  data: Query<GetUnreadRegistrationApplicationCount>,
-  context: Data<LemmyContext>,
+    data: Query<GetUnreadRegistrationApplicationCount>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<GetUnreadRegistrationApplicationCountResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
-  let local_site = LocalSite::read(&mut context.pool()).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
 
-  // Only let admins do this
-  is_admin(&local_user_view)?;
+    // Only let admins do this
+    is_admin(&local_user_view)?;
 
-  let verified_email_only = local_site.require_email_verification;
+    let verified_email_only = local_site.require_email_verification;
 
-  let registration_applications =
-    RegistrationApplicationView::get_unread_count(&mut context.pool(), verified_email_only).await?;
+    let registration_applications =
+        RegistrationApplicationView::get_unread_count(&mut context.pool(), verified_email_only)
+            .await?;
 
-  Ok(Json(GetUnreadRegistrationApplicationCountResponse {
-    registration_applications,
-  }))
+    Ok(Json(GetUnreadRegistrationApplicationCountResponse {
+        registration_applications,
+    }))
 }

--- a/crates/api/src/sitemap.rs
+++ b/crates/api/src/sitemap.rs
@@ -1,7 +1,7 @@
 use actix_web::{
-  http::header::{self, CacheDirective},
-  web::Data,
-  HttpResponse,
+    http::header::{self, CacheDirective},
+    web::Data,
+    HttpResponse,
 };
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::{newtypes::DbUrl, source::post::Post};
@@ -10,133 +10,127 @@ use sitemap_rs::{url::Url, url_set::UrlSet};
 use tracing::info;
 
 async fn generate_urlset(
-  posts: Vec<(DbUrl, chrono::DateTime<chrono::Utc>)>,
+    posts: Vec<(DbUrl, chrono::DateTime<chrono::Utc>)>,
 ) -> LemmyResult<UrlSet> {
-  let urls = posts
-    .into_iter()
-    .map_while(|post| {
-      Url::builder(post.0.to_string())
-        .last_modified(post.1.into())
-        .build()
-        .ok()
-    })
-    .collect();
+    let urls = posts
+        .into_iter()
+        .map_while(|post| {
+            Url::builder(post.0.to_string())
+                .last_modified(post.1.into())
+                .build()
+                .ok()
+        })
+        .collect();
 
-  Ok(UrlSet::new(urls)?)
+    Ok(UrlSet::new(urls)?)
 }
 
 pub async fn get_sitemap(context: Data<LemmyContext>) -> LemmyResult<HttpResponse> {
-  info!("Generating sitemap with posts from last {} hours...", 24);
-  let posts = Post::list_for_sitemap(&mut context.pool()).await?;
-  info!("Loaded latest {} posts", posts.len());
+    info!("Generating sitemap with posts from last {} hours...", 24);
+    let posts = Post::list_for_sitemap(&mut context.pool()).await?;
+    info!("Loaded latest {} posts", posts.len());
 
-  let mut buf = Vec::<u8>::new();
-  generate_urlset(posts).await?.write(&mut buf)?;
+    let mut buf = Vec::<u8>::new();
+    generate_urlset(posts).await?.write(&mut buf)?;
 
-  Ok(
-    HttpResponse::Ok()
-      .content_type("application/xml")
-      .insert_header(header::CacheControl(vec![CacheDirective::MaxAge(86_400)])) // 24 h
-      .body(buf),
-  )
+    Ok(HttpResponse::Ok()
+        .content_type("application/xml")
+        .insert_header(header::CacheControl(vec![CacheDirective::MaxAge(86_400)])) // 24 h
+        .body(buf))
 }
 
 #[cfg(test)]
 pub(crate) mod tests {
-  #![allow(clippy::unwrap_used)]
+    #![allow(clippy::unwrap_used)]
 
-  use crate::sitemap::generate_urlset;
-  use chrono::{DateTime, NaiveDate, Utc};
-  use elementtree::Element;
-  use lemmy_db_schema::newtypes::DbUrl;
-  use url::Url;
+    use crate::sitemap::generate_urlset;
+    use chrono::{DateTime, NaiveDate, Utc};
+    use elementtree::Element;
+    use lemmy_db_schema::newtypes::DbUrl;
+    use url::Url;
 
-  #[tokio::test]
-  async fn test_generate_urlset() {
-    let posts: Vec<(DbUrl, DateTime<Utc>)> = vec![
-      (
-        Url::parse("https://example.com").unwrap().into(),
-        NaiveDate::from_ymd_opt(2022, 12, 1)
-          .unwrap()
-          .and_hms_opt(9, 10, 11)
-          .unwrap()
-          .and_utc(),
-      ),
-      (
-        Url::parse("https://lemmy.ml").unwrap().into(),
-        NaiveDate::from_ymd_opt(2023, 1, 1)
-          .unwrap()
-          .and_hms_opt(1, 2, 3)
-          .unwrap()
-          .and_utc(),
-      ),
-    ];
+    #[tokio::test]
+    async fn test_generate_urlset() {
+        let posts: Vec<(DbUrl, DateTime<Utc>)> = vec![
+            (
+                Url::parse("https://example.com").unwrap().into(),
+                NaiveDate::from_ymd_opt(2022, 12, 1)
+                    .unwrap()
+                    .and_hms_opt(9, 10, 11)
+                    .unwrap()
+                    .and_utc(),
+            ),
+            (
+                Url::parse("https://lemmy.ml").unwrap().into(),
+                NaiveDate::from_ymd_opt(2023, 1, 1)
+                    .unwrap()
+                    .and_hms_opt(1, 2, 3)
+                    .unwrap()
+                    .and_utc(),
+            ),
+        ];
 
-    let mut buf = Vec::<u8>::new();
-    generate_urlset(posts)
-      .await
-      .unwrap()
-      .write(&mut buf)
-      .unwrap();
-    let root = Element::from_reader(buf.as_slice()).unwrap();
+        let mut buf = Vec::<u8>::new();
+        generate_urlset(posts)
+            .await
+            .unwrap()
+            .write(&mut buf)
+            .unwrap();
+        let root = Element::from_reader(buf.as_slice()).unwrap();
 
-    assert_eq!(root.tag().name(), "urlset");
-    assert_eq!(root.child_count(), 2);
+        assert_eq!(root.tag().name(), "urlset");
+        assert_eq!(root.child_count(), 2);
 
-    assert!(root.children().all(|url| url.tag().name() == "url"));
-    assert!(root.children().all(|url| url.child_count() == 2));
-    assert!(root.children().all(|url| url
-      .children()
-      .next()
-      .is_some_and(|element| element.tag().name() == "loc")));
-    assert!(root.children().all(|url| url
-      .children()
-      .nth(1)
-      .is_some_and(|element| element.tag().name() == "lastmod")));
+        assert!(root.children().all(|url| url.tag().name() == "url"));
+        assert!(root.children().all(|url| url.child_count() == 2));
+        assert!(root.children().all(|url| url
+            .children()
+            .next()
+            .is_some_and(|element| element.tag().name() == "loc")));
+        assert!(root.children().all(|url| url
+            .children()
+            .nth(1)
+            .is_some_and(|element| element.tag().name() == "lastmod")));
 
-    assert_eq!(
-      root
-        .children()
-        .next()
-        .unwrap()
-        .children()
-        .find(|element| element.tag().name() == "loc")
-        .unwrap()
-        .text(),
-      "https://example.com/"
-    );
-    assert_eq!(
-      root
-        .children()
-        .next()
-        .unwrap()
-        .children()
-        .find(|element| element.tag().name() == "lastmod")
-        .unwrap()
-        .text(),
-      "2022-12-01T09:10:11+00:00"
-    );
-    assert_eq!(
-      root
-        .children()
-        .nth(1)
-        .unwrap()
-        .children()
-        .find(|element| element.tag().name() == "loc")
-        .unwrap()
-        .text(),
-      "https://lemmy.ml/"
-    );
-    assert_eq!(
-      root
-        .children()
-        .nth(1)
-        .unwrap()
-        .children()
-        .find(|element| element.tag().name() == "lastmod")
-        .unwrap()
-        .text(),
-      "2023-01-01T01:02:03+00:00"
-    );
-  }
+        assert_eq!(
+            root.children()
+                .next()
+                .unwrap()
+                .children()
+                .find(|element| element.tag().name() == "loc")
+                .unwrap()
+                .text(),
+            "https://example.com/"
+        );
+        assert_eq!(
+            root.children()
+                .next()
+                .unwrap()
+                .children()
+                .find(|element| element.tag().name() == "lastmod")
+                .unwrap()
+                .text(),
+            "2022-12-01T09:10:11+00:00"
+        );
+        assert_eq!(
+            root.children()
+                .nth(1)
+                .unwrap()
+                .children()
+                .find(|element| element.tag().name() == "loc")
+                .unwrap()
+                .text(),
+            "https://lemmy.ml/"
+        );
+        assert_eq!(
+            root.children()
+                .nth(1)
+                .unwrap()
+                .children()
+                .find(|element| element.tag().name() == "lastmod")
+                .unwrap()
+                .text(),
+            "2023-01-01T01:02:03+00:00"
+        );
+    }
 }

--- a/crates/api_common/src/build_response.rs
+++ b/crates/api_common/src/build_response.rs
@@ -1,217 +1,230 @@
 use crate::{
-  comment::CommentResponse,
-  community::CommunityResponse,
-  context::LemmyContext,
-  post::PostResponse,
-  utils::{check_person_block, get_interface_language, is_mod_or_admin, send_email_to_user},
+    comment::CommentResponse,
+    community::CommunityResponse,
+    context::LemmyContext,
+    post::PostResponse,
+    utils::{check_person_block, get_interface_language, is_mod_or_admin, send_email_to_user},
 };
 use actix_web::web::Json;
 use lemmy_db_schema::{
-  newtypes::{CommentId, CommunityId, LocalUserId, PersonId, PostId},
-  source::{
-    actor_language::CommunityLanguage,
-    comment::Comment,
-    comment_reply::{CommentReply, CommentReplyInsertForm},
-    person::Person,
-    person_mention::{PersonMention, PersonMentionInsertForm},
-    post::Post,
-  },
-  traits::Crud,
+    newtypes::{CommentId, CommunityId, LocalUserId, PersonId, PostId},
+    source::{
+        actor_language::CommunityLanguage,
+        comment::Comment,
+        comment_reply::{CommentReply, CommentReplyInsertForm},
+        person::Person,
+        person_mention::{PersonMention, PersonMentionInsertForm},
+        post::Post,
+    },
+    traits::Crud,
 };
 use lemmy_db_views::structs::{CommentView, LocalUserView, PostView};
 use lemmy_db_views_actor::structs::CommunityView;
 use lemmy_utils::{error::LemmyError, utils::mention::MentionData};
 
 pub async fn build_comment_response(
-  context: &LemmyContext,
-  comment_id: CommentId,
-  local_user_view: Option<LocalUserView>,
-  recipient_ids: Vec<LocalUserId>,
+    context: &LemmyContext,
+    comment_id: CommentId,
+    local_user_view: Option<LocalUserView>,
+    recipient_ids: Vec<LocalUserId>,
 ) -> Result<CommentResponse, LemmyError> {
-  let person_id = local_user_view.map(|l| l.person.id);
-  let comment_view = CommentView::read(&mut context.pool(), comment_id, person_id).await?;
-  Ok(CommentResponse {
-    comment_view,
-    recipient_ids,
-  })
+    let person_id = local_user_view.map(|l| l.person.id);
+    let comment_view = CommentView::read(&mut context.pool(), comment_id, person_id).await?;
+    Ok(CommentResponse {
+        comment_view,
+        recipient_ids,
+    })
 }
 
 pub async fn build_community_response(
-  context: &LemmyContext,
-  local_user_view: LocalUserView,
-  community_id: CommunityId,
+    context: &LemmyContext,
+    local_user_view: LocalUserView,
+    community_id: CommunityId,
 ) -> Result<Json<CommunityResponse>, LemmyError> {
-  let is_mod_or_admin =
-    is_mod_or_admin(&mut context.pool(), local_user_view.person.id, community_id)
-      .await
-      .is_ok();
-  let person_id = local_user_view.person.id;
-  let community_view = CommunityView::read(
-    &mut context.pool(),
-    community_id,
-    Some(person_id),
-    is_mod_or_admin,
-  )
-  .await?;
-  let discussion_languages = CommunityLanguage::read(&mut context.pool(), community_id).await?;
+    let is_mod_or_admin =
+        is_mod_or_admin(&mut context.pool(), local_user_view.person.id, community_id)
+            .await
+            .is_ok();
+    let person_id = local_user_view.person.id;
+    let community_view = CommunityView::read(
+        &mut context.pool(),
+        community_id,
+        Some(person_id),
+        is_mod_or_admin,
+    )
+    .await?;
+    let discussion_languages = CommunityLanguage::read(&mut context.pool(), community_id).await?;
 
-  Ok(Json(CommunityResponse {
-    community_view,
-    discussion_languages,
-  }))
+    Ok(Json(CommunityResponse {
+        community_view,
+        discussion_languages,
+    }))
 }
 
 pub async fn build_post_response(
-  context: &LemmyContext,
-  community_id: CommunityId,
-  person_id: PersonId,
-  post_id: PostId,
+    context: &LemmyContext,
+    community_id: CommunityId,
+    person_id: PersonId,
+    post_id: PostId,
 ) -> Result<Json<PostResponse>, LemmyError> {
-  let is_mod_or_admin = is_mod_or_admin(&mut context.pool(), person_id, community_id)
-    .await
-    .is_ok();
-  let post_view = PostView::read(
-    &mut context.pool(),
-    post_id,
-    Some(person_id),
-    is_mod_or_admin,
-  )
-  .await?;
-  Ok(Json(PostResponse { post_view }))
+    let is_mod_or_admin = is_mod_or_admin(&mut context.pool(), person_id, community_id)
+        .await
+        .is_ok();
+    let post_view = PostView::read(
+        &mut context.pool(),
+        post_id,
+        Some(person_id),
+        is_mod_or_admin,
+    )
+    .await?;
+    Ok(Json(PostResponse { post_view }))
 }
 
 // TODO: this function is a mess and should be split up to handle email seperately
 #[tracing::instrument(skip_all)]
 pub async fn send_local_notifs(
-  mentions: Vec<MentionData>,
-  comment: &Comment,
-  person: &Person,
-  post: &Post,
-  do_send_email: bool,
-  context: &LemmyContext,
+    mentions: Vec<MentionData>,
+    comment: &Comment,
+    person: &Person,
+    post: &Post,
+    do_send_email: bool,
+    context: &LemmyContext,
 ) -> Result<Vec<LocalUserId>, LemmyError> {
-  let mut recipient_ids = Vec::new();
-  let inbox_link = format!("{}/inbox", context.settings().get_protocol_and_hostname());
+    let mut recipient_ids = Vec::new();
+    let inbox_link = format!("{}/inbox", context.settings().get_protocol_and_hostname());
 
-  // Send the local mentions
-  for mention in mentions
-    .iter()
-    .filter(|m| m.is_local(&context.settings().hostname) && m.name.ne(&person.name))
-  {
-    let mention_name = mention.name.clone();
-    let user_view = LocalUserView::read_from_name(&mut context.pool(), &mention_name).await;
-    if let Ok(mention_user_view) = user_view {
-      // TODO
-      // At some point, make it so you can't tag the parent creator either
-      // This can cause two notifications, one for reply and the other for mention
-      recipient_ids.push(mention_user_view.local_user.id);
+    // Send the local mentions
+    for mention in mentions
+        .iter()
+        .filter(|m| m.is_local(&context.settings().hostname) && m.name.ne(&person.name))
+    {
+        let mention_name = mention.name.clone();
+        let user_view = LocalUserView::read_from_name(&mut context.pool(), &mention_name).await;
+        if let Ok(mention_user_view) = user_view {
+            // TODO
+            // At some point, make it so you can't tag the parent creator either
+            // This can cause two notifications, one for reply and the other for mention
+            recipient_ids.push(mention_user_view.local_user.id);
 
-      let user_mention_form = PersonMentionInsertForm {
-        recipient_id: mention_user_view.person.id,
-        comment_id: comment.id,
-        read: None,
-      };
+            let user_mention_form = PersonMentionInsertForm {
+                recipient_id: mention_user_view.person.id,
+                comment_id: comment.id,
+                read: None,
+            };
 
-      // Allow this to fail softly, since comment edits might re-update or replace it
-      // Let the uniqueness handle this fail
-      PersonMention::create(&mut context.pool(), &user_mention_form)
-        .await
-        .ok();
+            // Allow this to fail softly, since comment edits might re-update or replace it
+            // Let the uniqueness handle this fail
+            PersonMention::create(&mut context.pool(), &user_mention_form)
+                .await
+                .ok();
 
-      // Send an email to those local users that have notifications on
-      if do_send_email {
-        let lang = get_interface_language(&mention_user_view);
-        send_email_to_user(
-          &mention_user_view,
-          &lang.notification_mentioned_by_subject(&person.name),
-          &lang.notification_mentioned_by_body(&comment.content, &inbox_link, &person.name),
-          context.settings(),
-        )
-        .await
-      }
-    }
-  }
-
-  // Send comment_reply to the parent commenter / poster
-  if let Some(parent_comment_id) = comment.parent_comment_id() {
-    let parent_comment = Comment::read(&mut context.pool(), parent_comment_id).await?;
-
-    // Get the parent commenter local_user
-    let parent_creator_id = parent_comment.creator_id;
-
-    // Only add to recipients if that person isn't blocked
-    let creator_blocked = check_person_block(person.id, parent_creator_id, &mut context.pool())
-      .await
-      .is_err();
-
-    // Don't send a notif to yourself
-    if parent_comment.creator_id != person.id && !creator_blocked {
-      let user_view = LocalUserView::read_person(&mut context.pool(), parent_creator_id).await;
-      if let Ok(parent_user_view) = user_view {
-        recipient_ids.push(parent_user_view.local_user.id);
-
-        let comment_reply_form = CommentReplyInsertForm {
-          recipient_id: parent_user_view.person.id,
-          comment_id: comment.id,
-          read: None,
-        };
-
-        // Allow this to fail softly, since comment edits might re-update or replace it
-        // Let the uniqueness handle this fail
-        CommentReply::create(&mut context.pool(), &comment_reply_form)
-          .await
-          .ok();
-
-        if do_send_email {
-          let lang = get_interface_language(&parent_user_view);
-          send_email_to_user(
-            &parent_user_view,
-            &lang.notification_comment_reply_subject(&person.name),
-            &lang.notification_comment_reply_body(&comment.content, &inbox_link, &person.name),
-            context.settings(),
-          )
-          .await
+            // Send an email to those local users that have notifications on
+            if do_send_email {
+                let lang = get_interface_language(&mention_user_view);
+                send_email_to_user(
+                    &mention_user_view,
+                    &lang.notification_mentioned_by_subject(&person.name),
+                    &lang.notification_mentioned_by_body(
+                        &comment.content,
+                        &inbox_link,
+                        &person.name,
+                    ),
+                    context.settings(),
+                )
+                .await
+            }
         }
-      }
     }
-  } else {
-    // If there's no parent, its the post creator
-    // Only add to recipients if that person isn't blocked
-    let creator_blocked = check_person_block(person.id, post.creator_id, &mut context.pool())
-      .await
-      .is_err();
 
-    if post.creator_id != person.id && !creator_blocked {
-      let creator_id = post.creator_id;
-      let parent_user = LocalUserView::read_person(&mut context.pool(), creator_id).await;
-      if let Ok(parent_user_view) = parent_user {
-        recipient_ids.push(parent_user_view.local_user.id);
+    // Send comment_reply to the parent commenter / poster
+    if let Some(parent_comment_id) = comment.parent_comment_id() {
+        let parent_comment = Comment::read(&mut context.pool(), parent_comment_id).await?;
 
-        let comment_reply_form = CommentReplyInsertForm {
-          recipient_id: parent_user_view.person.id,
-          comment_id: comment.id,
-          read: None,
-        };
+        // Get the parent commenter local_user
+        let parent_creator_id = parent_comment.creator_id;
 
-        // Allow this to fail softly, since comment edits might re-update or replace it
-        // Let the uniqueness handle this fail
-        CommentReply::create(&mut context.pool(), &comment_reply_form)
-          .await
-          .ok();
+        // Only add to recipients if that person isn't blocked
+        let creator_blocked = check_person_block(person.id, parent_creator_id, &mut context.pool())
+            .await
+            .is_err();
 
-        if do_send_email {
-          let lang = get_interface_language(&parent_user_view);
-          send_email_to_user(
-            &parent_user_view,
-            &lang.notification_post_reply_subject(&person.name),
-            &lang.notification_post_reply_body(&comment.content, &inbox_link, &person.name),
-            context.settings(),
-          )
-          .await
+        // Don't send a notif to yourself
+        if parent_comment.creator_id != person.id && !creator_blocked {
+            let user_view =
+                LocalUserView::read_person(&mut context.pool(), parent_creator_id).await;
+            if let Ok(parent_user_view) = user_view {
+                recipient_ids.push(parent_user_view.local_user.id);
+
+                let comment_reply_form = CommentReplyInsertForm {
+                    recipient_id: parent_user_view.person.id,
+                    comment_id: comment.id,
+                    read: None,
+                };
+
+                // Allow this to fail softly, since comment edits might re-update or replace it
+                // Let the uniqueness handle this fail
+                CommentReply::create(&mut context.pool(), &comment_reply_form)
+                    .await
+                    .ok();
+
+                if do_send_email {
+                    let lang = get_interface_language(&parent_user_view);
+                    send_email_to_user(
+                        &parent_user_view,
+                        &lang.notification_comment_reply_subject(&person.name),
+                        &lang.notification_comment_reply_body(
+                            &comment.content,
+                            &inbox_link,
+                            &person.name,
+                        ),
+                        context.settings(),
+                    )
+                    .await
+                }
+            }
         }
-      }
-    }
-  }
+    } else {
+        // If there's no parent, its the post creator
+        // Only add to recipients if that person isn't blocked
+        let creator_blocked = check_person_block(person.id, post.creator_id, &mut context.pool())
+            .await
+            .is_err();
 
-  Ok(recipient_ids)
+        if post.creator_id != person.id && !creator_blocked {
+            let creator_id = post.creator_id;
+            let parent_user = LocalUserView::read_person(&mut context.pool(), creator_id).await;
+            if let Ok(parent_user_view) = parent_user {
+                recipient_ids.push(parent_user_view.local_user.id);
+
+                let comment_reply_form = CommentReplyInsertForm {
+                    recipient_id: parent_user_view.person.id,
+                    comment_id: comment.id,
+                    read: None,
+                };
+
+                // Allow this to fail softly, since comment edits might re-update or replace it
+                // Let the uniqueness handle this fail
+                CommentReply::create(&mut context.pool(), &comment_reply_form)
+                    .await
+                    .ok();
+
+                if do_send_email {
+                    let lang = get_interface_language(&parent_user_view);
+                    send_email_to_user(
+                        &parent_user_view,
+                        &lang.notification_post_reply_subject(&person.name),
+                        &lang.notification_post_reply_body(
+                            &comment.content,
+                            &inbox_link,
+                            &person.name,
+                        ),
+                        context.settings(),
+                    )
+                    .await
+                }
+            }
+        }
+    }
+
+    Ok(recipient_ids)
 }

--- a/crates/api_common/src/comment.rs
+++ b/crates/api_common/src/comment.rs
@@ -1,8 +1,7 @@
 use crate::sensitive::Sensitive;
 use lemmy_db_schema::{
-  newtypes::{CommentId, CommentReportId, CommunityId, LanguageId, LocalUserId, PostId},
-  CommentSortType,
-  ListingType,
+    newtypes::{CommentId, CommentReportId, CommunityId, LanguageId, LocalUserId, PostId},
+    CommentSortType, ListingType,
 };
 use lemmy_db_views::structs::{CommentReportView, CommentView};
 use serde::{Deserialize, Serialize};
@@ -16,11 +15,11 @@ use ts_rs::TS;
 #[cfg_attr(feature = "full", ts(export))]
 /// Create a comment.
 pub struct CreateComment {
-  pub content: String,
-  pub post_id: PostId,
-  pub parent_id: Option<CommentId>,
-  pub language_id: Option<LanguageId>,
-  pub auth: Sensitive<String>,
+    pub content: String,
+    pub post_id: PostId,
+    pub parent_id: Option<CommentId>,
+    pub language_id: Option<LanguageId>,
+    pub auth: Sensitive<String>,
 }
 
 #[skip_serializing_none]
@@ -29,8 +28,8 @@ pub struct CreateComment {
 #[cfg_attr(feature = "full", ts(export))]
 /// Fetch an individual comment.
 pub struct GetComment {
-  pub id: CommentId,
-  pub auth: Option<Sensitive<String>>,
+    pub id: CommentId,
+    pub auth: Option<Sensitive<String>>,
 }
 
 #[skip_serializing_none]
@@ -39,10 +38,10 @@ pub struct GetComment {
 #[cfg_attr(feature = "full", ts(export))]
 /// Edit a comment.
 pub struct EditComment {
-  pub comment_id: CommentId,
-  pub content: Option<String>,
-  pub language_id: Option<LanguageId>,
-  pub auth: Sensitive<String>,
+    pub comment_id: CommentId,
+    pub content: Option<String>,
+    pub language_id: Option<LanguageId>,
+    pub auth: Sensitive<String>,
 }
 
 #[skip_serializing_none]
@@ -51,9 +50,9 @@ pub struct EditComment {
 #[cfg_attr(feature = "full", ts(export))]
 /// Distinguish a comment (IE speak as moderator).
 pub struct DistinguishComment {
-  pub comment_id: CommentId,
-  pub distinguished: bool,
-  pub auth: Sensitive<String>,
+    pub comment_id: CommentId,
+    pub distinguished: bool,
+    pub auth: Sensitive<String>,
 }
 
 #[skip_serializing_none]
@@ -62,9 +61,9 @@ pub struct DistinguishComment {
 #[cfg_attr(feature = "full", ts(export))]
 /// Delete your own comment.
 pub struct DeleteComment {
-  pub comment_id: CommentId,
-  pub deleted: bool,
-  pub auth: Sensitive<String>,
+    pub comment_id: CommentId,
+    pub deleted: bool,
+    pub auth: Sensitive<String>,
 }
 
 #[skip_serializing_none]
@@ -73,10 +72,10 @@ pub struct DeleteComment {
 #[cfg_attr(feature = "full", ts(export))]
 /// Remove a comment (only doable by mods).
 pub struct RemoveComment {
-  pub comment_id: CommentId,
-  pub removed: bool,
-  pub reason: Option<String>,
-  pub auth: Sensitive<String>,
+    pub comment_id: CommentId,
+    pub removed: bool,
+    pub reason: Option<String>,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -84,9 +83,9 @@ pub struct RemoveComment {
 #[cfg_attr(feature = "full", ts(export))]
 /// Save / bookmark a comment.
 pub struct SaveComment {
-  pub comment_id: CommentId,
-  pub save: bool,
-  pub auth: Sensitive<String>,
+    pub comment_id: CommentId,
+    pub save: bool,
+    pub auth: Sensitive<String>,
 }
 
 #[skip_serializing_none]
@@ -95,8 +94,8 @@ pub struct SaveComment {
 #[cfg_attr(feature = "full", ts(export))]
 /// A comment response.
 pub struct CommentResponse {
-  pub comment_view: CommentView,
-  pub recipient_ids: Vec<LocalUserId>,
+    pub comment_view: CommentView,
+    pub recipient_ids: Vec<LocalUserId>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -104,10 +103,10 @@ pub struct CommentResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Like a comment.
 pub struct CreateCommentLike {
-  pub comment_id: CommentId,
-  /// Must be -1, 0, or 1 .
-  pub score: i16,
-  pub auth: Sensitive<String>,
+    pub comment_id: CommentId,
+    /// Must be -1, 0, or 1 .
+    pub score: i16,
+    pub auth: Sensitive<String>,
 }
 
 #[skip_serializing_none]
@@ -116,19 +115,19 @@ pub struct CreateCommentLike {
 #[cfg_attr(feature = "full", ts(export))]
 /// Get a list of comments.
 pub struct GetComments {
-  pub type_: Option<ListingType>,
-  pub sort: Option<CommentSortType>,
-  pub max_depth: Option<i32>,
-  pub page: Option<i64>,
-  pub limit: Option<i64>,
-  pub community_id: Option<CommunityId>,
-  pub community_name: Option<String>,
-  pub post_id: Option<PostId>,
-  pub parent_id: Option<CommentId>,
-  pub saved_only: Option<bool>,
-  pub liked_only: Option<bool>,
-  pub disliked_only: Option<bool>,
-  pub auth: Option<Sensitive<String>>,
+    pub type_: Option<ListingType>,
+    pub sort: Option<CommentSortType>,
+    pub max_depth: Option<i32>,
+    pub page: Option<i64>,
+    pub limit: Option<i64>,
+    pub community_id: Option<CommunityId>,
+    pub community_name: Option<String>,
+    pub post_id: Option<PostId>,
+    pub parent_id: Option<CommentId>,
+    pub saved_only: Option<bool>,
+    pub liked_only: Option<bool>,
+    pub disliked_only: Option<bool>,
+    pub auth: Option<Sensitive<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -136,7 +135,7 @@ pub struct GetComments {
 #[cfg_attr(feature = "full", ts(export))]
 /// The comment list response.
 pub struct GetCommentsResponse {
-  pub comments: Vec<CommentView>,
+    pub comments: Vec<CommentView>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -144,9 +143,9 @@ pub struct GetCommentsResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Report a comment.
 pub struct CreateCommentReport {
-  pub comment_id: CommentId,
-  pub reason: String,
-  pub auth: Sensitive<String>,
+    pub comment_id: CommentId,
+    pub reason: String,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -154,7 +153,7 @@ pub struct CreateCommentReport {
 #[cfg_attr(feature = "full", ts(export))]
 /// The comment report response.
 pub struct CommentReportResponse {
-  pub comment_report_view: CommentReportView,
+    pub comment_report_view: CommentReportView,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -162,9 +161,9 @@ pub struct CommentReportResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Resolve a comment report (only doable by mods).
 pub struct ResolveCommentReport {
-  pub report_id: CommentReportId,
-  pub resolved: bool,
-  pub auth: Sensitive<String>,
+    pub report_id: CommentReportId,
+    pub resolved: bool,
+    pub auth: Sensitive<String>,
 }
 
 #[skip_serializing_none]
@@ -173,13 +172,13 @@ pub struct ResolveCommentReport {
 #[cfg_attr(feature = "full", ts(export))]
 /// List comment reports.
 pub struct ListCommentReports {
-  pub page: Option<i64>,
-  pub limit: Option<i64>,
-  /// Only shows the unresolved reports
-  pub unresolved_only: Option<bool>,
-  /// if no community is given, it returns reports for all communities moderated by the auth user
-  pub community_id: Option<CommunityId>,
-  pub auth: Sensitive<String>,
+    pub page: Option<i64>,
+    pub limit: Option<i64>,
+    /// Only shows the unresolved reports
+    pub unresolved_only: Option<bool>,
+    /// if no community is given, it returns reports for all communities moderated by the auth user
+    pub community_id: Option<CommunityId>,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -187,5 +186,5 @@ pub struct ListCommentReports {
 #[cfg_attr(feature = "full", ts(export))]
 /// The comment report list response.
 pub struct ListCommentReportsResponse {
-  pub comment_reports: Vec<CommentReportView>,
+    pub comment_reports: Vec<CommentReportView>,
 }

--- a/crates/api_common/src/community.rs
+++ b/crates/api_common/src/community.rs
@@ -1,9 +1,8 @@
 use crate::sensitive::Sensitive;
 use lemmy_db_schema::{
-  newtypes::{CommunityId, LanguageId, PersonId},
-  source::site::Site,
-  ListingType,
-  SortType,
+    newtypes::{CommunityId, LanguageId, PersonId},
+    source::site::Site,
+    ListingType, SortType,
 };
 use lemmy_db_views_actor::structs::{CommunityModeratorView, CommunityView, PersonView};
 use serde::{Deserialize, Serialize};
@@ -17,10 +16,10 @@ use ts_rs::TS;
 #[cfg_attr(feature = "full", ts(export))]
 /// Get a community. Must provide either an id, or a name.
 pub struct GetCommunity {
-  pub id: Option<CommunityId>,
-  /// Example: star_trek , or star_trek@xyz.tld
-  pub name: Option<String>,
-  pub auth: Option<Sensitive<String>>,
+    pub id: Option<CommunityId>,
+    /// Example: star_trek , or star_trek@xyz.tld
+    pub name: Option<String>,
+    pub auth: Option<Sensitive<String>>,
 }
 
 #[skip_serializing_none]
@@ -29,10 +28,10 @@ pub struct GetCommunity {
 #[cfg_attr(feature = "full", ts(export))]
 /// The community response.
 pub struct GetCommunityResponse {
-  pub community_view: CommunityView,
-  pub site: Option<Site>,
-  pub moderators: Vec<CommunityModeratorView>,
-  pub discussion_languages: Vec<LanguageId>,
+    pub community_view: CommunityView,
+    pub site: Option<Site>,
+    pub moderators: Vec<CommunityModeratorView>,
+    pub discussion_languages: Vec<LanguageId>,
 }
 
 #[skip_serializing_none]
@@ -41,22 +40,22 @@ pub struct GetCommunityResponse {
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 /// Create a community.
 pub struct CreateCommunity {
-  /// The unique name.
-  pub name: String,
-  /// A longer title.
-  pub title: String,
-  /// A longer sidebar, or description of your community, in markdown.
-  pub description: Option<String>,
-  /// An icon URL.
-  pub icon: Option<String>,
-  /// A banner URL.
-  pub banner: Option<String>,
-  /// Whether its an NSFW community.
-  pub nsfw: Option<bool>,
-  /// Whether to restrict posting only to moderators.
-  pub posting_restricted_to_mods: Option<bool>,
-  pub discussion_languages: Option<Vec<LanguageId>>,
-  pub auth: Sensitive<String>,
+    /// The unique name.
+    pub name: String,
+    /// A longer title.
+    pub title: String,
+    /// A longer sidebar, or description of your community, in markdown.
+    pub description: Option<String>,
+    /// An icon URL.
+    pub icon: Option<String>,
+    /// A banner URL.
+    pub banner: Option<String>,
+    /// Whether its an NSFW community.
+    pub nsfw: Option<bool>,
+    /// Whether to restrict posting only to moderators.
+    pub posting_restricted_to_mods: Option<bool>,
+    pub discussion_languages: Option<Vec<LanguageId>>,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -64,8 +63,8 @@ pub struct CreateCommunity {
 #[cfg_attr(feature = "full", ts(export))]
 /// A simple community response.
 pub struct CommunityResponse {
-  pub community_view: CommunityView,
-  pub discussion_languages: Vec<LanguageId>,
+    pub community_view: CommunityView,
+    pub discussion_languages: Vec<LanguageId>,
 }
 
 #[skip_serializing_none]
@@ -74,12 +73,12 @@ pub struct CommunityResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Fetches a list of communities.
 pub struct ListCommunities {
-  pub type_: Option<ListingType>,
-  pub sort: Option<SortType>,
-  pub show_nsfw: Option<bool>,
-  pub page: Option<i64>,
-  pub limit: Option<i64>,
-  pub auth: Option<Sensitive<String>>,
+    pub type_: Option<ListingType>,
+    pub sort: Option<SortType>,
+    pub show_nsfw: Option<bool>,
+    pub page: Option<i64>,
+    pub limit: Option<i64>,
+    pub auth: Option<Sensitive<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -87,7 +86,7 @@ pub struct ListCommunities {
 #[cfg_attr(feature = "full", ts(export))]
 /// The response for listing communities.
 pub struct ListCommunitiesResponse {
-  pub communities: Vec<CommunityView>,
+    pub communities: Vec<CommunityView>,
 }
 
 #[skip_serializing_none]
@@ -96,13 +95,13 @@ pub struct ListCommunitiesResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Ban a user from a community.
 pub struct BanFromCommunity {
-  pub community_id: CommunityId,
-  pub person_id: PersonId,
-  pub ban: bool,
-  pub remove_data: Option<bool>,
-  pub reason: Option<String>,
-  pub expires: Option<i64>,
-  pub auth: Sensitive<String>,
+    pub community_id: CommunityId,
+    pub person_id: PersonId,
+    pub ban: bool,
+    pub remove_data: Option<bool>,
+    pub reason: Option<String>,
+    pub expires: Option<i64>,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -110,8 +109,8 @@ pub struct BanFromCommunity {
 #[cfg_attr(feature = "full", ts(export))]
 /// The response for banning a user from a community.
 pub struct BanFromCommunityResponse {
-  pub person_view: PersonView,
-  pub banned: bool,
+    pub person_view: PersonView,
+    pub banned: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -119,10 +118,10 @@ pub struct BanFromCommunityResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Add a moderator to a community.
 pub struct AddModToCommunity {
-  pub community_id: CommunityId,
-  pub person_id: PersonId,
-  pub added: bool,
-  pub auth: Sensitive<String>,
+    pub community_id: CommunityId,
+    pub person_id: PersonId,
+    pub added: bool,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -130,7 +129,7 @@ pub struct AddModToCommunity {
 #[cfg_attr(feature = "full", ts(export))]
 /// The response of adding a moderator to a community.
 pub struct AddModToCommunityResponse {
-  pub moderators: Vec<CommunityModeratorView>,
+    pub moderators: Vec<CommunityModeratorView>,
 }
 
 #[skip_serializing_none]
@@ -139,21 +138,21 @@ pub struct AddModToCommunityResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Edit a community.
 pub struct EditCommunity {
-  pub community_id: CommunityId,
-  /// A longer title.
-  pub title: Option<String>,
-  /// A longer sidebar, or description of your community, in markdown.
-  pub description: Option<String>,
-  /// An icon URL.
-  pub icon: Option<String>,
-  /// A banner URL.
-  pub banner: Option<String>,
-  /// Whether its an NSFW community.
-  pub nsfw: Option<bool>,
-  /// Whether to restrict posting only to moderators.
-  pub posting_restricted_to_mods: Option<bool>,
-  pub discussion_languages: Option<Vec<LanguageId>>,
-  pub auth: Sensitive<String>,
+    pub community_id: CommunityId,
+    /// A longer title.
+    pub title: Option<String>,
+    /// A longer sidebar, or description of your community, in markdown.
+    pub description: Option<String>,
+    /// An icon URL.
+    pub icon: Option<String>,
+    /// A banner URL.
+    pub banner: Option<String>,
+    /// Whether its an NSFW community.
+    pub nsfw: Option<bool>,
+    /// Whether to restrict posting only to moderators.
+    pub posting_restricted_to_mods: Option<bool>,
+    pub discussion_languages: Option<Vec<LanguageId>>,
+    pub auth: Sensitive<String>,
 }
 
 #[skip_serializing_none]
@@ -163,10 +162,10 @@ pub struct EditCommunity {
 /// Hide a community from the main view.
 // TODO this should really be a part of edit community. And why does it contain a reason, that should be in the mod tables.
 pub struct HideCommunity {
-  pub community_id: CommunityId,
-  pub hidden: bool,
-  pub reason: Option<String>,
-  pub auth: Sensitive<String>,
+    pub community_id: CommunityId,
+    pub hidden: bool,
+    pub reason: Option<String>,
+    pub auth: Sensitive<String>,
 }
 
 #[skip_serializing_none]
@@ -175,9 +174,9 @@ pub struct HideCommunity {
 #[cfg_attr(feature = "full", ts(export))]
 /// Delete your own community.
 pub struct DeleteCommunity {
-  pub community_id: CommunityId,
-  pub deleted: bool,
-  pub auth: Sensitive<String>,
+    pub community_id: CommunityId,
+    pub deleted: bool,
+    pub auth: Sensitive<String>,
 }
 
 #[skip_serializing_none]
@@ -186,11 +185,11 @@ pub struct DeleteCommunity {
 #[cfg_attr(feature = "full", ts(export))]
 /// Remove a community (only doable by moderators).
 pub struct RemoveCommunity {
-  pub community_id: CommunityId,
-  pub removed: bool,
-  pub reason: Option<String>,
-  pub expires: Option<i64>,
-  pub auth: Sensitive<String>,
+    pub community_id: CommunityId,
+    pub removed: bool,
+    pub reason: Option<String>,
+    pub expires: Option<i64>,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -198,9 +197,9 @@ pub struct RemoveCommunity {
 #[cfg_attr(feature = "full", ts(export))]
 /// Follow / subscribe to a community.
 pub struct FollowCommunity {
-  pub community_id: CommunityId,
-  pub follow: bool,
-  pub auth: Sensitive<String>,
+    pub community_id: CommunityId,
+    pub follow: bool,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -208,9 +207,9 @@ pub struct FollowCommunity {
 #[cfg_attr(feature = "full", ts(export))]
 /// Block a community.
 pub struct BlockCommunity {
-  pub community_id: CommunityId,
-  pub block: bool,
-  pub auth: Sensitive<String>,
+    pub community_id: CommunityId,
+    pub block: bool,
+    pub auth: Sensitive<String>,
 }
 
 #[skip_serializing_none]
@@ -219,8 +218,8 @@ pub struct BlockCommunity {
 #[cfg_attr(feature = "full", ts(export))]
 /// The block community response.
 pub struct BlockCommunityResponse {
-  pub community_view: CommunityView,
-  pub blocked: bool,
+    pub community_view: CommunityView,
+    pub blocked: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -228,7 +227,7 @@ pub struct BlockCommunityResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Transfer a community to a new owner.
 pub struct TransferCommunity {
-  pub community_id: CommunityId,
-  pub person_id: PersonId,
-  pub auth: Sensitive<String>,
+    pub community_id: CommunityId,
+    pub person_id: PersonId,
+    pub auth: Sensitive<String>,
 }

--- a/crates/api_common/src/context.rs
+++ b/crates/api_common/src/context.rs
@@ -1,52 +1,52 @@
 use lemmy_db_schema::{
-  source::secret::Secret,
-  utils::{ActualDbPool, DbPool},
+    source::secret::Secret,
+    utils::{ActualDbPool, DbPool},
 };
 use lemmy_utils::{
-  rate_limit::RateLimitCell,
-  settings::{structs::Settings, SETTINGS},
+    rate_limit::RateLimitCell,
+    settings::{structs::Settings, SETTINGS},
 };
 use reqwest_middleware::ClientWithMiddleware;
 use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct LemmyContext {
-  pool: ActualDbPool,
-  client: Arc<ClientWithMiddleware>,
-  secret: Arc<Secret>,
-  rate_limit_cell: RateLimitCell,
+    pool: ActualDbPool,
+    client: Arc<ClientWithMiddleware>,
+    secret: Arc<Secret>,
+    rate_limit_cell: RateLimitCell,
 }
 
 impl LemmyContext {
-  pub fn create(
-    pool: ActualDbPool,
-    client: ClientWithMiddleware,
-    secret: Secret,
-    rate_limit_cell: RateLimitCell,
-  ) -> LemmyContext {
-    LemmyContext {
-      pool,
-      client: Arc::new(client),
-      secret: Arc::new(secret),
-      rate_limit_cell,
+    pub fn create(
+        pool: ActualDbPool,
+        client: ClientWithMiddleware,
+        secret: Secret,
+        rate_limit_cell: RateLimitCell,
+    ) -> LemmyContext {
+        LemmyContext {
+            pool,
+            client: Arc::new(client),
+            secret: Arc::new(secret),
+            rate_limit_cell,
+        }
     }
-  }
-  pub fn pool(&self) -> DbPool<'_> {
-    DbPool::Pool(&self.pool)
-  }
-  pub fn inner_pool(&self) -> &ActualDbPool {
-    &self.pool
-  }
-  pub fn client(&self) -> &ClientWithMiddleware {
-    &self.client
-  }
-  pub fn settings(&self) -> &'static Settings {
-    &SETTINGS
-  }
-  pub fn secret(&self) -> &Secret {
-    &self.secret
-  }
-  pub fn settings_updated_channel(&self) -> &RateLimitCell {
-    &self.rate_limit_cell
-  }
+    pub fn pool(&self) -> DbPool<'_> {
+        DbPool::Pool(&self.pool)
+    }
+    pub fn inner_pool(&self) -> &ActualDbPool {
+        &self.pool
+    }
+    pub fn client(&self) -> &ClientWithMiddleware {
+        &self.client
+    }
+    pub fn settings(&self) -> &'static Settings {
+        &SETTINGS
+    }
+    pub fn secret(&self) -> &Secret {
+        &self.secret
+    }
+    pub fn settings_updated_channel(&self) -> &RateLimitCell {
+        &self.rate_limit_cell
+    }
 }

--- a/crates/api_common/src/custom_emoji.rs
+++ b/crates/api_common/src/custom_emoji.rs
@@ -11,13 +11,13 @@ use url::Url;
 #[cfg_attr(feature = "full", ts(export))]
 /// Create a custom emoji.
 pub struct CreateCustomEmoji {
-  pub category: String,
-  pub shortcode: String,
-  #[cfg_attr(feature = "full", ts(type = "string"))]
-  pub image_url: Url,
-  pub alt_text: String,
-  pub keywords: Vec<String>,
-  pub auth: Sensitive<String>,
+    pub category: String,
+    pub shortcode: String,
+    #[cfg_attr(feature = "full", ts(type = "string"))]
+    pub image_url: Url,
+    pub alt_text: String,
+    pub keywords: Vec<String>,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -25,13 +25,13 @@ pub struct CreateCustomEmoji {
 #[cfg_attr(feature = "full", ts(export))]
 /// Edit  a custom emoji.
 pub struct EditCustomEmoji {
-  pub id: CustomEmojiId,
-  pub category: String,
-  #[cfg_attr(feature = "full", ts(type = "string"))]
-  pub image_url: Url,
-  pub alt_text: String,
-  pub keywords: Vec<String>,
-  pub auth: Sensitive<String>,
+    pub id: CustomEmojiId,
+    pub category: String,
+    #[cfg_attr(feature = "full", ts(type = "string"))]
+    pub image_url: Url,
+    pub alt_text: String,
+    pub keywords: Vec<String>,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -39,8 +39,8 @@ pub struct EditCustomEmoji {
 #[cfg_attr(feature = "full", ts(export))]
 /// Delete a custom emoji.
 pub struct DeleteCustomEmoji {
-  pub id: CustomEmojiId,
-  pub auth: Sensitive<String>,
+    pub id: CustomEmojiId,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -48,8 +48,8 @@ pub struct DeleteCustomEmoji {
 #[cfg_attr(feature = "full", ts(export))]
 /// The response for deleting a custom emoji.
 pub struct DeleteCustomEmojiResponse {
-  pub id: CustomEmojiId,
-  pub success: bool,
+    pub id: CustomEmojiId,
+    pub success: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -57,5 +57,5 @@ pub struct DeleteCustomEmojiResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// A response for a custom emoji.
 pub struct CustomEmojiResponse {
-  pub custom_emoji: CustomEmojiView,
+    pub custom_emoji: CustomEmojiView,
 }

--- a/crates/api_common/src/person.rs
+++ b/crates/api_common/src/person.rs
@@ -1,16 +1,11 @@
 use crate::sensitive::Sensitive;
 use lemmy_db_schema::{
-  newtypes::{CommentReplyId, CommunityId, LanguageId, LocalUserId, PersonId, PersonMentionId},
-  CommentSortType,
-  ListingType,
-  SortType,
+    newtypes::{CommentReplyId, CommunityId, LanguageId, LocalUserId, PersonId, PersonMentionId},
+    CommentSortType, ListingType, SortType,
 };
 use lemmy_db_views::structs::{CommentView, PostView};
 use lemmy_db_views_actor::structs::{
-  CommentReplyView,
-  CommunityModeratorView,
-  PersonMentionView,
-  PersonView,
+    CommentReplyView, CommunityModeratorView, PersonMentionView, PersonView,
 };
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -23,10 +18,10 @@ use ts_rs::TS;
 #[cfg_attr(feature = "full", ts(export))]
 /// Logging into lemmy.
 pub struct Login {
-  pub username_or_email: Sensitive<String>,
-  pub password: Sensitive<String>,
-  /// May be required, if totp is enabled for their account.
-  pub totp_2fa_token: Option<String>,
+    pub username_or_email: Sensitive<String>,
+    pub password: Sensitive<String>,
+    /// May be required, if totp is enabled for their account.
+    pub totp_2fa_token: Option<String>,
 }
 
 #[skip_serializing_none]
@@ -35,20 +30,20 @@ pub struct Login {
 #[cfg_attr(feature = "full", ts(export))]
 /// Register / Sign up to lemmy.
 pub struct Register {
-  pub username: String,
-  pub password: Sensitive<String>,
-  pub password_verify: Sensitive<String>,
-  pub show_nsfw: bool,
-  /// email is mandatory if email verification is enabled on the server
-  pub email: Option<Sensitive<String>>,
-  /// The UUID of the captcha item.
-  pub captcha_uuid: Option<String>,
-  /// Your captcha answer.
-  pub captcha_answer: Option<String>,
-  /// A form field to trick signup bots. Should be None.
-  pub honeypot: Option<String>,
-  /// An answer is mandatory if require application is enabled on the server
-  pub answer: Option<String>,
+    pub username: String,
+    pub password: Sensitive<String>,
+    pub password_verify: Sensitive<String>,
+    pub show_nsfw: bool,
+    /// email is mandatory if email verification is enabled on the server
+    pub email: Option<Sensitive<String>>,
+    /// The UUID of the captcha item.
+    pub captcha_uuid: Option<String>,
+    /// Your captcha answer.
+    pub captcha_answer: Option<String>,
+    /// A form field to trick signup bots. Should be None.
+    pub honeypot: Option<String>,
+    /// An answer is mandatory if require application is enabled on the server
+    pub answer: Option<String>,
 }
 
 #[skip_serializing_none]
@@ -57,8 +52,8 @@ pub struct Register {
 #[cfg_attr(feature = "full", ts(export))]
 /// A wrapper for the captcha response.
 pub struct GetCaptchaResponse {
-  /// Will be None if captchas are disabled.
-  pub ok: Option<CaptchaResponse>,
+    /// Will be None if captchas are disabled.
+    pub ok: Option<CaptchaResponse>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -66,12 +61,12 @@ pub struct GetCaptchaResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// A captcha response.
 pub struct CaptchaResponse {
-  /// A Base64 encoded png
-  pub png: String,
-  /// A Base64 encoded wav audio
-  pub wav: String,
-  /// The UUID for the captcha item.
-  pub uuid: String,
+    /// A Base64 encoded png
+    pub png: String,
+    /// A Base64 encoded wav audio
+    pub wav: String,
+    /// The UUID for the captcha item.
+    pub uuid: String,
 }
 
 #[skip_serializing_none]
@@ -80,54 +75,54 @@ pub struct CaptchaResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Saves settings for your user.
 pub struct SaveUserSettings {
-  /// Show nsfw posts.
-  pub show_nsfw: Option<bool>,
-  pub blur_nsfw: Option<bool>,
-  pub auto_expand: Option<bool>,
-  /// Show post and comment scores.
-  pub show_scores: Option<bool>,
-  /// Your user's theme.
-  pub theme: Option<String>,
-  pub default_sort_type: Option<SortType>,
-  pub default_listing_type: Option<ListingType>,
-  /// The language of the lemmy interface
-  pub interface_language: Option<String>,
-  /// A URL for your avatar.
-  pub avatar: Option<String>,
-  /// A URL for your banner.
-  pub banner: Option<String>,
-  /// Your display name, which can contain strange characters, and does not need to be unique.
-  pub display_name: Option<String>,
-  /// Your email.
-  pub email: Option<Sensitive<String>>,
-  /// Your bio / info, in markdown.
-  pub bio: Option<String>,
-  /// Your matrix user id. Ex: @my_user:matrix.org
-  pub matrix_user_id: Option<String>,
-  /// Whether to show or hide avatars.
-  pub show_avatars: Option<bool>,
-  /// Sends notifications to your email.
-  pub send_notifications_to_email: Option<bool>,
-  /// Whether this account is a bot account. Users can hide these accounts easily if they wish.
-  pub bot_account: Option<bool>,
-  /// Whether to show bot accounts.
-  pub show_bot_accounts: Option<bool>,
-  /// Whether to show read posts.
-  pub show_read_posts: Option<bool>,
-  /// Whether to show notifications for new posts.
-  // TODO notifs need to be reworked.
-  pub show_new_post_notifs: Option<bool>,
-  /// A list of languages you are able to see discussion in.
-  pub discussion_languages: Option<Vec<LanguageId>>,
-  /// Generates a TOTP / 2-factor authentication token.
-  ///
-  /// None leaves it as is, true will generate or regenerate it, false clears it out.
-  pub generate_totp_2fa: Option<bool>,
-  pub auth: Sensitive<String>,
-  /// Open links in a new tab
-  pub open_links_in_new_tab: Option<bool>,
-  /// Enable infinite scroll
-  pub infinite_scroll_enabled: Option<bool>,
+    /// Show nsfw posts.
+    pub show_nsfw: Option<bool>,
+    pub blur_nsfw: Option<bool>,
+    pub auto_expand: Option<bool>,
+    /// Show post and comment scores.
+    pub show_scores: Option<bool>,
+    /// Your user's theme.
+    pub theme: Option<String>,
+    pub default_sort_type: Option<SortType>,
+    pub default_listing_type: Option<ListingType>,
+    /// The language of the lemmy interface
+    pub interface_language: Option<String>,
+    /// A URL for your avatar.
+    pub avatar: Option<String>,
+    /// A URL for your banner.
+    pub banner: Option<String>,
+    /// Your display name, which can contain strange characters, and does not need to be unique.
+    pub display_name: Option<String>,
+    /// Your email.
+    pub email: Option<Sensitive<String>>,
+    /// Your bio / info, in markdown.
+    pub bio: Option<String>,
+    /// Your matrix user id. Ex: @my_user:matrix.org
+    pub matrix_user_id: Option<String>,
+    /// Whether to show or hide avatars.
+    pub show_avatars: Option<bool>,
+    /// Sends notifications to your email.
+    pub send_notifications_to_email: Option<bool>,
+    /// Whether this account is a bot account. Users can hide these accounts easily if they wish.
+    pub bot_account: Option<bool>,
+    /// Whether to show bot accounts.
+    pub show_bot_accounts: Option<bool>,
+    /// Whether to show read posts.
+    pub show_read_posts: Option<bool>,
+    /// Whether to show notifications for new posts.
+    // TODO notifs need to be reworked.
+    pub show_new_post_notifs: Option<bool>,
+    /// A list of languages you are able to see discussion in.
+    pub discussion_languages: Option<Vec<LanguageId>>,
+    /// Generates a TOTP / 2-factor authentication token.
+    ///
+    /// None leaves it as is, true will generate or regenerate it, false clears it out.
+    pub generate_totp_2fa: Option<bool>,
+    pub auth: Sensitive<String>,
+    /// Open links in a new tab
+    pub open_links_in_new_tab: Option<bool>,
+    /// Enable infinite scroll
+    pub infinite_scroll_enabled: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -135,10 +130,10 @@ pub struct SaveUserSettings {
 #[cfg_attr(feature = "full", ts(export))]
 /// Changes your account password.
 pub struct ChangePassword {
-  pub new_password: Sensitive<String>,
-  pub new_password_verify: Sensitive<String>,
-  pub old_password: Sensitive<String>,
-  pub auth: Sensitive<String>,
+    pub new_password: Sensitive<String>,
+    pub new_password_verify: Sensitive<String>,
+    pub old_password: Sensitive<String>,
+    pub auth: Sensitive<String>,
 }
 
 #[skip_serializing_none]
@@ -147,12 +142,12 @@ pub struct ChangePassword {
 #[cfg_attr(feature = "full", ts(export))]
 /// A response for your login.
 pub struct LoginResponse {
-  /// This is None in response to `Register` if email verification is enabled, or the server requires registration applications.
-  pub jwt: Option<Sensitive<String>>,
-  /// If registration applications are required, this will return true for a signup response.
-  pub registration_created: bool,
-  /// If email verifications are required, this will return true for a signup response.
-  pub verify_email_sent: bool,
+    /// This is None in response to `Register` if email verification is enabled, or the server requires registration applications.
+    pub jwt: Option<Sensitive<String>>,
+    /// If registration applications are required, this will return true for a signup response.
+    pub registration_created: bool,
+    /// If email verifications are required, this will return true for a signup response.
+    pub verify_email_sent: bool,
 }
 
 #[skip_serializing_none]
@@ -163,15 +158,15 @@ pub struct LoginResponse {
 ///
 /// Either person_id, or username are required.
 pub struct GetPersonDetails {
-  pub person_id: Option<PersonId>,
-  /// Example: dessalines , or dessalines@xyz.tld
-  pub username: Option<String>,
-  pub sort: Option<SortType>,
-  pub page: Option<i64>,
-  pub limit: Option<i64>,
-  pub community_id: Option<CommunityId>,
-  pub saved_only: Option<bool>,
-  pub auth: Option<Sensitive<String>>,
+    pub person_id: Option<PersonId>,
+    /// Example: dessalines , or dessalines@xyz.tld
+    pub username: Option<String>,
+    pub sort: Option<SortType>,
+    pub page: Option<i64>,
+    pub limit: Option<i64>,
+    pub community_id: Option<CommunityId>,
+    pub saved_only: Option<bool>,
+    pub auth: Option<Sensitive<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -179,10 +174,10 @@ pub struct GetPersonDetails {
 #[cfg_attr(feature = "full", ts(export))]
 /// A person's details response.
 pub struct GetPersonDetailsResponse {
-  pub person_view: PersonView,
-  pub comments: Vec<CommentView>,
-  pub posts: Vec<PostView>,
-  pub moderates: Vec<CommunityModeratorView>,
+    pub person_view: PersonView,
+    pub comments: Vec<CommentView>,
+    pub posts: Vec<PostView>,
+    pub moderates: Vec<CommunityModeratorView>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -190,7 +185,7 @@ pub struct GetPersonDetailsResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Marks all notifications as read.
 pub struct MarkAllAsRead {
-  pub auth: Sensitive<String>,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -198,9 +193,9 @@ pub struct MarkAllAsRead {
 #[cfg_attr(feature = "full", ts(export))]
 /// Adds an admin to a site.
 pub struct AddAdmin {
-  pub local_user_id: LocalUserId,
-  pub added: bool,
-  pub auth: Sensitive<String>,
+    pub local_user_id: LocalUserId,
+    pub added: bool,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -208,7 +203,7 @@ pub struct AddAdmin {
 #[cfg_attr(feature = "full", ts(export))]
 /// The response of current admins.
 pub struct AddAdminResponse {
-  pub admins: Vec<PersonView>,
+    pub admins: Vec<PersonView>,
 }
 
 #[skip_serializing_none]
@@ -217,13 +212,13 @@ pub struct AddAdminResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Ban a person from the site.
 pub struct BanPerson {
-  pub person_id: PersonId,
-  pub ban: bool,
-  /// Optionally remove all their data. Useful for new troll accounts.
-  pub remove_data: Option<bool>,
-  pub reason: Option<String>,
-  pub expires: Option<i64>,
-  pub auth: Sensitive<String>,
+    pub person_id: PersonId,
+    pub ban: bool,
+    /// Optionally remove all their data. Useful for new troll accounts.
+    pub remove_data: Option<bool>,
+    pub reason: Option<String>,
+    pub expires: Option<i64>,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -232,7 +227,7 @@ pub struct BanPerson {
 /// Get a list of banned persons.
 // TODO, this should be paged, since the list can be quite long.
 pub struct GetBannedPersons {
-  pub auth: Sensitive<String>,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -240,7 +235,7 @@ pub struct GetBannedPersons {
 #[cfg_attr(feature = "full", ts(export))]
 /// The list of banned persons.
 pub struct BannedPersonsResponse {
-  pub banned: Vec<PersonView>,
+    pub banned: Vec<PersonView>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -248,8 +243,8 @@ pub struct BannedPersonsResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// A response for a banned person.
 pub struct BanPersonResponse {
-  pub person_view: PersonView,
-  pub banned: bool,
+    pub person_view: PersonView,
+    pub banned: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -257,9 +252,9 @@ pub struct BanPersonResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Block a person.
 pub struct BlockPerson {
-  pub person_id: PersonId,
-  pub block: bool,
-  pub auth: Sensitive<String>,
+    pub person_id: PersonId,
+    pub block: bool,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -267,8 +262,8 @@ pub struct BlockPerson {
 #[cfg_attr(feature = "full", ts(export))]
 /// The response for a person block.
 pub struct BlockPersonResponse {
-  pub person_view: PersonView,
-  pub blocked: bool,
+    pub person_view: PersonView,
+    pub blocked: bool,
 }
 
 #[skip_serializing_none]
@@ -277,11 +272,11 @@ pub struct BlockPersonResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Get comment replies.
 pub struct GetReplies {
-  pub sort: Option<CommentSortType>,
-  pub page: Option<i64>,
-  pub limit: Option<i64>,
-  pub unread_only: Option<bool>,
-  pub auth: Sensitive<String>,
+    pub sort: Option<CommentSortType>,
+    pub page: Option<i64>,
+    pub limit: Option<i64>,
+    pub unread_only: Option<bool>,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -290,7 +285,7 @@ pub struct GetReplies {
 /// Fetches your replies.
 // TODO, replies and mentions below should be redone as tagged enums.
 pub struct GetRepliesResponse {
-  pub replies: Vec<CommentReplyView>,
+    pub replies: Vec<CommentReplyView>,
 }
 
 #[skip_serializing_none]
@@ -299,11 +294,11 @@ pub struct GetRepliesResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Get mentions for your user.
 pub struct GetPersonMentions {
-  pub sort: Option<CommentSortType>,
-  pub page: Option<i64>,
-  pub limit: Option<i64>,
-  pub unread_only: Option<bool>,
-  pub auth: Sensitive<String>,
+    pub sort: Option<CommentSortType>,
+    pub page: Option<i64>,
+    pub limit: Option<i64>,
+    pub unread_only: Option<bool>,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -311,7 +306,7 @@ pub struct GetPersonMentions {
 #[cfg_attr(feature = "full", ts(export))]
 /// The response of mentions for your user.
 pub struct GetPersonMentionsResponse {
-  pub mentions: Vec<PersonMentionView>,
+    pub mentions: Vec<PersonMentionView>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -319,9 +314,9 @@ pub struct GetPersonMentionsResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Mark a person mention as read.
 pub struct MarkPersonMentionAsRead {
-  pub person_mention_id: PersonMentionId,
-  pub read: bool,
-  pub auth: Sensitive<String>,
+    pub person_mention_id: PersonMentionId,
+    pub read: bool,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -329,7 +324,7 @@ pub struct MarkPersonMentionAsRead {
 #[cfg_attr(feature = "full", ts(export))]
 /// The response for a person mention action.
 pub struct PersonMentionResponse {
-  pub person_mention_view: PersonMentionView,
+    pub person_mention_view: PersonMentionView,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -337,9 +332,9 @@ pub struct PersonMentionResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Mark a comment reply as read.
 pub struct MarkCommentReplyAsRead {
-  pub comment_reply_id: CommentReplyId,
-  pub read: bool,
-  pub auth: Sensitive<String>,
+    pub comment_reply_id: CommentReplyId,
+    pub read: bool,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -347,7 +342,7 @@ pub struct MarkCommentReplyAsRead {
 #[cfg_attr(feature = "full", ts(export))]
 /// The response for a comment reply action.
 pub struct CommentReplyResponse {
-  pub comment_reply_view: CommentReplyView,
+    pub comment_reply_view: CommentReplyView,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -355,9 +350,9 @@ pub struct CommentReplyResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Delete your account.
 pub struct DeleteAccount {
-  pub password: Sensitive<String>,
-  pub delete_content: bool,
-  pub auth: Sensitive<String>,
+    pub password: Sensitive<String>,
+    pub delete_content: bool,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -371,7 +366,7 @@ pub struct DeleteAccountResponse {}
 #[cfg_attr(feature = "full", ts(export))]
 /// Reset your password via email.
 pub struct PasswordReset {
-  pub email: Sensitive<String>,
+    pub email: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -385,9 +380,9 @@ pub struct PasswordResetResponse {}
 #[cfg_attr(feature = "full", ts(export))]
 /// Change your password after receiving a reset request.
 pub struct PasswordChangeAfterReset {
-  pub token: Sensitive<String>,
-  pub password: Sensitive<String>,
-  pub password_verify: Sensitive<String>,
+    pub token: Sensitive<String>,
+    pub password: Sensitive<String>,
+    pub password_verify: Sensitive<String>,
 }
 
 #[skip_serializing_none]
@@ -396,8 +391,8 @@ pub struct PasswordChangeAfterReset {
 #[cfg_attr(feature = "full", ts(export))]
 /// Get a count of the number of reports.
 pub struct GetReportCount {
-  pub community_id: Option<CommunityId>,
-  pub auth: Sensitive<String>,
+    pub community_id: Option<CommunityId>,
+    pub auth: Sensitive<String>,
 }
 
 #[skip_serializing_none]
@@ -406,10 +401,10 @@ pub struct GetReportCount {
 #[cfg_attr(feature = "full", ts(export))]
 /// A response for the number of reports.
 pub struct GetReportCountResponse {
-  pub community_id: Option<CommunityId>,
-  pub comment_reports: i64,
-  pub post_reports: i64,
-  pub private_message_reports: Option<i64>,
+    pub community_id: Option<CommunityId>,
+    pub comment_reports: i64,
+    pub post_reports: i64,
+    pub private_message_reports: Option<i64>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -417,7 +412,7 @@ pub struct GetReportCountResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Get a count of unread notifications.
 pub struct GetUnreadCount {
-  pub auth: Sensitive<String>,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -425,9 +420,9 @@ pub struct GetUnreadCount {
 #[cfg_attr(feature = "full", ts(export))]
 /// A response containing counts for your notifications.
 pub struct GetUnreadCountResponse {
-  pub replies: i64,
-  pub mentions: i64,
-  pub private_messages: i64,
+    pub replies: i64,
+    pub mentions: i64,
+    pub private_messages: i64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Default, Debug)]
@@ -435,7 +430,7 @@ pub struct GetUnreadCountResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Verify your email.
 pub struct VerifyEmail {
-  pub token: String,
+    pub token: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/crates/api_common/src/post.rs
+++ b/crates/api_common/src/post.rs
@@ -1,9 +1,7 @@
 use crate::sensitive::Sensitive;
 use lemmy_db_schema::{
-  newtypes::{CommentId, CommunityId, DbUrl, LanguageId, PostId, PostReportId},
-  ListingType,
-  PostFeatureType,
-  SortType,
+    newtypes::{CommentId, CommunityId, DbUrl, LanguageId, PostId, PostReportId},
+    ListingType, PostFeatureType, SortType,
 };
 use lemmy_db_views::structs::{PostReportView, PostView};
 use lemmy_db_views_actor::structs::{CommunityModeratorView, CommunityView};
@@ -19,24 +17,24 @@ use url::Url;
 #[cfg_attr(feature = "full", ts(export))]
 /// Create a post.
 pub struct CreatePost {
-  pub name: String,
-  pub community_id: CommunityId,
-  #[cfg_attr(feature = "full", ts(type = "string"))]
-  pub url: Option<Url>,
-  /// An optional body for the post in markdown.
-  pub body: Option<String>,
-  /// A honeypot to catch bots. Should be None.
-  pub honeypot: Option<String>,
-  pub nsfw: Option<bool>,
-  pub language_id: Option<LanguageId>,
-  pub auth: Sensitive<String>,
+    pub name: String,
+    pub community_id: CommunityId,
+    #[cfg_attr(feature = "full", ts(type = "string"))]
+    pub url: Option<Url>,
+    /// An optional body for the post in markdown.
+    pub body: Option<String>,
+    /// A honeypot to catch bots. Should be None.
+    pub honeypot: Option<String>,
+    pub nsfw: Option<bool>,
+    pub language_id: Option<LanguageId>,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "full", derive(TS))]
 #[cfg_attr(feature = "full", ts(export))]
 pub struct PostResponse {
-  pub post_view: PostView,
+    pub post_view: PostView,
 }
 
 #[skip_serializing_none]
@@ -45,9 +43,9 @@ pub struct PostResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Get a post. Needs either the post id, or comment_id.
 pub struct GetPost {
-  pub id: Option<PostId>,
-  pub comment_id: Option<CommentId>,
-  pub auth: Option<Sensitive<String>>,
+    pub id: Option<PostId>,
+    pub comment_id: Option<CommentId>,
+    pub auth: Option<Sensitive<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -55,11 +53,11 @@ pub struct GetPost {
 #[cfg_attr(feature = "full", ts(export))]
 /// The post response.
 pub struct GetPostResponse {
-  pub post_view: PostView,
-  pub community_view: CommunityView,
-  pub moderators: Vec<CommunityModeratorView>,
-  /// A list of cross-posts, or other times / communities this link has been posted to.
-  pub cross_posts: Vec<PostView>,
+    pub post_view: PostView,
+    pub community_view: CommunityView,
+    pub moderators: Vec<CommunityModeratorView>,
+    /// A list of cross-posts, or other times / communities this link has been posted to.
+    pub cross_posts: Vec<PostView>,
 }
 
 #[skip_serializing_none]
@@ -68,16 +66,16 @@ pub struct GetPostResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Get a list of posts.
 pub struct GetPosts {
-  pub type_: Option<ListingType>,
-  pub sort: Option<SortType>,
-  pub page: Option<i64>,
-  pub limit: Option<i64>,
-  pub community_id: Option<CommunityId>,
-  pub community_name: Option<String>,
-  pub saved_only: Option<bool>,
-  pub liked_only: Option<bool>,
-  pub disliked_only: Option<bool>,
-  pub auth: Option<Sensitive<String>>,
+    pub type_: Option<ListingType>,
+    pub sort: Option<SortType>,
+    pub page: Option<i64>,
+    pub limit: Option<i64>,
+    pub community_id: Option<CommunityId>,
+    pub community_name: Option<String>,
+    pub saved_only: Option<bool>,
+    pub liked_only: Option<bool>,
+    pub disliked_only: Option<bool>,
+    pub auth: Option<Sensitive<String>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -85,7 +83,7 @@ pub struct GetPosts {
 #[cfg_attr(feature = "full", ts(export))]
 /// The post list response.
 pub struct GetPostsResponse {
-  pub posts: Vec<PostView>,
+    pub posts: Vec<PostView>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -93,10 +91,10 @@ pub struct GetPostsResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Like a post.
 pub struct CreatePostLike {
-  pub post_id: PostId,
-  /// Score must be -1, 0, or 1.
-  pub score: i16,
-  pub auth: Sensitive<String>,
+    pub post_id: PostId,
+    /// Score must be -1, 0, or 1.
+    pub score: i16,
+    pub auth: Sensitive<String>,
 }
 
 #[skip_serializing_none]
@@ -105,15 +103,15 @@ pub struct CreatePostLike {
 #[cfg_attr(feature = "full", ts(export))]
 /// Edit a post.
 pub struct EditPost {
-  pub post_id: PostId,
-  pub name: Option<String>,
-  #[cfg_attr(feature = "full", ts(type = "string"))]
-  pub url: Option<Url>,
-  /// An optional body for the post in markdown.
-  pub body: Option<String>,
-  pub nsfw: Option<bool>,
-  pub language_id: Option<LanguageId>,
-  pub auth: Sensitive<String>,
+    pub post_id: PostId,
+    pub name: Option<String>,
+    #[cfg_attr(feature = "full", ts(type = "string"))]
+    pub url: Option<Url>,
+    /// An optional body for the post in markdown.
+    pub body: Option<String>,
+    pub nsfw: Option<bool>,
+    pub language_id: Option<LanguageId>,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -121,9 +119,9 @@ pub struct EditPost {
 #[cfg_attr(feature = "full", ts(export))]
 /// Delete a post.
 pub struct DeletePost {
-  pub post_id: PostId,
-  pub deleted: bool,
-  pub auth: Sensitive<String>,
+    pub post_id: PostId,
+    pub deleted: bool,
+    pub auth: Sensitive<String>,
 }
 
 #[skip_serializing_none]
@@ -132,10 +130,10 @@ pub struct DeletePost {
 #[cfg_attr(feature = "full", ts(export))]
 /// Remove a post (only doable by mods).
 pub struct RemovePost {
-  pub post_id: PostId,
-  pub removed: bool,
-  pub reason: Option<String>,
-  pub auth: Sensitive<String>,
+    pub post_id: PostId,
+    pub removed: bool,
+    pub reason: Option<String>,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -143,9 +141,9 @@ pub struct RemovePost {
 #[cfg_attr(feature = "full", ts(export))]
 /// Mark a post as read.
 pub struct MarkPostAsRead {
-  pub post_id: PostId,
-  pub read: bool,
-  pub auth: Sensitive<String>,
+    pub post_id: PostId,
+    pub read: bool,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -153,9 +151,9 @@ pub struct MarkPostAsRead {
 #[cfg_attr(feature = "full", ts(export))]
 /// Lock a post (prevent new comments).
 pub struct LockPost {
-  pub post_id: PostId,
-  pub locked: bool,
-  pub auth: Sensitive<String>,
+    pub post_id: PostId,
+    pub locked: bool,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -163,10 +161,10 @@ pub struct LockPost {
 #[cfg_attr(feature = "full", ts(export))]
 /// Feature a post (stickies / pins to the top).
 pub struct FeaturePost {
-  pub post_id: PostId,
-  pub featured: bool,
-  pub feature_type: PostFeatureType,
-  pub auth: Sensitive<String>,
+    pub post_id: PostId,
+    pub featured: bool,
+    pub feature_type: PostFeatureType,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -174,9 +172,9 @@ pub struct FeaturePost {
 #[cfg_attr(feature = "full", ts(export))]
 /// Save / bookmark a post.
 pub struct SavePost {
-  pub post_id: PostId,
-  pub save: bool,
-  pub auth: Sensitive<String>,
+    pub post_id: PostId,
+    pub save: bool,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -184,9 +182,9 @@ pub struct SavePost {
 #[cfg_attr(feature = "full", ts(export))]
 /// Create a post report.
 pub struct CreatePostReport {
-  pub post_id: PostId,
-  pub reason: String,
-  pub auth: Sensitive<String>,
+    pub post_id: PostId,
+    pub reason: String,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -194,7 +192,7 @@ pub struct CreatePostReport {
 #[cfg_attr(feature = "full", ts(export))]
 /// The post report response.
 pub struct PostReportResponse {
-  pub post_report_view: PostReportView,
+    pub post_report_view: PostReportView,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -202,9 +200,9 @@ pub struct PostReportResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Resolve a post report (mods only).
 pub struct ResolvePostReport {
-  pub report_id: PostReportId,
-  pub resolved: bool,
-  pub auth: Sensitive<String>,
+    pub report_id: PostReportId,
+    pub resolved: bool,
+    pub auth: Sensitive<String>,
 }
 
 #[skip_serializing_none]
@@ -213,13 +211,13 @@ pub struct ResolvePostReport {
 #[cfg_attr(feature = "full", ts(export))]
 /// List post reports.
 pub struct ListPostReports {
-  pub page: Option<i64>,
-  pub limit: Option<i64>,
-  /// Only shows the unresolved reports
-  pub unresolved_only: Option<bool>,
-  /// if no community is given, it returns reports for all communities moderated by the auth user
-  pub community_id: Option<CommunityId>,
-  pub auth: Sensitive<String>,
+    pub page: Option<i64>,
+    pub limit: Option<i64>,
+    /// Only shows the unresolved reports
+    pub unresolved_only: Option<bool>,
+    /// if no community is given, it returns reports for all communities moderated by the auth user
+    pub community_id: Option<CommunityId>,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -227,7 +225,7 @@ pub struct ListPostReports {
 #[cfg_attr(feature = "full", ts(export))]
 /// The post reports response.
 pub struct ListPostReportsResponse {
-  pub post_reports: Vec<PostReportView>,
+    pub post_reports: Vec<PostReportView>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -235,8 +233,8 @@ pub struct ListPostReportsResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Get metadata for a given site.
 pub struct GetSiteMetadata {
-  #[cfg_attr(feature = "full", ts(type = "string"))]
-  pub url: Url,
+    #[cfg_attr(feature = "full", ts(type = "string"))]
+    pub url: Url,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -244,7 +242,7 @@ pub struct GetSiteMetadata {
 #[cfg_attr(feature = "full", ts(export))]
 /// The site metadata response.
 pub struct GetSiteMetadataResponse {
-  pub metadata: SiteMetadata,
+    pub metadata: SiteMetadata,
 }
 
 #[skip_serializing_none]
@@ -253,8 +251,8 @@ pub struct GetSiteMetadataResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Site metadata, from its opengraph tags.
 pub struct SiteMetadata {
-  pub title: Option<String>,
-  pub description: Option<String>,
-  pub(crate) image: Option<DbUrl>,
-  pub embed_video_url: Option<DbUrl>,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub(crate) image: Option<DbUrl>,
+    pub embed_video_url: Option<DbUrl>,
 }

--- a/crates/api_common/src/private_message.rs
+++ b/crates/api_common/src/private_message.rs
@@ -11,9 +11,9 @@ use ts_rs::TS;
 #[cfg_attr(feature = "full", ts(export))]
 /// Create a private message.
 pub struct CreatePrivateMessage {
-  pub content: String,
-  pub recipient_id: PersonId,
-  pub auth: Sensitive<String>,
+    pub content: String,
+    pub recipient_id: PersonId,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -21,9 +21,9 @@ pub struct CreatePrivateMessage {
 #[cfg_attr(feature = "full", ts(export))]
 /// Edit a private message.
 pub struct EditPrivateMessage {
-  pub private_message_id: PrivateMessageId,
-  pub content: String,
-  pub auth: Sensitive<String>,
+    pub private_message_id: PrivateMessageId,
+    pub content: String,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -31,9 +31,9 @@ pub struct EditPrivateMessage {
 #[cfg_attr(feature = "full", ts(export))]
 /// Delete a private message.
 pub struct DeletePrivateMessage {
-  pub private_message_id: PrivateMessageId,
-  pub deleted: bool,
-  pub auth: Sensitive<String>,
+    pub private_message_id: PrivateMessageId,
+    pub deleted: bool,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -41,9 +41,9 @@ pub struct DeletePrivateMessage {
 #[cfg_attr(feature = "full", ts(export))]
 /// Mark a private message as read.
 pub struct MarkPrivateMessageAsRead {
-  pub private_message_id: PrivateMessageId,
-  pub read: bool,
-  pub auth: Sensitive<String>,
+    pub private_message_id: PrivateMessageId,
+    pub read: bool,
+    pub auth: Sensitive<String>,
 }
 
 #[skip_serializing_none]
@@ -52,11 +52,11 @@ pub struct MarkPrivateMessageAsRead {
 #[cfg_attr(feature = "full", ts(export))]
 /// Get your private messages.
 pub struct GetPrivateMessages {
-  pub unread_only: Option<bool>,
-  pub page: Option<i64>,
-  pub limit: Option<i64>,
-  pub creator_id: Option<PersonId>,
-  pub auth: Sensitive<String>,
+    pub unread_only: Option<bool>,
+    pub page: Option<i64>,
+    pub limit: Option<i64>,
+    pub creator_id: Option<PersonId>,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -64,7 +64,7 @@ pub struct GetPrivateMessages {
 #[cfg_attr(feature = "full", ts(export))]
 /// The private messages response.
 pub struct PrivateMessagesResponse {
-  pub private_messages: Vec<PrivateMessageView>,
+    pub private_messages: Vec<PrivateMessageView>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -72,7 +72,7 @@ pub struct PrivateMessagesResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// A single private message response.
 pub struct PrivateMessageResponse {
-  pub private_message_view: PrivateMessageView,
+    pub private_message_view: PrivateMessageView,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -80,9 +80,9 @@ pub struct PrivateMessageResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Create a report for a private message.
 pub struct CreatePrivateMessageReport {
-  pub private_message_id: PrivateMessageId,
-  pub reason: String,
-  pub auth: Sensitive<String>,
+    pub private_message_id: PrivateMessageId,
+    pub reason: String,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -90,7 +90,7 @@ pub struct CreatePrivateMessageReport {
 #[cfg_attr(feature = "full", ts(export))]
 /// A private message report response.
 pub struct PrivateMessageReportResponse {
-  pub private_message_report_view: PrivateMessageReportView,
+    pub private_message_report_view: PrivateMessageReportView,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -98,9 +98,9 @@ pub struct PrivateMessageReportResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Resolve a private message report.
 pub struct ResolvePrivateMessageReport {
-  pub report_id: PrivateMessageReportId,
-  pub resolved: bool,
-  pub auth: Sensitive<String>,
+    pub report_id: PrivateMessageReportId,
+    pub resolved: bool,
+    pub auth: Sensitive<String>,
 }
 
 #[skip_serializing_none]
@@ -110,11 +110,11 @@ pub struct ResolvePrivateMessageReport {
 /// List private message reports.
 // TODO , perhaps GetReports should be a tagged enum list too.
 pub struct ListPrivateMessageReports {
-  pub page: Option<i64>,
-  pub limit: Option<i64>,
-  /// Only shows the unresolved reports
-  pub unresolved_only: Option<bool>,
-  pub auth: Sensitive<String>,
+    pub page: Option<i64>,
+    pub limit: Option<i64>,
+    /// Only shows the unresolved reports
+    pub unresolved_only: Option<bool>,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -122,5 +122,5 @@ pub struct ListPrivateMessageReports {
 #[cfg_attr(feature = "full", ts(export))]
 /// The response for list private message reports.
 pub struct ListPrivateMessageReportsResponse {
-  pub private_message_reports: Vec<PrivateMessageReportView>,
+    pub private_message_reports: Vec<PrivateMessageReportView>,
 }

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -2,10 +2,10 @@ use crate::{context::LemmyContext, post::SiteMetadata};
 use encoding::{all::encodings, DecoderTrap};
 use lemmy_db_schema::newtypes::DbUrl;
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorType},
-  settings::structs::Settings,
-  version::VERSION,
-  REQWEST_TIMEOUT,
+    error::{LemmyError, LemmyErrorType},
+    settings::structs::Settings,
+    version::VERSION,
+    REQWEST_TIMEOUT,
 };
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use reqwest_middleware::ClientWithMiddleware;
@@ -17,136 +17,138 @@ use webpage::HTML;
 /// Fetches the post link html tags (like title, description, image, etc)
 #[tracing::instrument(skip_all)]
 pub async fn fetch_site_metadata(
-  client: &ClientWithMiddleware,
-  url: &Url,
+    client: &ClientWithMiddleware,
+    url: &Url,
 ) -> Result<SiteMetadata, LemmyError> {
-  info!("Fetching site metadata for url: {}", url);
-  let response = client.get(url.as_str()).send().await?;
+    info!("Fetching site metadata for url: {}", url);
+    let response = client.get(url.as_str()).send().await?;
 
-  // Can't use .text() here, because it only checks the content header, not the actual bytes
-  // https://github.com/LemmyNet/lemmy/issues/1964
-  let html_bytes = response.bytes().await.map_err(LemmyError::from)?.to_vec();
+    // Can't use .text() here, because it only checks the content header, not the actual bytes
+    // https://github.com/LemmyNet/lemmy/issues/1964
+    let html_bytes = response.bytes().await.map_err(LemmyError::from)?.to_vec();
 
-  let tags = html_to_site_metadata(&html_bytes, url)?;
+    let tags = html_to_site_metadata(&html_bytes, url)?;
 
-  Ok(tags)
+    Ok(tags)
 }
 
 fn html_to_site_metadata(html_bytes: &[u8], url: &Url) -> Result<SiteMetadata, LemmyError> {
-  let html = String::from_utf8_lossy(html_bytes);
+    let html = String::from_utf8_lossy(html_bytes);
 
-  // Make sure the first line is doctype html
-  let first_line = html
-    .trim_start()
-    .lines()
-    .next()
-    .ok_or(LemmyErrorType::NoLinesInHtml)?
-    .to_lowercase();
+    // Make sure the first line is doctype html
+    let first_line = html
+        .trim_start()
+        .lines()
+        .next()
+        .ok_or(LemmyErrorType::NoLinesInHtml)?
+        .to_lowercase();
 
-  if !first_line.starts_with("<!doctype html>") {
-    Err(LemmyErrorType::SiteMetadataPageIsNotDoctypeHtml)?
-  }
-
-  let mut page = HTML::from_string(html.to_string(), None)?;
-
-  // If the web page specifies that it isn't actually UTF-8, re-decode the received bytes with the
-  // proper encoding. If the specified encoding cannot be found, fall back to the original UTF-8
-  // version.
-  if let Some(charset) = page.meta.get("charset") {
-    if charset.to_lowercase() != "utf-8" {
-      if let Some(encoding_ref) = encodings().iter().find(|e| e.name() == charset) {
-        if let Ok(html_with_encoding) = encoding_ref.decode(html_bytes, DecoderTrap::Replace) {
-          page = HTML::from_string(html_with_encoding, None)?;
-        }
-      }
+    if !first_line.starts_with("<!doctype html>") {
+        Err(LemmyErrorType::SiteMetadataPageIsNotDoctypeHtml)?
     }
-  }
 
-  let page_title = page.title;
-  let page_description = page.description;
+    let mut page = HTML::from_string(html.to_string(), None)?;
 
-  let og_description = page
-    .opengraph
-    .properties
-    .get("description")
-    .map(std::string::ToString::to_string);
-  let og_title = page
-    .opengraph
-    .properties
-    .get("title")
-    .map(std::string::ToString::to_string);
-  let og_image = page
-    .opengraph
-    .images
-    .first()
-    // join also works if the target URL is absolute
-    .and_then(|ogo| url.join(&ogo.url).ok());
-  let og_embed_url = page
-    .opengraph
-    .videos
-    .first()
-    // join also works if the target URL is absolute
-    .and_then(|v| url.join(&v.url).ok());
+    // If the web page specifies that it isn't actually UTF-8, re-decode the received bytes with the
+    // proper encoding. If the specified encoding cannot be found, fall back to the original UTF-8
+    // version.
+    if let Some(charset) = page.meta.get("charset") {
+        if charset.to_lowercase() != "utf-8" {
+            if let Some(encoding_ref) = encodings().iter().find(|e| e.name() == charset) {
+                if let Ok(html_with_encoding) =
+                    encoding_ref.decode(html_bytes, DecoderTrap::Replace)
+                {
+                    page = HTML::from_string(html_with_encoding, None)?;
+                }
+            }
+        }
+    }
 
-  Ok(SiteMetadata {
-    title: og_title.or(page_title),
-    description: og_description.or(page_description),
-    image: og_image.map(Into::into),
-    embed_video_url: og_embed_url.map(Into::into),
-  })
+    let page_title = page.title;
+    let page_description = page.description;
+
+    let og_description = page
+        .opengraph
+        .properties
+        .get("description")
+        .map(std::string::ToString::to_string);
+    let og_title = page
+        .opengraph
+        .properties
+        .get("title")
+        .map(std::string::ToString::to_string);
+    let og_image = page
+        .opengraph
+        .images
+        .first()
+        // join also works if the target URL is absolute
+        .and_then(|ogo| url.join(&ogo.url).ok());
+    let og_embed_url = page
+        .opengraph
+        .videos
+        .first()
+        // join also works if the target URL is absolute
+        .and_then(|v| url.join(&v.url).ok());
+
+    Ok(SiteMetadata {
+        title: og_title.or(page_title),
+        description: og_description.or(page_description),
+        image: og_image.map(Into::into),
+        embed_video_url: og_embed_url.map(Into::into),
+    })
 }
 
 #[derive(Deserialize, Debug, Clone)]
 pub(crate) struct PictrsResponse {
-  files: Vec<PictrsFile>,
-  msg: String,
+    files: Vec<PictrsFile>,
+    msg: String,
 }
 
 #[derive(Deserialize, Debug, Clone)]
 pub(crate) struct PictrsFile {
-  file: String,
-  #[allow(dead_code)]
-  delete_token: String,
+    file: String,
+    #[allow(dead_code)]
+    delete_token: String,
 }
 
 #[derive(Deserialize, Debug, Clone)]
 pub(crate) struct PictrsPurgeResponse {
-  msg: String,
+    msg: String,
 }
 
 #[tracing::instrument(skip_all)]
 pub(crate) async fn fetch_pictrs(
-  client: &ClientWithMiddleware,
-  settings: &Settings,
-  image_url: &Url,
+    client: &ClientWithMiddleware,
+    settings: &Settings,
+    image_url: &Url,
 ) -> Result<PictrsResponse, LemmyError> {
-  let pictrs_config = settings.pictrs_config()?;
-  is_image_content_type(client, image_url).await?;
+    let pictrs_config = settings.pictrs_config()?;
+    is_image_content_type(client, image_url).await?;
 
-  if pictrs_config.cache_remote_images {
-    // fetch remote non-pictrs images for persistent thumbnail link
-    let fetch_url = format!(
-      "{}image/download?url={}",
-      pictrs_config.url,
-      utf8_percent_encode(image_url.as_str(), NON_ALPHANUMERIC) // TODO this might not be needed
-    );
+    if pictrs_config.cache_remote_images {
+        // fetch remote non-pictrs images for persistent thumbnail link
+        let fetch_url = format!(
+            "{}image/download?url={}",
+            pictrs_config.url,
+            utf8_percent_encode(image_url.as_str(), NON_ALPHANUMERIC) // TODO this might not be needed
+        );
 
-    let response = client
-      .get(&fetch_url)
-      .timeout(REQWEST_TIMEOUT)
-      .send()
-      .await?;
+        let response = client
+            .get(&fetch_url)
+            .timeout(REQWEST_TIMEOUT)
+            .send()
+            .await?;
 
-    let response: PictrsResponse = response.json().await.map_err(LemmyError::from)?;
+        let response: PictrsResponse = response.json().await.map_err(LemmyError::from)?;
 
-    if response.msg == "ok" {
-      Ok(response)
+        if response.msg == "ok" {
+            Ok(response)
+        } else {
+            Err(LemmyErrorType::PictrsResponseError(response.msg))?
+        }
     } else {
-      Err(LemmyErrorType::PictrsResponseError(response.msg))?
+        Err(LemmyErrorType::PictrsCachingDisabled)?
     }
-  } else {
-    Err(LemmyErrorType::PictrsCachingDisabled)?
-  }
 }
 
 /// Purges an image from pictrs
@@ -155,209 +157,208 @@ pub(crate) async fn fetch_pictrs(
 /// - It might not be an image
 /// - Pictrs might not be set up
 pub async fn purge_image_from_pictrs(
-  image_url: &Url,
-  context: &LemmyContext,
+    image_url: &Url,
+    context: &LemmyContext,
 ) -> Result<(), LemmyError> {
-  let pictrs_config = context.settings().pictrs_config()?;
-  is_image_content_type(context.client(), image_url).await?;
+    let pictrs_config = context.settings().pictrs_config()?;
+    is_image_content_type(context.client(), image_url).await?;
 
-  let alias = image_url
-    .path_segments()
-    .ok_or(LemmyErrorType::ImageUrlMissingPathSegments)?
-    .next_back()
-    .ok_or(LemmyErrorType::ImageUrlMissingLastPathSegment)?;
+    let alias = image_url
+        .path_segments()
+        .ok_or(LemmyErrorType::ImageUrlMissingPathSegments)?
+        .next_back()
+        .ok_or(LemmyErrorType::ImageUrlMissingLastPathSegment)?;
 
-  let purge_url = format!("{}/internal/purge?alias={}", pictrs_config.url, alias);
+    let purge_url = format!("{}/internal/purge?alias={}", pictrs_config.url, alias);
 
-  let pictrs_api_key = pictrs_config
-    .api_key
-    .ok_or(LemmyErrorType::PictrsApiKeyNotProvided)?;
-  let response = context
-    .client()
-    .post(&purge_url)
-    .timeout(REQWEST_TIMEOUT)
-    .header("x-api-token", pictrs_api_key)
-    .send()
-    .await?;
+    let pictrs_api_key = pictrs_config
+        .api_key
+        .ok_or(LemmyErrorType::PictrsApiKeyNotProvided)?;
+    let response = context
+        .client()
+        .post(&purge_url)
+        .timeout(REQWEST_TIMEOUT)
+        .header("x-api-token", pictrs_api_key)
+        .send()
+        .await?;
 
-  let response: PictrsPurgeResponse = response.json().await.map_err(LemmyError::from)?;
+    let response: PictrsPurgeResponse = response.json().await.map_err(LemmyError::from)?;
 
-  if response.msg == "ok" {
-    Ok(())
-  } else {
-    Err(LemmyErrorType::PictrsPurgeResponseError(response.msg))?
-  }
+    if response.msg == "ok" {
+        Ok(())
+    } else {
+        Err(LemmyErrorType::PictrsPurgeResponseError(response.msg))?
+    }
 }
 
 /// Both are options, since the URL might be either an html page, or an image
 /// Returns the SiteMetadata, and an image URL, if there is a picture associated
 #[tracing::instrument(skip_all)]
 pub async fn fetch_site_data(
-  client: &ClientWithMiddleware,
-  settings: &Settings,
-  url: Option<&Url>,
-  include_image: bool,
+    client: &ClientWithMiddleware,
+    settings: &Settings,
+    url: Option<&Url>,
+    include_image: bool,
 ) -> (Option<SiteMetadata>, Option<DbUrl>) {
-  match &url {
-    Some(url) => {
-      // Fetch metadata
-      // Ignore errors, since it may be an image, or not have the data.
-      // Warning, this may ignore SSL errors
-      let metadata_option = fetch_site_metadata(client, url).await.ok();
-      if !include_image {
-        (metadata_option, None)
-      } else {
-        let thumbnail_url =
-          fetch_pictrs_url_from_site_metadata(client, &metadata_option, settings, url)
-            .await
-            .ok();
-        (metadata_option, thumbnail_url)
-      }
+    match &url {
+        Some(url) => {
+            // Fetch metadata
+            // Ignore errors, since it may be an image, or not have the data.
+            // Warning, this may ignore SSL errors
+            let metadata_option = fetch_site_metadata(client, url).await.ok();
+            if !include_image {
+                (metadata_option, None)
+            } else {
+                let thumbnail_url =
+                    fetch_pictrs_url_from_site_metadata(client, &metadata_option, settings, url)
+                        .await
+                        .ok();
+                (metadata_option, thumbnail_url)
+            }
+        }
+        None => (None, None),
     }
-    None => (None, None),
-  }
 }
 
 async fn fetch_pictrs_url_from_site_metadata(
-  client: &ClientWithMiddleware,
-  metadata_option: &Option<SiteMetadata>,
-  settings: &Settings,
-  url: &Url,
+    client: &ClientWithMiddleware,
+    metadata_option: &Option<SiteMetadata>,
+    settings: &Settings,
+    url: &Url,
 ) -> Result<DbUrl, LemmyError> {
-  let pictrs_res = match metadata_option {
-    Some(metadata_res) => match &metadata_res.image {
-      // Metadata, with image
-      // Try to generate a small thumbnail if there's a full sized one from post-links
-      Some(metadata_image) => fetch_pictrs(client, settings, metadata_image).await,
-      // Metadata, but no image
-      None => fetch_pictrs(client, settings, url).await,
-    },
-    // No metadata, try to fetch the URL as an image
-    None => fetch_pictrs(client, settings, url).await,
-  }?;
+    let pictrs_res = match metadata_option {
+        Some(metadata_res) => match &metadata_res.image {
+            // Metadata, with image
+            // Try to generate a small thumbnail if there's a full sized one from post-links
+            Some(metadata_image) => fetch_pictrs(client, settings, metadata_image).await,
+            // Metadata, but no image
+            None => fetch_pictrs(client, settings, url).await,
+        },
+        // No metadata, try to fetch the URL as an image
+        None => fetch_pictrs(client, settings, url).await,
+    }?;
 
-  Url::parse(&format!(
-    "{}/pictrs/image/{}",
-    settings.get_protocol_and_hostname(),
-    pictrs_res.files.first().expect("missing pictrs file").file
-  ))
-  .map(Into::into)
-  .map_err(Into::into)
+    Url::parse(&format!(
+        "{}/pictrs/image/{}",
+        settings.get_protocol_and_hostname(),
+        pictrs_res.files.first().expect("missing pictrs file").file
+    ))
+    .map(Into::into)
+    .map_err(Into::into)
 }
 
 #[tracing::instrument(skip_all)]
 async fn is_image_content_type(client: &ClientWithMiddleware, url: &Url) -> Result<(), LemmyError> {
-  let response = client.get(url.as_str()).send().await?;
-  if response
-    .headers()
-    .get("Content-Type")
-    .ok_or(LemmyErrorType::NoContentTypeHeader)?
-    .to_str()?
-    .starts_with("image/")
-  {
-    Ok(())
-  } else {
-    Err(LemmyErrorType::NotAnImageType)?
-  }
+    let response = client.get(url.as_str()).send().await?;
+    if response
+        .headers()
+        .get("Content-Type")
+        .ok_or(LemmyErrorType::NoContentTypeHeader)?
+        .to_str()?
+        .starts_with("image/")
+    {
+        Ok(())
+    } else {
+        Err(LemmyErrorType::NotAnImageType)?
+    }
 }
 
 pub fn build_user_agent(settings: &Settings) -> String {
-  format!(
-    "Lemmy/{}; +{}",
-    VERSION,
-    settings.get_protocol_and_hostname()
-  )
+    format!(
+        "Lemmy/{}; +{}",
+        VERSION,
+        settings.get_protocol_and_hostname()
+    )
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::request::{
-    build_user_agent,
-    fetch_site_metadata,
-    html_to_site_metadata,
-    SiteMetadata,
-  };
-  use lemmy_utils::settings::SETTINGS;
-  use url::Url;
+    use crate::request::{
+        build_user_agent, fetch_site_metadata, html_to_site_metadata, SiteMetadata,
+    };
+    use lemmy_utils::settings::SETTINGS;
+    use url::Url;
 
-  // These helped with testing
-  #[tokio::test]
-  async fn test_site_metadata() {
-    let settings = &SETTINGS.clone();
-    let client = reqwest::Client::builder()
-      .user_agent(build_user_agent(settings))
-      .build()
-      .unwrap()
-      .into();
-    let sample_url = Url::parse("https://gitlab.com/IzzyOnDroid/repo/-/wikis/FAQ").unwrap();
-    let sample_res = fetch_site_metadata(&client, &sample_url).await.unwrap();
-    assert_eq!(
-      SiteMetadata {
-        title: Some("FAQ · Wiki · IzzyOnDroid / repo · GitLab".to_string()),
-        description: Some(
-          "The F-Droid compatible repo at https://apt.izzysoft.de/fdroid/".to_string()
-        ),
-        image: Some(
-          Url::parse("https://gitlab.com/uploads/-/system/project/avatar/4877469/iod_logo.png")
+    // These helped with testing
+    #[tokio::test]
+    async fn test_site_metadata() {
+        let settings = &SETTINGS.clone();
+        let client = reqwest::Client::builder()
+            .user_agent(build_user_agent(settings))
+            .build()
             .unwrap()
-            .into()
-        ),
-        embed_video_url: None,
-      },
-      sample_res
-    );
-  }
+            .into();
+        let sample_url = Url::parse("https://gitlab.com/IzzyOnDroid/repo/-/wikis/FAQ").unwrap();
+        let sample_res = fetch_site_metadata(&client, &sample_url).await.unwrap();
+        assert_eq!(
+            SiteMetadata {
+                title: Some("FAQ · Wiki · IzzyOnDroid / repo · GitLab".to_string()),
+                description: Some(
+                    "The F-Droid compatible repo at https://apt.izzysoft.de/fdroid/".to_string()
+                ),
+                image: Some(
+                    Url::parse(
+                        "https://gitlab.com/uploads/-/system/project/avatar/4877469/iod_logo.png"
+                    )
+                    .unwrap()
+                    .into()
+                ),
+                embed_video_url: None,
+            },
+            sample_res
+        );
+    }
 
-  // #[test]
-  // fn test_pictshare() {
-  //   let res = fetch_pictshare("https://upload.wikimedia.org/wikipedia/en/2/27/The_Mandalorian_logo.jpg");
-  //   assert!(res.is_ok());
-  //   let res_other = fetch_pictshare("https://upload.wikimedia.org/wikipedia/en/2/27/The_Mandalorian_logo.jpgaoeu");
-  //   assert!(res_other.is_err());
-  // }
+    // #[test]
+    // fn test_pictshare() {
+    //   let res = fetch_pictshare("https://upload.wikimedia.org/wikipedia/en/2/27/The_Mandalorian_logo.jpg");
+    //   assert!(res.is_ok());
+    //   let res_other = fetch_pictshare("https://upload.wikimedia.org/wikipedia/en/2/27/The_Mandalorian_logo.jpgaoeu");
+    //   assert!(res_other.is_err());
+    // }
 
-  #[test]
-  fn test_resolve_image_url() {
-    // url that lists the opengraph fields
-    let url = Url::parse("https://example.com/one/two.html").unwrap();
+    #[test]
+    fn test_resolve_image_url() {
+        // url that lists the opengraph fields
+        let url = Url::parse("https://example.com/one/two.html").unwrap();
 
-    // root relative url
-    let html_bytes = b"<!DOCTYPE html><html><head><meta property='og:image' content='/image.jpg'></head><body></body></html>";
-    let metadata = html_to_site_metadata(html_bytes, &url).expect("Unable to parse metadata");
-    assert_eq!(
-      metadata.image,
-      Some(Url::parse("https://example.com/image.jpg").unwrap().into())
-    );
+        // root relative url
+        let html_bytes = b"<!DOCTYPE html><html><head><meta property='og:image' content='/image.jpg'></head><body></body></html>";
+        let metadata = html_to_site_metadata(html_bytes, &url).expect("Unable to parse metadata");
+        assert_eq!(
+            metadata.image,
+            Some(Url::parse("https://example.com/image.jpg").unwrap().into())
+        );
 
-    // base relative url
-    let html_bytes = b"<!DOCTYPE html><html><head><meta property='og:image' content='image.jpg'></head><body></body></html>";
-    let metadata = html_to_site_metadata(html_bytes, &url).expect("Unable to parse metadata");
-    assert_eq!(
-      metadata.image,
-      Some(
-        Url::parse("https://example.com/one/image.jpg")
-          .unwrap()
-          .into()
-      )
-    );
+        // base relative url
+        let html_bytes = b"<!DOCTYPE html><html><head><meta property='og:image' content='image.jpg'></head><body></body></html>";
+        let metadata = html_to_site_metadata(html_bytes, &url).expect("Unable to parse metadata");
+        assert_eq!(
+            metadata.image,
+            Some(
+                Url::parse("https://example.com/one/image.jpg")
+                    .unwrap()
+                    .into()
+            )
+        );
 
-    // absolute url
-    let html_bytes = b"<!DOCTYPE html><html><head><meta property='og:image' content='https://cdn.host.com/image.jpg'></head><body></body></html>";
-    let metadata = html_to_site_metadata(html_bytes, &url).expect("Unable to parse metadata");
-    assert_eq!(
-      metadata.image,
-      Some(Url::parse("https://cdn.host.com/image.jpg").unwrap().into())
-    );
+        // absolute url
+        let html_bytes = b"<!DOCTYPE html><html><head><meta property='og:image' content='https://cdn.host.com/image.jpg'></head><body></body></html>";
+        let metadata = html_to_site_metadata(html_bytes, &url).expect("Unable to parse metadata");
+        assert_eq!(
+            metadata.image,
+            Some(Url::parse("https://cdn.host.com/image.jpg").unwrap().into())
+        );
 
-    // protocol relative url
-    let html_bytes = b"<!DOCTYPE html><html><head><meta property='og:image' content='//example.com/image.jpg'></head><body></body></html>";
-    let metadata = html_to_site_metadata(html_bytes, &url).expect("Unable to parse metadata");
-    assert_eq!(
-      metadata.image,
-      Some(Url::parse("https://example.com/image.jpg").unwrap().into())
-    );
-  }
+        // protocol relative url
+        let html_bytes = b"<!DOCTYPE html><html><head><meta property='og:image' content='//example.com/image.jpg'></head><body></body></html>";
+        let metadata = html_to_site_metadata(html_bytes, &url).expect("Unable to parse metadata");
+        assert_eq!(
+            metadata.image,
+            Some(Url::parse("https://example.com/image.jpg").unwrap().into())
+        );
+    }
 }

--- a/crates/api_common/src/send_activity.rs
+++ b/crates/api_common/src/send_activity.rs
@@ -1,112 +1,109 @@
 use crate::{
-  community::BanFromCommunity,
-  context::LemmyContext,
-  person::BanPerson,
-  post::{DeletePost, RemovePost},
+    community::BanFromCommunity,
+    context::LemmyContext,
+    person::BanPerson,
+    post::{DeletePost, RemovePost},
 };
 use activitypub_federation::config::Data;
 use futures::future::BoxFuture;
 use lemmy_db_schema::{
-  newtypes::{CommunityId, DbUrl, PersonId},
-  source::{
-    comment::Comment,
-    community::Community,
-    person::Person,
-    post::Post,
-    private_message::PrivateMessage,
-  },
+    newtypes::{CommunityId, DbUrl, PersonId},
+    source::{
+        comment::Comment, community::Community, person::Person, post::Post,
+        private_message::PrivateMessage,
+    },
 };
 use lemmy_db_views::structs::PrivateMessageView;
 use lemmy_utils::{error::LemmyResult, SYNCHRONOUS_FEDERATION};
 use once_cell::sync::{Lazy, OnceCell};
 use tokio::{
-  sync::{
-    mpsc,
-    mpsc::{UnboundedReceiver, UnboundedSender, WeakUnboundedSender},
-    Mutex,
-  },
-  task::JoinHandle,
+    sync::{
+        mpsc,
+        mpsc::{UnboundedReceiver, UnboundedSender, WeakUnboundedSender},
+        Mutex,
+    },
+    task::JoinHandle,
 };
 use url::Url;
 
 type MatchOutgoingActivitiesBoxed =
-  Box<for<'a> fn(SendActivityData, &'a Data<LemmyContext>) -> BoxFuture<'a, LemmyResult<()>>>;
+    Box<for<'a> fn(SendActivityData, &'a Data<LemmyContext>) -> BoxFuture<'a, LemmyResult<()>>>;
 
 /// This static is necessary so that activities can be sent out synchronously for tests.
 pub static MATCH_OUTGOING_ACTIVITIES: OnceCell<MatchOutgoingActivitiesBoxed> = OnceCell::new();
 
 #[derive(Debug)]
 pub enum SendActivityData {
-  CreatePost(Post),
-  UpdatePost(Post),
-  DeletePost(Post, Person, DeletePost),
-  RemovePost(Post, Person, RemovePost),
-  LockPost(Post, Person, bool),
-  FeaturePost(Post, Person, bool),
-  CreateComment(Comment),
-  UpdateComment(Comment),
-  DeleteComment(Comment, Person, Community),
-  RemoveComment(Comment, Person, Community, Option<String>),
-  LikePostOrComment(DbUrl, Person, Community, i16),
-  FollowCommunity(Community, Person, bool),
-  UpdateCommunity(Person, Community),
-  DeleteCommunity(Person, Community, bool),
-  RemoveCommunity(Person, Community, Option<String>, bool),
-  AddModToCommunity(Person, CommunityId, PersonId, bool),
-  BanFromCommunity(Person, CommunityId, Person, BanFromCommunity),
-  BanFromSite(Person, Person, BanPerson),
-  CreatePrivateMessage(PrivateMessageView),
-  UpdatePrivateMessage(PrivateMessageView),
-  DeletePrivateMessage(Person, PrivateMessage, bool),
-  DeleteUser(Person, bool),
-  CreateReport(Url, Person, Community, String),
+    CreatePost(Post),
+    UpdatePost(Post),
+    DeletePost(Post, Person, DeletePost),
+    RemovePost(Post, Person, RemovePost),
+    LockPost(Post, Person, bool),
+    FeaturePost(Post, Person, bool),
+    CreateComment(Comment),
+    UpdateComment(Comment),
+    DeleteComment(Comment, Person, Community),
+    RemoveComment(Comment, Person, Community, Option<String>),
+    LikePostOrComment(DbUrl, Person, Community, i16),
+    FollowCommunity(Community, Person, bool),
+    UpdateCommunity(Person, Community),
+    DeleteCommunity(Person, Community, bool),
+    RemoveCommunity(Person, Community, Option<String>, bool),
+    AddModToCommunity(Person, CommunityId, PersonId, bool),
+    BanFromCommunity(Person, CommunityId, Person, BanFromCommunity),
+    BanFromSite(Person, Person, BanPerson),
+    CreatePrivateMessage(PrivateMessageView),
+    UpdatePrivateMessage(PrivateMessageView),
+    DeletePrivateMessage(Person, PrivateMessage, bool),
+    DeleteUser(Person, bool),
+    CreateReport(Url, Person, Community, String),
 }
 
 // TODO: instead of static, move this into LemmyContext. make sure that stopping the process with
 //       ctrl+c still works.
 static ACTIVITY_CHANNEL: Lazy<ActivityChannel> = Lazy::new(|| {
-  let (sender, receiver) = mpsc::unbounded_channel();
-  let weak_sender = sender.downgrade();
-  ActivityChannel {
-    weak_sender,
-    receiver: Mutex::new(receiver),
-    keepalive_sender: Mutex::new(Some(sender)),
-  }
+    let (sender, receiver) = mpsc::unbounded_channel();
+    let weak_sender = sender.downgrade();
+    ActivityChannel {
+        weak_sender,
+        receiver: Mutex::new(receiver),
+        keepalive_sender: Mutex::new(Some(sender)),
+    }
 });
 
 pub struct ActivityChannel {
-  weak_sender: WeakUnboundedSender<SendActivityData>,
-  receiver: Mutex<UnboundedReceiver<SendActivityData>>,
-  keepalive_sender: Mutex<Option<UnboundedSender<SendActivityData>>>,
+    weak_sender: WeakUnboundedSender<SendActivityData>,
+    receiver: Mutex<UnboundedReceiver<SendActivityData>>,
+    keepalive_sender: Mutex<Option<UnboundedSender<SendActivityData>>>,
 }
 
 impl ActivityChannel {
-  pub async fn retrieve_activity() -> Option<SendActivityData> {
-    let mut lock = ACTIVITY_CHANNEL.receiver.lock().await;
-    lock.recv().await
-  }
-
-  pub async fn submit_activity(
-    data: SendActivityData,
-    context: &Data<LemmyContext>,
-  ) -> LemmyResult<()> {
-    if *SYNCHRONOUS_FEDERATION {
-      MATCH_OUTGOING_ACTIVITIES
-        .get()
-        .expect("retrieve function pointer")(data, context)
-      .await?;
+    pub async fn retrieve_activity() -> Option<SendActivityData> {
+        let mut lock = ACTIVITY_CHANNEL.receiver.lock().await;
+        lock.recv().await
     }
-    // could do `ACTIVITY_CHANNEL.keepalive_sender.lock()` instead and get rid of weak_sender,
-    // not sure which way is more efficient
-    else if let Some(sender) = ACTIVITY_CHANNEL.weak_sender.upgrade() {
-      sender.send(data)?;
-    }
-    Ok(())
-  }
 
-  pub async fn close(outgoing_activities_task: JoinHandle<LemmyResult<()>>) -> LemmyResult<()> {
-    ACTIVITY_CHANNEL.keepalive_sender.lock().await.take();
-    outgoing_activities_task.await??;
-    Ok(())
-  }
+    pub async fn submit_activity(
+        data: SendActivityData,
+        context: &Data<LemmyContext>,
+    ) -> LemmyResult<()> {
+        if *SYNCHRONOUS_FEDERATION {
+            MATCH_OUTGOING_ACTIVITIES
+                .get()
+                .expect("retrieve function pointer")(data, context)
+            .await?;
+        }
+        // could do `ACTIVITY_CHANNEL.keepalive_sender.lock()` instead and get rid of weak_sender,
+        // not sure which way is more efficient
+        else if let Some(sender) = ACTIVITY_CHANNEL.weak_sender.upgrade() {
+            sender.send(data)?;
+        }
+        Ok(())
+    }
+
+    pub async fn close(outgoing_activities_task: JoinHandle<LemmyResult<()>>) -> LemmyResult<()> {
+        ACTIVITY_CHANNEL.keepalive_sender.lock().await.take();
+        outgoing_activities_task.await??;
+        Ok(())
+    }
 }

--- a/crates/api_common/src/sensitive.rs
+++ b/crates/api_common/src/sensitive.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::{
-  borrow::Borrow,
-  ops::{Deref, DerefMut},
+    borrow::Borrow,
+    ops::{Deref, DerefMut},
 };
 #[cfg(feature = "full")]
 use ts_rs::TS;
@@ -11,106 +11,106 @@ use ts_rs::TS;
 pub struct Sensitive<T>(T);
 
 impl<T> Sensitive<T> {
-  pub fn new(item: T) -> Self {
-    Sensitive(item)
-  }
-  pub fn into_inner(self) -> T {
-    self.0
-  }
+    pub fn new(item: T) -> Self {
+        Sensitive(item)
+    }
+    pub fn into_inner(self) -> T {
+        self.0
+    }
 }
 
 impl<T> std::fmt::Debug for Sensitive<T> {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    f.debug_struct("Sensitive").finish()
-  }
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Sensitive").finish()
+    }
 }
 
 impl<T> AsRef<T> for Sensitive<T> {
-  fn as_ref(&self) -> &T {
-    &self.0
-  }
+    fn as_ref(&self) -> &T {
+        &self.0
+    }
 }
 
 impl AsRef<str> for Sensitive<String> {
-  fn as_ref(&self) -> &str {
-    &self.0
-  }
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
 }
 
 impl AsRef<[u8]> for Sensitive<String> {
-  fn as_ref(&self) -> &[u8] {
-    self.0.as_ref()
-  }
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
 }
 
 impl AsRef<[u8]> for Sensitive<Vec<u8>> {
-  fn as_ref(&self) -> &[u8] {
-    self.0.as_ref()
-  }
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
 }
 
 impl<T> AsMut<T> for Sensitive<T> {
-  fn as_mut(&mut self) -> &mut T {
-    &mut self.0
-  }
+    fn as_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
 }
 
 impl AsMut<str> for Sensitive<String> {
-  fn as_mut(&mut self) -> &mut str {
-    &mut self.0
-  }
+    fn as_mut(&mut self) -> &mut str {
+        &mut self.0
+    }
 }
 
 impl Deref for Sensitive<String> {
-  type Target = str;
+    type Target = str;
 
-  fn deref(&self) -> &Self::Target {
-    &self.0
-  }
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 impl DerefMut for Sensitive<String> {
-  fn deref_mut(&mut self) -> &mut Self::Target {
-    &mut self.0
-  }
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
 }
 
 impl<T> From<T> for Sensitive<T> {
-  fn from(t: T) -> Self {
-    Sensitive(t)
-  }
+    fn from(t: T) -> Self {
+        Sensitive(t)
+    }
 }
 
 impl From<&str> for Sensitive<String> {
-  fn from(s: &str) -> Self {
-    Sensitive(s.into())
-  }
+    fn from(s: &str) -> Self {
+        Sensitive(s.into())
+    }
 }
 
 impl<T> Borrow<T> for Sensitive<T> {
-  fn borrow(&self) -> &T {
-    &self.0
-  }
+    fn borrow(&self) -> &T {
+        &self.0
+    }
 }
 
 impl Borrow<str> for Sensitive<String> {
-  fn borrow(&self) -> &str {
-    &self.0
-  }
+    fn borrow(&self) -> &str {
+        &self.0
+    }
 }
 
 #[cfg(feature = "full")]
 impl TS for Sensitive<String> {
-  fn name() -> String {
-    "string".to_string()
-  }
-  fn name_with_type_args(_args: Vec<String>) -> String {
-    "string".to_string()
-  }
-  fn dependencies() -> Vec<ts_rs::Dependency> {
-    Vec::new()
-  }
-  fn transparent() -> bool {
-    true
-  }
+    fn name() -> String {
+        "string".to_string()
+    }
+    fn name_with_type_args(_args: Vec<String>) -> String {
+        "string".to_string()
+    }
+    fn dependencies() -> Vec<ts_rs::Dependency> {
+        Vec::new()
+    }
+    fn transparent() -> bool {
+        true
+    }
 }

--- a/crates/api_common/src/site.rs
+++ b/crates/api_common/src/site.rs
@@ -1,45 +1,21 @@
 use crate::sensitive::Sensitive;
 use lemmy_db_schema::{
-  newtypes::{CommentId, CommunityId, LanguageId, PersonId, PostId},
-  source::{instance::Instance, language::Language, tagline::Tagline},
-  ListingType,
-  ModlogActionType,
-  RegistrationMode,
-  SearchType,
-  SortType,
+    newtypes::{CommentId, CommunityId, LanguageId, PersonId, PostId},
+    source::{instance::Instance, language::Language, tagline::Tagline},
+    ListingType, ModlogActionType, RegistrationMode, SearchType, SortType,
 };
 use lemmy_db_views::structs::{
-  CommentView,
-  CustomEmojiView,
-  LocalUserView,
-  PostView,
-  RegistrationApplicationView,
-  SiteView,
+    CommentView, CustomEmojiView, LocalUserView, PostView, RegistrationApplicationView, SiteView,
 };
 use lemmy_db_views_actor::structs::{
-  CommunityBlockView,
-  CommunityFollowerView,
-  CommunityModeratorView,
-  CommunityView,
-  PersonBlockView,
-  PersonView,
+    CommunityBlockView, CommunityFollowerView, CommunityModeratorView, CommunityView,
+    PersonBlockView, PersonView,
 };
 use lemmy_db_views_moderator::structs::{
-  AdminPurgeCommentView,
-  AdminPurgeCommunityView,
-  AdminPurgePersonView,
-  AdminPurgePostView,
-  ModAddCommunityView,
-  ModAddView,
-  ModBanFromCommunityView,
-  ModBanView,
-  ModFeaturePostView,
-  ModHideCommunityView,
-  ModLockPostView,
-  ModRemoveCommentView,
-  ModRemoveCommunityView,
-  ModRemovePostView,
-  ModTransferCommunityView,
+    AdminPurgeCommentView, AdminPurgeCommunityView, AdminPurgePersonView, AdminPurgePostView,
+    ModAddCommunityView, ModAddView, ModBanFromCommunityView, ModBanView, ModFeaturePostView,
+    ModHideCommunityView, ModLockPostView, ModRemoveCommentView, ModRemoveCommunityView,
+    ModRemovePostView, ModTransferCommunityView,
 };
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -52,16 +28,16 @@ use ts_rs::TS;
 #[cfg_attr(feature = "full", ts(export))]
 /// Searches the site, given a query string, and some optional filters.
 pub struct Search {
-  pub q: String,
-  pub community_id: Option<CommunityId>,
-  pub community_name: Option<String>,
-  pub creator_id: Option<PersonId>,
-  pub type_: Option<SearchType>,
-  pub sort: Option<SortType>,
-  pub listing_type: Option<ListingType>,
-  pub page: Option<i64>,
-  pub limit: Option<i64>,
-  pub auth: Option<Sensitive<String>>,
+    pub q: String,
+    pub community_id: Option<CommunityId>,
+    pub community_name: Option<String>,
+    pub creator_id: Option<PersonId>,
+    pub type_: Option<SearchType>,
+    pub sort: Option<SortType>,
+    pub listing_type: Option<ListingType>,
+    pub page: Option<i64>,
+    pub limit: Option<i64>,
+    pub auth: Option<Sensitive<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -70,11 +46,11 @@ pub struct Search {
 /// The search response, containing lists of the return type possibilities
 // TODO this should be redone as a list of tagged enums
 pub struct SearchResponse {
-  pub type_: SearchType,
-  pub comments: Vec<CommentView>,
-  pub posts: Vec<PostView>,
-  pub communities: Vec<CommunityView>,
-  pub users: Vec<PersonView>,
+    pub type_: SearchType,
+    pub comments: Vec<CommentView>,
+    pub posts: Vec<PostView>,
+    pub communities: Vec<CommunityView>,
+    pub users: Vec<PersonView>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -82,9 +58,9 @@ pub struct SearchResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Does an apub fetch for an object.
 pub struct ResolveObject {
-  /// Can be the full url, or a shortened version like: !fediverse@lemmy.ml
-  pub q: String,
-  pub auth: Option<Sensitive<String>>,
+    /// Can be the full url, or a shortened version like: !fediverse@lemmy.ml
+    pub q: String,
+    pub auth: Option<Sensitive<String>>,
 }
 
 #[skip_serializing_none]
@@ -94,10 +70,10 @@ pub struct ResolveObject {
 // TODO Change this to an enum
 /// The response of an apub object fetch.
 pub struct ResolveObjectResponse {
-  pub comment: Option<CommentView>,
-  pub post: Option<PostView>,
-  pub community: Option<CommunityView>,
-  pub person: Option<PersonView>,
+    pub comment: Option<CommentView>,
+    pub post: Option<PostView>,
+    pub community: Option<CommunityView>,
+    pub person: Option<PersonView>,
 }
 
 #[skip_serializing_none]
@@ -106,13 +82,13 @@ pub struct ResolveObjectResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Fetches the modlog.
 pub struct GetModlog {
-  pub mod_person_id: Option<PersonId>,
-  pub community_id: Option<CommunityId>,
-  pub page: Option<i64>,
-  pub limit: Option<i64>,
-  pub type_: Option<ModlogActionType>,
-  pub other_person_id: Option<PersonId>,
-  pub auth: Option<Sensitive<String>>,
+    pub mod_person_id: Option<PersonId>,
+    pub community_id: Option<CommunityId>,
+    pub page: Option<i64>,
+    pub limit: Option<i64>,
+    pub type_: Option<ModlogActionType>,
+    pub other_person_id: Option<PersonId>,
+    pub auth: Option<Sensitive<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -121,21 +97,21 @@ pub struct GetModlog {
 /// The modlog fetch response.
 // TODO this should be redone as a list of tagged enums
 pub struct GetModlogResponse {
-  pub removed_posts: Vec<ModRemovePostView>,
-  pub locked_posts: Vec<ModLockPostView>,
-  pub featured_posts: Vec<ModFeaturePostView>,
-  pub removed_comments: Vec<ModRemoveCommentView>,
-  pub removed_communities: Vec<ModRemoveCommunityView>,
-  pub banned_from_community: Vec<ModBanFromCommunityView>,
-  pub banned: Vec<ModBanView>,
-  pub added_to_community: Vec<ModAddCommunityView>,
-  pub transferred_to_community: Vec<ModTransferCommunityView>,
-  pub added: Vec<ModAddView>,
-  pub admin_purged_persons: Vec<AdminPurgePersonView>,
-  pub admin_purged_communities: Vec<AdminPurgeCommunityView>,
-  pub admin_purged_posts: Vec<AdminPurgePostView>,
-  pub admin_purged_comments: Vec<AdminPurgeCommentView>,
-  pub hidden_communities: Vec<ModHideCommunityView>,
+    pub removed_posts: Vec<ModRemovePostView>,
+    pub locked_posts: Vec<ModLockPostView>,
+    pub featured_posts: Vec<ModFeaturePostView>,
+    pub removed_comments: Vec<ModRemoveCommentView>,
+    pub removed_communities: Vec<ModRemoveCommunityView>,
+    pub banned_from_community: Vec<ModBanFromCommunityView>,
+    pub banned: Vec<ModBanView>,
+    pub added_to_community: Vec<ModAddCommunityView>,
+    pub transferred_to_community: Vec<ModTransferCommunityView>,
+    pub added: Vec<ModAddView>,
+    pub admin_purged_persons: Vec<AdminPurgePersonView>,
+    pub admin_purged_communities: Vec<AdminPurgeCommunityView>,
+    pub admin_purged_posts: Vec<AdminPurgePostView>,
+    pub admin_purged_comments: Vec<AdminPurgeCommentView>,
+    pub hidden_communities: Vec<ModHideCommunityView>,
 }
 
 #[skip_serializing_none]
@@ -144,46 +120,46 @@ pub struct GetModlogResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Creates a site. Should be done after first running lemmy.
 pub struct CreateSite {
-  pub name: String,
-  pub sidebar: Option<String>,
-  pub description: Option<String>,
-  pub icon: Option<String>,
-  pub banner: Option<String>,
-  pub enable_downvotes: Option<bool>,
-  pub enable_nsfw: Option<bool>,
-  pub community_creation_admin_only: Option<bool>,
-  pub require_email_verification: Option<bool>,
-  pub application_question: Option<String>,
-  pub private_instance: Option<bool>,
-  pub default_theme: Option<String>,
-  pub default_post_listing_type: Option<ListingType>,
-  pub legal_information: Option<String>,
-  pub application_email_admins: Option<bool>,
-  pub hide_modlog_mod_names: Option<bool>,
-  pub discussion_languages: Option<Vec<LanguageId>>,
-  pub slur_filter_regex: Option<String>,
-  pub actor_name_max_length: Option<i32>,
-  pub rate_limit_message: Option<i32>,
-  pub rate_limit_message_per_second: Option<i32>,
-  pub rate_limit_post: Option<i32>,
-  pub rate_limit_post_per_second: Option<i32>,
-  pub rate_limit_register: Option<i32>,
-  pub rate_limit_register_per_second: Option<i32>,
-  pub rate_limit_image: Option<i32>,
-  pub rate_limit_image_per_second: Option<i32>,
-  pub rate_limit_comment: Option<i32>,
-  pub rate_limit_comment_per_second: Option<i32>,
-  pub rate_limit_search: Option<i32>,
-  pub rate_limit_search_per_second: Option<i32>,
-  pub federation_enabled: Option<bool>,
-  pub federation_debug: Option<bool>,
-  pub captcha_enabled: Option<bool>,
-  pub captcha_difficulty: Option<String>,
-  pub allowed_instances: Option<Vec<String>>,
-  pub blocked_instances: Option<Vec<String>>,
-  pub taglines: Option<Vec<String>>,
-  pub registration_mode: Option<RegistrationMode>,
-  pub auth: Sensitive<String>,
+    pub name: String,
+    pub sidebar: Option<String>,
+    pub description: Option<String>,
+    pub icon: Option<String>,
+    pub banner: Option<String>,
+    pub enable_downvotes: Option<bool>,
+    pub enable_nsfw: Option<bool>,
+    pub community_creation_admin_only: Option<bool>,
+    pub require_email_verification: Option<bool>,
+    pub application_question: Option<String>,
+    pub private_instance: Option<bool>,
+    pub default_theme: Option<String>,
+    pub default_post_listing_type: Option<ListingType>,
+    pub legal_information: Option<String>,
+    pub application_email_admins: Option<bool>,
+    pub hide_modlog_mod_names: Option<bool>,
+    pub discussion_languages: Option<Vec<LanguageId>>,
+    pub slur_filter_regex: Option<String>,
+    pub actor_name_max_length: Option<i32>,
+    pub rate_limit_message: Option<i32>,
+    pub rate_limit_message_per_second: Option<i32>,
+    pub rate_limit_post: Option<i32>,
+    pub rate_limit_post_per_second: Option<i32>,
+    pub rate_limit_register: Option<i32>,
+    pub rate_limit_register_per_second: Option<i32>,
+    pub rate_limit_image: Option<i32>,
+    pub rate_limit_image_per_second: Option<i32>,
+    pub rate_limit_comment: Option<i32>,
+    pub rate_limit_comment_per_second: Option<i32>,
+    pub rate_limit_search: Option<i32>,
+    pub rate_limit_search_per_second: Option<i32>,
+    pub federation_enabled: Option<bool>,
+    pub federation_debug: Option<bool>,
+    pub captcha_enabled: Option<bool>,
+    pub captcha_difficulty: Option<String>,
+    pub allowed_instances: Option<Vec<String>>,
+    pub blocked_instances: Option<Vec<String>>,
+    pub taglines: Option<Vec<String>>,
+    pub registration_mode: Option<RegistrationMode>,
+    pub auth: Sensitive<String>,
 }
 
 #[skip_serializing_none]
@@ -192,77 +168,77 @@ pub struct CreateSite {
 #[cfg_attr(feature = "full", ts(export))]
 /// Edits a site.
 pub struct EditSite {
-  pub name: Option<String>,
-  pub sidebar: Option<String>,
-  /// A shorter, one line description of your site.
-  pub description: Option<String>,
-  /// A url for your site's icon.
-  pub icon: Option<String>,
-  /// A url for your site's banner.
-  pub banner: Option<String>,
-  /// Whether to enable downvotes.
-  pub enable_downvotes: Option<bool>,
-  /// Whether to enable NSFW.
-  pub enable_nsfw: Option<bool>,
-  /// Limits community creation to admins only.
-  pub community_creation_admin_only: Option<bool>,
-  /// Whether to require email verification.
-  pub require_email_verification: Option<bool>,
-  /// Your application question form. This is in markdown, and can be many questions.
-  pub application_question: Option<String>,
-  /// Whether your instance is public, or private.
-  pub private_instance: Option<bool>,
-  /// The default theme. Usually "browser"
-  pub default_theme: Option<String>,
-  pub default_post_listing_type: Option<ListingType>,
-  /// An optional page of legal information
-  pub legal_information: Option<String>,
-  /// Whether to email admins when receiving a new application.
-  pub application_email_admins: Option<bool>,
-  /// Whether to hide moderator names from the modlog.
-  pub hide_modlog_mod_names: Option<bool>,
-  /// A list of allowed discussion languages.
-  pub discussion_languages: Option<Vec<LanguageId>>,
-  /// A regex string of items to filter.
-  pub slur_filter_regex: Option<String>,
-  /// The max length of actor names.
-  pub actor_name_max_length: Option<i32>,
-  /// The number of messages allowed in a given time frame.
-  pub rate_limit_message: Option<i32>,
-  pub rate_limit_message_per_second: Option<i32>,
-  /// The number of posts allowed in a given time frame.
-  pub rate_limit_post: Option<i32>,
-  pub rate_limit_post_per_second: Option<i32>,
-  /// The number of registrations allowed in a given time frame.
-  pub rate_limit_register: Option<i32>,
-  pub rate_limit_register_per_second: Option<i32>,
-  /// The number of image uploads allowed in a given time frame.
-  pub rate_limit_image: Option<i32>,
-  pub rate_limit_image_per_second: Option<i32>,
-  /// The number of comments allowed in a given time frame.
-  pub rate_limit_comment: Option<i32>,
-  pub rate_limit_comment_per_second: Option<i32>,
-  /// The number of searches allowed in a given time frame.
-  pub rate_limit_search: Option<i32>,
-  pub rate_limit_search_per_second: Option<i32>,
-  /// Whether to enable federation.
-  pub federation_enabled: Option<bool>,
-  /// Enables federation debugging.
-  pub federation_debug: Option<bool>,
-  /// Whether to enable captchas for signups.
-  pub captcha_enabled: Option<bool>,
-  /// The captcha difficulty. Can be easy, medium, or hard
-  pub captcha_difficulty: Option<String>,
-  /// A list of allowed instances. If none are set, federation is open.
-  pub allowed_instances: Option<Vec<String>>,
-  /// A list of blocked instances.
-  pub blocked_instances: Option<Vec<String>>,
-  /// A list of taglines shown at the top of the front page.
-  pub taglines: Option<Vec<String>>,
-  pub registration_mode: Option<RegistrationMode>,
-  /// Whether to email admins for new reports.
-  pub reports_email_admins: Option<bool>,
-  pub auth: Sensitive<String>,
+    pub name: Option<String>,
+    pub sidebar: Option<String>,
+    /// A shorter, one line description of your site.
+    pub description: Option<String>,
+    /// A url for your site's icon.
+    pub icon: Option<String>,
+    /// A url for your site's banner.
+    pub banner: Option<String>,
+    /// Whether to enable downvotes.
+    pub enable_downvotes: Option<bool>,
+    /// Whether to enable NSFW.
+    pub enable_nsfw: Option<bool>,
+    /// Limits community creation to admins only.
+    pub community_creation_admin_only: Option<bool>,
+    /// Whether to require email verification.
+    pub require_email_verification: Option<bool>,
+    /// Your application question form. This is in markdown, and can be many questions.
+    pub application_question: Option<String>,
+    /// Whether your instance is public, or private.
+    pub private_instance: Option<bool>,
+    /// The default theme. Usually "browser"
+    pub default_theme: Option<String>,
+    pub default_post_listing_type: Option<ListingType>,
+    /// An optional page of legal information
+    pub legal_information: Option<String>,
+    /// Whether to email admins when receiving a new application.
+    pub application_email_admins: Option<bool>,
+    /// Whether to hide moderator names from the modlog.
+    pub hide_modlog_mod_names: Option<bool>,
+    /// A list of allowed discussion languages.
+    pub discussion_languages: Option<Vec<LanguageId>>,
+    /// A regex string of items to filter.
+    pub slur_filter_regex: Option<String>,
+    /// The max length of actor names.
+    pub actor_name_max_length: Option<i32>,
+    /// The number of messages allowed in a given time frame.
+    pub rate_limit_message: Option<i32>,
+    pub rate_limit_message_per_second: Option<i32>,
+    /// The number of posts allowed in a given time frame.
+    pub rate_limit_post: Option<i32>,
+    pub rate_limit_post_per_second: Option<i32>,
+    /// The number of registrations allowed in a given time frame.
+    pub rate_limit_register: Option<i32>,
+    pub rate_limit_register_per_second: Option<i32>,
+    /// The number of image uploads allowed in a given time frame.
+    pub rate_limit_image: Option<i32>,
+    pub rate_limit_image_per_second: Option<i32>,
+    /// The number of comments allowed in a given time frame.
+    pub rate_limit_comment: Option<i32>,
+    pub rate_limit_comment_per_second: Option<i32>,
+    /// The number of searches allowed in a given time frame.
+    pub rate_limit_search: Option<i32>,
+    pub rate_limit_search_per_second: Option<i32>,
+    /// Whether to enable federation.
+    pub federation_enabled: Option<bool>,
+    /// Enables federation debugging.
+    pub federation_debug: Option<bool>,
+    /// Whether to enable captchas for signups.
+    pub captcha_enabled: Option<bool>,
+    /// The captcha difficulty. Can be easy, medium, or hard
+    pub captcha_difficulty: Option<String>,
+    /// A list of allowed instances. If none are set, federation is open.
+    pub allowed_instances: Option<Vec<String>>,
+    /// A list of blocked instances.
+    pub blocked_instances: Option<Vec<String>>,
+    /// A list of taglines shown at the top of the front page.
+    pub taglines: Option<Vec<String>>,
+    pub registration_mode: Option<RegistrationMode>,
+    /// Whether to email admins for new reports.
+    pub reports_email_admins: Option<bool>,
+    pub auth: Sensitive<String>,
 }
 
 #[skip_serializing_none]
@@ -271,7 +247,7 @@ pub struct EditSite {
 #[cfg_attr(feature = "full", ts(export))]
 /// Fetches the site.
 pub struct GetSite {
-  pub auth: Option<Sensitive<String>>,
+    pub auth: Option<Sensitive<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -279,8 +255,8 @@ pub struct GetSite {
 #[cfg_attr(feature = "full", ts(export))]
 /// The response for a site.
 pub struct SiteResponse {
-  pub site_view: SiteView,
-  pub taglines: Vec<Tagline>,
+    pub site_view: SiteView,
+    pub taglines: Vec<Tagline>,
 }
 
 #[skip_serializing_none]
@@ -289,16 +265,16 @@ pub struct SiteResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// An expanded response for a site.
 pub struct GetSiteResponse {
-  pub site_view: SiteView,
-  pub admins: Vec<PersonView>,
-  pub version: String,
-  pub my_user: Option<MyUserInfo>,
-  pub all_languages: Vec<Language>,
-  pub discussion_languages: Vec<LanguageId>,
-  /// A list of taglines shown at the top of the front page.
-  pub taglines: Vec<Tagline>,
-  /// A list of custom emojis your site supports.
-  pub custom_emojis: Vec<CustomEmojiView>,
+    pub site_view: SiteView,
+    pub admins: Vec<PersonView>,
+    pub version: String,
+    pub my_user: Option<MyUserInfo>,
+    pub all_languages: Vec<Language>,
+    pub discussion_languages: Vec<LanguageId>,
+    /// A list of taglines shown at the top of the front page.
+    pub taglines: Vec<Tagline>,
+    /// A list of custom emojis your site supports.
+    pub custom_emojis: Vec<CustomEmojiView>,
 }
 
 #[skip_serializing_none]
@@ -307,8 +283,8 @@ pub struct GetSiteResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// A response of federated instances.
 pub struct GetFederatedInstancesResponse {
-  /// Optional, because federation may be disabled.
-  pub federated_instances: Option<FederatedInstances>,
+    /// Optional, because federation may be disabled.
+    pub federated_instances: Option<FederatedInstances>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -316,12 +292,12 @@ pub struct GetFederatedInstancesResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Your user info.
 pub struct MyUserInfo {
-  pub local_user_view: LocalUserView,
-  pub follows: Vec<CommunityFollowerView>,
-  pub moderates: Vec<CommunityModeratorView>,
-  pub community_blocks: Vec<CommunityBlockView>,
-  pub person_blocks: Vec<PersonBlockView>,
-  pub discussion_languages: Vec<LanguageId>,
+    pub local_user_view: LocalUserView,
+    pub follows: Vec<CommunityFollowerView>,
+    pub moderates: Vec<CommunityModeratorView>,
+    pub community_blocks: Vec<CommunityBlockView>,
+    pub person_blocks: Vec<PersonBlockView>,
+    pub discussion_languages: Vec<LanguageId>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -329,7 +305,7 @@ pub struct MyUserInfo {
 #[cfg_attr(feature = "full", ts(export))]
 /// Leaves the admin team.
 pub struct LeaveAdmin {
-  pub auth: Sensitive<String>,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -337,9 +313,9 @@ pub struct LeaveAdmin {
 #[cfg_attr(feature = "full", ts(export))]
 /// A list of federated instances.
 pub struct FederatedInstances {
-  pub linked: Vec<Instance>,
-  pub allowed: Vec<Instance>,
-  pub blocked: Vec<Instance>,
+    pub linked: Vec<Instance>,
+    pub allowed: Vec<Instance>,
+    pub blocked: Vec<Instance>,
 }
 
 #[skip_serializing_none]
@@ -348,9 +324,9 @@ pub struct FederatedInstances {
 #[cfg_attr(feature = "full", ts(export))]
 /// Purges a person from the database. This will delete all content attached to that person.
 pub struct PurgePerson {
-  pub person_id: PersonId,
-  pub reason: Option<String>,
-  pub auth: Sensitive<String>,
+    pub person_id: PersonId,
+    pub reason: Option<String>,
+    pub auth: Sensitive<String>,
 }
 
 #[skip_serializing_none]
@@ -359,9 +335,9 @@ pub struct PurgePerson {
 #[cfg_attr(feature = "full", ts(export))]
 /// Purges a community from the database. This will delete all content attached to that community.
 pub struct PurgeCommunity {
-  pub community_id: CommunityId,
-  pub reason: Option<String>,
-  pub auth: Sensitive<String>,
+    pub community_id: CommunityId,
+    pub reason: Option<String>,
+    pub auth: Sensitive<String>,
 }
 
 #[skip_serializing_none]
@@ -370,9 +346,9 @@ pub struct PurgeCommunity {
 #[cfg_attr(feature = "full", ts(export))]
 /// Purges a post from the database. This will delete all content attached to that post.
 pub struct PurgePost {
-  pub post_id: PostId,
-  pub reason: Option<String>,
-  pub auth: Sensitive<String>,
+    pub post_id: PostId,
+    pub reason: Option<String>,
+    pub auth: Sensitive<String>,
 }
 
 #[skip_serializing_none]
@@ -381,9 +357,9 @@ pub struct PurgePost {
 #[cfg_attr(feature = "full", ts(export))]
 /// Purges a comment from the database. This will delete all content attached to that comment.
 pub struct PurgeComment {
-  pub comment_id: CommentId,
-  pub reason: Option<String>,
-  pub auth: Sensitive<String>,
+    pub comment_id: CommentId,
+    pub reason: Option<String>,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -391,7 +367,7 @@ pub struct PurgeComment {
 #[cfg_attr(feature = "full", ts(export))]
 /// The response for purged items.
 pub struct PurgeItemResponse {
-  pub success: bool,
+    pub success: bool,
 }
 
 #[skip_serializing_none]
@@ -400,11 +376,11 @@ pub struct PurgeItemResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Fetches a list of registration applications.
 pub struct ListRegistrationApplications {
-  /// Only shows the unread applications (IE those without an admin actor)
-  pub unread_only: Option<bool>,
-  pub page: Option<i64>,
-  pub limit: Option<i64>,
-  pub auth: Sensitive<String>,
+    /// Only shows the unread applications (IE those without an admin actor)
+    pub unread_only: Option<bool>,
+    pub page: Option<i64>,
+    pub limit: Option<i64>,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -412,7 +388,7 @@ pub struct ListRegistrationApplications {
 #[cfg_attr(feature = "full", ts(export))]
 /// The list of registration applications.
 pub struct ListRegistrationApplicationsResponse {
-  pub registration_applications: Vec<RegistrationApplicationView>,
+    pub registration_applications: Vec<RegistrationApplicationView>,
 }
 
 #[skip_serializing_none]
@@ -421,10 +397,10 @@ pub struct ListRegistrationApplicationsResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Approves a registration application.
 pub struct ApproveRegistrationApplication {
-  pub id: i32,
-  pub approve: bool,
-  pub deny_reason: Option<String>,
-  pub auth: Sensitive<String>,
+    pub id: i32,
+    pub approve: bool,
+    pub deny_reason: Option<String>,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -432,7 +408,7 @@ pub struct ApproveRegistrationApplication {
 #[cfg_attr(feature = "full", ts(export))]
 /// The response of an action done to a registration application.
 pub struct RegistrationApplicationResponse {
-  pub registration_application: RegistrationApplicationView,
+    pub registration_application: RegistrationApplicationView,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -440,7 +416,7 @@ pub struct RegistrationApplicationResponse {
 #[cfg_attr(feature = "full", ts(export))]
 /// Gets a count of unread registration applications.
 pub struct GetUnreadRegistrationApplicationCount {
-  pub auth: Sensitive<String>,
+    pub auth: Sensitive<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -448,5 +424,5 @@ pub struct GetUnreadRegistrationApplicationCount {
 #[cfg_attr(feature = "full", ts(export))]
 /// The count of unread registration applications.
 pub struct GetUnreadRegistrationApplicationCountResponse {
-  pub registration_applications: i64,
+    pub registration_applications: i64,
 }

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -1,45 +1,41 @@
 use crate::{
-  context::LemmyContext,
-  request::purge_image_from_pictrs,
-  sensitive::Sensitive,
-  site::FederatedInstances,
+    context::LemmyContext, request::purge_image_from_pictrs, sensitive::Sensitive,
+    site::FederatedInstances,
 };
 use anyhow::Context;
 use chrono::{DateTime, Utc};
 use lemmy_db_schema::{
-  impls::person::is_banned,
-  newtypes::{CommunityId, DbUrl, LocalUserId, PersonId, PostId},
-  source::{
-    comment::{Comment, CommentUpdateForm},
-    community::{Community, CommunityModerator, CommunityUpdateForm},
-    email_verification::{EmailVerification, EmailVerificationForm},
-    instance::Instance,
-    local_site::LocalSite,
-    local_site_rate_limit::LocalSiteRateLimit,
-    password_reset_request::PasswordResetRequest,
-    person::{Person, PersonUpdateForm},
-    person_block::PersonBlock,
-    post::{Post, PostRead, PostReadForm},
-    registration_application::RegistrationApplication,
-  },
-  traits::{Crud, Readable},
-  utils::DbPool,
-  RegistrationMode,
+    impls::person::is_banned,
+    newtypes::{CommunityId, DbUrl, LocalUserId, PersonId, PostId},
+    source::{
+        comment::{Comment, CommentUpdateForm},
+        community::{Community, CommunityModerator, CommunityUpdateForm},
+        email_verification::{EmailVerification, EmailVerificationForm},
+        instance::Instance,
+        local_site::LocalSite,
+        local_site_rate_limit::LocalSiteRateLimit,
+        password_reset_request::PasswordResetRequest,
+        person::{Person, PersonUpdateForm},
+        person_block::PersonBlock,
+        post::{Post, PostRead, PostReadForm},
+        registration_application::RegistrationApplication,
+    },
+    traits::{Crud, Readable},
+    utils::DbPool,
+    RegistrationMode,
 };
 use lemmy_db_views::{comment_view::CommentQuery, structs::LocalUserView};
 use lemmy_db_views_actor::structs::{
-  CommunityModeratorView,
-  CommunityPersonBanView,
-  CommunityView,
+    CommunityModeratorView, CommunityPersonBanView, CommunityView,
 };
 use lemmy_utils::{
-  claims::Claims,
-  email::{send_email, translations::Lang},
-  error::{LemmyError, LemmyErrorExt, LemmyErrorExt2, LemmyErrorType},
-  location_info,
-  rate_limit::RateLimitConfig,
-  settings::structs::Settings,
-  utils::slurs::build_slur_regex,
+    claims::Claims,
+    email::{send_email, translations::Lang},
+    error::{LemmyError, LemmyErrorExt, LemmyErrorExt2, LemmyErrorType},
+    location_info,
+    rate_limit::RateLimitConfig,
+    settings::structs::Settings,
+    utils::slurs::build_slur_regex,
 };
 use regex::Regex;
 use rosetta_i18n::{Language, LanguageId};
@@ -48,781 +44,784 @@ use url::{ParseError, Url};
 
 #[tracing::instrument(skip_all)]
 pub async fn is_mod_or_admin(
-  pool: &mut DbPool<'_>,
-  person_id: PersonId,
-  community_id: CommunityId,
+    pool: &mut DbPool<'_>,
+    person_id: PersonId,
+    community_id: CommunityId,
 ) -> Result<(), LemmyError> {
-  let is_mod_or_admin = CommunityView::is_mod_or_admin(pool, person_id, community_id).await?;
-  if !is_mod_or_admin {
-    Err(LemmyErrorType::NotAModOrAdmin)?
-  } else {
-    Ok(())
-  }
+    let is_mod_or_admin = CommunityView::is_mod_or_admin(pool, person_id, community_id).await?;
+    if !is_mod_or_admin {
+        Err(LemmyErrorType::NotAModOrAdmin)?
+    } else {
+        Ok(())
+    }
 }
 
 #[tracing::instrument(skip_all)]
 pub async fn is_mod_or_admin_opt(
-  pool: &mut DbPool<'_>,
-  local_user_view: Option<&LocalUserView>,
-  community_id: Option<CommunityId>,
+    pool: &mut DbPool<'_>,
+    local_user_view: Option<&LocalUserView>,
+    community_id: Option<CommunityId>,
 ) -> Result<(), LemmyError> {
-  if let Some(local_user_view) = local_user_view {
-    if let Some(community_id) = community_id {
-      is_mod_or_admin(pool, local_user_view.person.id, community_id).await
+    if let Some(local_user_view) = local_user_view {
+        if let Some(community_id) = community_id {
+            is_mod_or_admin(pool, local_user_view.person.id, community_id).await
+        } else {
+            is_admin(local_user_view)
+        }
     } else {
-      is_admin(local_user_view)
+        Err(LemmyErrorType::NotAModOrAdmin)?
     }
-  } else {
-    Err(LemmyErrorType::NotAModOrAdmin)?
-  }
 }
 
 pub fn is_admin(local_user_view: &LocalUserView) -> Result<(), LemmyError> {
-  if !local_user_view.local_user.admin {
-    Err(LemmyErrorType::NotAnAdmin)?
-  } else {
-    Ok(())
-  }
+    if !local_user_view.local_user.admin {
+        Err(LemmyErrorType::NotAnAdmin)?
+    } else {
+        Ok(())
+    }
 }
 
 pub fn is_top_mod(
-  local_user_view: &LocalUserView,
-  community_mods: &[CommunityModeratorView],
+    local_user_view: &LocalUserView,
+    community_mods: &[CommunityModeratorView],
 ) -> Result<(), LemmyError> {
-  if local_user_view.person.id
-    != community_mods
-      .first()
-      .map(|cm| cm.moderator.id)
-      .unwrap_or(PersonId(0))
-  {
-    Err(LemmyErrorType::NotTopMod)?
-  } else {
-    Ok(())
-  }
+    if local_user_view.person.id
+        != community_mods
+            .first()
+            .map(|cm| cm.moderator.id)
+            .unwrap_or(PersonId(0))
+    {
+        Err(LemmyErrorType::NotTopMod)?
+    } else {
+        Ok(())
+    }
 }
 
 #[tracing::instrument(skip_all)]
 pub async fn get_post(post_id: PostId, pool: &mut DbPool<'_>) -> Result<Post, LemmyError> {
-  Post::read(pool, post_id)
-    .await
-    .with_lemmy_type(LemmyErrorType::CouldntFindPost)
+    Post::read(pool, post_id)
+        .await
+        .with_lemmy_type(LemmyErrorType::CouldntFindPost)
 }
 
 #[tracing::instrument(skip_all)]
 pub async fn mark_post_as_read(
-  person_id: PersonId,
-  post_id: PostId,
-  pool: &mut DbPool<'_>,
+    person_id: PersonId,
+    post_id: PostId,
+    pool: &mut DbPool<'_>,
 ) -> Result<PostRead, LemmyError> {
-  let post_read_form = PostReadForm { post_id, person_id };
+    let post_read_form = PostReadForm { post_id, person_id };
 
-  PostRead::mark_as_read(pool, &post_read_form)
-    .await
-    .with_lemmy_type(LemmyErrorType::CouldntMarkPostAsRead)
+    PostRead::mark_as_read(pool, &post_read_form)
+        .await
+        .with_lemmy_type(LemmyErrorType::CouldntMarkPostAsRead)
 }
 
 #[tracing::instrument(skip_all)]
 pub async fn mark_post_as_unread(
-  person_id: PersonId,
-  post_id: PostId,
-  pool: &mut DbPool<'_>,
+    person_id: PersonId,
+    post_id: PostId,
+    pool: &mut DbPool<'_>,
 ) -> Result<usize, LemmyError> {
-  let post_read_form = PostReadForm { post_id, person_id };
+    let post_read_form = PostReadForm { post_id, person_id };
 
-  PostRead::mark_as_unread(pool, &post_read_form)
-    .await
-    .with_lemmy_type(LemmyErrorType::CouldntMarkPostAsRead)
+    PostRead::mark_as_unread(pool, &post_read_form)
+        .await
+        .with_lemmy_type(LemmyErrorType::CouldntMarkPostAsRead)
 }
 
 #[tracing::instrument(skip_all)]
 pub async fn local_user_view_from_jwt(
-  jwt: &str,
-  context: &LemmyContext,
+    jwt: &str,
+    context: &LemmyContext,
 ) -> Result<LocalUserView, LemmyError> {
-  let claims = Claims::decode(jwt, &context.secret().jwt_secret)
-    .with_lemmy_type(LemmyErrorType::NotLoggedIn)?
-    .claims;
-  let local_user_id = LocalUserId(claims.sub);
-  let local_user_view = LocalUserView::read(&mut context.pool(), local_user_id).await?;
-  check_user_valid(
-    local_user_view.person.banned,
-    local_user_view.person.ban_expires,
-    local_user_view.person.deleted,
-  )?;
+    let claims = Claims::decode(jwt, &context.secret().jwt_secret)
+        .with_lemmy_type(LemmyErrorType::NotLoggedIn)?
+        .claims;
+    let local_user_id = LocalUserId(claims.sub);
+    let local_user_view = LocalUserView::read(&mut context.pool(), local_user_id).await?;
+    check_user_valid(
+        local_user_view.person.banned,
+        local_user_view.person.ban_expires,
+        local_user_view.person.deleted,
+    )?;
 
-  check_validator_time(&local_user_view.local_user.validator_time, &claims)?;
+    check_validator_time(&local_user_view.local_user.validator_time, &claims)?;
 
-  Ok(local_user_view)
+    Ok(local_user_view)
 }
 
 #[tracing::instrument(skip_all)]
 pub async fn local_user_view_from_jwt_opt(
-  jwt: Option<&Sensitive<String>>,
-  context: &LemmyContext,
+    jwt: Option<&Sensitive<String>>,
+    context: &LemmyContext,
 ) -> Option<LocalUserView> {
-  local_user_view_from_jwt(jwt?, context).await.ok()
+    local_user_view_from_jwt(jwt?, context).await.ok()
 }
 #[tracing::instrument(skip_all)]
 pub async fn local_user_view_from_jwt_opt_new(
-  local_user_view: &mut Option<LocalUserView>,
-  jwt: Option<&Sensitive<String>>,
-  context: &LemmyContext,
+    local_user_view: &mut Option<LocalUserView>,
+    jwt: Option<&Sensitive<String>>,
+    context: &LemmyContext,
 ) {
-  if local_user_view.is_none() {
-    *local_user_view = local_user_view_from_jwt_opt(jwt, context).await;
-  }
+    if local_user_view.is_none() {
+        *local_user_view = local_user_view_from_jwt_opt(jwt, context).await;
+    }
 }
 
 /// Checks if user's token was issued before user's password reset.
 pub fn check_validator_time(
-  validator_time: &DateTime<Utc>,
-  claims: &Claims,
+    validator_time: &DateTime<Utc>,
+    claims: &Claims,
 ) -> Result<(), LemmyError> {
-  let user_validation_time = validator_time.timestamp();
-  if user_validation_time > claims.iat {
-    Err(LemmyErrorType::NotLoggedIn)?
-  } else {
-    Ok(())
-  }
+    let user_validation_time = validator_time.timestamp();
+    if user_validation_time > claims.iat {
+        Err(LemmyErrorType::NotLoggedIn)?
+    } else {
+        Ok(())
+    }
 }
 
 pub fn check_user_valid(
-  banned: bool,
-  ban_expires: Option<DateTime<Utc>>,
-  deleted: bool,
+    banned: bool,
+    ban_expires: Option<DateTime<Utc>>,
+    deleted: bool,
 ) -> Result<(), LemmyError> {
-  // Check for a site ban
-  if is_banned(banned, ban_expires) {
-    Err(LemmyErrorType::SiteBan)?
-  }
-  // check for account deletion
-  else if deleted {
-    Err(LemmyErrorType::Deleted)?
-  } else {
-    Ok(())
-  }
+    // Check for a site ban
+    if is_banned(banned, ban_expires) {
+        Err(LemmyErrorType::SiteBan)?
+    }
+    // check for account deletion
+    else if deleted {
+        Err(LemmyErrorType::Deleted)?
+    } else {
+        Ok(())
+    }
 }
 
 #[tracing::instrument(skip_all)]
 pub async fn check_community_ban(
-  person_id: PersonId,
-  community_id: CommunityId,
-  pool: &mut DbPool<'_>,
+    person_id: PersonId,
+    community_id: CommunityId,
+    pool: &mut DbPool<'_>,
 ) -> Result<(), LemmyError> {
-  let is_banned = CommunityPersonBanView::get(pool, person_id, community_id)
-    .await
-    .is_ok();
-  if is_banned {
-    Err(LemmyErrorType::BannedFromCommunity)?
-  } else {
-    Ok(())
-  }
+    let is_banned = CommunityPersonBanView::get(pool, person_id, community_id)
+        .await
+        .is_ok();
+    if is_banned {
+        Err(LemmyErrorType::BannedFromCommunity)?
+    } else {
+        Ok(())
+    }
 }
 
 #[tracing::instrument(skip_all)]
 pub async fn check_community_deleted_or_removed(
-  community_id: CommunityId,
-  pool: &mut DbPool<'_>,
+    community_id: CommunityId,
+    pool: &mut DbPool<'_>,
 ) -> Result<(), LemmyError> {
-  let community = Community::read(pool, community_id)
-    .await
-    .with_lemmy_type(LemmyErrorType::CouldntFindCommunity)?;
-  if community.deleted || community.removed {
-    Err(LemmyErrorType::Deleted)?
-  } else {
-    Ok(())
-  }
+    let community = Community::read(pool, community_id)
+        .await
+        .with_lemmy_type(LemmyErrorType::CouldntFindCommunity)?;
+    if community.deleted || community.removed {
+        Err(LemmyErrorType::Deleted)?
+    } else {
+        Ok(())
+    }
 }
 
 pub fn check_post_deleted_or_removed(post: &Post) -> Result<(), LemmyError> {
-  if post.deleted || post.removed {
-    Err(LemmyErrorType::Deleted)?
-  } else {
-    Ok(())
-  }
+    if post.deleted || post.removed {
+        Err(LemmyErrorType::Deleted)?
+    } else {
+        Ok(())
+    }
 }
 
 #[tracing::instrument(skip_all)]
 pub async fn check_person_block(
-  my_id: PersonId,
-  potential_blocker_id: PersonId,
-  pool: &mut DbPool<'_>,
+    my_id: PersonId,
+    potential_blocker_id: PersonId,
+    pool: &mut DbPool<'_>,
 ) -> Result<(), LemmyError> {
-  let is_blocked = PersonBlock::read(pool, potential_blocker_id, my_id)
-    .await
-    .is_ok();
-  if is_blocked {
-    Err(LemmyErrorType::PersonIsBlocked)?
-  } else {
-    Ok(())
-  }
+    let is_blocked = PersonBlock::read(pool, potential_blocker_id, my_id)
+        .await
+        .is_ok();
+    if is_blocked {
+        Err(LemmyErrorType::PersonIsBlocked)?
+    } else {
+        Ok(())
+    }
 }
 
 #[tracing::instrument(skip_all)]
 pub fn check_downvotes_enabled(score: i16, local_site: &LocalSite) -> Result<(), LemmyError> {
-  if score == -1 && !local_site.enable_downvotes {
-    Err(LemmyErrorType::DownvotesAreDisabled)?
-  } else {
-    Ok(())
-  }
+    if score == -1 && !local_site.enable_downvotes {
+        Err(LemmyErrorType::DownvotesAreDisabled)?
+    } else {
+        Ok(())
+    }
 }
 
 #[tracing::instrument(skip_all)]
 pub fn check_private_instance(
-  local_user_view: &Option<LocalUserView>,
-  local_site: &LocalSite,
+    local_user_view: &Option<LocalUserView>,
+    local_site: &LocalSite,
 ) -> Result<(), LemmyError> {
-  if local_user_view.is_none() && local_site.private_instance {
-    Err(LemmyErrorType::InstanceIsPrivate)?
-  } else {
-    Ok(())
-  }
+    if local_user_view.is_none() && local_site.private_instance {
+        Err(LemmyErrorType::InstanceIsPrivate)?
+    } else {
+        Ok(())
+    }
 }
 
 #[tracing::instrument(skip_all)]
 pub async fn build_federated_instances(
-  local_site: &LocalSite,
-  pool: &mut DbPool<'_>,
+    local_site: &LocalSite,
+    pool: &mut DbPool<'_>,
 ) -> Result<Option<FederatedInstances>, LemmyError> {
-  if local_site.federation_enabled {
-    // TODO I hate that this requires 3 queries
-    let (linked, allowed, blocked) = lemmy_db_schema::try_join_with_pool!(pool => (
-      Instance::linked,
-      Instance::allowlist,
-      Instance::blocklist
-    ))?;
+    if local_site.federation_enabled {
+        // TODO I hate that this requires 3 queries
+        let (linked, allowed, blocked) = lemmy_db_schema::try_join_with_pool!(pool => (
+          Instance::linked,
+          Instance::allowlist,
+          Instance::blocklist
+        ))?;
 
-    Ok(Some(FederatedInstances {
-      linked,
-      allowed,
-      blocked,
-    }))
-  } else {
-    Ok(None)
-  }
+        Ok(Some(FederatedInstances {
+            linked,
+            allowed,
+            blocked,
+        }))
+    } else {
+        Ok(None)
+    }
 }
 
 /// Checks the password length
 pub fn password_length_check(pass: &str) -> Result<(), LemmyError> {
-  if !(10..=60).contains(&pass.chars().count()) {
-    Err(LemmyErrorType::InvalidPassword)?
-  } else {
-    Ok(())
-  }
+    if !(10..=60).contains(&pass.chars().count()) {
+        Err(LemmyErrorType::InvalidPassword)?
+    } else {
+        Ok(())
+    }
 }
 
 /// Checks for a honeypot. If this field is filled, fail the rest of the function
 pub fn honeypot_check(honeypot: &Option<String>) -> Result<(), LemmyError> {
-  if honeypot.is_some() && honeypot != &Some(String::new()) {
-    Err(LemmyErrorType::HoneypotFailed)?
-  } else {
-    Ok(())
-  }
+    if honeypot.is_some() && honeypot != &Some(String::new()) {
+        Err(LemmyErrorType::HoneypotFailed)?
+    } else {
+        Ok(())
+    }
 }
 
 pub async fn send_email_to_user(
-  local_user_view: &LocalUserView,
-  subject: &str,
-  body: &str,
-  settings: &Settings,
+    local_user_view: &LocalUserView,
+    subject: &str,
+    body: &str,
+    settings: &Settings,
 ) {
-  if local_user_view.person.banned || !local_user_view.local_user.send_notifications_to_email {
-    return;
-  }
+    if local_user_view.person.banned || !local_user_view.local_user.send_notifications_to_email {
+        return;
+    }
 
-  if let Some(user_email) = &local_user_view.local_user.email {
-    match send_email(
-      subject,
-      user_email,
-      &local_user_view.person.name,
-      body,
-      settings,
-    )
-    .await
-    {
-      Ok(_o) => _o,
-      Err(e) => warn!("{}", e),
-    };
-  }
+    if let Some(user_email) = &local_user_view.local_user.email {
+        match send_email(
+            subject,
+            user_email,
+            &local_user_view.person.name,
+            body,
+            settings,
+        )
+        .await
+        {
+            Ok(_o) => _o,
+            Err(e) => warn!("{}", e),
+        };
+    }
 }
 
 pub async fn send_password_reset_email(
-  user: &LocalUserView,
-  pool: &mut DbPool<'_>,
-  settings: &Settings,
+    user: &LocalUserView,
+    pool: &mut DbPool<'_>,
+    settings: &Settings,
 ) -> Result<(), LemmyError> {
-  // Generate a random token
-  let token = uuid::Uuid::new_v4().to_string();
+    // Generate a random token
+    let token = uuid::Uuid::new_v4().to_string();
 
-  // Insert the row
-  let local_user_id = user.local_user.id;
-  PasswordResetRequest::create_token(pool, local_user_id, token.clone()).await?;
+    // Insert the row
+    let local_user_id = user.local_user.id;
+    PasswordResetRequest::create_token(pool, local_user_id, token.clone()).await?;
 
-  let email = &user.local_user.email.clone().expect("email");
-  let lang = get_interface_language(user);
-  let subject = &lang.password_reset_subject(&user.person.name);
-  let protocol_and_hostname = settings.get_protocol_and_hostname();
-  let reset_link = format!("{}/password_change/{}", protocol_and_hostname, &token);
-  let body = &lang.password_reset_body(reset_link, &user.person.name);
-  send_email(subject, email, &user.person.name, body, settings).await
+    let email = &user.local_user.email.clone().expect("email");
+    let lang = get_interface_language(user);
+    let subject = &lang.password_reset_subject(&user.person.name);
+    let protocol_and_hostname = settings.get_protocol_and_hostname();
+    let reset_link = format!("{}/password_change/{}", protocol_and_hostname, &token);
+    let body = &lang.password_reset_body(reset_link, &user.person.name);
+    send_email(subject, email, &user.person.name, body, settings).await
 }
 
 /// Send a verification email
 pub async fn send_verification_email(
-  user: &LocalUserView,
-  new_email: &str,
-  pool: &mut DbPool<'_>,
-  settings: &Settings,
+    user: &LocalUserView,
+    new_email: &str,
+    pool: &mut DbPool<'_>,
+    settings: &Settings,
 ) -> Result<(), LemmyError> {
-  let form = EmailVerificationForm {
-    local_user_id: user.local_user.id,
-    email: new_email.to_string(),
-    verification_token: uuid::Uuid::new_v4().to_string(),
-  };
-  let verify_link = format!(
-    "{}/verify_email/{}",
-    settings.get_protocol_and_hostname(),
-    &form.verification_token
-  );
-  EmailVerification::create(pool, &form).await?;
+    let form = EmailVerificationForm {
+        local_user_id: user.local_user.id,
+        email: new_email.to_string(),
+        verification_token: uuid::Uuid::new_v4().to_string(),
+    };
+    let verify_link = format!(
+        "{}/verify_email/{}",
+        settings.get_protocol_and_hostname(),
+        &form.verification_token
+    );
+    EmailVerification::create(pool, &form).await?;
 
-  let lang = get_interface_language(user);
-  let subject = lang.verify_email_subject(&settings.hostname);
-  let body = lang.verify_email_body(&settings.hostname, &user.person.name, verify_link);
-  send_email(&subject, new_email, &user.person.name, &body, settings).await?;
+    let lang = get_interface_language(user);
+    let subject = lang.verify_email_subject(&settings.hostname);
+    let body = lang.verify_email_body(&settings.hostname, &user.person.name, verify_link);
+    send_email(&subject, new_email, &user.person.name, &body, settings).await?;
 
-  Ok(())
+    Ok(())
 }
 
 pub fn get_interface_language(user: &LocalUserView) -> Lang {
-  lang_str_to_lang(&user.local_user.interface_language)
+    lang_str_to_lang(&user.local_user.interface_language)
 }
 
 pub fn get_interface_language_from_settings(user: &LocalUserView) -> Lang {
-  lang_str_to_lang(&user.local_user.interface_language)
+    lang_str_to_lang(&user.local_user.interface_language)
 }
 
 fn lang_str_to_lang(lang: &str) -> Lang {
-  let lang_id = LanguageId::new(lang);
-  Lang::from_language_id(&lang_id).unwrap_or_else(|| {
-    let en = LanguageId::new("en");
-    Lang::from_language_id(&en).expect("default language")
-  })
+    let lang_id = LanguageId::new(lang);
+    Lang::from_language_id(&lang_id).unwrap_or_else(|| {
+        let en = LanguageId::new("en");
+        Lang::from_language_id(&en).expect("default language")
+    })
 }
 
 pub fn local_site_rate_limit_to_rate_limit_config(
-  local_site_rate_limit: &LocalSiteRateLimit,
+    local_site_rate_limit: &LocalSiteRateLimit,
 ) -> RateLimitConfig {
-  let l = local_site_rate_limit;
-  RateLimitConfig {
-    message: l.message,
-    message_per_second: l.message_per_second,
-    post: l.post,
-    post_per_second: l.post_per_second,
-    register: l.register,
-    register_per_second: l.register_per_second,
-    image: l.image,
-    image_per_second: l.image_per_second,
-    comment: l.comment,
-    comment_per_second: l.comment_per_second,
-    search: l.search,
-    search_per_second: l.search_per_second,
-  }
+    let l = local_site_rate_limit;
+    RateLimitConfig {
+        message: l.message,
+        message_per_second: l.message_per_second,
+        post: l.post,
+        post_per_second: l.post_per_second,
+        register: l.register,
+        register_per_second: l.register_per_second,
+        image: l.image,
+        image_per_second: l.image_per_second,
+        comment: l.comment,
+        comment_per_second: l.comment_per_second,
+        search: l.search,
+        search_per_second: l.search_per_second,
+    }
 }
 
 pub fn local_site_to_slur_regex(local_site: &LocalSite) -> Option<Regex> {
-  build_slur_regex(local_site.slur_filter_regex.as_deref())
+    build_slur_regex(local_site.slur_filter_regex.as_deref())
 }
 
 pub fn local_site_opt_to_slur_regex(local_site: &Option<LocalSite>) -> Option<Regex> {
-  local_site
-    .as_ref()
-    .map(local_site_to_slur_regex)
-    .unwrap_or(None)
+    local_site
+        .as_ref()
+        .map(local_site_to_slur_regex)
+        .unwrap_or(None)
 }
 
 pub fn local_site_opt_to_sensitive(local_site: &Option<LocalSite>) -> bool {
-  local_site
-    .as_ref()
-    .map(|site| site.enable_nsfw)
-    .unwrap_or(false)
+    local_site
+        .as_ref()
+        .map(|site| site.enable_nsfw)
+        .unwrap_or(false)
 }
 
 pub async fn send_application_approved_email(
-  user: &LocalUserView,
-  settings: &Settings,
+    user: &LocalUserView,
+    settings: &Settings,
 ) -> Result<(), LemmyError> {
-  let email = &user.local_user.email.clone().expect("email");
-  let lang = get_interface_language(user);
-  let subject = lang.registration_approved_subject(&user.person.actor_id);
-  let body = lang.registration_approved_body(&settings.hostname);
-  send_email(&subject, email, &user.person.name, &body, settings).await
+    let email = &user.local_user.email.clone().expect("email");
+    let lang = get_interface_language(user);
+    let subject = lang.registration_approved_subject(&user.person.actor_id);
+    let body = lang.registration_approved_body(&settings.hostname);
+    send_email(&subject, email, &user.person.name, &body, settings).await
 }
 
 /// Send a new applicant email notification to all admins
 pub async fn send_new_applicant_email_to_admins(
-  applicant_username: &str,
-  pool: &mut DbPool<'_>,
-  settings: &Settings,
+    applicant_username: &str,
+    pool: &mut DbPool<'_>,
+    settings: &Settings,
 ) -> Result<(), LemmyError> {
-  // Collect the admins with emails
-  let admins = LocalUserView::list_admins_with_emails(pool).await?;
+    // Collect the admins with emails
+    let admins = LocalUserView::list_admins_with_emails(pool).await?;
 
-  let applications_link = &format!(
-    "{}/registration_applications",
-    settings.get_protocol_and_hostname(),
-  );
+    let applications_link = &format!(
+        "{}/registration_applications",
+        settings.get_protocol_and_hostname(),
+    );
 
-  for admin in &admins {
-    let email = &admin.local_user.email.clone().expect("email");
-    let lang = get_interface_language_from_settings(admin);
-    let subject = lang.new_application_subject(&settings.hostname, applicant_username);
-    let body = lang.new_application_body(applications_link);
-    send_email(&subject, email, &admin.person.name, &body, settings).await?;
-  }
-  Ok(())
+    for admin in &admins {
+        let email = &admin.local_user.email.clone().expect("email");
+        let lang = get_interface_language_from_settings(admin);
+        let subject = lang.new_application_subject(&settings.hostname, applicant_username);
+        let body = lang.new_application_body(applications_link);
+        send_email(&subject, email, &admin.person.name, &body, settings).await?;
+    }
+    Ok(())
 }
 
 /// Send a report to all admins
 pub async fn send_new_report_email_to_admins(
-  reporter_username: &str,
-  reported_username: &str,
-  pool: &mut DbPool<'_>,
-  settings: &Settings,
+    reporter_username: &str,
+    reported_username: &str,
+    pool: &mut DbPool<'_>,
+    settings: &Settings,
 ) -> Result<(), LemmyError> {
-  // Collect the admins with emails
-  let admins = LocalUserView::list_admins_with_emails(pool).await?;
+    // Collect the admins with emails
+    let admins = LocalUserView::list_admins_with_emails(pool).await?;
 
-  let reports_link = &format!("{}/reports", settings.get_protocol_and_hostname(),);
+    let reports_link = &format!("{}/reports", settings.get_protocol_and_hostname(),);
 
-  for admin in &admins {
-    let email = &admin.local_user.email.clone().expect("email");
-    let lang = get_interface_language_from_settings(admin);
-    let subject = lang.new_report_subject(&settings.hostname, reported_username, reporter_username);
-    let body = lang.new_report_body(reports_link);
-    send_email(&subject, email, &admin.person.name, &body, settings).await?;
-  }
-  Ok(())
+    for admin in &admins {
+        let email = &admin.local_user.email.clone().expect("email");
+        let lang = get_interface_language_from_settings(admin);
+        let subject =
+            lang.new_report_subject(&settings.hostname, reported_username, reporter_username);
+        let body = lang.new_report_body(reports_link);
+        send_email(&subject, email, &admin.person.name, &body, settings).await?;
+    }
+    Ok(())
 }
 
 pub async fn check_registration_application(
-  local_user_view: &LocalUserView,
-  local_site: &LocalSite,
-  pool: &mut DbPool<'_>,
+    local_user_view: &LocalUserView,
+    local_site: &LocalSite,
+    pool: &mut DbPool<'_>,
 ) -> Result<(), LemmyError> {
-  if (local_site.registration_mode == RegistrationMode::RequireApplication
-    || local_site.registration_mode == RegistrationMode::Closed)
-    && !local_user_view.local_user.accepted_application
-    && !local_user_view.local_user.admin
-  {
-    // Fetch the registration, see if its denied
-    let local_user_id = local_user_view.local_user.id;
-    let registration = RegistrationApplication::find_by_local_user_id(pool, local_user_id).await?;
-    if let Some(deny_reason) = registration.deny_reason {
-      let lang = get_interface_language(local_user_view);
-      let registration_denied_message = format!("{}: {}", lang.registration_denied(), deny_reason);
-      Err(LemmyErrorType::RegistrationDenied(
-        registration_denied_message,
-      ))?
-    } else {
-      Err(LemmyErrorType::RegistrationApplicationIsPending)?
+    if (local_site.registration_mode == RegistrationMode::RequireApplication
+        || local_site.registration_mode == RegistrationMode::Closed)
+        && !local_user_view.local_user.accepted_application
+        && !local_user_view.local_user.admin
+    {
+        // Fetch the registration, see if its denied
+        let local_user_id = local_user_view.local_user.id;
+        let registration =
+            RegistrationApplication::find_by_local_user_id(pool, local_user_id).await?;
+        if let Some(deny_reason) = registration.deny_reason {
+            let lang = get_interface_language(local_user_view);
+            let registration_denied_message =
+                format!("{}: {}", lang.registration_denied(), deny_reason);
+            Err(LemmyErrorType::RegistrationDenied(
+                registration_denied_message,
+            ))?
+        } else {
+            Err(LemmyErrorType::RegistrationApplicationIsPending)?
+        }
     }
-  }
-  Ok(())
+    Ok(())
 }
 
 pub fn check_private_instance_and_federation_enabled(
-  local_site: &LocalSite,
+    local_site: &LocalSite,
 ) -> Result<(), LemmyError> {
-  if local_site.private_instance && local_site.federation_enabled {
-    Err(LemmyErrorType::CantEnablePrivateInstanceAndFederationTogether)?
-  } else {
-    Ok(())
-  }
+    if local_site.private_instance && local_site.federation_enabled {
+        Err(LemmyErrorType::CantEnablePrivateInstanceAndFederationTogether)?
+    } else {
+        Ok(())
+    }
 }
 
 pub async fn purge_image_posts_for_person(
-  banned_person_id: PersonId,
-  context: &LemmyContext,
+    banned_person_id: PersonId,
+    context: &LemmyContext,
 ) -> Result<(), LemmyError> {
-  let pool = &mut context.pool();
-  let posts = Post::fetch_pictrs_posts_for_creator(pool, banned_person_id).await?;
-  for post in posts {
-    if let Some(url) = post.url {
-      purge_image_from_pictrs(&url, context).await.ok();
+    let pool = &mut context.pool();
+    let posts = Post::fetch_pictrs_posts_for_creator(pool, banned_person_id).await?;
+    for post in posts {
+        if let Some(url) = post.url {
+            purge_image_from_pictrs(&url, context).await.ok();
+        }
+        if let Some(thumbnail_url) = post.thumbnail_url {
+            purge_image_from_pictrs(&thumbnail_url, context).await.ok();
+        }
     }
-    if let Some(thumbnail_url) = post.thumbnail_url {
-      purge_image_from_pictrs(&thumbnail_url, context).await.ok();
-    }
-  }
 
-  Post::remove_pictrs_post_images_and_thumbnails_for_creator(pool, banned_person_id).await?;
+    Post::remove_pictrs_post_images_and_thumbnails_for_creator(pool, banned_person_id).await?;
 
-  Ok(())
+    Ok(())
 }
 
 pub async fn purge_image_posts_for_community(
-  banned_community_id: CommunityId,
-  context: &LemmyContext,
+    banned_community_id: CommunityId,
+    context: &LemmyContext,
 ) -> Result<(), LemmyError> {
-  let pool = &mut context.pool();
-  let posts = Post::fetch_pictrs_posts_for_community(pool, banned_community_id).await?;
-  for post in posts {
-    if let Some(url) = post.url {
-      purge_image_from_pictrs(&url, context).await.ok();
+    let pool = &mut context.pool();
+    let posts = Post::fetch_pictrs_posts_for_community(pool, banned_community_id).await?;
+    for post in posts {
+        if let Some(url) = post.url {
+            purge_image_from_pictrs(&url, context).await.ok();
+        }
+        if let Some(thumbnail_url) = post.thumbnail_url {
+            purge_image_from_pictrs(&thumbnail_url, context).await.ok();
+        }
     }
-    if let Some(thumbnail_url) = post.thumbnail_url {
-      purge_image_from_pictrs(&thumbnail_url, context).await.ok();
-    }
-  }
 
-  Post::remove_pictrs_post_images_and_thumbnails_for_community(pool, banned_community_id).await?;
+    Post::remove_pictrs_post_images_and_thumbnails_for_community(pool, banned_community_id).await?;
 
-  Ok(())
+    Ok(())
 }
 
 pub async fn remove_user_data(
-  banned_person_id: PersonId,
-  context: &LemmyContext,
+    banned_person_id: PersonId,
+    context: &LemmyContext,
 ) -> Result<(), LemmyError> {
-  let pool = &mut context.pool();
-  // Purge user images
-  let person = Person::read(pool, banned_person_id).await?;
-  if let Some(avatar) = person.avatar {
-    purge_image_from_pictrs(&avatar, context).await.ok();
-  }
-  if let Some(banner) = person.banner {
-    purge_image_from_pictrs(&banner, context).await.ok();
-  }
-
-  // Update the fields to None
-  Person::update(
-    pool,
-    banned_person_id,
-    &PersonUpdateForm {
-      avatar: Some(None),
-      banner: Some(None),
-      ..Default::default()
-    },
-  )
-  .await?;
-
-  // Posts
-  Post::update_removed_for_creator(pool, banned_person_id, None, true).await?;
-
-  // Purge image posts
-  purge_image_posts_for_person(banned_person_id, context).await?;
-
-  // Communities
-  // Remove all communities where they're the top mod
-  // for now, remove the communities manually
-  let first_mod_communities = CommunityModeratorView::get_community_first_mods(pool).await?;
-
-  // Filter to only this banned users top communities
-  let banned_user_first_communities: Vec<CommunityModeratorView> = first_mod_communities
-    .into_iter()
-    .filter(|fmc| fmc.moderator.id == banned_person_id)
-    .collect();
-
-  for first_mod_community in banned_user_first_communities {
-    let community_id = first_mod_community.community.id;
-    Community::update(
-      pool,
-      community_id,
-      &CommunityUpdateForm {
-        removed: Some(true),
-        ..Default::default()
-      },
-    )
-    .await?;
-
-    // Delete the community images
-    if let Some(icon) = first_mod_community.community.icon {
-      purge_image_from_pictrs(&icon, context).await.ok();
+    let pool = &mut context.pool();
+    // Purge user images
+    let person = Person::read(pool, banned_person_id).await?;
+    if let Some(avatar) = person.avatar {
+        purge_image_from_pictrs(&avatar, context).await.ok();
     }
-    if let Some(banner) = first_mod_community.community.banner {
-      purge_image_from_pictrs(&banner, context).await.ok();
+    if let Some(banner) = person.banner {
+        purge_image_from_pictrs(&banner, context).await.ok();
     }
+
     // Update the fields to None
-    Community::update(
-      pool,
-      community_id,
-      &CommunityUpdateForm {
-        icon: Some(None),
-        banner: Some(None),
-        ..Default::default()
-      },
+    Person::update(
+        pool,
+        banned_person_id,
+        &PersonUpdateForm {
+            avatar: Some(None),
+            banner: Some(None),
+            ..Default::default()
+        },
     )
     .await?;
-  }
 
-  // Comments
-  Comment::update_removed_for_creator(pool, banned_person_id, true).await?;
+    // Posts
+    Post::update_removed_for_creator(pool, banned_person_id, None, true).await?;
 
-  Ok(())
+    // Purge image posts
+    purge_image_posts_for_person(banned_person_id, context).await?;
+
+    // Communities
+    // Remove all communities where they're the top mod
+    // for now, remove the communities manually
+    let first_mod_communities = CommunityModeratorView::get_community_first_mods(pool).await?;
+
+    // Filter to only this banned users top communities
+    let banned_user_first_communities: Vec<CommunityModeratorView> = first_mod_communities
+        .into_iter()
+        .filter(|fmc| fmc.moderator.id == banned_person_id)
+        .collect();
+
+    for first_mod_community in banned_user_first_communities {
+        let community_id = first_mod_community.community.id;
+        Community::update(
+            pool,
+            community_id,
+            &CommunityUpdateForm {
+                removed: Some(true),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+        // Delete the community images
+        if let Some(icon) = first_mod_community.community.icon {
+            purge_image_from_pictrs(&icon, context).await.ok();
+        }
+        if let Some(banner) = first_mod_community.community.banner {
+            purge_image_from_pictrs(&banner, context).await.ok();
+        }
+        // Update the fields to None
+        Community::update(
+            pool,
+            community_id,
+            &CommunityUpdateForm {
+                icon: Some(None),
+                banner: Some(None),
+                ..Default::default()
+            },
+        )
+        .await?;
+    }
+
+    // Comments
+    Comment::update_removed_for_creator(pool, banned_person_id, true).await?;
+
+    Ok(())
 }
 
 pub async fn remove_user_data_in_community(
-  community_id: CommunityId,
-  banned_person_id: PersonId,
-  pool: &mut DbPool<'_>,
+    community_id: CommunityId,
+    banned_person_id: PersonId,
+    pool: &mut DbPool<'_>,
 ) -> Result<(), LemmyError> {
-  // Posts
-  Post::update_removed_for_creator(pool, banned_person_id, Some(community_id), true).await?;
+    // Posts
+    Post::update_removed_for_creator(pool, banned_person_id, Some(community_id), true).await?;
 
-  // Comments
-  // TODO Diesel doesn't allow updates with joins, so this has to be a loop
-  let comments = CommentQuery {
-    creator_id: Some(banned_person_id),
-    community_id: Some(community_id),
-    ..Default::default()
-  }
-  .list(pool)
-  .await?;
-
-  for comment_view in &comments {
-    let comment_id = comment_view.comment.id;
-    Comment::update(
-      pool,
-      comment_id,
-      &CommentUpdateForm {
-        removed: Some(true),
+    // Comments
+    // TODO Diesel doesn't allow updates with joins, so this has to be a loop
+    let comments = CommentQuery {
+        creator_id: Some(banned_person_id),
+        community_id: Some(community_id),
         ..Default::default()
-      },
-    )
+    }
+    .list(pool)
     .await?;
-  }
 
-  Ok(())
+    for comment_view in &comments {
+        let comment_id = comment_view.comment.id;
+        Comment::update(
+            pool,
+            comment_id,
+            &CommentUpdateForm {
+                removed: Some(true),
+                ..Default::default()
+            },
+        )
+        .await?;
+    }
+
+    Ok(())
 }
 
 pub async fn purge_user_account(
-  person_id: PersonId,
-  context: &LemmyContext,
+    person_id: PersonId,
+    context: &LemmyContext,
 ) -> Result<(), LemmyError> {
-  let pool = &mut context.pool();
-  // Delete their images
-  let person = Person::read(pool, person_id).await?;
-  if let Some(avatar) = person.avatar {
-    purge_image_from_pictrs(&avatar, context).await.ok();
-  }
-  if let Some(banner) = person.banner {
-    purge_image_from_pictrs(&banner, context).await.ok();
-  }
-  // No need to update avatar and banner, those are handled in Person::delete_account
+    let pool = &mut context.pool();
+    // Delete their images
+    let person = Person::read(pool, person_id).await?;
+    if let Some(avatar) = person.avatar {
+        purge_image_from_pictrs(&avatar, context).await.ok();
+    }
+    if let Some(banner) = person.banner {
+        purge_image_from_pictrs(&banner, context).await.ok();
+    }
+    // No need to update avatar and banner, those are handled in Person::delete_account
 
-  // Comments
-  Comment::permadelete_for_creator(pool, person_id)
-    .await
-    .with_lemmy_type(LemmyErrorType::CouldntUpdateComment)?;
+    // Comments
+    Comment::permadelete_for_creator(pool, person_id)
+        .await
+        .with_lemmy_type(LemmyErrorType::CouldntUpdateComment)?;
 
-  // Posts
-  Post::permadelete_for_creator(pool, person_id)
-    .await
-    .with_lemmy_type(LemmyErrorType::CouldntUpdatePost)?;
+    // Posts
+    Post::permadelete_for_creator(pool, person_id)
+        .await
+        .with_lemmy_type(LemmyErrorType::CouldntUpdatePost)?;
 
-  // Purge image posts
-  purge_image_posts_for_person(person_id, context).await?;
+    // Purge image posts
+    purge_image_posts_for_person(person_id, context).await?;
 
-  // Leave communities they mod
-  CommunityModerator::leave_all_communities(pool, person_id).await?;
+    // Leave communities they mod
+    CommunityModerator::leave_all_communities(pool, person_id).await?;
 
-  Person::delete_account(pool, person_id).await?;
+    Person::delete_account(pool, person_id).await?;
 
-  Ok(())
+    Ok(())
 }
 
 pub enum EndpointType {
-  Community,
-  Person,
-  Post,
-  Comment,
-  PrivateMessage,
+    Community,
+    Person,
+    Post,
+    Comment,
+    PrivateMessage,
 }
 
 /// Generates an apub endpoint for a given domain, IE xyz.tld
 pub fn generate_local_apub_endpoint(
-  endpoint_type: EndpointType,
-  name: &str,
-  domain: &str,
+    endpoint_type: EndpointType,
+    name: &str,
+    domain: &str,
 ) -> Result<DbUrl, ParseError> {
-  let point = match endpoint_type {
-    EndpointType::Community => "c",
-    EndpointType::Person => "u",
-    EndpointType::Post => "post",
-    EndpointType::Comment => "comment",
-    EndpointType::PrivateMessage => "private_message",
-  };
+    let point = match endpoint_type {
+        EndpointType::Community => "c",
+        EndpointType::Person => "u",
+        EndpointType::Post => "post",
+        EndpointType::Comment => "comment",
+        EndpointType::PrivateMessage => "private_message",
+    };
 
-  Ok(Url::parse(&format!("{domain}/{point}/{name}"))?.into())
+    Ok(Url::parse(&format!("{domain}/{point}/{name}"))?.into())
 }
 
 pub fn generate_followers_url(actor_id: &DbUrl) -> Result<DbUrl, ParseError> {
-  Ok(Url::parse(&format!("{actor_id}/followers"))?.into())
+    Ok(Url::parse(&format!("{actor_id}/followers"))?.into())
 }
 
 pub fn generate_inbox_url(actor_id: &DbUrl) -> Result<DbUrl, ParseError> {
-  Ok(Url::parse(&format!("{actor_id}/inbox"))?.into())
+    Ok(Url::parse(&format!("{actor_id}/inbox"))?.into())
 }
 
 pub fn generate_site_inbox_url(actor_id: &DbUrl) -> Result<DbUrl, ParseError> {
-  let mut actor_id: Url = actor_id.clone().into();
-  actor_id.set_path("site_inbox");
-  Ok(actor_id.into())
+    let mut actor_id: Url = actor_id.clone().into();
+    actor_id.set_path("site_inbox");
+    Ok(actor_id.into())
 }
 
 pub fn generate_shared_inbox_url(actor_id: &DbUrl) -> Result<DbUrl, LemmyError> {
-  let actor_id: Url = actor_id.clone().into();
-  let url = format!(
-    "{}://{}{}/inbox",
-    &actor_id.scheme(),
-    &actor_id.host_str().context(location_info!())?,
-    if let Some(port) = actor_id.port() {
-      format!(":{port}")
-    } else {
-      String::new()
-    },
-  );
-  Ok(Url::parse(&url)?.into())
+    let actor_id: Url = actor_id.clone().into();
+    let url = format!(
+        "{}://{}{}/inbox",
+        &actor_id.scheme(),
+        &actor_id.host_str().context(location_info!())?,
+        if let Some(port) = actor_id.port() {
+            format!(":{port}")
+        } else {
+            String::new()
+        },
+    );
+    Ok(Url::parse(&url)?.into())
 }
 
 pub fn generate_outbox_url(actor_id: &DbUrl) -> Result<DbUrl, ParseError> {
-  Ok(Url::parse(&format!("{actor_id}/outbox"))?.into())
+    Ok(Url::parse(&format!("{actor_id}/outbox"))?.into())
 }
 
 pub fn generate_featured_url(actor_id: &DbUrl) -> Result<DbUrl, ParseError> {
-  Ok(Url::parse(&format!("{actor_id}/featured"))?.into())
+    Ok(Url::parse(&format!("{actor_id}/featured"))?.into())
 }
 
 pub fn generate_moderators_url(community_id: &DbUrl) -> Result<DbUrl, LemmyError> {
-  Ok(Url::parse(&format!("{community_id}/moderators"))?.into())
+    Ok(Url::parse(&format!("{community_id}/moderators"))?.into())
 }
 
 /// Sanitize HTML with default options. Additionally, dont allow bypassing markdown
 /// links and images
 pub fn sanitize_html(data: &str) -> String {
-  ammonia::Builder::default()
-    .rm_tags(&["a", "img"])
-    .clean(data)
-    .to_string()
-    // restore markdown quotes
-    .replace("&gt;", ">")
-    // restore white space
-    .replace("&nbsp;", " ")
+    ammonia::Builder::default()
+        .rm_tags(&["a", "img"])
+        .clean(data)
+        .to_string()
+        // restore markdown quotes
+        .replace("&gt;", ">")
+        // restore white space
+        .replace("&nbsp;", " ")
 }
 
 pub fn sanitize_html_opt(data: &Option<String>) -> Option<String> {
-  data.as_ref().map(|d| sanitize_html(d))
+    data.as_ref().map(|d| sanitize_html(d))
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::utils::{honeypot_check, password_length_check, sanitize_html};
+    use crate::utils::{honeypot_check, password_length_check, sanitize_html};
 
-  #[test]
+    #[test]
   #[rustfmt::skip]
   fn password_length() {
     assert!(password_length_check("Õ¼¾°3yË,o¸ãtÌÈú|ÇÁÙAøüÒI©·¤(T]/ð>æºWæ[C¤bªWöaÃÎñ·{=û³&§½K/c").is_ok());
@@ -831,21 +830,21 @@ mod tests {
     assert!(password_length_check("looooooooooooooooooooooooooooooooooooooooooooooooooooooooooong").is_err());
   }
 
-  #[test]
-  fn honeypot() {
-    assert!(honeypot_check(&None).is_ok());
-    assert!(honeypot_check(&Some(String::new())).is_ok());
-    assert!(honeypot_check(&Some("1".to_string())).is_err());
-    assert!(honeypot_check(&Some("message".to_string())).is_err());
-  }
+    #[test]
+    fn honeypot() {
+        assert!(honeypot_check(&None).is_ok());
+        assert!(honeypot_check(&Some(String::new())).is_ok());
+        assert!(honeypot_check(&Some("1".to_string())).is_err());
+        assert!(honeypot_check(&Some("message".to_string())).is_err());
+    }
 
-  #[test]
-  fn test_sanitize_html() {
-    let sanitized = sanitize_html("<script>alert(1);</script> hello");
-    assert_eq!(sanitized, " hello");
-    let sanitized = sanitize_html("<img src='http://example.com'> test");
-    assert_eq!(sanitized, " test");
-    let sanitized = sanitize_html("Hello&nbsp;World");
-    assert_eq!(sanitized, "Hello World");
-  }
+    #[test]
+    fn test_sanitize_html() {
+        let sanitized = sanitize_html("<script>alert(1);</script> hello");
+        assert_eq!(sanitized, " hello");
+        let sanitized = sanitize_html("<img src='http://example.com'> test");
+        assert_eq!(sanitized, " test");
+        let sanitized = sanitize_html("Hello&nbsp;World");
+        assert_eq!(sanitized, "Hello World");
+    }
 }

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -822,13 +822,13 @@ mod tests {
     use crate::utils::{honeypot_check, password_length_check, sanitize_html};
 
     #[test]
-  #[rustfmt::skip]
-  fn password_length() {
-    assert!(password_length_check("Õ¼¾°3yË,o¸ãtÌÈú|ÇÁÙAøüÒI©·¤(T]/ð>æºWæ[C¤bªWöaÃÎñ·{=û³&§½K/c").is_ok());
-    assert!(password_length_check("1234567890").is_ok());
-    assert!(password_length_check("short").is_err());
-    assert!(password_length_check("looooooooooooooooooooooooooooooooooooooooooooooooooooooooooong").is_err());
-  }
+    #[rustfmt::skip]
+    fn password_length() {
+        assert!(password_length_check("Õ¼¾°3yË,o¸ãtÌÈú|ÇÁÙAøüÒI©·¤(T]/ð>æºWæ[C¤bªWöaÃÎñ·{=û³&§½K/c").is_ok());
+        assert!(password_length_check("1234567890").is_ok());
+        assert!(password_length_check("short").is_err());
+        assert!(password_length_check("looooooooooooooooooooooooooooooooooooooooooooooooooooooooooong").is_err());
+    }
 
     #[test]
     fn honeypot() {

--- a/crates/api_crud/src/comment/create.rs
+++ b/crates/api_crud/src/comment/create.rs
@@ -1,218 +1,212 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  build_response::{build_comment_response, send_local_notifs},
-  comment::{CommentResponse, CreateComment},
-  context::LemmyContext,
-  send_activity::{ActivityChannel, SendActivityData},
-  utils::{
-    check_community_ban,
-    check_community_deleted_or_removed,
-    check_post_deleted_or_removed,
-    generate_local_apub_endpoint,
-    get_post,
-    local_site_to_slur_regex,
-    local_user_view_from_jwt,
-    sanitize_html,
-    EndpointType,
-  },
+    build_response::{build_comment_response, send_local_notifs},
+    comment::{CommentResponse, CreateComment},
+    context::LemmyContext,
+    send_activity::{ActivityChannel, SendActivityData},
+    utils::{
+        check_community_ban, check_community_deleted_or_removed, check_post_deleted_or_removed,
+        generate_local_apub_endpoint, get_post, local_site_to_slur_regex, local_user_view_from_jwt,
+        sanitize_html, EndpointType,
+    },
 };
 use lemmy_db_schema::{
-  impls::actor_language::default_post_language,
-  source::{
-    actor_language::CommunityLanguage,
-    comment::{Comment, CommentInsertForm, CommentLike, CommentLikeForm, CommentUpdateForm},
-    comment_reply::{CommentReply, CommentReplyUpdateForm},
-    local_site::LocalSite,
-    person_mention::{PersonMention, PersonMentionUpdateForm},
-  },
-  traits::{Crud, Likeable},
+    impls::actor_language::default_post_language,
+    source::{
+        actor_language::CommunityLanguage,
+        comment::{Comment, CommentInsertForm, CommentLike, CommentLikeForm, CommentUpdateForm},
+        comment_reply::{CommentReply, CommentReplyUpdateForm},
+        local_site::LocalSite,
+        person_mention::{PersonMention, PersonMentionUpdateForm},
+    },
+    traits::{Crud, Likeable},
 };
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
-  utils::{
-    mention::scrape_text_for_mentions,
-    slurs::remove_slurs,
-    validation::is_valid_body_field,
-  },
+    error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+    utils::{
+        mention::scrape_text_for_mentions, slurs::remove_slurs, validation::is_valid_body_field,
+    },
 };
 
 const MAX_COMMENT_DEPTH_LIMIT: usize = 100;
 
 #[tracing::instrument(skip(context))]
 pub async fn create_comment(
-  data: Json<CreateComment>,
-  context: Data<LemmyContext>,
+    data: Json<CreateComment>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<CommentResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
-  let local_site = LocalSite::read(&mut context.pool()).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
 
-  let content = remove_slurs(
-    &data.content.clone(),
-    &local_site_to_slur_regex(&local_site),
-  );
-  is_valid_body_field(&Some(content.clone()), false)?;
-  let content = sanitize_html(&content);
+    let content = remove_slurs(
+        &data.content.clone(),
+        &local_site_to_slur_regex(&local_site),
+    );
+    is_valid_body_field(&Some(content.clone()), false)?;
+    let content = sanitize_html(&content);
 
-  // Check for a community ban
-  let post_id = data.post_id;
-  let post = get_post(post_id, &mut context.pool()).await?;
-  let community_id = post.community_id;
+    // Check for a community ban
+    let post_id = data.post_id;
+    let post = get_post(post_id, &mut context.pool()).await?;
+    let community_id = post.community_id;
 
-  check_community_ban(local_user_view.person.id, community_id, &mut context.pool()).await?;
-  check_community_deleted_or_removed(community_id, &mut context.pool()).await?;
-  check_post_deleted_or_removed(&post)?;
+    check_community_ban(local_user_view.person.id, community_id, &mut context.pool()).await?;
+    check_community_deleted_or_removed(community_id, &mut context.pool()).await?;
+    check_post_deleted_or_removed(&post)?;
 
-  // Check if post is locked, no new comments
-  if post.locked {
-    Err(LemmyErrorType::Locked)?
-  }
-
-  // Fetch the parent, if it exists
-  let parent_opt = if let Some(parent_id) = data.parent_id {
-    Comment::read(&mut context.pool(), parent_id).await.ok()
-  } else {
-    None
-  };
-
-  // If there's a parent_id, check to make sure that comment is in that post
-  // Strange issue where sometimes the post ID of the parent comment is incorrect
-  if let Some(parent) = parent_opt.as_ref() {
-    if parent.post_id != post_id {
-      Err(LemmyErrorType::CouldntCreateComment)?
+    // Check if post is locked, no new comments
+    if post.locked {
+        Err(LemmyErrorType::Locked)?
     }
-    check_comment_depth(parent)?;
-  }
 
-  CommunityLanguage::is_allowed_community_language(
-    &mut context.pool(),
-    data.language_id,
-    community_id,
-  )
-  .await?;
+    // Fetch the parent, if it exists
+    let parent_opt = if let Some(parent_id) = data.parent_id {
+        Comment::read(&mut context.pool(), parent_id).await.ok()
+    } else {
+        None
+    };
 
-  // attempt to set default language if none was provided
-  let language_id = match data.language_id {
-    Some(lid) => Some(lid),
-    None => {
-      default_post_language(
+    // If there's a parent_id, check to make sure that comment is in that post
+    // Strange issue where sometimes the post ID of the parent comment is incorrect
+    if let Some(parent) = parent_opt.as_ref() {
+        if parent.post_id != post_id {
+            Err(LemmyErrorType::CouldntCreateComment)?
+        }
+        check_comment_depth(parent)?;
+    }
+
+    CommunityLanguage::is_allowed_community_language(
         &mut context.pool(),
+        data.language_id,
         community_id,
-        local_user_view.local_user.id,
-      )
-      .await?
-    }
-  };
+    )
+    .await?;
 
-  let comment_form = CommentInsertForm::builder()
-    .content(content.clone())
-    .post_id(data.post_id)
-    .creator_id(local_user_view.person.id)
-    .language_id(language_id)
-    .build();
+    // attempt to set default language if none was provided
+    let language_id = match data.language_id {
+        Some(lid) => Some(lid),
+        None => {
+            default_post_language(
+                &mut context.pool(),
+                community_id,
+                local_user_view.local_user.id,
+            )
+            .await?
+        }
+    };
 
-  // Create the comment
-  let parent_path = parent_opt.clone().map(|t| t.path);
-  let inserted_comment = Comment::create(&mut context.pool(), &comment_form, parent_path.as_ref())
+    let comment_form = CommentInsertForm::builder()
+        .content(content.clone())
+        .post_id(data.post_id)
+        .creator_id(local_user_view.person.id)
+        .language_id(language_id)
+        .build();
+
+    // Create the comment
+    let parent_path = parent_opt.clone().map(|t| t.path);
+    let inserted_comment =
+        Comment::create(&mut context.pool(), &comment_form, parent_path.as_ref())
+            .await
+            .with_lemmy_type(LemmyErrorType::CouldntCreateComment)?;
+
+    // Necessary to update the ap_id
+    let inserted_comment_id = inserted_comment.id;
+    let protocol_and_hostname = context.settings().get_protocol_and_hostname();
+
+    let apub_id = generate_local_apub_endpoint(
+        EndpointType::Comment,
+        &inserted_comment_id.to_string(),
+        &protocol_and_hostname,
+    )?;
+    let updated_comment = Comment::update(
+        &mut context.pool(),
+        inserted_comment_id,
+        &CommentUpdateForm {
+            ap_id: Some(apub_id),
+            ..Default::default()
+        },
+    )
     .await
     .with_lemmy_type(LemmyErrorType::CouldntCreateComment)?;
 
-  // Necessary to update the ap_id
-  let inserted_comment_id = inserted_comment.id;
-  let protocol_and_hostname = context.settings().get_protocol_and_hostname();
-
-  let apub_id = generate_local_apub_endpoint(
-    EndpointType::Comment,
-    &inserted_comment_id.to_string(),
-    &protocol_and_hostname,
-  )?;
-  let updated_comment = Comment::update(
-    &mut context.pool(),
-    inserted_comment_id,
-    &CommentUpdateForm {
-      ap_id: Some(apub_id),
-      ..Default::default()
-    },
-  )
-  .await
-  .with_lemmy_type(LemmyErrorType::CouldntCreateComment)?;
-
-  // Scan the comment for user mentions, add those rows
-  let mentions = scrape_text_for_mentions(&content);
-  let recipient_ids = send_local_notifs(
-    mentions,
-    &updated_comment,
-    &local_user_view.person,
-    &post,
-    true,
-    &context,
-  )
-  .await?;
-
-  // You like your own comment by default
-  let like_form = CommentLikeForm {
-    comment_id: inserted_comment.id,
-    post_id: post.id,
-    person_id: local_user_view.person.id,
-    score: 1,
-  };
-
-  CommentLike::like(&mut context.pool(), &like_form)
-    .await
-    .with_lemmy_type(LemmyErrorType::CouldntLikeComment)?;
-
-  ActivityChannel::submit_activity(
-    SendActivityData::CreateComment(updated_comment.clone()),
-    &context,
-  )
-  .await?;
-
-  // If its a reply, mark the parent as read
-  if let Some(parent) = parent_opt {
-    let parent_id = parent.id;
-    let comment_reply = CommentReply::read_by_comment(&mut context.pool(), parent_id).await;
-    if let Ok(reply) = comment_reply {
-      CommentReply::update(
-        &mut context.pool(),
-        reply.id,
-        &CommentReplyUpdateForm { read: Some(true) },
-      )
-      .await
-      .with_lemmy_type(LemmyErrorType::CouldntUpdateReplies)?;
-    }
-
-    // If the parent has PersonMentions mark them as read too
-    let person_id = local_user_view.person.id;
-    let person_mention =
-      PersonMention::read_by_comment_and_person(&mut context.pool(), parent_id, person_id).await;
-    if let Ok(mention) = person_mention {
-      PersonMention::update(
-        &mut context.pool(),
-        mention.id,
-        &PersonMentionUpdateForm { read: Some(true) },
-      )
-      .await
-      .with_lemmy_type(LemmyErrorType::CouldntUpdatePersonMentions)?;
-    }
-  }
-
-  Ok(Json(
-    build_comment_response(
-      &context,
-      inserted_comment.id,
-      Some(local_user_view),
-      recipient_ids,
+    // Scan the comment for user mentions, add those rows
+    let mentions = scrape_text_for_mentions(&content);
+    let recipient_ids = send_local_notifs(
+        mentions,
+        &updated_comment,
+        &local_user_view.person,
+        &post,
+        true,
+        &context,
     )
-    .await?,
-  ))
+    .await?;
+
+    // You like your own comment by default
+    let like_form = CommentLikeForm {
+        comment_id: inserted_comment.id,
+        post_id: post.id,
+        person_id: local_user_view.person.id,
+        score: 1,
+    };
+
+    CommentLike::like(&mut context.pool(), &like_form)
+        .await
+        .with_lemmy_type(LemmyErrorType::CouldntLikeComment)?;
+
+    ActivityChannel::submit_activity(
+        SendActivityData::CreateComment(updated_comment.clone()),
+        &context,
+    )
+    .await?;
+
+    // If its a reply, mark the parent as read
+    if let Some(parent) = parent_opt {
+        let parent_id = parent.id;
+        let comment_reply = CommentReply::read_by_comment(&mut context.pool(), parent_id).await;
+        if let Ok(reply) = comment_reply {
+            CommentReply::update(
+                &mut context.pool(),
+                reply.id,
+                &CommentReplyUpdateForm { read: Some(true) },
+            )
+            .await
+            .with_lemmy_type(LemmyErrorType::CouldntUpdateReplies)?;
+        }
+
+        // If the parent has PersonMentions mark them as read too
+        let person_id = local_user_view.person.id;
+        let person_mention =
+            PersonMention::read_by_comment_and_person(&mut context.pool(), parent_id, person_id)
+                .await;
+        if let Ok(mention) = person_mention {
+            PersonMention::update(
+                &mut context.pool(),
+                mention.id,
+                &PersonMentionUpdateForm { read: Some(true) },
+            )
+            .await
+            .with_lemmy_type(LemmyErrorType::CouldntUpdatePersonMentions)?;
+        }
+    }
+
+    Ok(Json(
+        build_comment_response(
+            &context,
+            inserted_comment.id,
+            Some(local_user_view),
+            recipient_ids,
+        )
+        .await?,
+    ))
 }
 
 pub fn check_comment_depth(comment: &Comment) -> Result<(), LemmyError> {
-  let path = &comment.path.0;
-  let length = path.split('.').count();
-  if length > MAX_COMMENT_DEPTH_LIMIT {
-    Err(LemmyErrorType::MaxCommentDepthReached)?
-  } else {
-    Ok(())
-  }
+    let path = &comment.path.0;
+    let length = path.split('.').count();
+    if length > MAX_COMMENT_DEPTH_LIMIT {
+        Err(LemmyErrorType::MaxCommentDepthReached)?
+    } else {
+        Ok(())
+    }
 }

--- a/crates/api_crud/src/comment/delete.rs
+++ b/crates/api_crud/src/comment/delete.rs
@@ -1,92 +1,92 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  build_response::{build_comment_response, send_local_notifs},
-  comment::{CommentResponse, DeleteComment},
-  context::LemmyContext,
-  send_activity::{ActivityChannel, SendActivityData},
-  utils::{check_community_ban, local_user_view_from_jwt},
+    build_response::{build_comment_response, send_local_notifs},
+    comment::{CommentResponse, DeleteComment},
+    context::LemmyContext,
+    send_activity::{ActivityChannel, SendActivityData},
+    utils::{check_community_ban, local_user_view_from_jwt},
 };
 use lemmy_db_schema::{
-  source::{
-    comment::{Comment, CommentUpdateForm},
-    post::Post,
-  },
-  traits::Crud,
+    source::{
+        comment::{Comment, CommentUpdateForm},
+        post::Post,
+    },
+    traits::Crud,
 };
 use lemmy_db_views::structs::CommentView;
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn delete_comment(
-  data: Json<DeleteComment>,
-  context: Data<LemmyContext>,
+    data: Json<DeleteComment>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<CommentResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  let comment_id = data.comment_id;
-  let orig_comment = CommentView::read(&mut context.pool(), comment_id, None).await?;
+    let comment_id = data.comment_id;
+    let orig_comment = CommentView::read(&mut context.pool(), comment_id, None).await?;
 
-  // Dont delete it if its already been deleted.
-  if orig_comment.comment.deleted == data.deleted {
-    Err(LemmyErrorType::CouldntUpdateComment)?
-  }
+    // Dont delete it if its already been deleted.
+    if orig_comment.comment.deleted == data.deleted {
+        Err(LemmyErrorType::CouldntUpdateComment)?
+    }
 
-  check_community_ban(
-    local_user_view.person.id,
-    orig_comment.community.id,
-    &mut context.pool(),
-  )
-  .await?;
-
-  // Verify that only the creator can delete
-  if local_user_view.person.id != orig_comment.creator.id {
-    Err(LemmyErrorType::NoCommentEditAllowed)?
-  }
-
-  // Do the delete
-  let deleted = data.deleted;
-  let updated_comment = Comment::update(
-    &mut context.pool(),
-    comment_id,
-    &CommentUpdateForm {
-      deleted: Some(deleted),
-      ..Default::default()
-    },
-  )
-  .await
-  .with_lemmy_type(LemmyErrorType::CouldntUpdateComment)?;
-
-  let post_id = updated_comment.post_id;
-  let post = Post::read(&mut context.pool(), post_id).await?;
-  let recipient_ids = send_local_notifs(
-    vec![],
-    &updated_comment,
-    &local_user_view.person,
-    &post,
-    false,
-    &context,
-  )
-  .await?;
-  let updated_comment_id = updated_comment.id;
-
-  ActivityChannel::submit_activity(
-    SendActivityData::DeleteComment(
-      updated_comment,
-      local_user_view.person.clone(),
-      orig_comment.community,
-    ),
-    &context,
-  )
-  .await?;
-
-  Ok(Json(
-    build_comment_response(
-      &context,
-      updated_comment_id,
-      Some(local_user_view),
-      recipient_ids,
+    check_community_ban(
+        local_user_view.person.id,
+        orig_comment.community.id,
+        &mut context.pool(),
     )
-    .await?,
-  ))
+    .await?;
+
+    // Verify that only the creator can delete
+    if local_user_view.person.id != orig_comment.creator.id {
+        Err(LemmyErrorType::NoCommentEditAllowed)?
+    }
+
+    // Do the delete
+    let deleted = data.deleted;
+    let updated_comment = Comment::update(
+        &mut context.pool(),
+        comment_id,
+        &CommentUpdateForm {
+            deleted: Some(deleted),
+            ..Default::default()
+        },
+    )
+    .await
+    .with_lemmy_type(LemmyErrorType::CouldntUpdateComment)?;
+
+    let post_id = updated_comment.post_id;
+    let post = Post::read(&mut context.pool(), post_id).await?;
+    let recipient_ids = send_local_notifs(
+        vec![],
+        &updated_comment,
+        &local_user_view.person,
+        &post,
+        false,
+        &context,
+    )
+    .await?;
+    let updated_comment_id = updated_comment.id;
+
+    ActivityChannel::submit_activity(
+        SendActivityData::DeleteComment(
+            updated_comment,
+            local_user_view.person.clone(),
+            orig_comment.community,
+        ),
+        &context,
+    )
+    .await?;
+
+    Ok(Json(
+        build_comment_response(
+            &context,
+            updated_comment_id,
+            Some(local_user_view),
+            recipient_ids,
+        )
+        .await?,
+    ))
 }

--- a/crates/api_crud/src/comment/read.rs
+++ b/crates/api_crud/src/comment/read.rs
@@ -1,24 +1,24 @@
 use actix_web::web::{Data, Json, Query};
 use lemmy_api_common::{
-  build_response::build_comment_response,
-  comment::{CommentResponse, GetComment},
-  context::LemmyContext,
-  utils::{check_private_instance, local_user_view_from_jwt_opt},
+    build_response::build_comment_response,
+    comment::{CommentResponse, GetComment},
+    context::LemmyContext,
+    utils::{check_private_instance, local_user_view_from_jwt_opt},
 };
 use lemmy_db_schema::source::local_site::LocalSite;
 use lemmy_utils::error::LemmyError;
 
 #[tracing::instrument(skip(context))]
 pub async fn get_comment(
-  data: Query<GetComment>,
-  context: Data<LemmyContext>,
+    data: Query<GetComment>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<CommentResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt_opt(data.auth.as_ref(), &context).await;
-  let local_site = LocalSite::read(&mut context.pool()).await?;
+    let local_user_view = local_user_view_from_jwt_opt(data.auth.as_ref(), &context).await;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
 
-  check_private_instance(&local_user_view, &local_site)?;
+    check_private_instance(&local_user_view, &local_site)?;
 
-  Ok(Json(
-    build_comment_response(&context, data.id, local_user_view, vec![]).await?,
-  ))
+    Ok(Json(
+        build_comment_response(&context, data.id, local_user_view, vec![]).await?,
+    ))
 }

--- a/crates/api_crud/src/comment/remove.rs
+++ b/crates/api_crud/src/comment/remove.rs
@@ -1,101 +1,101 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  build_response::{build_comment_response, send_local_notifs},
-  comment::{CommentResponse, RemoveComment},
-  context::LemmyContext,
-  send_activity::{ActivityChannel, SendActivityData},
-  utils::{check_community_ban, is_mod_or_admin, local_user_view_from_jwt},
+    build_response::{build_comment_response, send_local_notifs},
+    comment::{CommentResponse, RemoveComment},
+    context::LemmyContext,
+    send_activity::{ActivityChannel, SendActivityData},
+    utils::{check_community_ban, is_mod_or_admin, local_user_view_from_jwt},
 };
 use lemmy_db_schema::{
-  source::{
-    comment::{Comment, CommentUpdateForm},
-    moderator::{ModRemoveComment, ModRemoveCommentForm},
-    post::Post,
-  },
-  traits::Crud,
+    source::{
+        comment::{Comment, CommentUpdateForm},
+        moderator::{ModRemoveComment, ModRemoveCommentForm},
+        post::Post,
+    },
+    traits::Crud,
 };
 use lemmy_db_views::structs::CommentView;
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn remove_comment(
-  data: Json<RemoveComment>,
-  context: Data<LemmyContext>,
+    data: Json<RemoveComment>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<CommentResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  let comment_id = data.comment_id;
-  let orig_comment = CommentView::read(&mut context.pool(), comment_id, None).await?;
+    let comment_id = data.comment_id;
+    let orig_comment = CommentView::read(&mut context.pool(), comment_id, None).await?;
 
-  check_community_ban(
-    local_user_view.person.id,
-    orig_comment.community.id,
-    &mut context.pool(),
-  )
-  .await?;
-
-  // Verify that only a mod or admin can remove
-  is_mod_or_admin(
-    &mut context.pool(),
-    local_user_view.person.id,
-    orig_comment.community.id,
-  )
-  .await?;
-
-  // Do the remove
-  let removed = data.removed;
-  let updated_comment = Comment::update(
-    &mut context.pool(),
-    comment_id,
-    &CommentUpdateForm {
-      removed: Some(removed),
-      ..Default::default()
-    },
-  )
-  .await
-  .with_lemmy_type(LemmyErrorType::CouldntUpdateComment)?;
-
-  // Mod tables
-  let form = ModRemoveCommentForm {
-    mod_person_id: local_user_view.person.id,
-    comment_id: data.comment_id,
-    removed: Some(removed),
-    reason: data.reason.clone(),
-  };
-  ModRemoveComment::create(&mut context.pool(), &form).await?;
-
-  let post_id = updated_comment.post_id;
-  let post = Post::read(&mut context.pool(), post_id).await?;
-  let recipient_ids = send_local_notifs(
-    vec![],
-    &updated_comment,
-    &local_user_view.person.clone(),
-    &post,
-    false,
-    &context,
-  )
-  .await?;
-  let updated_comment_id = updated_comment.id;
-
-  ActivityChannel::submit_activity(
-    SendActivityData::RemoveComment(
-      updated_comment,
-      local_user_view.person.clone(),
-      orig_comment.community,
-      data.reason.clone(),
-    ),
-    &context,
-  )
-  .await?;
-
-  Ok(Json(
-    build_comment_response(
-      &context,
-      updated_comment_id,
-      Some(local_user_view),
-      recipient_ids,
+    check_community_ban(
+        local_user_view.person.id,
+        orig_comment.community.id,
+        &mut context.pool(),
     )
-    .await?,
-  ))
+    .await?;
+
+    // Verify that only a mod or admin can remove
+    is_mod_or_admin(
+        &mut context.pool(),
+        local_user_view.person.id,
+        orig_comment.community.id,
+    )
+    .await?;
+
+    // Do the remove
+    let removed = data.removed;
+    let updated_comment = Comment::update(
+        &mut context.pool(),
+        comment_id,
+        &CommentUpdateForm {
+            removed: Some(removed),
+            ..Default::default()
+        },
+    )
+    .await
+    .with_lemmy_type(LemmyErrorType::CouldntUpdateComment)?;
+
+    // Mod tables
+    let form = ModRemoveCommentForm {
+        mod_person_id: local_user_view.person.id,
+        comment_id: data.comment_id,
+        removed: Some(removed),
+        reason: data.reason.clone(),
+    };
+    ModRemoveComment::create(&mut context.pool(), &form).await?;
+
+    let post_id = updated_comment.post_id;
+    let post = Post::read(&mut context.pool(), post_id).await?;
+    let recipient_ids = send_local_notifs(
+        vec![],
+        &updated_comment,
+        &local_user_view.person.clone(),
+        &post,
+        false,
+        &context,
+    )
+    .await?;
+    let updated_comment_id = updated_comment.id;
+
+    ActivityChannel::submit_activity(
+        SendActivityData::RemoveComment(
+            updated_comment,
+            local_user_view.person.clone(),
+            orig_comment.community,
+            data.reason.clone(),
+        ),
+        &context,
+    )
+    .await?;
+
+    Ok(Json(
+        build_comment_response(
+            &context,
+            updated_comment_id,
+            Some(local_user_view),
+            recipient_ids,
+        )
+        .await?,
+    ))
 }

--- a/crates/api_crud/src/comment/update.rs
+++ b/crates/api_crud/src/comment/update.rs
@@ -1,112 +1,107 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  build_response::{build_comment_response, send_local_notifs},
-  comment::{CommentResponse, EditComment},
-  context::LemmyContext,
-  send_activity::{ActivityChannel, SendActivityData},
-  utils::{
-    check_community_ban,
-    local_site_to_slur_regex,
-    local_user_view_from_jwt,
-    sanitize_html_opt,
-  },
+    build_response::{build_comment_response, send_local_notifs},
+    comment::{CommentResponse, EditComment},
+    context::LemmyContext,
+    send_activity::{ActivityChannel, SendActivityData},
+    utils::{
+        check_community_ban, local_site_to_slur_regex, local_user_view_from_jwt, sanitize_html_opt,
+    },
 };
 use lemmy_db_schema::{
-  source::{
-    actor_language::CommunityLanguage,
-    comment::{Comment, CommentUpdateForm},
-    local_site::LocalSite,
-  },
-  traits::Crud,
-  utils::naive_now,
+    source::{
+        actor_language::CommunityLanguage,
+        comment::{Comment, CommentUpdateForm},
+        local_site::LocalSite,
+    },
+    traits::Crud,
+    utils::naive_now,
 };
 use lemmy_db_views::structs::CommentView;
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
-  utils::{
-    mention::scrape_text_for_mentions,
-    slurs::remove_slurs,
-    validation::is_valid_body_field,
-  },
+    error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+    utils::{
+        mention::scrape_text_for_mentions, slurs::remove_slurs, validation::is_valid_body_field,
+    },
 };
 
 #[tracing::instrument(skip(context))]
 pub async fn update_comment(
-  data: Json<EditComment>,
-  context: Data<LemmyContext>,
+    data: Json<EditComment>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<CommentResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
-  let local_site = LocalSite::read(&mut context.pool()).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
 
-  let comment_id = data.comment_id;
-  let orig_comment = CommentView::read(&mut context.pool(), comment_id, None).await?;
+    let comment_id = data.comment_id;
+    let orig_comment = CommentView::read(&mut context.pool(), comment_id, None).await?;
 
-  check_community_ban(
-    local_user_view.person.id,
-    orig_comment.community.id,
-    &mut context.pool(),
-  )
-  .await?;
-
-  // Verify that only the creator can edit
-  if local_user_view.person.id != orig_comment.creator.id {
-    Err(LemmyErrorType::NoCommentEditAllowed)?
-  }
-
-  let language_id = data.language_id;
-  CommunityLanguage::is_allowed_community_language(
-    &mut context.pool(),
-    language_id,
-    orig_comment.community.id,
-  )
-  .await?;
-
-  // Update the Content
-  let content = data
-    .content
-    .as_ref()
-    .map(|c| remove_slurs(c, &local_site_to_slur_regex(&local_site)));
-  is_valid_body_field(&content, false)?;
-  let content = sanitize_html_opt(&content);
-
-  let comment_id = data.comment_id;
-  let form = CommentUpdateForm {
-    content,
-    language_id: data.language_id,
-    updated: Some(Some(naive_now())),
-    ..Default::default()
-  };
-  let updated_comment = Comment::update(&mut context.pool(), comment_id, &form)
-    .await
-    .with_lemmy_type(LemmyErrorType::CouldntUpdateComment)?;
-
-  // Do the mentions / recipients
-  let updated_comment_content = updated_comment.content.clone();
-  let mentions = scrape_text_for_mentions(&updated_comment_content);
-  let recipient_ids = send_local_notifs(
-    mentions,
-    &updated_comment,
-    &local_user_view.person,
-    &orig_comment.post,
-    false,
-    &context,
-  )
-  .await?;
-
-  ActivityChannel::submit_activity(
-    SendActivityData::UpdateComment(updated_comment.clone()),
-    &context,
-  )
-  .await?;
-
-  Ok(Json(
-    build_comment_response(
-      &context,
-      updated_comment.id,
-      Some(local_user_view),
-      recipient_ids,
+    check_community_ban(
+        local_user_view.person.id,
+        orig_comment.community.id,
+        &mut context.pool(),
     )
-    .await?,
-  ))
+    .await?;
+
+    // Verify that only the creator can edit
+    if local_user_view.person.id != orig_comment.creator.id {
+        Err(LemmyErrorType::NoCommentEditAllowed)?
+    }
+
+    let language_id = data.language_id;
+    CommunityLanguage::is_allowed_community_language(
+        &mut context.pool(),
+        language_id,
+        orig_comment.community.id,
+    )
+    .await?;
+
+    // Update the Content
+    let content = data
+        .content
+        .as_ref()
+        .map(|c| remove_slurs(c, &local_site_to_slur_regex(&local_site)));
+    is_valid_body_field(&content, false)?;
+    let content = sanitize_html_opt(&content);
+
+    let comment_id = data.comment_id;
+    let form = CommentUpdateForm {
+        content,
+        language_id: data.language_id,
+        updated: Some(Some(naive_now())),
+        ..Default::default()
+    };
+    let updated_comment = Comment::update(&mut context.pool(), comment_id, &form)
+        .await
+        .with_lemmy_type(LemmyErrorType::CouldntUpdateComment)?;
+
+    // Do the mentions / recipients
+    let updated_comment_content = updated_comment.content.clone();
+    let mentions = scrape_text_for_mentions(&updated_comment_content);
+    let recipient_ids = send_local_notifs(
+        mentions,
+        &updated_comment,
+        &local_user_view.person,
+        &orig_comment.post,
+        false,
+        &context,
+    )
+    .await?;
+
+    ActivityChannel::submit_activity(
+        SendActivityData::UpdateComment(updated_comment.clone()),
+        &context,
+    )
+    .await?;
+
+    Ok(Json(
+        build_comment_response(
+            &context,
+            updated_comment.id,
+            Some(local_user_view),
+            recipient_ids,
+        )
+        .await?,
+    ))
 }

--- a/crates/api_crud/src/community/create.rs
+++ b/crates/api_crud/src/community/create.rs
@@ -1,144 +1,133 @@
 use activitypub_federation::{config::Data, http_signatures::generate_actor_keypair};
 use actix_web::web::Json;
 use lemmy_api_common::{
-  build_response::build_community_response,
-  community::{CommunityResponse, CreateCommunity},
-  context::LemmyContext,
-  utils::{
-    generate_followers_url,
-    generate_inbox_url,
-    generate_local_apub_endpoint,
-    generate_shared_inbox_url,
-    is_admin,
-    local_site_to_slur_regex,
-    local_user_view_from_jwt,
-    sanitize_html,
-    sanitize_html_opt,
-    EndpointType,
-  },
+    build_response::build_community_response,
+    community::{CommunityResponse, CreateCommunity},
+    context::LemmyContext,
+    utils::{
+        generate_followers_url, generate_inbox_url, generate_local_apub_endpoint,
+        generate_shared_inbox_url, is_admin, local_site_to_slur_regex, local_user_view_from_jwt,
+        sanitize_html, sanitize_html_opt, EndpointType,
+    },
 };
 use lemmy_db_schema::{
-  source::{
-    actor_language::{CommunityLanguage, SiteLanguage},
-    community::{
-      Community,
-      CommunityFollower,
-      CommunityFollowerForm,
-      CommunityInsertForm,
-      CommunityModerator,
-      CommunityModeratorForm,
+    source::{
+        actor_language::{CommunityLanguage, SiteLanguage},
+        community::{
+            Community, CommunityFollower, CommunityFollowerForm, CommunityInsertForm,
+            CommunityModerator, CommunityModeratorForm,
+        },
     },
-  },
-  traits::{ApubActor, Crud, Followable, Joinable},
-  utils::diesel_option_overwrite_to_url_create,
+    traits::{ApubActor, Crud, Followable, Joinable},
+    utils::diesel_option_overwrite_to_url_create,
 };
 use lemmy_db_views::structs::SiteView;
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
-  utils::{
-    slurs::{check_slurs, check_slurs_opt},
-    validation::{is_valid_actor_name, is_valid_body_field},
-  },
+    error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+    utils::{
+        slurs::{check_slurs, check_slurs_opt},
+        validation::{is_valid_actor_name, is_valid_body_field},
+    },
 };
 
 #[tracing::instrument(skip(context))]
 pub async fn create_community(
-  data: Json<CreateCommunity>,
-  context: Data<LemmyContext>,
+    data: Json<CreateCommunity>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<CommunityResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
-  let site_view = SiteView::read_local(&mut context.pool()).await?;
-  let local_site = site_view.local_site;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let site_view = SiteView::read_local(&mut context.pool()).await?;
+    let local_site = site_view.local_site;
 
-  if local_site.community_creation_admin_only && is_admin(&local_user_view).is_err() {
-    Err(LemmyErrorType::OnlyAdminsCanCreateCommunities)?
-  }
-
-  // Check to make sure the icon and banners are urls
-  let icon = diesel_option_overwrite_to_url_create(&data.icon)?;
-  let banner = diesel_option_overwrite_to_url_create(&data.banner)?;
-
-  let name = sanitize_html(&data.name);
-  let title = sanitize_html(&data.title);
-  let description = sanitize_html_opt(&data.description);
-
-  let slur_regex = local_site_to_slur_regex(&local_site);
-  check_slurs(&name, &slur_regex)?;
-  check_slurs(&title, &slur_regex)?;
-  check_slurs_opt(&description, &slur_regex)?;
-
-  is_valid_actor_name(&data.name, local_site.actor_name_max_length as usize)?;
-  is_valid_body_field(&data.description, false)?;
-
-  // Double check for duplicate community actor_ids
-  let community_actor_id = generate_local_apub_endpoint(
-    EndpointType::Community,
-    &data.name,
-    &context.settings().get_protocol_and_hostname(),
-  )?;
-  let community_dupe =
-    Community::read_from_apub_id(&mut context.pool(), &community_actor_id).await?;
-  if community_dupe.is_some() {
-    Err(LemmyErrorType::CommunityAlreadyExists)?
-  }
-
-  // When you create a community, make sure the user becomes a moderator and a follower
-  let keypair = generate_actor_keypair()?;
-
-  let community_form = CommunityInsertForm::builder()
-    .name(name)
-    .title(title)
-    .description(description)
-    .icon(icon)
-    .banner(banner)
-    .nsfw(data.nsfw)
-    .actor_id(Some(community_actor_id.clone()))
-    .private_key(Some(keypair.private_key))
-    .public_key(keypair.public_key)
-    .followers_url(Some(generate_followers_url(&community_actor_id)?))
-    .inbox_url(Some(generate_inbox_url(&community_actor_id)?))
-    .shared_inbox_url(Some(generate_shared_inbox_url(&community_actor_id)?))
-    .posting_restricted_to_mods(data.posting_restricted_to_mods)
-    .instance_id(site_view.site.instance_id)
-    .build();
-
-  let inserted_community = Community::create(&mut context.pool(), &community_form)
-    .await
-    .with_lemmy_type(LemmyErrorType::CommunityAlreadyExists)?;
-
-  // The community creator becomes a moderator
-  let community_moderator_form = CommunityModeratorForm {
-    community_id: inserted_community.id,
-    person_id: local_user_view.person.id,
-  };
-
-  CommunityModerator::join(&mut context.pool(), &community_moderator_form)
-    .await
-    .with_lemmy_type(LemmyErrorType::CommunityModeratorAlreadyExists)?;
-
-  // Follow your own community
-  let community_follower_form = CommunityFollowerForm {
-    community_id: inserted_community.id,
-    person_id: local_user_view.person.id,
-    pending: false,
-  };
-
-  CommunityFollower::follow(&mut context.pool(), &community_follower_form)
-    .await
-    .with_lemmy_type(LemmyErrorType::CommunityFollowerAlreadyExists)?;
-
-  // Update the discussion_languages if that's provided
-  let community_id = inserted_community.id;
-  if let Some(languages) = data.discussion_languages.clone() {
-    let site_languages = SiteLanguage::read_local_raw(&mut context.pool()).await?;
-    // check that community languages are a subset of site languages
-    // https://stackoverflow.com/a/64227550
-    let is_subset = languages.iter().all(|item| site_languages.contains(item));
-    if !is_subset {
-      Err(LemmyErrorType::LanguageNotAllowed)?
+    if local_site.community_creation_admin_only && is_admin(&local_user_view).is_err() {
+        Err(LemmyErrorType::OnlyAdminsCanCreateCommunities)?
     }
-    CommunityLanguage::update(&mut context.pool(), languages, community_id).await?;
-  }
 
-  build_community_response(&context, local_user_view, community_id).await
+    // Check to make sure the icon and banners are urls
+    let icon = diesel_option_overwrite_to_url_create(&data.icon)?;
+    let banner = diesel_option_overwrite_to_url_create(&data.banner)?;
+
+    let name = sanitize_html(&data.name);
+    let title = sanitize_html(&data.title);
+    let description = sanitize_html_opt(&data.description);
+
+    let slur_regex = local_site_to_slur_regex(&local_site);
+    check_slurs(&name, &slur_regex)?;
+    check_slurs(&title, &slur_regex)?;
+    check_slurs_opt(&description, &slur_regex)?;
+
+    is_valid_actor_name(&data.name, local_site.actor_name_max_length as usize)?;
+    is_valid_body_field(&data.description, false)?;
+
+    // Double check for duplicate community actor_ids
+    let community_actor_id = generate_local_apub_endpoint(
+        EndpointType::Community,
+        &data.name,
+        &context.settings().get_protocol_and_hostname(),
+    )?;
+    let community_dupe =
+        Community::read_from_apub_id(&mut context.pool(), &community_actor_id).await?;
+    if community_dupe.is_some() {
+        Err(LemmyErrorType::CommunityAlreadyExists)?
+    }
+
+    // When you create a community, make sure the user becomes a moderator and a follower
+    let keypair = generate_actor_keypair()?;
+
+    let community_form = CommunityInsertForm::builder()
+        .name(name)
+        .title(title)
+        .description(description)
+        .icon(icon)
+        .banner(banner)
+        .nsfw(data.nsfw)
+        .actor_id(Some(community_actor_id.clone()))
+        .private_key(Some(keypair.private_key))
+        .public_key(keypair.public_key)
+        .followers_url(Some(generate_followers_url(&community_actor_id)?))
+        .inbox_url(Some(generate_inbox_url(&community_actor_id)?))
+        .shared_inbox_url(Some(generate_shared_inbox_url(&community_actor_id)?))
+        .posting_restricted_to_mods(data.posting_restricted_to_mods)
+        .instance_id(site_view.site.instance_id)
+        .build();
+
+    let inserted_community = Community::create(&mut context.pool(), &community_form)
+        .await
+        .with_lemmy_type(LemmyErrorType::CommunityAlreadyExists)?;
+
+    // The community creator becomes a moderator
+    let community_moderator_form = CommunityModeratorForm {
+        community_id: inserted_community.id,
+        person_id: local_user_view.person.id,
+    };
+
+    CommunityModerator::join(&mut context.pool(), &community_moderator_form)
+        .await
+        .with_lemmy_type(LemmyErrorType::CommunityModeratorAlreadyExists)?;
+
+    // Follow your own community
+    let community_follower_form = CommunityFollowerForm {
+        community_id: inserted_community.id,
+        person_id: local_user_view.person.id,
+        pending: false,
+    };
+
+    CommunityFollower::follow(&mut context.pool(), &community_follower_form)
+        .await
+        .with_lemmy_type(LemmyErrorType::CommunityFollowerAlreadyExists)?;
+
+    // Update the discussion_languages if that's provided
+    let community_id = inserted_community.id;
+    if let Some(languages) = data.discussion_languages.clone() {
+        let site_languages = SiteLanguage::read_local_raw(&mut context.pool()).await?;
+        // check that community languages are a subset of site languages
+        // https://stackoverflow.com/a/64227550
+        let is_subset = languages.iter().all(|item| site_languages.contains(item));
+        if !is_subset {
+            Err(LemmyErrorType::LanguageNotAllowed)?
+        }
+        CommunityLanguage::update(&mut context.pool(), languages, community_id).await?;
+    }
+
+    build_community_response(&context, local_user_view, community_id).await
 }

--- a/crates/api_crud/src/community/delete.rs
+++ b/crates/api_crud/src/community/delete.rs
@@ -1,53 +1,53 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  build_response::build_community_response,
-  community::{CommunityResponse, DeleteCommunity},
-  context::LemmyContext,
-  send_activity::{ActivityChannel, SendActivityData},
-  utils::{is_top_mod, local_user_view_from_jwt},
+    build_response::build_community_response,
+    community::{CommunityResponse, DeleteCommunity},
+    context::LemmyContext,
+    send_activity::{ActivityChannel, SendActivityData},
+    utils::{is_top_mod, local_user_view_from_jwt},
 };
 use lemmy_db_schema::{
-  source::community::{Community, CommunityUpdateForm},
-  traits::Crud,
+    source::community::{Community, CommunityUpdateForm},
+    traits::Crud,
 };
 use lemmy_db_views_actor::structs::CommunityModeratorView;
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn delete_community(
-  data: Json<DeleteCommunity>,
-  context: Data<LemmyContext>,
+    data: Json<DeleteCommunity>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<CommunityResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  // Fetch the community mods
-  let community_id = data.community_id;
-  let community_mods =
-    CommunityModeratorView::for_community(&mut context.pool(), community_id).await?;
+    // Fetch the community mods
+    let community_id = data.community_id;
+    let community_mods =
+        CommunityModeratorView::for_community(&mut context.pool(), community_id).await?;
 
-  // Make sure deleter is the top mod
-  is_top_mod(&local_user_view, &community_mods)?;
+    // Make sure deleter is the top mod
+    is_top_mod(&local_user_view, &community_mods)?;
 
-  // Do the delete
-  let community_id = data.community_id;
-  let deleted = data.deleted;
-  let community = Community::update(
-    &mut context.pool(),
-    community_id,
-    &CommunityUpdateForm {
-      deleted: Some(deleted),
-      ..Default::default()
-    },
-  )
-  .await
-  .with_lemmy_type(LemmyErrorType::CouldntUpdateCommunity)?;
+    // Do the delete
+    let community_id = data.community_id;
+    let deleted = data.deleted;
+    let community = Community::update(
+        &mut context.pool(),
+        community_id,
+        &CommunityUpdateForm {
+            deleted: Some(deleted),
+            ..Default::default()
+        },
+    )
+    .await
+    .with_lemmy_type(LemmyErrorType::CouldntUpdateCommunity)?;
 
-  ActivityChannel::submit_activity(
-    SendActivityData::DeleteCommunity(local_user_view.person.clone(), community, data.deleted),
-    &context,
-  )
-  .await?;
+    ActivityChannel::submit_activity(
+        SendActivityData::DeleteCommunity(local_user_view.person.clone(), community, data.deleted),
+        &context,
+    )
+    .await?;
 
-  build_community_response(&context, local_user_view, community_id).await
+    build_community_response(&context, local_user_view, community_id).await
 }

--- a/crates/api_crud/src/community/list.rs
+++ b/crates/api_crud/src/community/list.rs
@@ -1,8 +1,8 @@
 use actix_web::web::{Data, Json, Query};
 use lemmy_api_common::{
-  community::{ListCommunities, ListCommunitiesResponse},
-  context::LemmyContext,
-  utils::{check_private_instance, is_admin, local_user_view_from_jwt_opt},
+    community::{ListCommunities, ListCommunitiesResponse},
+    context::LemmyContext,
+    utils::{check_private_instance, is_admin, local_user_view_from_jwt_opt},
 };
 use lemmy_db_schema::source::local_site::LocalSite;
 use lemmy_db_views_actor::community_view::CommunityQuery;
@@ -10,37 +10,37 @@ use lemmy_utils::error::LemmyError;
 
 #[tracing::instrument(skip(context))]
 pub async fn list_communities(
-  data: Query<ListCommunities>,
-  context: Data<LemmyContext>,
+    data: Query<ListCommunities>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<ListCommunitiesResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt_opt(data.auth.as_ref(), &context).await;
-  let local_site = LocalSite::read(&mut context.pool()).await?;
-  let is_admin = local_user_view
-    .as_ref()
-    .map(|luv| is_admin(luv).is_ok())
-    .unwrap_or_default();
+    let local_user_view = local_user_view_from_jwt_opt(data.auth.as_ref(), &context).await;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
+    let is_admin = local_user_view
+        .as_ref()
+        .map(|luv| is_admin(luv).is_ok())
+        .unwrap_or_default();
 
-  check_private_instance(&local_user_view, &local_site)?;
+    check_private_instance(&local_user_view, &local_site)?;
 
-  let sort = data.sort;
-  let listing_type = data.type_;
-  let show_nsfw = data.show_nsfw.unwrap_or_default();
-  let page = data.page;
-  let limit = data.limit;
-  let local_user = local_user_view.map(|l| l.local_user);
-  let communities = CommunityQuery {
-    listing_type,
-    show_nsfw,
-    sort,
-    local_user: local_user.as_ref(),
-    page,
-    limit,
-    is_mod_or_admin: is_admin,
-    ..Default::default()
-  }
-  .list(&mut context.pool())
-  .await?;
+    let sort = data.sort;
+    let listing_type = data.type_;
+    let show_nsfw = data.show_nsfw.unwrap_or_default();
+    let page = data.page;
+    let limit = data.limit;
+    let local_user = local_user_view.map(|l| l.local_user);
+    let communities = CommunityQuery {
+        listing_type,
+        show_nsfw,
+        sort,
+        local_user: local_user.as_ref(),
+        page,
+        limit,
+        is_mod_or_admin: is_admin,
+        ..Default::default()
+    }
+    .list(&mut context.pool())
+    .await?;
 
-  // Return the jwt
-  Ok(Json(ListCommunitiesResponse { communities }))
+    // Return the jwt
+    Ok(Json(ListCommunitiesResponse { communities }))
 }

--- a/crates/api_crud/src/community/remove.rs
+++ b/crates/api_crud/src/community/remove.rs
@@ -1,69 +1,69 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  build_response::build_community_response,
-  community::{CommunityResponse, RemoveCommunity},
-  context::LemmyContext,
-  send_activity::{ActivityChannel, SendActivityData},
-  utils::{is_admin, local_user_view_from_jwt},
+    build_response::build_community_response,
+    community::{CommunityResponse, RemoveCommunity},
+    context::LemmyContext,
+    send_activity::{ActivityChannel, SendActivityData},
+    utils::{is_admin, local_user_view_from_jwt},
 };
 use lemmy_db_schema::{
-  source::{
-    community::{Community, CommunityUpdateForm},
-    moderator::{ModRemoveCommunity, ModRemoveCommunityForm},
-  },
-  traits::Crud,
+    source::{
+        community::{Community, CommunityUpdateForm},
+        moderator::{ModRemoveCommunity, ModRemoveCommunityForm},
+    },
+    traits::Crud,
 };
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
-  utils::time::naive_from_unix,
+    error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+    utils::time::naive_from_unix,
 };
 
 #[tracing::instrument(skip(context))]
 pub async fn remove_community(
-  data: Json<RemoveCommunity>,
-  context: Data<LemmyContext>,
+    data: Json<RemoveCommunity>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<CommunityResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  // Verify its an admin (only an admin can remove a community)
-  is_admin(&local_user_view)?;
+    // Verify its an admin (only an admin can remove a community)
+    is_admin(&local_user_view)?;
 
-  // Do the remove
-  let community_id = data.community_id;
-  let removed = data.removed;
-  let community = Community::update(
-    &mut context.pool(),
-    community_id,
-    &CommunityUpdateForm {
-      removed: Some(removed),
-      ..Default::default()
-    },
-  )
-  .await
-  .with_lemmy_type(LemmyErrorType::CouldntUpdateCommunity)?;
+    // Do the remove
+    let community_id = data.community_id;
+    let removed = data.removed;
+    let community = Community::update(
+        &mut context.pool(),
+        community_id,
+        &CommunityUpdateForm {
+            removed: Some(removed),
+            ..Default::default()
+        },
+    )
+    .await
+    .with_lemmy_type(LemmyErrorType::CouldntUpdateCommunity)?;
 
-  // Mod tables
-  let expires = data.expires.map(naive_from_unix);
-  let form = ModRemoveCommunityForm {
-    mod_person_id: local_user_view.person.id,
-    community_id: data.community_id,
-    removed: Some(removed),
-    reason: data.reason.clone(),
-    expires,
-  };
-  ModRemoveCommunity::create(&mut context.pool(), &form).await?;
+    // Mod tables
+    let expires = data.expires.map(naive_from_unix);
+    let form = ModRemoveCommunityForm {
+        mod_person_id: local_user_view.person.id,
+        community_id: data.community_id,
+        removed: Some(removed),
+        reason: data.reason.clone(),
+        expires,
+    };
+    ModRemoveCommunity::create(&mut context.pool(), &form).await?;
 
-  ActivityChannel::submit_activity(
-    SendActivityData::RemoveCommunity(
-      local_user_view.person.clone(),
-      community,
-      data.reason.clone(),
-      data.removed,
-    ),
-    &context,
-  )
-  .await?;
+    ActivityChannel::submit_activity(
+        SendActivityData::RemoveCommunity(
+            local_user_view.person.clone(),
+            community,
+            data.reason.clone(),
+            data.removed,
+        ),
+        &context,
+    )
+    .await?;
 
-  build_community_response(&context, local_user_view, community_id).await
+    build_community_response(&context, local_user_view, community_id).await
 }

--- a/crates/api_crud/src/community/update.rs
+++ b/crates/api_crud/src/community/update.rs
@@ -1,91 +1,91 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  build_response::build_community_response,
-  community::{CommunityResponse, EditCommunity},
-  context::LemmyContext,
-  send_activity::{ActivityChannel, SendActivityData},
-  utils::{local_site_to_slur_regex, local_user_view_from_jwt, sanitize_html_opt},
+    build_response::build_community_response,
+    community::{CommunityResponse, EditCommunity},
+    context::LemmyContext,
+    send_activity::{ActivityChannel, SendActivityData},
+    utils::{local_site_to_slur_regex, local_user_view_from_jwt, sanitize_html_opt},
 };
 use lemmy_db_schema::{
-  newtypes::PersonId,
-  source::{
-    actor_language::{CommunityLanguage, SiteLanguage},
-    community::{Community, CommunityUpdateForm},
-    local_site::LocalSite,
-  },
-  traits::Crud,
-  utils::{diesel_option_overwrite, diesel_option_overwrite_to_url, naive_now},
+    newtypes::PersonId,
+    source::{
+        actor_language::{CommunityLanguage, SiteLanguage},
+        community::{Community, CommunityUpdateForm},
+        local_site::LocalSite,
+    },
+    traits::Crud,
+    utils::{diesel_option_overwrite, diesel_option_overwrite_to_url, naive_now},
 };
 use lemmy_db_views_actor::structs::CommunityModeratorView;
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
-  utils::{slurs::check_slurs_opt, validation::is_valid_body_field},
+    error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+    utils::{slurs::check_slurs_opt, validation::is_valid_body_field},
 };
 
 #[tracing::instrument(skip(context))]
 pub async fn update_community(
-  data: Json<EditCommunity>,
-  context: Data<LemmyContext>,
+    data: Json<EditCommunity>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<CommunityResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
-  let local_site = LocalSite::read(&mut context.pool()).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
 
-  let slur_regex = local_site_to_slur_regex(&local_site);
-  check_slurs_opt(&data.title, &slur_regex)?;
-  check_slurs_opt(&data.description, &slur_regex)?;
-  is_valid_body_field(&data.description, false)?;
+    let slur_regex = local_site_to_slur_regex(&local_site);
+    check_slurs_opt(&data.title, &slur_regex)?;
+    check_slurs_opt(&data.description, &slur_regex)?;
+    is_valid_body_field(&data.description, false)?;
 
-  let title = sanitize_html_opt(&data.title);
-  let description = sanitize_html_opt(&data.description);
+    let title = sanitize_html_opt(&data.title);
+    let description = sanitize_html_opt(&data.description);
 
-  let icon = diesel_option_overwrite_to_url(&data.icon)?;
-  let banner = diesel_option_overwrite_to_url(&data.banner)?;
-  let description = diesel_option_overwrite(description);
+    let icon = diesel_option_overwrite_to_url(&data.icon)?;
+    let banner = diesel_option_overwrite_to_url(&data.banner)?;
+    let description = diesel_option_overwrite(description);
 
-  // Verify its a mod (only mods can edit it)
-  let community_id = data.community_id;
-  let mods: Vec<PersonId> =
-    CommunityModeratorView::for_community(&mut context.pool(), community_id)
-      .await
-      .map(|v| v.into_iter().map(|m| m.moderator.id).collect())?;
-  if !mods.contains(&local_user_view.person.id) {
-    Err(LemmyErrorType::NotAModerator)?
-  }
-
-  let community_id = data.community_id;
-  if let Some(languages) = data.discussion_languages.clone() {
-    let site_languages = SiteLanguage::read_local_raw(&mut context.pool()).await?;
-    // check that community languages are a subset of site languages
-    // https://stackoverflow.com/a/64227550
-    let is_subset = languages.iter().all(|item| site_languages.contains(item));
-    if !is_subset {
-      Err(LemmyErrorType::LanguageNotAllowed)?
+    // Verify its a mod (only mods can edit it)
+    let community_id = data.community_id;
+    let mods: Vec<PersonId> =
+        CommunityModeratorView::for_community(&mut context.pool(), community_id)
+            .await
+            .map(|v| v.into_iter().map(|m| m.moderator.id).collect())?;
+    if !mods.contains(&local_user_view.person.id) {
+        Err(LemmyErrorType::NotAModerator)?
     }
-    CommunityLanguage::update(&mut context.pool(), languages, community_id).await?;
-  }
 
-  let community_form = CommunityUpdateForm {
-    title,
-    description,
-    icon,
-    banner,
-    nsfw: data.nsfw,
-    posting_restricted_to_mods: data.posting_restricted_to_mods,
-    updated: Some(Some(naive_now())),
-    ..Default::default()
-  };
+    let community_id = data.community_id;
+    if let Some(languages) = data.discussion_languages.clone() {
+        let site_languages = SiteLanguage::read_local_raw(&mut context.pool()).await?;
+        // check that community languages are a subset of site languages
+        // https://stackoverflow.com/a/64227550
+        let is_subset = languages.iter().all(|item| site_languages.contains(item));
+        if !is_subset {
+            Err(LemmyErrorType::LanguageNotAllowed)?
+        }
+        CommunityLanguage::update(&mut context.pool(), languages, community_id).await?;
+    }
 
-  let community_id = data.community_id;
-  let community = Community::update(&mut context.pool(), community_id, &community_form)
-    .await
-    .with_lemmy_type(LemmyErrorType::CouldntUpdateCommunity)?;
+    let community_form = CommunityUpdateForm {
+        title,
+        description,
+        icon,
+        banner,
+        nsfw: data.nsfw,
+        posting_restricted_to_mods: data.posting_restricted_to_mods,
+        updated: Some(Some(naive_now())),
+        ..Default::default()
+    };
 
-  ActivityChannel::submit_activity(
-    SendActivityData::UpdateCommunity(local_user_view.person.clone(), community),
-    &context,
-  )
-  .await?;
+    let community_id = data.community_id;
+    let community = Community::update(&mut context.pool(), community_id, &community_form)
+        .await
+        .with_lemmy_type(LemmyErrorType::CouldntUpdateCommunity)?;
 
-  build_community_response(&context, local_user_view, community_id).await
+    ActivityChannel::submit_activity(
+        SendActivityData::UpdateCommunity(local_user_view.person.clone(), community),
+        &context,
+    )
+    .await?;
+
+    build_community_response(&context, local_user_view, community_id).await
 }

--- a/crates/api_crud/src/custom_emoji/create.rs
+++ b/crates/api_crud/src/custom_emoji/create.rs
@@ -1,50 +1,50 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  context::LemmyContext,
-  custom_emoji::{CreateCustomEmoji, CustomEmojiResponse},
-  utils::{is_admin, local_user_view_from_jwt, sanitize_html},
+    context::LemmyContext,
+    custom_emoji::{CreateCustomEmoji, CustomEmojiResponse},
+    utils::{is_admin, local_user_view_from_jwt, sanitize_html},
 };
 use lemmy_db_schema::source::{
-  custom_emoji::{CustomEmoji, CustomEmojiInsertForm},
-  custom_emoji_keyword::{CustomEmojiKeyword, CustomEmojiKeywordInsertForm},
-  local_site::LocalSite,
+    custom_emoji::{CustomEmoji, CustomEmojiInsertForm},
+    custom_emoji_keyword::{CustomEmojiKeyword, CustomEmojiKeywordInsertForm},
+    local_site::LocalSite,
 };
 use lemmy_db_views::structs::CustomEmojiView;
 use lemmy_utils::error::LemmyError;
 
 #[tracing::instrument(skip(context))]
 pub async fn create_custom_emoji(
-  data: Json<CreateCustomEmoji>,
-  context: Data<LemmyContext>,
+    data: Json<CreateCustomEmoji>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<CustomEmojiResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  let local_site = LocalSite::read(&mut context.pool()).await?;
-  // Make sure user is an admin
-  is_admin(&local_user_view)?;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
+    // Make sure user is an admin
+    is_admin(&local_user_view)?;
 
-  let shortcode = sanitize_html(data.shortcode.to_lowercase().trim());
-  let alt_text = sanitize_html(&data.alt_text);
-  let category = sanitize_html(&data.category);
+    let shortcode = sanitize_html(data.shortcode.to_lowercase().trim());
+    let alt_text = sanitize_html(&data.alt_text);
+    let category = sanitize_html(&data.category);
 
-  let emoji_form = CustomEmojiInsertForm::builder()
-    .local_site_id(local_site.id)
-    .shortcode(shortcode)
-    .alt_text(alt_text)
-    .category(category)
-    .image_url(data.clone().image_url.into())
-    .build();
-  let emoji = CustomEmoji::create(&mut context.pool(), &emoji_form).await?;
-  let mut keywords = vec![];
-  for keyword in &data.keywords {
-    let keyword_form = CustomEmojiKeywordInsertForm::builder()
-      .custom_emoji_id(emoji.id)
-      .keyword(keyword.to_lowercase().trim().to_string())
-      .build();
-    keywords.push(keyword_form);
-  }
-  CustomEmojiKeyword::create(&mut context.pool(), keywords).await?;
-  let view = CustomEmojiView::get(&mut context.pool(), emoji.id).await?;
-  Ok(Json(CustomEmojiResponse { custom_emoji: view }))
+    let emoji_form = CustomEmojiInsertForm::builder()
+        .local_site_id(local_site.id)
+        .shortcode(shortcode)
+        .alt_text(alt_text)
+        .category(category)
+        .image_url(data.clone().image_url.into())
+        .build();
+    let emoji = CustomEmoji::create(&mut context.pool(), &emoji_form).await?;
+    let mut keywords = vec![];
+    for keyword in &data.keywords {
+        let keyword_form = CustomEmojiKeywordInsertForm::builder()
+            .custom_emoji_id(emoji.id)
+            .keyword(keyword.to_lowercase().trim().to_string())
+            .build();
+        keywords.push(keyword_form);
+    }
+    CustomEmojiKeyword::create(&mut context.pool(), keywords).await?;
+    let view = CustomEmojiView::get(&mut context.pool(), emoji.id).await?;
+    Ok(Json(CustomEmojiResponse { custom_emoji: view }))
 }

--- a/crates/api_crud/src/custom_emoji/delete.rs
+++ b/crates/api_crud/src/custom_emoji/delete.rs
@@ -1,25 +1,25 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  context::LemmyContext,
-  custom_emoji::{DeleteCustomEmoji, DeleteCustomEmojiResponse},
-  utils::{is_admin, local_user_view_from_jwt},
+    context::LemmyContext,
+    custom_emoji::{DeleteCustomEmoji, DeleteCustomEmojiResponse},
+    utils::{is_admin, local_user_view_from_jwt},
 };
 use lemmy_db_schema::source::custom_emoji::CustomEmoji;
 use lemmy_utils::error::LemmyError;
 
 #[tracing::instrument(skip(context))]
 pub async fn delete_custom_emoji(
-  data: Json<DeleteCustomEmoji>,
-  context: Data<LemmyContext>,
+    data: Json<DeleteCustomEmoji>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<DeleteCustomEmojiResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  // Make sure user is an admin
-  is_admin(&local_user_view)?;
-  CustomEmoji::delete(&mut context.pool(), data.id).await?;
-  Ok(Json(DeleteCustomEmojiResponse {
-    id: data.id,
-    success: true,
-  }))
+    // Make sure user is an admin
+    is_admin(&local_user_view)?;
+    CustomEmoji::delete(&mut context.pool(), data.id).await?;
+    Ok(Json(DeleteCustomEmojiResponse {
+        id: data.id,
+        success: true,
+    }))
 }

--- a/crates/api_crud/src/custom_emoji/update.rs
+++ b/crates/api_crud/src/custom_emoji/update.rs
@@ -1,49 +1,49 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  context::LemmyContext,
-  custom_emoji::{CustomEmojiResponse, EditCustomEmoji},
-  utils::{is_admin, local_user_view_from_jwt, sanitize_html},
+    context::LemmyContext,
+    custom_emoji::{CustomEmojiResponse, EditCustomEmoji},
+    utils::{is_admin, local_user_view_from_jwt, sanitize_html},
 };
 use lemmy_db_schema::source::{
-  custom_emoji::{CustomEmoji, CustomEmojiUpdateForm},
-  custom_emoji_keyword::{CustomEmojiKeyword, CustomEmojiKeywordInsertForm},
-  local_site::LocalSite,
+    custom_emoji::{CustomEmoji, CustomEmojiUpdateForm},
+    custom_emoji_keyword::{CustomEmojiKeyword, CustomEmojiKeywordInsertForm},
+    local_site::LocalSite,
 };
 use lemmy_db_views::structs::CustomEmojiView;
 use lemmy_utils::error::LemmyError;
 
 #[tracing::instrument(skip(context))]
 pub async fn update_custom_emoji(
-  data: Json<EditCustomEmoji>,
-  context: Data<LemmyContext>,
+    data: Json<EditCustomEmoji>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<CustomEmojiResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  let local_site = LocalSite::read(&mut context.pool()).await?;
-  // Make sure user is an admin
-  is_admin(&local_user_view)?;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
+    // Make sure user is an admin
+    is_admin(&local_user_view)?;
 
-  let alt_text = sanitize_html(&data.alt_text);
-  let category = sanitize_html(&data.category);
+    let alt_text = sanitize_html(&data.alt_text);
+    let category = sanitize_html(&data.category);
 
-  let emoji_form = CustomEmojiUpdateForm::builder()
-    .local_site_id(local_site.id)
-    .alt_text(alt_text)
-    .category(category)
-    .image_url(data.clone().image_url.into())
-    .build();
-  let emoji = CustomEmoji::update(&mut context.pool(), data.id, &emoji_form).await?;
-  CustomEmojiKeyword::delete(&mut context.pool(), data.id).await?;
-  let mut keywords = vec![];
-  for keyword in &data.keywords {
-    let keyword_form = CustomEmojiKeywordInsertForm::builder()
-      .custom_emoji_id(emoji.id)
-      .keyword(keyword.to_lowercase().trim().to_string())
-      .build();
-    keywords.push(keyword_form);
-  }
-  CustomEmojiKeyword::create(&mut context.pool(), keywords).await?;
-  let view = CustomEmojiView::get(&mut context.pool(), emoji.id).await?;
-  Ok(Json(CustomEmojiResponse { custom_emoji: view }))
+    let emoji_form = CustomEmojiUpdateForm::builder()
+        .local_site_id(local_site.id)
+        .alt_text(alt_text)
+        .category(category)
+        .image_url(data.clone().image_url.into())
+        .build();
+    let emoji = CustomEmoji::update(&mut context.pool(), data.id, &emoji_form).await?;
+    CustomEmojiKeyword::delete(&mut context.pool(), data.id).await?;
+    let mut keywords = vec![];
+    for keyword in &data.keywords {
+        let keyword_form = CustomEmojiKeywordInsertForm::builder()
+            .custom_emoji_id(emoji.id)
+            .keyword(keyword.to_lowercase().trim().to_string())
+            .build();
+        keywords.push(keyword_form);
+    }
+    CustomEmojiKeyword::create(&mut context.pool(), keywords).await?;
+    let view = CustomEmojiView::get(&mut context.pool(), emoji.id).await?;
+    Ok(Json(CustomEmojiResponse { custom_emoji: view }))
 }

--- a/crates/api_crud/src/post/create.rs
+++ b/crates/api_crud/src/post/create.rs
@@ -1,43 +1,38 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  build_response::build_post_response,
-  context::LemmyContext,
-  post::{CreatePost, PostResponse},
-  request::fetch_site_data,
-  send_activity::{ActivityChannel, SendActivityData},
-  utils::{
-    check_community_ban,
-    check_community_deleted_or_removed,
-    generate_local_apub_endpoint,
-    honeypot_check,
-    local_site_to_slur_regex,
-    local_user_view_from_jwt,
-    mark_post_as_read,
-    sanitize_html,
-    sanitize_html_opt,
-    EndpointType,
-  },
+    build_response::build_post_response,
+    context::LemmyContext,
+    post::{CreatePost, PostResponse},
+    request::fetch_site_data,
+    send_activity::{ActivityChannel, SendActivityData},
+    utils::{
+        check_community_ban, check_community_deleted_or_removed, generate_local_apub_endpoint,
+        honeypot_check, local_site_to_slur_regex, local_user_view_from_jwt, mark_post_as_read,
+        sanitize_html, sanitize_html_opt, EndpointType,
+    },
 };
 use lemmy_db_schema::{
-  impls::actor_language::default_post_language,
-  source::{
-    actor_language::CommunityLanguage,
-    community::Community,
-    local_site::LocalSite,
-    post::{Post, PostInsertForm, PostLike, PostLikeForm, PostUpdateForm},
-  },
-  traits::{Crud, Likeable},
+    impls::actor_language::default_post_language,
+    source::{
+        actor_language::CommunityLanguage,
+        community::Community,
+        local_site::LocalSite,
+        post::{Post, PostInsertForm, PostLike, PostLikeForm, PostUpdateForm},
+    },
+    traits::{Crud, Likeable},
 };
 use lemmy_db_views_actor::structs::CommunityView;
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
-  spawn_try_task,
-  utils::{
-    slurs::{check_slurs, check_slurs_opt},
-    validation::{check_url_scheme, clean_url_params, is_valid_body_field, is_valid_post_title},
-  },
-  SYNCHRONOUS_FEDERATION,
+    error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+    spawn_try_task,
+    utils::{
+        slurs::{check_slurs, check_slurs_opt},
+        validation::{
+            check_url_scheme, clean_url_params, is_valid_body_field, is_valid_post_title,
+        },
+    },
+    SYNCHRONOUS_FEDERATION,
 };
 use tracing::Instrument;
 use url::Url;
@@ -45,157 +40,157 @@ use webmention::{Webmention, WebmentionError};
 
 #[tracing::instrument(skip(context))]
 pub async fn create_post(
-  data: Json<CreatePost>,
-  context: Data<LemmyContext>,
+    data: Json<CreatePost>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<PostResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
-  let local_site = LocalSite::read(&mut context.pool()).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
 
-  let slur_regex = local_site_to_slur_regex(&local_site);
-  check_slurs(&data.name, &slur_regex)?;
-  check_slurs_opt(&data.body, &slur_regex)?;
-  honeypot_check(&data.honeypot)?;
+    let slur_regex = local_site_to_slur_regex(&local_site);
+    check_slurs(&data.name, &slur_regex)?;
+    check_slurs_opt(&data.body, &slur_regex)?;
+    honeypot_check(&data.honeypot)?;
 
-  let data_url = data.url.as_ref();
-  let url = data_url.map(clean_url_params).map(Into::into); // TODO no good way to handle a "clear"
+    let data_url = data.url.as_ref();
+    let url = data_url.map(clean_url_params).map(Into::into); // TODO no good way to handle a "clear"
 
-  is_valid_post_title(&data.name)?;
-  is_valid_body_field(&data.body, true)?;
-  check_url_scheme(&data.url)?;
+    is_valid_post_title(&data.name)?;
+    is_valid_body_field(&data.body, true)?;
+    check_url_scheme(&data.url)?;
 
-  check_community_ban(
-    local_user_view.person.id,
-    data.community_id,
-    &mut context.pool(),
-  )
-  .await?;
-  check_community_deleted_or_removed(data.community_id, &mut context.pool()).await?;
-
-  let community_id = data.community_id;
-  let community = Community::read(&mut context.pool(), community_id).await?;
-  if community.posting_restricted_to_mods {
-    let community_id = data.community_id;
-    let is_mod = CommunityView::is_mod_or_admin(
-      &mut context.pool(),
-      local_user_view.local_user.person_id,
-      community_id,
+    check_community_ban(
+        local_user_view.person.id,
+        data.community_id,
+        &mut context.pool(),
     )
     .await?;
-    if !is_mod {
-      Err(LemmyErrorType::OnlyModsCanPostInCommunity)?
+    check_community_deleted_or_removed(data.community_id, &mut context.pool()).await?;
+
+    let community_id = data.community_id;
+    let community = Community::read(&mut context.pool(), community_id).await?;
+    if community.posting_restricted_to_mods {
+        let community_id = data.community_id;
+        let is_mod = CommunityView::is_mod_or_admin(
+            &mut context.pool(),
+            local_user_view.local_user.person_id,
+            community_id,
+        )
+        .await?;
+        if !is_mod {
+            Err(LemmyErrorType::OnlyModsCanPostInCommunity)?
+        }
     }
-  }
 
-  // Fetch post links and pictrs cached image
-  let (metadata_res, thumbnail_url) =
-    fetch_site_data(context.client(), context.settings(), data_url, true).await;
-  let (embed_title, embed_description, embed_video_url) = metadata_res
-    .map(|u| (u.title, u.description, u.embed_video_url))
-    .unwrap_or_default();
+    // Fetch post links and pictrs cached image
+    let (metadata_res, thumbnail_url) =
+        fetch_site_data(context.client(), context.settings(), data_url, true).await;
+    let (embed_title, embed_description, embed_video_url) = metadata_res
+        .map(|u| (u.title, u.description, u.embed_video_url))
+        .unwrap_or_default();
 
-  let name = sanitize_html(data.name.trim());
-  let body = sanitize_html_opt(&data.body);
-  let embed_title = sanitize_html_opt(&embed_title);
-  let embed_description = sanitize_html_opt(&embed_description);
+    let name = sanitize_html(data.name.trim());
+    let body = sanitize_html_opt(&data.body);
+    let embed_title = sanitize_html_opt(&embed_title);
+    let embed_description = sanitize_html_opt(&embed_description);
 
-  // Only need to check if language is allowed in case user set it explicitly. When using default
-  // language, it already only returns allowed languages.
-  CommunityLanguage::is_allowed_community_language(
-    &mut context.pool(),
-    data.language_id,
-    community_id,
-  )
-  .await?;
-
-  // attempt to set default language if none was provided
-  let language_id = match data.language_id {
-    Some(lid) => Some(lid),
-    None => {
-      default_post_language(
+    // Only need to check if language is allowed in case user set it explicitly. When using default
+    // language, it already only returns allowed languages.
+    CommunityLanguage::is_allowed_community_language(
         &mut context.pool(),
+        data.language_id,
         community_id,
-        local_user_view.local_user.id,
-      )
-      .await?
-    }
-  };
+    )
+    .await?;
 
-  let post_form = PostInsertForm::builder()
-    .name(name)
-    .url(url)
-    .body(body)
-    .community_id(data.community_id)
-    .creator_id(local_user_view.person.id)
-    .nsfw(data.nsfw)
-    .embed_title(embed_title)
-    .embed_description(embed_description)
-    .embed_video_url(embed_video_url)
-    .language_id(language_id)
-    .thumbnail_url(thumbnail_url)
-    .build();
+    // attempt to set default language if none was provided
+    let language_id = match data.language_id {
+        Some(lid) => Some(lid),
+        None => {
+            default_post_language(
+                &mut context.pool(),
+                community_id,
+                local_user_view.local_user.id,
+            )
+            .await?
+        }
+    };
 
-  let inserted_post = Post::create(&mut context.pool(), &post_form)
+    let post_form = PostInsertForm::builder()
+        .name(name)
+        .url(url)
+        .body(body)
+        .community_id(data.community_id)
+        .creator_id(local_user_view.person.id)
+        .nsfw(data.nsfw)
+        .embed_title(embed_title)
+        .embed_description(embed_description)
+        .embed_video_url(embed_video_url)
+        .language_id(language_id)
+        .thumbnail_url(thumbnail_url)
+        .build();
+
+    let inserted_post = Post::create(&mut context.pool(), &post_form)
+        .await
+        .with_lemmy_type(LemmyErrorType::CouldntCreatePost)?;
+
+    let inserted_post_id = inserted_post.id;
+    let protocol_and_hostname = context.settings().get_protocol_and_hostname();
+    let apub_id = generate_local_apub_endpoint(
+        EndpointType::Post,
+        &inserted_post_id.to_string(),
+        &protocol_and_hostname,
+    )?;
+    let updated_post = Post::update(
+        &mut context.pool(),
+        inserted_post_id,
+        &PostUpdateForm {
+            ap_id: Some(apub_id),
+            ..Default::default()
+        },
+    )
     .await
     .with_lemmy_type(LemmyErrorType::CouldntCreatePost)?;
 
-  let inserted_post_id = inserted_post.id;
-  let protocol_and_hostname = context.settings().get_protocol_and_hostname();
-  let apub_id = generate_local_apub_endpoint(
-    EndpointType::Post,
-    &inserted_post_id.to_string(),
-    &protocol_and_hostname,
-  )?;
-  let updated_post = Post::update(
-    &mut context.pool(),
-    inserted_post_id,
-    &PostUpdateForm {
-      ap_id: Some(apub_id),
-      ..Default::default()
-    },
-  )
-  .await
-  .with_lemmy_type(LemmyErrorType::CouldntCreatePost)?;
-
-  // They like their own post by default
-  let person_id = local_user_view.person.id;
-  let post_id = inserted_post.id;
-  let like_form = PostLikeForm {
-    post_id,
-    person_id,
-    score: 1,
-  };
-
-  PostLike::like(&mut context.pool(), &like_form)
-    .await
-    .with_lemmy_type(LemmyErrorType::CouldntLikePost)?;
-
-  ActivityChannel::submit_activity(SendActivityData::CreatePost(updated_post.clone()), &context)
-    .await?;
-
-  // Mark the post as read
-  mark_post_as_read(person_id, post_id, &mut context.pool()).await?;
-
-  if let Some(url) = updated_post.url.clone() {
-    let task = async move {
-      let mut webmention =
-        Webmention::new::<Url>(updated_post.ap_id.clone().into(), url.clone().into())?;
-      webmention.set_checked(true);
-      match webmention
-        .send()
-        .instrument(tracing::info_span!("Sending webmention"))
-        .await
-      {
-        Err(WebmentionError::NoEndpointDiscovered(_)) => Ok(()),
-        Ok(_) => Ok(()),
-        Err(e) => Err(e).with_lemmy_type(LemmyErrorType::CouldntSendWebmention),
-      }
+    // They like their own post by default
+    let person_id = local_user_view.person.id;
+    let post_id = inserted_post.id;
+    let like_form = PostLikeForm {
+        post_id,
+        person_id,
+        score: 1,
     };
-    if *SYNCHRONOUS_FEDERATION {
-      task.await?;
-    } else {
-      spawn_try_task(task);
-    }
-  };
 
-  build_post_response(&context, community_id, person_id, post_id).await
+    PostLike::like(&mut context.pool(), &like_form)
+        .await
+        .with_lemmy_type(LemmyErrorType::CouldntLikePost)?;
+
+    ActivityChannel::submit_activity(SendActivityData::CreatePost(updated_post.clone()), &context)
+        .await?;
+
+    // Mark the post as read
+    mark_post_as_read(person_id, post_id, &mut context.pool()).await?;
+
+    if let Some(url) = updated_post.url.clone() {
+        let task = async move {
+            let mut webmention =
+                Webmention::new::<Url>(updated_post.ap_id.clone().into(), url.clone().into())?;
+            webmention.set_checked(true);
+            match webmention
+                .send()
+                .instrument(tracing::info_span!("Sending webmention"))
+                .await
+            {
+                Err(WebmentionError::NoEndpointDiscovered(_)) => Ok(()),
+                Ok(_) => Ok(()),
+                Err(e) => Err(e).with_lemmy_type(LemmyErrorType::CouldntSendWebmention),
+            }
+        };
+        if *SYNCHRONOUS_FEDERATION {
+            task.await?;
+        } else {
+            spawn_try_task(task);
+        }
+    };
+
+    build_post_response(&context, community_id, person_id, post_id).await
 }

--- a/crates/api_crud/src/post/delete.rs
+++ b/crates/api_crud/src/post/delete.rs
@@ -1,63 +1,63 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  build_response::build_post_response,
-  context::LemmyContext,
-  post::{DeletePost, PostResponse},
-  send_activity::{ActivityChannel, SendActivityData},
-  utils::{check_community_ban, check_community_deleted_or_removed, local_user_view_from_jwt},
+    build_response::build_post_response,
+    context::LemmyContext,
+    post::{DeletePost, PostResponse},
+    send_activity::{ActivityChannel, SendActivityData},
+    utils::{check_community_ban, check_community_deleted_or_removed, local_user_view_from_jwt},
 };
 use lemmy_db_schema::{
-  source::post::{Post, PostUpdateForm},
-  traits::Crud,
+    source::post::{Post, PostUpdateForm},
+    traits::Crud,
 };
 use lemmy_utils::error::{LemmyError, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn delete_post(
-  data: Json<DeletePost>,
-  context: Data<LemmyContext>,
+    data: Json<DeletePost>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<PostResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  let post_id = data.post_id;
-  let orig_post = Post::read(&mut context.pool(), post_id).await?;
+    let post_id = data.post_id;
+    let orig_post = Post::read(&mut context.pool(), post_id).await?;
 
-  // Dont delete it if its already been deleted.
-  if orig_post.deleted == data.deleted {
-    Err(LemmyErrorType::CouldntUpdatePost)?
-  }
+    // Dont delete it if its already been deleted.
+    if orig_post.deleted == data.deleted {
+        Err(LemmyErrorType::CouldntUpdatePost)?
+    }
 
-  check_community_ban(
-    local_user_view.person.id,
-    orig_post.community_id,
-    &mut context.pool(),
-  )
-  .await?;
-  check_community_deleted_or_removed(orig_post.community_id, &mut context.pool()).await?;
+    check_community_ban(
+        local_user_view.person.id,
+        orig_post.community_id,
+        &mut context.pool(),
+    )
+    .await?;
+    check_community_deleted_or_removed(orig_post.community_id, &mut context.pool()).await?;
 
-  // Verify that only the creator can delete
-  if !Post::is_post_creator(local_user_view.person.id, orig_post.creator_id) {
-    Err(LemmyErrorType::NoPostEditAllowed)?
-  }
+    // Verify that only the creator can delete
+    if !Post::is_post_creator(local_user_view.person.id, orig_post.creator_id) {
+        Err(LemmyErrorType::NoPostEditAllowed)?
+    }
 
-  // Update the post
-  let post = Post::update(
-    &mut context.pool(),
-    data.post_id,
-    &PostUpdateForm {
-      deleted: Some(data.deleted),
-      ..Default::default()
-    },
-  )
-  .await?;
+    // Update the post
+    let post = Post::update(
+        &mut context.pool(),
+        data.post_id,
+        &PostUpdateForm {
+            deleted: Some(data.deleted),
+            ..Default::default()
+        },
+    )
+    .await?;
 
-  let person_id = local_user_view.person.id;
-  ActivityChannel::submit_activity(
-    SendActivityData::DeletePost(post, local_user_view.person, data.0.clone()),
-    &context,
-  )
-  .await?;
+    let person_id = local_user_view.person.id;
+    ActivityChannel::submit_activity(
+        SendActivityData::DeletePost(post, local_user_view.person, data.0.clone()),
+        &context,
+    )
+    .await?;
 
-  build_post_response(&context, orig_post.community_id, person_id, data.post_id).await
+    build_post_response(&context, orig_post.community_id, person_id, data.post_id).await
 }

--- a/crates/api_crud/src/post/read.rs
+++ b/crates/api_crud/src/post/read.rs
@@ -1,18 +1,16 @@
 use actix_web::web::{Data, Json, Query};
 use lemmy_api_common::{
-  context::LemmyContext,
-  post::{GetPost, GetPostResponse},
-  utils::{
-    check_private_instance,
-    is_mod_or_admin_opt,
-    local_user_view_from_jwt_opt,
-    mark_post_as_read,
-  },
+    context::LemmyContext,
+    post::{GetPost, GetPostResponse},
+    utils::{
+        check_private_instance, is_mod_or_admin_opt, local_user_view_from_jwt_opt,
+        mark_post_as_read,
+    },
 };
 use lemmy_db_schema::{
-  aggregates::structs::{PersonPostAggregates, PersonPostAggregatesForm},
-  source::{comment::Comment, local_site::LocalSite, post::Post},
-  traits::Crud,
+    aggregates::structs::{PersonPostAggregates, PersonPostAggregatesForm},
+    source::{comment::Comment, local_site::LocalSite, post::Post},
+    traits::Crud,
 };
 use lemmy_db_views::{post_view::PostQuery, structs::PostView};
 use lemmy_db_views_actor::structs::{CommunityModeratorView, CommunityView};
@@ -20,96 +18,97 @@ use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn get_post(
-  data: Query<GetPost>,
-  context: Data<LemmyContext>,
+    data: Query<GetPost>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<GetPostResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt_opt(data.auth.as_ref(), &context).await;
-  let local_site = LocalSite::read(&mut context.pool()).await?;
+    let local_user_view = local_user_view_from_jwt_opt(data.auth.as_ref(), &context).await;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
 
-  check_private_instance(&local_user_view, &local_site)?;
+    check_private_instance(&local_user_view, &local_site)?;
 
-  let person_id = local_user_view.as_ref().map(|u| u.person.id);
+    let person_id = local_user_view.as_ref().map(|u| u.person.id);
 
-  // I'd prefer fetching the post_view by a comment join, but it adds a lot of boilerplate
-  let post_id = if let Some(id) = data.id {
-    id
-  } else if let Some(comment_id) = data.comment_id {
-    Comment::read(&mut context.pool(), comment_id)
-      .await
-      .with_lemmy_type(LemmyErrorType::CouldntFindPost)?
-      .post_id
-  } else {
-    Err(LemmyErrorType::CouldntFindPost)?
-  };
-
-  // Check to see if the person is a mod or admin, to show deleted / removed
-  let community_id = Post::read(&mut context.pool(), post_id).await?.community_id;
-  let is_mod_or_admin = is_mod_or_admin_opt(
-    &mut context.pool(),
-    local_user_view.as_ref(),
-    Some(community_id),
-  )
-  .await
-  .is_ok();
-
-  let post_view = PostView::read(&mut context.pool(), post_id, person_id, is_mod_or_admin)
-    .await
-    .with_lemmy_type(LemmyErrorType::CouldntFindPost)?;
-
-  // Mark the post as read
-  let post_id = post_view.post.id;
-  if let Some(person_id) = person_id {
-    mark_post_as_read(person_id, post_id, &mut context.pool()).await?;
-  }
-
-  // Necessary for the sidebar subscribed
-  let community_view = CommunityView::read(
-    &mut context.pool(),
-    community_id,
-    person_id,
-    is_mod_or_admin,
-  )
-  .await
-  .with_lemmy_type(LemmyErrorType::CouldntFindCommunity)?;
-
-  // Insert into PersonPostAggregates
-  // to update the read_comments count
-  if let Some(person_id) = person_id {
-    let read_comments = post_view.counts.comments;
-    let person_post_agg_form = PersonPostAggregatesForm {
-      person_id,
-      post_id,
-      read_comments,
-      ..PersonPostAggregatesForm::default()
+    // I'd prefer fetching the post_view by a comment join, but it adds a lot of boilerplate
+    let post_id = if let Some(id) = data.id {
+        id
+    } else if let Some(comment_id) = data.comment_id {
+        Comment::read(&mut context.pool(), comment_id)
+            .await
+            .with_lemmy_type(LemmyErrorType::CouldntFindPost)?
+            .post_id
+    } else {
+        Err(LemmyErrorType::CouldntFindPost)?
     };
-    PersonPostAggregates::upsert(&mut context.pool(), &person_post_agg_form)
-      .await
-      .with_lemmy_type(LemmyErrorType::CouldntFindPost)?;
-  }
 
-  let moderators = CommunityModeratorView::for_community(&mut context.pool(), community_id).await?;
+    // Check to see if the person is a mod or admin, to show deleted / removed
+    let community_id = Post::read(&mut context.pool(), post_id).await?.community_id;
+    let is_mod_or_admin = is_mod_or_admin_opt(
+        &mut context.pool(),
+        local_user_view.as_ref(),
+        Some(community_id),
+    )
+    .await
+    .is_ok();
 
-  // Fetch the cross_posts
-  let cross_posts = if let Some(url) = &post_view.post.url {
-    let mut x_posts = PostQuery {
-      url_search: Some(url.inner().as_str().into()),
-      ..Default::default()
+    let post_view = PostView::read(&mut context.pool(), post_id, person_id, is_mod_or_admin)
+        .await
+        .with_lemmy_type(LemmyErrorType::CouldntFindPost)?;
+
+    // Mark the post as read
+    let post_id = post_view.post.id;
+    if let Some(person_id) = person_id {
+        mark_post_as_read(person_id, post_id, &mut context.pool()).await?;
     }
-    .list(&mut context.pool())
-    .await?;
 
-    // Don't return this post as one of the cross_posts
-    x_posts.retain(|x| x.post.id != post_id);
-    x_posts
-  } else {
-    Vec::new()
-  };
+    // Necessary for the sidebar subscribed
+    let community_view = CommunityView::read(
+        &mut context.pool(),
+        community_id,
+        person_id,
+        is_mod_or_admin,
+    )
+    .await
+    .with_lemmy_type(LemmyErrorType::CouldntFindCommunity)?;
 
-  // Return the jwt
-  Ok(Json(GetPostResponse {
-    post_view,
-    community_view,
-    moderators,
-    cross_posts,
-  }))
+    // Insert into PersonPostAggregates
+    // to update the read_comments count
+    if let Some(person_id) = person_id {
+        let read_comments = post_view.counts.comments;
+        let person_post_agg_form = PersonPostAggregatesForm {
+            person_id,
+            post_id,
+            read_comments,
+            ..PersonPostAggregatesForm::default()
+        };
+        PersonPostAggregates::upsert(&mut context.pool(), &person_post_agg_form)
+            .await
+            .with_lemmy_type(LemmyErrorType::CouldntFindPost)?;
+    }
+
+    let moderators =
+        CommunityModeratorView::for_community(&mut context.pool(), community_id).await?;
+
+    // Fetch the cross_posts
+    let cross_posts = if let Some(url) = &post_view.post.url {
+        let mut x_posts = PostQuery {
+            url_search: Some(url.inner().as_str().into()),
+            ..Default::default()
+        }
+        .list(&mut context.pool())
+        .await?;
+
+        // Don't return this post as one of the cross_posts
+        x_posts.retain(|x| x.post.id != post_id);
+        x_posts
+    } else {
+        Vec::new()
+    };
+
+    // Return the jwt
+    Ok(Json(GetPostResponse {
+        post_view,
+        community_view,
+        moderators,
+        cross_posts,
+    }))
 }

--- a/crates/api_crud/src/post/remove.rs
+++ b/crates/api_crud/src/post/remove.rs
@@ -1,74 +1,74 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  build_response::build_post_response,
-  context::LemmyContext,
-  post::{PostResponse, RemovePost},
-  send_activity::{ActivityChannel, SendActivityData},
-  utils::{check_community_ban, is_mod_or_admin, local_user_view_from_jwt},
+    build_response::build_post_response,
+    context::LemmyContext,
+    post::{PostResponse, RemovePost},
+    send_activity::{ActivityChannel, SendActivityData},
+    utils::{check_community_ban, is_mod_or_admin, local_user_view_from_jwt},
 };
 use lemmy_db_schema::{
-  source::{
-    moderator::{ModRemovePost, ModRemovePostForm},
-    post::{Post, PostUpdateForm},
-  },
-  traits::Crud,
+    source::{
+        moderator::{ModRemovePost, ModRemovePostForm},
+        post::{Post, PostUpdateForm},
+    },
+    traits::Crud,
 };
 use lemmy_utils::error::LemmyError;
 
 #[tracing::instrument(skip(context))]
 pub async fn remove_post(
-  data: Json<RemovePost>,
-  context: Data<LemmyContext>,
+    data: Json<RemovePost>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<PostResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  let post_id = data.post_id;
-  let orig_post = Post::read(&mut context.pool(), post_id).await?;
+    let post_id = data.post_id;
+    let orig_post = Post::read(&mut context.pool(), post_id).await?;
 
-  check_community_ban(
-    local_user_view.person.id,
-    orig_post.community_id,
-    &mut context.pool(),
-  )
-  .await?;
+    check_community_ban(
+        local_user_view.person.id,
+        orig_post.community_id,
+        &mut context.pool(),
+    )
+    .await?;
 
-  // Verify that only the mods can remove
-  is_mod_or_admin(
-    &mut context.pool(),
-    local_user_view.person.id,
-    orig_post.community_id,
-  )
-  .await?;
+    // Verify that only the mods can remove
+    is_mod_or_admin(
+        &mut context.pool(),
+        local_user_view.person.id,
+        orig_post.community_id,
+    )
+    .await?;
 
-  // Update the post
-  let post_id = data.post_id;
-  let removed = data.removed;
-  let post = Post::update(
-    &mut context.pool(),
-    post_id,
-    &PostUpdateForm {
-      removed: Some(removed),
-      ..Default::default()
-    },
-  )
-  .await?;
+    // Update the post
+    let post_id = data.post_id;
+    let removed = data.removed;
+    let post = Post::update(
+        &mut context.pool(),
+        post_id,
+        &PostUpdateForm {
+            removed: Some(removed),
+            ..Default::default()
+        },
+    )
+    .await?;
 
-  // Mod tables
-  let form = ModRemovePostForm {
-    mod_person_id: local_user_view.person.id,
-    post_id: data.post_id,
-    removed: Some(removed),
-    reason: data.reason.clone(),
-  };
-  ModRemovePost::create(&mut context.pool(), &form).await?;
+    // Mod tables
+    let form = ModRemovePostForm {
+        mod_person_id: local_user_view.person.id,
+        post_id: data.post_id,
+        removed: Some(removed),
+        reason: data.reason.clone(),
+    };
+    ModRemovePost::create(&mut context.pool(), &form).await?;
 
-  let person_id = local_user_view.person.id;
-  ActivityChannel::submit_activity(
-    SendActivityData::RemovePost(post, local_user_view.person, data.0),
-    &context,
-  )
-  .await?;
+    let person_id = local_user_view.person.id;
+    ActivityChannel::submit_activity(
+        SendActivityData::RemovePost(post, local_user_view.person, data.0),
+        &context,
+    )
+    .await?;
 
-  build_post_response(&context, orig_post.community_id, person_id, post_id).await
+    build_post_response(&context, orig_post.community_id, person_id, post_id).await
 }

--- a/crates/api_crud/src/post/update.rs
+++ b/crates/api_crud/src/post/update.rs
@@ -1,124 +1,123 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  build_response::build_post_response,
-  context::LemmyContext,
-  post::{EditPost, PostResponse},
-  request::fetch_site_data,
-  send_activity::{ActivityChannel, SendActivityData},
-  utils::{
-    check_community_ban,
-    local_site_to_slur_regex,
-    local_user_view_from_jwt,
-    sanitize_html_opt,
-  },
+    build_response::build_post_response,
+    context::LemmyContext,
+    post::{EditPost, PostResponse},
+    request::fetch_site_data,
+    send_activity::{ActivityChannel, SendActivityData},
+    utils::{
+        check_community_ban, local_site_to_slur_regex, local_user_view_from_jwt, sanitize_html_opt,
+    },
 };
 use lemmy_db_schema::{
-  source::{
-    actor_language::CommunityLanguage,
-    local_site::LocalSite,
-    post::{Post, PostUpdateForm},
-  },
-  traits::Crud,
-  utils::{diesel_option_overwrite, naive_now},
+    source::{
+        actor_language::CommunityLanguage,
+        local_site::LocalSite,
+        post::{Post, PostUpdateForm},
+    },
+    traits::Crud,
+    utils::{diesel_option_overwrite, naive_now},
 };
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
-  utils::{
-    slurs::check_slurs_opt,
-    validation::{check_url_scheme, clean_url_params, is_valid_body_field, is_valid_post_title},
-  },
+    error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+    utils::{
+        slurs::check_slurs_opt,
+        validation::{
+            check_url_scheme, clean_url_params, is_valid_body_field, is_valid_post_title,
+        },
+    },
 };
 use std::ops::Deref;
 
 #[tracing::instrument(skip(context))]
 pub async fn update_post(
-  data: Json<EditPost>,
-  context: Data<LemmyContext>,
+    data: Json<EditPost>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<PostResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
-  let local_site = LocalSite::read(&mut context.pool()).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
 
-  let data_url = data.url.as_ref();
+    let data_url = data.url.as_ref();
 
-  // TODO No good way to handle a clear.
-  // Issue link: https://github.com/LemmyNet/lemmy/issues/2287
-  let url = Some(data_url.map(clean_url_params).map(Into::into));
+    // TODO No good way to handle a clear.
+    // Issue link: https://github.com/LemmyNet/lemmy/issues/2287
+    let url = Some(data_url.map(clean_url_params).map(Into::into));
 
-  let slur_regex = local_site_to_slur_regex(&local_site);
-  check_slurs_opt(&data.name, &slur_regex)?;
-  check_slurs_opt(&data.body, &slur_regex)?;
+    let slur_regex = local_site_to_slur_regex(&local_site);
+    check_slurs_opt(&data.name, &slur_regex)?;
+    check_slurs_opt(&data.body, &slur_regex)?;
 
-  if let Some(name) = &data.name {
-    is_valid_post_title(name)?;
-  }
+    if let Some(name) = &data.name {
+        is_valid_post_title(name)?;
+    }
 
-  is_valid_body_field(&data.body, true)?;
-  check_url_scheme(&data.url)?;
+    is_valid_body_field(&data.body, true)?;
+    check_url_scheme(&data.url)?;
 
-  let post_id = data.post_id;
-  let orig_post = Post::read(&mut context.pool(), post_id).await?;
+    let post_id = data.post_id;
+    let orig_post = Post::read(&mut context.pool(), post_id).await?;
 
-  check_community_ban(
-    local_user_view.person.id,
-    orig_post.community_id,
-    &mut context.pool(),
-  )
-  .await?;
+    check_community_ban(
+        local_user_view.person.id,
+        orig_post.community_id,
+        &mut context.pool(),
+    )
+    .await?;
 
-  // Verify that only the creator can edit
-  if !Post::is_post_creator(local_user_view.person.id, orig_post.creator_id) {
-    Err(LemmyErrorType::NoPostEditAllowed)?
-  }
+    // Verify that only the creator can edit
+    if !Post::is_post_creator(local_user_view.person.id, orig_post.creator_id) {
+        Err(LemmyErrorType::NoPostEditAllowed)?
+    }
 
-  // Fetch post links and Pictrs cached image
-  let data_url = data.url.as_ref();
-  let (metadata_res, thumbnail_url) =
-    fetch_site_data(context.client(), context.settings(), data_url, true).await;
-  let (embed_title, embed_description, embed_video_url) = metadata_res
-    .map(|u| (Some(u.title), Some(u.description), Some(u.embed_video_url)))
-    .unwrap_or_default();
+    // Fetch post links and Pictrs cached image
+    let data_url = data.url.as_ref();
+    let (metadata_res, thumbnail_url) =
+        fetch_site_data(context.client(), context.settings(), data_url, true).await;
+    let (embed_title, embed_description, embed_video_url) = metadata_res
+        .map(|u| (Some(u.title), Some(u.description), Some(u.embed_video_url)))
+        .unwrap_or_default();
 
-  let name = sanitize_html_opt(&data.name);
-  let body = sanitize_html_opt(&data.body);
-  let body = diesel_option_overwrite(body);
-  let embed_title = embed_title.map(|e| sanitize_html_opt(&e));
-  let embed_description = embed_description.map(|e| sanitize_html_opt(&e));
+    let name = sanitize_html_opt(&data.name);
+    let body = sanitize_html_opt(&data.body);
+    let body = diesel_option_overwrite(body);
+    let embed_title = embed_title.map(|e| sanitize_html_opt(&e));
+    let embed_description = embed_description.map(|e| sanitize_html_opt(&e));
 
-  let language_id = data.language_id;
-  CommunityLanguage::is_allowed_community_language(
-    &mut context.pool(),
-    language_id,
-    orig_post.community_id,
-  )
-  .await?;
+    let language_id = data.language_id;
+    CommunityLanguage::is_allowed_community_language(
+        &mut context.pool(),
+        language_id,
+        orig_post.community_id,
+    )
+    .await?;
 
-  let post_form = PostUpdateForm {
-    name,
-    url,
-    body,
-    nsfw: data.nsfw,
-    embed_title,
-    embed_description,
-    embed_video_url,
-    language_id: data.language_id,
-    thumbnail_url: Some(thumbnail_url),
-    updated: Some(Some(naive_now())),
-    ..Default::default()
-  };
+    let post_form = PostUpdateForm {
+        name,
+        url,
+        body,
+        nsfw: data.nsfw,
+        embed_title,
+        embed_description,
+        embed_video_url,
+        language_id: data.language_id,
+        thumbnail_url: Some(thumbnail_url),
+        updated: Some(Some(naive_now())),
+        ..Default::default()
+    };
 
-  let post_id = data.post_id;
-  let updated_post = Post::update(&mut context.pool(), post_id, &post_form)
+    let post_id = data.post_id;
+    let updated_post = Post::update(&mut context.pool(), post_id, &post_form)
+        .await
+        .with_lemmy_type(LemmyErrorType::CouldntUpdatePost)?;
+
+    ActivityChannel::submit_activity(SendActivityData::UpdatePost(updated_post), &context).await?;
+
+    build_post_response(
+        context.deref(),
+        orig_post.community_id,
+        local_user_view.person.id,
+        post_id,
+    )
     .await
-    .with_lemmy_type(LemmyErrorType::CouldntUpdatePost)?;
-
-  ActivityChannel::submit_activity(SendActivityData::UpdatePost(updated_post), &context).await?;
-
-  build_post_response(
-    context.deref(),
-    orig_post.community_id,
-    local_user_view.person.id,
-    post_id,
-  )
-  .await
 }

--- a/crates/api_crud/src/private_message/create.rs
+++ b/crates/api_crud/src/private_message/create.rs
@@ -1,105 +1,101 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  context::LemmyContext,
-  private_message::{CreatePrivateMessage, PrivateMessageResponse},
-  send_activity::{ActivityChannel, SendActivityData},
-  utils::{
-    check_person_block,
-    generate_local_apub_endpoint,
-    get_interface_language,
-    local_site_to_slur_regex,
-    local_user_view_from_jwt,
-    sanitize_html,
-    send_email_to_user,
-    EndpointType,
-  },
+    context::LemmyContext,
+    private_message::{CreatePrivateMessage, PrivateMessageResponse},
+    send_activity::{ActivityChannel, SendActivityData},
+    utils::{
+        check_person_block, generate_local_apub_endpoint, get_interface_language,
+        local_site_to_slur_regex, local_user_view_from_jwt, sanitize_html, send_email_to_user,
+        EndpointType,
+    },
 };
 use lemmy_db_schema::{
-  source::{
-    local_site::LocalSite,
-    private_message::{PrivateMessage, PrivateMessageInsertForm, PrivateMessageUpdateForm},
-  },
-  traits::Crud,
+    source::{
+        local_site::LocalSite,
+        private_message::{PrivateMessage, PrivateMessageInsertForm, PrivateMessageUpdateForm},
+    },
+    traits::Crud,
 };
 use lemmy_db_views::structs::{LocalUserView, PrivateMessageView};
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
-  utils::{slurs::remove_slurs, validation::is_valid_body_field},
+    error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+    utils::{slurs::remove_slurs, validation::is_valid_body_field},
 };
 
 #[tracing::instrument(skip(context))]
 pub async fn create_private_message(
-  data: Json<CreatePrivateMessage>,
-  context: Data<LemmyContext>,
+    data: Json<CreatePrivateMessage>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<PrivateMessageResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
-  let local_site = LocalSite::read(&mut context.pool()).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
 
-  let content = sanitize_html(&data.content);
-  let content = remove_slurs(&content, &local_site_to_slur_regex(&local_site));
-  is_valid_body_field(&Some(content.clone()), false)?;
+    let content = sanitize_html(&data.content);
+    let content = remove_slurs(&content, &local_site_to_slur_regex(&local_site));
+    is_valid_body_field(&Some(content.clone()), false)?;
 
-  check_person_block(
-    local_user_view.person.id,
-    data.recipient_id,
-    &mut context.pool(),
-  )
-  .await?;
+    check_person_block(
+        local_user_view.person.id,
+        data.recipient_id,
+        &mut context.pool(),
+    )
+    .await?;
 
-  let private_message_form = PrivateMessageInsertForm::builder()
-    .content(content.clone())
-    .creator_id(local_user_view.person.id)
-    .recipient_id(data.recipient_id)
-    .build();
+    let private_message_form = PrivateMessageInsertForm::builder()
+        .content(content.clone())
+        .creator_id(local_user_view.person.id)
+        .recipient_id(data.recipient_id)
+        .build();
 
-  let inserted_private_message = PrivateMessage::create(&mut context.pool(), &private_message_form)
+    let inserted_private_message =
+        PrivateMessage::create(&mut context.pool(), &private_message_form)
+            .await
+            .with_lemmy_type(LemmyErrorType::CouldntCreatePrivateMessage)?;
+
+    let inserted_private_message_id = inserted_private_message.id;
+    let protocol_and_hostname = context.settings().get_protocol_and_hostname();
+    let apub_id = generate_local_apub_endpoint(
+        EndpointType::PrivateMessage,
+        &inserted_private_message_id.to_string(),
+        &protocol_and_hostname,
+    )?;
+    PrivateMessage::update(
+        &mut context.pool(),
+        inserted_private_message.id,
+        &PrivateMessageUpdateForm {
+            ap_id: Some(apub_id),
+            ..Default::default()
+        },
+    )
     .await
     .with_lemmy_type(LemmyErrorType::CouldntCreatePrivateMessage)?;
 
-  let inserted_private_message_id = inserted_private_message.id;
-  let protocol_and_hostname = context.settings().get_protocol_and_hostname();
-  let apub_id = generate_local_apub_endpoint(
-    EndpointType::PrivateMessage,
-    &inserted_private_message_id.to_string(),
-    &protocol_and_hostname,
-  )?;
-  PrivateMessage::update(
-    &mut context.pool(),
-    inserted_private_message.id,
-    &PrivateMessageUpdateForm {
-      ap_id: Some(apub_id),
-      ..Default::default()
-    },
-  )
-  .await
-  .with_lemmy_type(LemmyErrorType::CouldntCreatePrivateMessage)?;
+    let view = PrivateMessageView::read(&mut context.pool(), inserted_private_message.id).await?;
 
-  let view = PrivateMessageView::read(&mut context.pool(), inserted_private_message.id).await?;
+    // Send email to the local recipient, if one exists
+    if view.recipient.local {
+        let recipient_id = data.recipient_id;
+        let local_recipient = LocalUserView::read_person(&mut context.pool(), recipient_id).await?;
+        let lang = get_interface_language(&local_recipient);
+        let inbox_link = format!("{}/inbox", context.settings().get_protocol_and_hostname());
+        let sender_name = &local_user_view.person.name;
+        send_email_to_user(
+            &local_recipient,
+            &lang.notification_private_message_subject(sender_name),
+            &lang.notification_private_message_body(inbox_link, &content, sender_name),
+            context.settings(),
+        )
+        .await;
+    }
 
-  // Send email to the local recipient, if one exists
-  if view.recipient.local {
-    let recipient_id = data.recipient_id;
-    let local_recipient = LocalUserView::read_person(&mut context.pool(), recipient_id).await?;
-    let lang = get_interface_language(&local_recipient);
-    let inbox_link = format!("{}/inbox", context.settings().get_protocol_and_hostname());
-    let sender_name = &local_user_view.person.name;
-    send_email_to_user(
-      &local_recipient,
-      &lang.notification_private_message_subject(sender_name),
-      &lang.notification_private_message_body(inbox_link, &content, sender_name),
-      context.settings(),
+    ActivityChannel::submit_activity(
+        SendActivityData::CreatePrivateMessage(view.clone()),
+        &context,
     )
-    .await;
-  }
+    .await?;
 
-  ActivityChannel::submit_activity(
-    SendActivityData::CreatePrivateMessage(view.clone()),
-    &context,
-  )
-  .await?;
-
-  Ok(Json(PrivateMessageResponse {
-    private_message_view: view,
-  }))
+    Ok(Json(PrivateMessageResponse {
+        private_message_view: view,
+    }))
 }

--- a/crates/api_crud/src/private_message/delete.rs
+++ b/crates/api_crud/src/private_message/delete.rs
@@ -1,54 +1,59 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  context::LemmyContext,
-  private_message::{DeletePrivateMessage, PrivateMessageResponse},
-  send_activity::{ActivityChannel, SendActivityData},
-  utils::local_user_view_from_jwt,
+    context::LemmyContext,
+    private_message::{DeletePrivateMessage, PrivateMessageResponse},
+    send_activity::{ActivityChannel, SendActivityData},
+    utils::local_user_view_from_jwt,
 };
 use lemmy_db_schema::{
-  source::private_message::{PrivateMessage, PrivateMessageUpdateForm},
-  traits::Crud,
+    source::private_message::{PrivateMessage, PrivateMessageUpdateForm},
+    traits::Crud,
 };
 use lemmy_db_views::structs::PrivateMessageView;
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn delete_private_message(
-  data: Json<DeletePrivateMessage>,
-  context: Data<LemmyContext>,
+    data: Json<DeletePrivateMessage>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<PrivateMessageResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
-  // Checking permissions
-  let private_message_id = data.private_message_id;
-  let orig_private_message = PrivateMessage::read(&mut context.pool(), private_message_id).await?;
-  if local_user_view.person.id != orig_private_message.creator_id {
-    Err(LemmyErrorType::EditPrivateMessageNotAllowed)?
-  }
+    // Checking permissions
+    let private_message_id = data.private_message_id;
+    let orig_private_message =
+        PrivateMessage::read(&mut context.pool(), private_message_id).await?;
+    if local_user_view.person.id != orig_private_message.creator_id {
+        Err(LemmyErrorType::EditPrivateMessageNotAllowed)?
+    }
 
-  // Doing the update
-  let private_message_id = data.private_message_id;
-  let deleted = data.deleted;
-  let private_message = PrivateMessage::update(
-    &mut context.pool(),
-    private_message_id,
-    &PrivateMessageUpdateForm {
-      deleted: Some(deleted),
-      ..Default::default()
-    },
-  )
-  .await
-  .with_lemmy_type(LemmyErrorType::CouldntUpdatePrivateMessage)?;
+    // Doing the update
+    let private_message_id = data.private_message_id;
+    let deleted = data.deleted;
+    let private_message = PrivateMessage::update(
+        &mut context.pool(),
+        private_message_id,
+        &PrivateMessageUpdateForm {
+            deleted: Some(deleted),
+            ..Default::default()
+        },
+    )
+    .await
+    .with_lemmy_type(LemmyErrorType::CouldntUpdatePrivateMessage)?;
 
-  ActivityChannel::submit_activity(
-    SendActivityData::DeletePrivateMessage(local_user_view.person, private_message, data.deleted),
-    &context,
-  )
-  .await?;
+    ActivityChannel::submit_activity(
+        SendActivityData::DeletePrivateMessage(
+            local_user_view.person,
+            private_message,
+            data.deleted,
+        ),
+        &context,
+    )
+    .await?;
 
-  let view = PrivateMessageView::read(&mut context.pool(), private_message_id).await?;
-  Ok(Json(PrivateMessageResponse {
-    private_message_view: view,
-  }))
+    let view = PrivateMessageView::read(&mut context.pool(), private_message_id).await?;
+    Ok(Json(PrivateMessageResponse {
+        private_message_view: view,
+    }))
 }

--- a/crates/api_crud/src/private_message/read.rs
+++ b/crates/api_crud/src/private_message/read.rs
@@ -1,42 +1,42 @@
 use actix_web::web::{Data, Json, Query};
 use lemmy_api_common::{
-  context::LemmyContext,
-  private_message::{GetPrivateMessages, PrivateMessagesResponse},
-  utils::local_user_view_from_jwt,
+    context::LemmyContext,
+    private_message::{GetPrivateMessages, PrivateMessagesResponse},
+    utils::local_user_view_from_jwt,
 };
 use lemmy_db_views::private_message_view::PrivateMessageQuery;
 use lemmy_utils::error::LemmyError;
 
 #[tracing::instrument(skip(context))]
 pub async fn get_private_message(
-  data: Query<GetPrivateMessages>,
-  context: Data<LemmyContext>,
+    data: Query<GetPrivateMessages>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<PrivateMessagesResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(data.auth.as_ref(), &context).await?;
-  let person_id = local_user_view.person.id;
+    let local_user_view = local_user_view_from_jwt(data.auth.as_ref(), &context).await?;
+    let person_id = local_user_view.person.id;
 
-  let page = data.page;
-  let limit = data.limit;
-  let unread_only = data.unread_only.unwrap_or_default();
-  let creator_id = data.creator_id;
-  let mut messages = PrivateMessageQuery {
-    page,
-    limit,
-    unread_only,
-    creator_id,
-  }
-  .list(&mut context.pool(), person_id)
-  .await?;
-
-  // Messages sent by ourselves should be marked as read. The `read` column in database is only
-  // for the recipient, and shouldnt be exposed to sender.
-  messages.iter_mut().for_each(|pmv| {
-    if pmv.creator.id == person_id {
-      pmv.private_message.read = true
+    let page = data.page;
+    let limit = data.limit;
+    let unread_only = data.unread_only.unwrap_or_default();
+    let creator_id = data.creator_id;
+    let mut messages = PrivateMessageQuery {
+        page,
+        limit,
+        unread_only,
+        creator_id,
     }
-  });
+    .list(&mut context.pool(), person_id)
+    .await?;
 
-  Ok(Json(PrivateMessagesResponse {
-    private_messages: messages,
-  }))
+    // Messages sent by ourselves should be marked as read. The `read` column in database is only
+    // for the recipient, and shouldnt be exposed to sender.
+    messages.iter_mut().for_each(|pmv| {
+        if pmv.creator.id == person_id {
+            pmv.private_message.read = true
+        }
+    });
+
+    Ok(Json(PrivateMessagesResponse {
+        private_messages: messages,
+    }))
 }

--- a/crates/api_crud/src/private_message/update.rs
+++ b/crates/api_crud/src/private_message/update.rs
@@ -1,67 +1,68 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  context::LemmyContext,
-  private_message::{EditPrivateMessage, PrivateMessageResponse},
-  send_activity::{ActivityChannel, SendActivityData},
-  utils::{local_site_to_slur_regex, local_user_view_from_jwt, sanitize_html},
+    context::LemmyContext,
+    private_message::{EditPrivateMessage, PrivateMessageResponse},
+    send_activity::{ActivityChannel, SendActivityData},
+    utils::{local_site_to_slur_regex, local_user_view_from_jwt, sanitize_html},
 };
 use lemmy_db_schema::{
-  source::{
-    local_site::LocalSite,
-    private_message::{PrivateMessage, PrivateMessageUpdateForm},
-  },
-  traits::Crud,
-  utils::naive_now,
+    source::{
+        local_site::LocalSite,
+        private_message::{PrivateMessage, PrivateMessageUpdateForm},
+    },
+    traits::Crud,
+    utils::naive_now,
 };
 use lemmy_db_views::structs::PrivateMessageView;
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
-  utils::{slurs::remove_slurs, validation::is_valid_body_field},
+    error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+    utils::{slurs::remove_slurs, validation::is_valid_body_field},
 };
 
 #[tracing::instrument(skip(context))]
 pub async fn update_private_message(
-  data: Json<EditPrivateMessage>,
-  context: Data<LemmyContext>,
+    data: Json<EditPrivateMessage>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<PrivateMessageResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
-  let local_site = LocalSite::read(&mut context.pool()).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
 
-  // Checking permissions
-  let private_message_id = data.private_message_id;
-  let orig_private_message = PrivateMessage::read(&mut context.pool(), private_message_id).await?;
-  if local_user_view.person.id != orig_private_message.creator_id {
-    Err(LemmyErrorType::EditPrivateMessageNotAllowed)?
-  }
+    // Checking permissions
+    let private_message_id = data.private_message_id;
+    let orig_private_message =
+        PrivateMessage::read(&mut context.pool(), private_message_id).await?;
+    if local_user_view.person.id != orig_private_message.creator_id {
+        Err(LemmyErrorType::EditPrivateMessageNotAllowed)?
+    }
 
-  // Doing the update
-  let content = sanitize_html(&data.content);
-  let content = remove_slurs(&content, &local_site_to_slur_regex(&local_site));
-  is_valid_body_field(&Some(content.clone()), false)?;
+    // Doing the update
+    let content = sanitize_html(&data.content);
+    let content = remove_slurs(&content, &local_site_to_slur_regex(&local_site));
+    is_valid_body_field(&Some(content.clone()), false)?;
 
-  let private_message_id = data.private_message_id;
-  PrivateMessage::update(
-    &mut context.pool(),
-    private_message_id,
-    &PrivateMessageUpdateForm {
-      content: Some(content),
-      updated: Some(Some(naive_now())),
-      ..Default::default()
-    },
-  )
-  .await
-  .with_lemmy_type(LemmyErrorType::CouldntUpdatePrivateMessage)?;
+    let private_message_id = data.private_message_id;
+    PrivateMessage::update(
+        &mut context.pool(),
+        private_message_id,
+        &PrivateMessageUpdateForm {
+            content: Some(content),
+            updated: Some(Some(naive_now())),
+            ..Default::default()
+        },
+    )
+    .await
+    .with_lemmy_type(LemmyErrorType::CouldntUpdatePrivateMessage)?;
 
-  let view = PrivateMessageView::read(&mut context.pool(), private_message_id).await?;
+    let view = PrivateMessageView::read(&mut context.pool(), private_message_id).await?;
 
-  ActivityChannel::submit_activity(
-    SendActivityData::UpdatePrivateMessage(view.clone()),
-    &context,
-  )
-  .await?;
+    ActivityChannel::submit_activity(
+        SendActivityData::UpdatePrivateMessage(view.clone()),
+        &context,
+    )
+    .await?;
 
-  Ok(Json(PrivateMessageResponse {
-    private_message_view: view,
-  }))
+    Ok(Json(PrivateMessageResponse {
+        private_message_view: view,
+    }))
 }

--- a/crates/api_crud/src/site/create.rs
+++ b/crates/api_crud/src/site/create.rs
@@ -2,205 +2,198 @@ use crate::site::{application_question_check, site_default_post_listing_type_che
 use activitypub_federation::http_signatures::generate_actor_keypair;
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  context::LemmyContext,
-  site::{CreateSite, SiteResponse},
-  utils::{
-    generate_site_inbox_url,
-    is_admin,
-    local_site_rate_limit_to_rate_limit_config,
-    local_user_view_from_jwt,
-    sanitize_html,
-    sanitize_html_opt,
-  },
+    context::LemmyContext,
+    site::{CreateSite, SiteResponse},
+    utils::{
+        generate_site_inbox_url, is_admin, local_site_rate_limit_to_rate_limit_config,
+        local_user_view_from_jwt, sanitize_html, sanitize_html_opt,
+    },
 };
 use lemmy_db_schema::{
-  newtypes::DbUrl,
-  source::{
-    local_site::{LocalSite, LocalSiteUpdateForm},
-    local_site_rate_limit::{LocalSiteRateLimit, LocalSiteRateLimitUpdateForm},
-    site::{Site, SiteUpdateForm},
-    tagline::Tagline,
-  },
-  traits::Crud,
-  utils::{diesel_option_overwrite, diesel_option_overwrite_to_url, naive_now},
+    newtypes::DbUrl,
+    source::{
+        local_site::{LocalSite, LocalSiteUpdateForm},
+        local_site_rate_limit::{LocalSiteRateLimit, LocalSiteRateLimitUpdateForm},
+        site::{Site, SiteUpdateForm},
+        tagline::Tagline,
+    },
+    traits::Crud,
+    utils::{diesel_option_overwrite, diesel_option_overwrite_to_url, naive_now},
 };
 use lemmy_db_views::structs::SiteView;
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorType, LemmyResult},
-  utils::{
-    slurs::{check_slurs, check_slurs_opt},
-    validation::{
-      build_and_check_regex,
-      check_site_visibility_valid,
-      is_valid_body_field,
-      site_description_length_check,
-      site_name_length_check,
+    error::{LemmyError, LemmyErrorType, LemmyResult},
+    utils::{
+        slurs::{check_slurs, check_slurs_opt},
+        validation::{
+            build_and_check_regex, check_site_visibility_valid, is_valid_body_field,
+            site_description_length_check, site_name_length_check,
+        },
     },
-  },
 };
 use url::Url;
 
 #[tracing::instrument(skip(context))]
 pub async fn create_site(
-  data: Json<CreateSite>,
-  context: Data<LemmyContext>,
+    data: Json<CreateSite>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<SiteResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
-  let local_site = LocalSite::read(&mut context.pool()).await?;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
 
-  // Make sure user is an admin; other types of users should not create site data...
-  is_admin(&local_user_view)?;
+    // Make sure user is an admin; other types of users should not create site data...
+    is_admin(&local_user_view)?;
 
-  validate_create_payload(&local_site, &data)?;
+    validate_create_payload(&local_site, &data)?;
 
-  let actor_id: DbUrl = Url::parse(&context.settings().get_protocol_and_hostname())?.into();
-  let inbox_url = Some(generate_site_inbox_url(&actor_id)?);
-  let keypair = generate_actor_keypair()?;
-  let name = sanitize_html(&data.name);
-  let sidebar = sanitize_html_opt(&data.sidebar);
-  let description = sanitize_html_opt(&data.description);
+    let actor_id: DbUrl = Url::parse(&context.settings().get_protocol_and_hostname())?.into();
+    let inbox_url = Some(generate_site_inbox_url(&actor_id)?);
+    let keypair = generate_actor_keypair()?;
+    let name = sanitize_html(&data.name);
+    let sidebar = sanitize_html_opt(&data.sidebar);
+    let description = sanitize_html_opt(&data.description);
 
-  let site_form = SiteUpdateForm {
-    name: Some(name),
-    sidebar: diesel_option_overwrite(sidebar),
-    description: diesel_option_overwrite(description),
-    icon: diesel_option_overwrite_to_url(&data.icon)?,
-    banner: diesel_option_overwrite_to_url(&data.banner)?,
-    actor_id: Some(actor_id),
-    last_refreshed_at: Some(naive_now()),
-    inbox_url,
-    private_key: Some(Some(keypair.private_key)),
-    public_key: Some(keypair.public_key),
-    ..Default::default()
-  };
+    let site_form = SiteUpdateForm {
+        name: Some(name),
+        sidebar: diesel_option_overwrite(sidebar),
+        description: diesel_option_overwrite(description),
+        icon: diesel_option_overwrite_to_url(&data.icon)?,
+        banner: diesel_option_overwrite_to_url(&data.banner)?,
+        actor_id: Some(actor_id),
+        last_refreshed_at: Some(naive_now()),
+        inbox_url,
+        private_key: Some(Some(keypair.private_key)),
+        public_key: Some(keypair.public_key),
+        ..Default::default()
+    };
 
-  let site_id = local_site.site_id;
+    let site_id = local_site.site_id;
 
-  Site::update(&mut context.pool(), site_id, &site_form).await?;
+    Site::update(&mut context.pool(), site_id, &site_form).await?;
 
-  let application_question = sanitize_html_opt(&data.application_question);
-  let default_theme = sanitize_html_opt(&data.default_theme);
-  let legal_information = sanitize_html_opt(&data.legal_information);
+    let application_question = sanitize_html_opt(&data.application_question);
+    let default_theme = sanitize_html_opt(&data.default_theme);
+    let legal_information = sanitize_html_opt(&data.legal_information);
 
-  let local_site_form = LocalSiteUpdateForm {
-    // Set the site setup to true
-    site_setup: Some(true),
-    enable_downvotes: data.enable_downvotes,
-    registration_mode: data.registration_mode,
-    enable_nsfw: data.enable_nsfw,
-    community_creation_admin_only: data.community_creation_admin_only,
-    require_email_verification: data.require_email_verification,
-    application_question: diesel_option_overwrite(application_question),
-    private_instance: data.private_instance,
-    default_theme,
-    default_post_listing_type: data.default_post_listing_type,
-    legal_information: diesel_option_overwrite(legal_information),
-    application_email_admins: data.application_email_admins,
-    hide_modlog_mod_names: data.hide_modlog_mod_names,
-    updated: Some(Some(naive_now())),
-    slur_filter_regex: diesel_option_overwrite(data.slur_filter_regex.clone()),
-    actor_name_max_length: data.actor_name_max_length,
-    federation_enabled: data.federation_enabled,
-    captcha_enabled: data.captcha_enabled,
-    captcha_difficulty: data.captcha_difficulty.clone(),
-    ..Default::default()
-  };
+    let local_site_form = LocalSiteUpdateForm {
+        // Set the site setup to true
+        site_setup: Some(true),
+        enable_downvotes: data.enable_downvotes,
+        registration_mode: data.registration_mode,
+        enable_nsfw: data.enable_nsfw,
+        community_creation_admin_only: data.community_creation_admin_only,
+        require_email_verification: data.require_email_verification,
+        application_question: diesel_option_overwrite(application_question),
+        private_instance: data.private_instance,
+        default_theme,
+        default_post_listing_type: data.default_post_listing_type,
+        legal_information: diesel_option_overwrite(legal_information),
+        application_email_admins: data.application_email_admins,
+        hide_modlog_mod_names: data.hide_modlog_mod_names,
+        updated: Some(Some(naive_now())),
+        slur_filter_regex: diesel_option_overwrite(data.slur_filter_regex.clone()),
+        actor_name_max_length: data.actor_name_max_length,
+        federation_enabled: data.federation_enabled,
+        captcha_enabled: data.captcha_enabled,
+        captcha_difficulty: data.captcha_difficulty.clone(),
+        ..Default::default()
+    };
 
-  LocalSite::update(&mut context.pool(), &local_site_form).await?;
+    LocalSite::update(&mut context.pool(), &local_site_form).await?;
 
-  let local_site_rate_limit_form = LocalSiteRateLimitUpdateForm {
-    message: data.rate_limit_message,
-    message_per_second: data.rate_limit_message_per_second,
-    post: data.rate_limit_post,
-    post_per_second: data.rate_limit_post_per_second,
-    register: data.rate_limit_register,
-    register_per_second: data.rate_limit_register_per_second,
-    image: data.rate_limit_image,
-    image_per_second: data.rate_limit_image_per_second,
-    comment: data.rate_limit_comment,
-    comment_per_second: data.rate_limit_comment_per_second,
-    search: data.rate_limit_search,
-    search_per_second: data.rate_limit_search_per_second,
-    ..Default::default()
-  };
+    let local_site_rate_limit_form = LocalSiteRateLimitUpdateForm {
+        message: data.rate_limit_message,
+        message_per_second: data.rate_limit_message_per_second,
+        post: data.rate_limit_post,
+        post_per_second: data.rate_limit_post_per_second,
+        register: data.rate_limit_register,
+        register_per_second: data.rate_limit_register_per_second,
+        image: data.rate_limit_image,
+        image_per_second: data.rate_limit_image_per_second,
+        comment: data.rate_limit_comment,
+        comment_per_second: data.rate_limit_comment_per_second,
+        search: data.rate_limit_search,
+        search_per_second: data.rate_limit_search_per_second,
+        ..Default::default()
+    };
 
-  LocalSiteRateLimit::update(&mut context.pool(), &local_site_rate_limit_form).await?;
+    LocalSiteRateLimit::update(&mut context.pool(), &local_site_rate_limit_form).await?;
 
-  let site_view = SiteView::read_local(&mut context.pool()).await?;
+    let site_view = SiteView::read_local(&mut context.pool()).await?;
 
-  let new_taglines = data.taglines.clone();
-  let taglines = Tagline::replace(&mut context.pool(), local_site.id, new_taglines).await?;
+    let new_taglines = data.taglines.clone();
+    let taglines = Tagline::replace(&mut context.pool(), local_site.id, new_taglines).await?;
 
-  let rate_limit_config =
-    local_site_rate_limit_to_rate_limit_config(&site_view.local_site_rate_limit);
-  context
-    .settings_updated_channel()
-    .send(rate_limit_config)
-    .await?;
+    let rate_limit_config =
+        local_site_rate_limit_to_rate_limit_config(&site_view.local_site_rate_limit);
+    context
+        .settings_updated_channel()
+        .send(rate_limit_config)
+        .await?;
 
-  Ok(Json(SiteResponse {
-    site_view,
-    taglines,
-  }))
+    Ok(Json(SiteResponse {
+        site_view,
+        taglines,
+    }))
 }
 
 fn validate_create_payload(local_site: &LocalSite, create_site: &CreateSite) -> LemmyResult<()> {
-  // Make sure the site hasn't already been set up...
-  if local_site.site_setup {
-    Err(LemmyErrorType::SiteAlreadyExists)?
-  };
+    // Make sure the site hasn't already been set up...
+    if local_site.site_setup {
+        Err(LemmyErrorType::SiteAlreadyExists)?
+    };
 
-  // Check that the slur regex compiles, and returns the regex if valid...
-  // Prioritize using new slur regex from the request; if not provided, use the existing regex.
-  let slur_regex = build_and_check_regex(
-    &create_site
-      .slur_filter_regex
-      .as_deref()
-      .or(local_site.slur_filter_regex.as_deref()),
-  )?;
+    // Check that the slur regex compiles, and returns the regex if valid...
+    // Prioritize using new slur regex from the request; if not provided, use the existing regex.
+    let slur_regex = build_and_check_regex(
+        &create_site
+            .slur_filter_regex
+            .as_deref()
+            .or(local_site.slur_filter_regex.as_deref()),
+    )?;
 
-  site_name_length_check(&create_site.name)?;
-  check_slurs(&create_site.name, &slur_regex)?;
+    site_name_length_check(&create_site.name)?;
+    check_slurs(&create_site.name, &slur_regex)?;
 
-  if let Some(desc) = &create_site.description {
-    site_description_length_check(desc)?;
-    check_slurs_opt(&create_site.description, &slur_regex)?;
-  }
+    if let Some(desc) = &create_site.description {
+        site_description_length_check(desc)?;
+        check_slurs_opt(&create_site.description, &slur_regex)?;
+    }
 
-  site_default_post_listing_type_check(&create_site.default_post_listing_type)?;
+    site_default_post_listing_type_check(&create_site.default_post_listing_type)?;
 
-  check_site_visibility_valid(
-    local_site.private_instance,
-    local_site.federation_enabled,
-    &create_site.private_instance,
-    &create_site.federation_enabled,
-  )?;
+    check_site_visibility_valid(
+        local_site.private_instance,
+        local_site.federation_enabled,
+        &create_site.private_instance,
+        &create_site.federation_enabled,
+    )?;
 
-  // Ensure that the sidebar has fewer than the max num characters...
-  is_valid_body_field(&create_site.sidebar, false)?;
+    // Ensure that the sidebar has fewer than the max num characters...
+    is_valid_body_field(&create_site.sidebar, false)?;
 
-  application_question_check(
-    &local_site.application_question,
-    &create_site.application_question,
-    create_site
-      .registration_mode
-      .unwrap_or(local_site.registration_mode),
-  )
+    application_question_check(
+        &local_site.application_question,
+        &create_site.application_question,
+        create_site
+            .registration_mode
+            .unwrap_or(local_site.registration_mode),
+    )
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::site::create::validate_create_payload;
-  use lemmy_api_common::site::CreateSite;
-  use lemmy_db_schema::{source::local_site::LocalSite, ListingType, RegistrationMode};
-  use lemmy_utils::error::LemmyErrorType;
+    use crate::site::create::validate_create_payload;
+    use lemmy_api_common::site::CreateSite;
+    use lemmy_db_schema::{source::local_site::LocalSite, ListingType, RegistrationMode};
+    use lemmy_utils::error::LemmyErrorType;
 
-  #[test]
-  fn test_validate_invalid_create_payload() {
-    let invalid_payloads = [
+    #[test]
+    fn test_validate_invalid_create_payload() {
+        let invalid_payloads = [
       (
         "CreateSite attempted on set up LocalSite",
         LemmyErrorType::SiteAlreadyExists,
@@ -364,7 +357,7 @@ mod tests {
       ),
     ];
 
-    invalid_payloads.iter().enumerate().for_each(
+        invalid_payloads.iter().enumerate().for_each(
       |(
          idx,
          &(reason, ref expected_err, local_site, create_site),
@@ -392,204 +385,204 @@ mod tests {
         }
       },
     );
-  }
-
-  #[test]
-  fn test_validate_valid_create_payload() {
-    let valid_payloads = [
-      (
-        "No changes between LocalSite and CreateSite",
-        &generate_local_site(
-          false,
-          None::<String>,
-          true,
-          false,
-          None::<String>,
-          RegistrationMode::Open,
-        ),
-        &generate_create_site(
-          String::from("site_name"),
-          None::<String>,
-          None::<String>,
-          None::<ListingType>,
-          None::<String>,
-          None::<bool>,
-          None::<bool>,
-          None::<String>,
-          None::<RegistrationMode>,
-        ),
-      ),
-      (
-        "CreateSite allows clearing and changing values",
-        &generate_local_site(
-          false,
-          None::<String>,
-          true,
-          false,
-          None::<String>,
-          RegistrationMode::Open,
-        ),
-        &generate_create_site(
-          String::from("site_name"),
-          Some(String::new()),
-          Some(String::new()),
-          Some(ListingType::All),
-          Some(String::new()),
-          Some(false),
-          Some(true),
-          Some(String::new()),
-          Some(RegistrationMode::Open),
-        ),
-      ),
-      (
-        "CreateSite clears existing slur filter regex",
-        &generate_local_site(
-          false,
-          Some(String::from("(foo|bar)")),
-          true,
-          false,
-          None::<String>,
-          RegistrationMode::Open,
-        ),
-        &generate_create_site(
-          String::from("foo site_name"),
-          None::<String>,
-          None::<String>,
-          None::<ListingType>,
-          Some(String::new()),
-          None::<bool>,
-          None::<bool>,
-          None::<String>,
-          None::<RegistrationMode>,
-        ),
-      ),
-      (
-        "LocalSite has application question and CreateSite now requires applications,",
-        &generate_local_site(
-          false,
-          None::<String>,
-          true,
-          false,
-          Some(String::from("question")),
-          RegistrationMode::Open,
-        ),
-        &generate_create_site(
-          String::from("site_name"),
-          None::<String>,
-          None::<String>,
-          None::<ListingType>,
-          None::<String>,
-          None::<bool>,
-          None::<bool>,
-          None::<String>,
-          Some(RegistrationMode::RequireApplication),
-        ),
-      ),
-    ];
-
-    valid_payloads
-      .iter()
-      .enumerate()
-      .for_each(|(idx, &(reason, local_site, edit_site))| {
-        assert!(
-          validate_create_payload(local_site, edit_site).is_ok(),
-          "Got Err, but should have got Ok for reason: {}. valid_payloads.nth({})",
-          reason,
-          idx
-        );
-      })
-  }
-
-  fn generate_local_site(
-    site_setup: bool,
-    site_slur_filter_regex: Option<String>,
-    site_is_private: bool,
-    site_is_federated: bool,
-    site_application_question: Option<String>,
-    site_registration_mode: RegistrationMode,
-  ) -> LocalSite {
-    LocalSite {
-      id: Default::default(),
-      site_id: Default::default(),
-      site_setup,
-      enable_downvotes: false,
-      enable_nsfw: false,
-      community_creation_admin_only: false,
-      require_email_verification: false,
-      application_question: site_application_question,
-      private_instance: site_is_private,
-      default_theme: String::new(),
-      default_post_listing_type: ListingType::All,
-      legal_information: None,
-      hide_modlog_mod_names: false,
-      application_email_admins: false,
-      slur_filter_regex: site_slur_filter_regex,
-      actor_name_max_length: 0,
-      federation_enabled: site_is_federated,
-      captcha_enabled: false,
-      captcha_difficulty: String::new(),
-      published: Default::default(),
-      updated: None,
-      registration_mode: site_registration_mode,
-      reports_email_admins: false,
     }
-  }
 
-  // Allow the test helper function to have too many arguments.
-  // It's either this or generate the entire struct each time for testing.
-  #[allow(clippy::too_many_arguments)]
-  fn generate_create_site(
-    site_name: String,
-    site_description: Option<String>,
-    site_sidebar: Option<String>,
-    site_listing_type: Option<ListingType>,
-    site_slur_filter_regex: Option<String>,
-    site_is_private: Option<bool>,
-    site_is_federated: Option<bool>,
-    site_application_question: Option<String>,
-    site_registration_mode: Option<RegistrationMode>,
-  ) -> CreateSite {
-    CreateSite {
-      name: site_name,
-      sidebar: site_sidebar,
-      description: site_description,
-      icon: None,
-      banner: None,
-      enable_downvotes: None,
-      enable_nsfw: None,
-      community_creation_admin_only: None,
-      require_email_verification: None,
-      application_question: site_application_question,
-      private_instance: site_is_private,
-      default_theme: None,
-      default_post_listing_type: site_listing_type,
-      legal_information: None,
-      application_email_admins: None,
-      hide_modlog_mod_names: None,
-      discussion_languages: None,
-      slur_filter_regex: site_slur_filter_regex,
-      actor_name_max_length: None,
-      rate_limit_message: None,
-      rate_limit_message_per_second: None,
-      rate_limit_post: None,
-      rate_limit_post_per_second: None,
-      rate_limit_register: None,
-      rate_limit_register_per_second: None,
-      rate_limit_image: None,
-      rate_limit_image_per_second: None,
-      rate_limit_comment: None,
-      rate_limit_comment_per_second: None,
-      rate_limit_search: None,
-      rate_limit_search_per_second: None,
-      federation_enabled: site_is_federated,
-      federation_debug: None,
-      captcha_enabled: None,
-      captcha_difficulty: None,
-      allowed_instances: None,
-      blocked_instances: None,
-      taglines: None,
-      registration_mode: site_registration_mode,
-      auth: Default::default(),
+    #[test]
+    fn test_validate_valid_create_payload() {
+        let valid_payloads = [
+            (
+                "No changes between LocalSite and CreateSite",
+                &generate_local_site(
+                    false,
+                    None::<String>,
+                    true,
+                    false,
+                    None::<String>,
+                    RegistrationMode::Open,
+                ),
+                &generate_create_site(
+                    String::from("site_name"),
+                    None::<String>,
+                    None::<String>,
+                    None::<ListingType>,
+                    None::<String>,
+                    None::<bool>,
+                    None::<bool>,
+                    None::<String>,
+                    None::<RegistrationMode>,
+                ),
+            ),
+            (
+                "CreateSite allows clearing and changing values",
+                &generate_local_site(
+                    false,
+                    None::<String>,
+                    true,
+                    false,
+                    None::<String>,
+                    RegistrationMode::Open,
+                ),
+                &generate_create_site(
+                    String::from("site_name"),
+                    Some(String::new()),
+                    Some(String::new()),
+                    Some(ListingType::All),
+                    Some(String::new()),
+                    Some(false),
+                    Some(true),
+                    Some(String::new()),
+                    Some(RegistrationMode::Open),
+                ),
+            ),
+            (
+                "CreateSite clears existing slur filter regex",
+                &generate_local_site(
+                    false,
+                    Some(String::from("(foo|bar)")),
+                    true,
+                    false,
+                    None::<String>,
+                    RegistrationMode::Open,
+                ),
+                &generate_create_site(
+                    String::from("foo site_name"),
+                    None::<String>,
+                    None::<String>,
+                    None::<ListingType>,
+                    Some(String::new()),
+                    None::<bool>,
+                    None::<bool>,
+                    None::<String>,
+                    None::<RegistrationMode>,
+                ),
+            ),
+            (
+                "LocalSite has application question and CreateSite now requires applications,",
+                &generate_local_site(
+                    false,
+                    None::<String>,
+                    true,
+                    false,
+                    Some(String::from("question")),
+                    RegistrationMode::Open,
+                ),
+                &generate_create_site(
+                    String::from("site_name"),
+                    None::<String>,
+                    None::<String>,
+                    None::<ListingType>,
+                    None::<String>,
+                    None::<bool>,
+                    None::<bool>,
+                    None::<String>,
+                    Some(RegistrationMode::RequireApplication),
+                ),
+            ),
+        ];
+
+        valid_payloads
+            .iter()
+            .enumerate()
+            .for_each(|(idx, &(reason, local_site, edit_site))| {
+                assert!(
+                    validate_create_payload(local_site, edit_site).is_ok(),
+                    "Got Err, but should have got Ok for reason: {}. valid_payloads.nth({})",
+                    reason,
+                    idx
+                );
+            })
     }
-  }
+
+    fn generate_local_site(
+        site_setup: bool,
+        site_slur_filter_regex: Option<String>,
+        site_is_private: bool,
+        site_is_federated: bool,
+        site_application_question: Option<String>,
+        site_registration_mode: RegistrationMode,
+    ) -> LocalSite {
+        LocalSite {
+            id: Default::default(),
+            site_id: Default::default(),
+            site_setup,
+            enable_downvotes: false,
+            enable_nsfw: false,
+            community_creation_admin_only: false,
+            require_email_verification: false,
+            application_question: site_application_question,
+            private_instance: site_is_private,
+            default_theme: String::new(),
+            default_post_listing_type: ListingType::All,
+            legal_information: None,
+            hide_modlog_mod_names: false,
+            application_email_admins: false,
+            slur_filter_regex: site_slur_filter_regex,
+            actor_name_max_length: 0,
+            federation_enabled: site_is_federated,
+            captcha_enabled: false,
+            captcha_difficulty: String::new(),
+            published: Default::default(),
+            updated: None,
+            registration_mode: site_registration_mode,
+            reports_email_admins: false,
+        }
+    }
+
+    // Allow the test helper function to have too many arguments.
+    // It's either this or generate the entire struct each time for testing.
+    #[allow(clippy::too_many_arguments)]
+    fn generate_create_site(
+        site_name: String,
+        site_description: Option<String>,
+        site_sidebar: Option<String>,
+        site_listing_type: Option<ListingType>,
+        site_slur_filter_regex: Option<String>,
+        site_is_private: Option<bool>,
+        site_is_federated: Option<bool>,
+        site_application_question: Option<String>,
+        site_registration_mode: Option<RegistrationMode>,
+    ) -> CreateSite {
+        CreateSite {
+            name: site_name,
+            sidebar: site_sidebar,
+            description: site_description,
+            icon: None,
+            banner: None,
+            enable_downvotes: None,
+            enable_nsfw: None,
+            community_creation_admin_only: None,
+            require_email_verification: None,
+            application_question: site_application_question,
+            private_instance: site_is_private,
+            default_theme: None,
+            default_post_listing_type: site_listing_type,
+            legal_information: None,
+            application_email_admins: None,
+            hide_modlog_mod_names: None,
+            discussion_languages: None,
+            slur_filter_regex: site_slur_filter_regex,
+            actor_name_max_length: None,
+            rate_limit_message: None,
+            rate_limit_message_per_second: None,
+            rate_limit_post: None,
+            rate_limit_post_per_second: None,
+            rate_limit_register: None,
+            rate_limit_register_per_second: None,
+            rate_limit_image: None,
+            rate_limit_image_per_second: None,
+            rate_limit_comment: None,
+            rate_limit_comment_per_second: None,
+            rate_limit_search: None,
+            rate_limit_search_per_second: None,
+            federation_enabled: site_is_federated,
+            federation_debug: None,
+            captcha_enabled: None,
+            captcha_difficulty: None,
+            allowed_instances: None,
+            blocked_instances: None,
+            taglines: None,
+            registration_mode: site_registration_mode,
+            auth: Default::default(),
+        }
+    }
 }

--- a/crates/api_crud/src/site/mod.rs
+++ b/crates/api_crud/src/site/mod.rs
@@ -7,90 +7,90 @@ pub mod update;
 
 /// Checks whether the default post listing type is valid for a site.
 pub fn site_default_post_listing_type_check(
-  default_post_listing_type: &Option<ListingType>,
+    default_post_listing_type: &Option<ListingType>,
 ) -> LemmyResult<()> {
-  if let Some(listing_type) = default_post_listing_type {
-    // Only allow all or local as default listing types...
-    if listing_type != &ListingType::All && listing_type != &ListingType::Local {
-      Err(LemmyErrorType::InvalidDefaultPostListingType)?
+    if let Some(listing_type) = default_post_listing_type {
+        // Only allow all or local as default listing types...
+        if listing_type != &ListingType::All && listing_type != &ListingType::Local {
+            Err(LemmyErrorType::InvalidDefaultPostListingType)?
+        } else {
+            Ok(())
+        }
     } else {
-      Ok(())
+        Ok(())
     }
-  } else {
-    Ok(())
-  }
 }
 
 /// Checks whether the application question and registration mode align.
 pub fn application_question_check(
-  current_application_question: &Option<String>,
-  new_application_question: &Option<String>,
-  registration_mode: RegistrationMode,
+    current_application_question: &Option<String>,
+    new_application_question: &Option<String>,
+    registration_mode: RegistrationMode,
 ) -> LemmyResult<()> {
-  let has_no_question: bool =
-    current_application_question.is_none() && new_application_question.is_none();
-  let is_nullifying_question: bool = new_application_question == &Some(String::new());
+    let has_no_question: bool =
+        current_application_question.is_none() && new_application_question.is_none();
+    let is_nullifying_question: bool = new_application_question == &Some(String::new());
 
-  if registration_mode == RegistrationMode::RequireApplication
-    && (has_no_question || is_nullifying_question)
-  {
-    Err(LemmyErrorType::ApplicationQuestionRequired)?
-  } else {
-    Ok(())
-  }
+    if registration_mode == RegistrationMode::RequireApplication
+        && (has_no_question || is_nullifying_question)
+    {
+        Err(LemmyErrorType::ApplicationQuestionRequired)?
+    } else {
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::site::{application_question_check, site_default_post_listing_type_check};
-  use lemmy_db_schema::{ListingType, RegistrationMode};
+    use crate::site::{application_question_check, site_default_post_listing_type_check};
+    use lemmy_db_schema::{ListingType, RegistrationMode};
 
-  #[test]
-  fn test_site_default_post_listing_type_check() {
-    assert!(site_default_post_listing_type_check(&None::<ListingType>).is_ok());
-    assert!(site_default_post_listing_type_check(&Some(ListingType::All)).is_ok());
-    assert!(site_default_post_listing_type_check(&Some(ListingType::Local)).is_ok());
-    assert!(site_default_post_listing_type_check(&Some(ListingType::Subscribed)).is_err());
-  }
+    #[test]
+    fn test_site_default_post_listing_type_check() {
+        assert!(site_default_post_listing_type_check(&None::<ListingType>).is_ok());
+        assert!(site_default_post_listing_type_check(&Some(ListingType::All)).is_ok());
+        assert!(site_default_post_listing_type_check(&Some(ListingType::Local)).is_ok());
+        assert!(site_default_post_listing_type_check(&Some(ListingType::Subscribed)).is_err());
+    }
 
-  #[test]
-  fn test_application_question_check() {
-    assert!(
+    #[test]
+    fn test_application_question_check() {
+        assert!(
       application_question_check(&Some(String::from("q")), &Some(String::new()), RegistrationMode::RequireApplication).is_err(),
       "Expected application to be invalid because an application is required, current question: {:?}, new question: {:?}",
       "q",
       String::new(),
     );
-    assert!(
+        assert!(
       application_question_check(&None, &None, RegistrationMode::RequireApplication).is_err(),
       "Expected application to be invalid because an application is required, current question: {:?}, new question: {:?}",
       None::<String>,
       None::<String>
     );
 
-    assert!(
+        assert!(
       application_question_check(&None, &None, RegistrationMode::Open).is_ok(),
       "Expected application to be valid because no application required, current question: {:?}, new question: {:?}, mode: {:?}",
       None::<String>,
       None::<String>,
       RegistrationMode::Open
     );
-    assert!(
+        assert!(
       application_question_check(&None, &Some(String::from("q")), RegistrationMode::RequireApplication).is_ok(),
       "Expected application to be valid because new application provided, current question: {:?}, new question: {:?}, mode: {:?}",
       None::<String>,
       Some(String::from("q")),
       RegistrationMode::RequireApplication
     );
-    assert!(
+        assert!(
       application_question_check(&Some(String::from("q")), &None, RegistrationMode::RequireApplication).is_ok(),
       "Expected application to be valid because application existed, current question: {:?}, new question: {:?}, mode: {:?}",
       Some(String::from("q")),
       None::<String>,
       RegistrationMode::RequireApplication
     );
-  }
+    }
 }

--- a/crates/api_crud/src/site/read.rs
+++ b/crates/api_crud/src/site/read.rs
@@ -1,125 +1,121 @@
 use actix_web::web::{Data, Json, Query};
 use lemmy_api_common::{
-  context::LemmyContext,
-  sensitive::Sensitive,
-  site::{GetSite, GetSiteResponse, MyUserInfo},
-  utils::{check_user_valid, check_validator_time},
+    context::LemmyContext,
+    sensitive::Sensitive,
+    site::{GetSite, GetSiteResponse, MyUserInfo},
+    utils::{check_user_valid, check_validator_time},
 };
 use lemmy_db_schema::{
-  newtypes::LocalUserId,
-  source::{
-    actor_language::{LocalUserLanguage, SiteLanguage},
-    language::Language,
-    tagline::Tagline,
-  },
+    newtypes::LocalUserId,
+    source::{
+        actor_language::{LocalUserLanguage, SiteLanguage},
+        language::Language,
+        tagline::Tagline,
+    },
 };
 use lemmy_db_views::structs::{CustomEmojiView, LocalUserView, SiteView};
 use lemmy_db_views_actor::structs::{
-  CommunityBlockView,
-  CommunityFollowerView,
-  CommunityModeratorView,
-  PersonBlockView,
-  PersonView,
+    CommunityBlockView, CommunityFollowerView, CommunityModeratorView, PersonBlockView, PersonView,
 };
 use lemmy_utils::{
-  claims::Claims,
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
-  version,
+    claims::Claims,
+    error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+    version,
 };
 
 #[tracing::instrument(skip(context))]
 pub async fn get_site(
-  data: Query<GetSite>,
-  context: Data<LemmyContext>,
+    data: Query<GetSite>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<GetSiteResponse>, LemmyError> {
-  let site_view = SiteView::read_local(&mut context.pool()).await?;
+    let site_view = SiteView::read_local(&mut context.pool()).await?;
 
-  let admins = PersonView::admins(&mut context.pool()).await?;
+    let admins = PersonView::admins(&mut context.pool()).await?;
 
-  // Build the local user
-  let my_user = if let Some(local_user_view) =
-    local_user_settings_view_from_jwt_opt(data.auth.as_ref(), &context).await
-  {
-    let person_id = local_user_view.person.id;
-    let local_user_id = local_user_view.local_user.id;
+    // Build the local user
+    let my_user = if let Some(local_user_view) =
+        local_user_settings_view_from_jwt_opt(data.auth.as_ref(), &context).await
+    {
+        let person_id = local_user_view.person.id;
+        let local_user_id = local_user_view.local_user.id;
 
-    let follows = CommunityFollowerView::for_person(&mut context.pool(), person_id)
-      .await
-      .with_lemmy_type(LemmyErrorType::SystemErrLogin)?;
+        let follows = CommunityFollowerView::for_person(&mut context.pool(), person_id)
+            .await
+            .with_lemmy_type(LemmyErrorType::SystemErrLogin)?;
 
-    let person_id = local_user_view.person.id;
-    let community_blocks = CommunityBlockView::for_person(&mut context.pool(), person_id)
-      .await
-      .with_lemmy_type(LemmyErrorType::SystemErrLogin)?;
+        let person_id = local_user_view.person.id;
+        let community_blocks = CommunityBlockView::for_person(&mut context.pool(), person_id)
+            .await
+            .with_lemmy_type(LemmyErrorType::SystemErrLogin)?;
 
-    let person_id = local_user_view.person.id;
-    let person_blocks = PersonBlockView::for_person(&mut context.pool(), person_id)
-      .await
-      .with_lemmy_type(LemmyErrorType::SystemErrLogin)?;
+        let person_id = local_user_view.person.id;
+        let person_blocks = PersonBlockView::for_person(&mut context.pool(), person_id)
+            .await
+            .with_lemmy_type(LemmyErrorType::SystemErrLogin)?;
 
-    let moderates = CommunityModeratorView::for_person(&mut context.pool(), person_id)
-      .await
-      .with_lemmy_type(LemmyErrorType::SystemErrLogin)?;
+        let moderates = CommunityModeratorView::for_person(&mut context.pool(), person_id)
+            .await
+            .with_lemmy_type(LemmyErrorType::SystemErrLogin)?;
 
-    let discussion_languages = LocalUserLanguage::read(&mut context.pool(), local_user_id)
-      .await
-      .with_lemmy_type(LemmyErrorType::SystemErrLogin)?;
+        let discussion_languages = LocalUserLanguage::read(&mut context.pool(), local_user_id)
+            .await
+            .with_lemmy_type(LemmyErrorType::SystemErrLogin)?;
 
-    Some(MyUserInfo {
-      local_user_view,
-      follows,
-      moderates,
-      community_blocks,
-      person_blocks,
-      discussion_languages,
-    })
-  } else {
-    None
-  };
+        Some(MyUserInfo {
+            local_user_view,
+            follows,
+            moderates,
+            community_blocks,
+            person_blocks,
+            discussion_languages,
+        })
+    } else {
+        None
+    };
 
-  let all_languages = Language::read_all(&mut context.pool()).await?;
-  let discussion_languages = SiteLanguage::read_local_raw(&mut context.pool()).await?;
-  let taglines = Tagline::get_all(&mut context.pool(), site_view.local_site.id).await?;
-  let custom_emojis =
-    CustomEmojiView::get_all(&mut context.pool(), site_view.local_site.id).await?;
+    let all_languages = Language::read_all(&mut context.pool()).await?;
+    let discussion_languages = SiteLanguage::read_local_raw(&mut context.pool()).await?;
+    let taglines = Tagline::get_all(&mut context.pool(), site_view.local_site.id).await?;
+    let custom_emojis =
+        CustomEmojiView::get_all(&mut context.pool(), site_view.local_site.id).await?;
 
-  Ok(Json(GetSiteResponse {
-    site_view,
-    admins,
-    version: version::VERSION.to_string(),
-    my_user,
-    all_languages,
-    discussion_languages,
-    taglines,
-    custom_emojis,
-  }))
+    Ok(Json(GetSiteResponse {
+        site_view,
+        admins,
+        version: version::VERSION.to_string(),
+        my_user,
+        all_languages,
+        discussion_languages,
+        taglines,
+        custom_emojis,
+    }))
 }
 
 #[tracing::instrument(skip_all)]
 async fn local_user_settings_view_from_jwt_opt(
-  jwt: Option<&Sensitive<String>>,
-  context: &LemmyContext,
+    jwt: Option<&Sensitive<String>>,
+    context: &LemmyContext,
 ) -> Option<LocalUserView> {
-  match jwt {
-    Some(jwt) => {
-      let claims = Claims::decode(jwt.as_ref(), &context.secret().jwt_secret)
-        .ok()?
-        .claims;
-      let local_user_id = LocalUserId(claims.sub);
-      let local_user_view = LocalUserView::read(&mut context.pool(), local_user_id)
-        .await
-        .ok()?;
-      check_user_valid(
-        local_user_view.person.banned,
-        local_user_view.person.ban_expires,
-        local_user_view.person.deleted,
-      )
-      .ok()?;
+    match jwt {
+        Some(jwt) => {
+            let claims = Claims::decode(jwt.as_ref(), &context.secret().jwt_secret)
+                .ok()?
+                .claims;
+            let local_user_id = LocalUserId(claims.sub);
+            let local_user_view = LocalUserView::read(&mut context.pool(), local_user_id)
+                .await
+                .ok()?;
+            check_user_valid(
+                local_user_view.person.banned,
+                local_user_view.person.ban_expires,
+                local_user_view.person.deleted,
+            )
+            .ok()?;
 
-      check_validator_time(&local_user_view.local_user.validator_time, &claims).ok()?;
+            check_validator_time(&local_user_view.local_user.validator_time, &claims).ok()?;
 
-      Some(local_user_view)
+            Some(local_user_view)
+        }
+        None => None,
     }
-    None => None,
-  }
 }

--- a/crates/api_crud/src/site/update.rs
+++ b/crates/api_crud/src/site/update.rs
@@ -1,241 +1,236 @@
 use crate::site::{application_question_check, site_default_post_listing_type_check};
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  context::LemmyContext,
-  site::{EditSite, SiteResponse},
-  utils::{
-    is_admin,
-    local_site_rate_limit_to_rate_limit_config,
-    local_user_view_from_jwt,
-    sanitize_html_opt,
-  },
+    context::LemmyContext,
+    site::{EditSite, SiteResponse},
+    utils::{
+        is_admin, local_site_rate_limit_to_rate_limit_config, local_user_view_from_jwt,
+        sanitize_html_opt,
+    },
 };
 use lemmy_db_schema::{
-  source::{
-    actor_language::SiteLanguage,
-    federation_allowlist::FederationAllowList,
-    federation_blocklist::FederationBlockList,
-    local_site::{LocalSite, LocalSiteUpdateForm},
-    local_site_rate_limit::{LocalSiteRateLimit, LocalSiteRateLimitUpdateForm},
-    local_user::LocalUser,
-    site::{Site, SiteUpdateForm},
-    tagline::Tagline,
-  },
-  traits::Crud,
-  utils::{diesel_option_overwrite, diesel_option_overwrite_to_url, naive_now},
-  RegistrationMode,
+    source::{
+        actor_language::SiteLanguage,
+        federation_allowlist::FederationAllowList,
+        federation_blocklist::FederationBlockList,
+        local_site::{LocalSite, LocalSiteUpdateForm},
+        local_site_rate_limit::{LocalSiteRateLimit, LocalSiteRateLimitUpdateForm},
+        local_user::LocalUser,
+        site::{Site, SiteUpdateForm},
+        tagline::Tagline,
+    },
+    traits::Crud,
+    utils::{diesel_option_overwrite, diesel_option_overwrite_to_url, naive_now},
+    RegistrationMode,
 };
 use lemmy_db_views::structs::SiteView;
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType, LemmyResult},
-  utils::{
-    slurs::check_slurs_opt,
-    validation::{
-      build_and_check_regex,
-      check_site_visibility_valid,
-      is_valid_body_field,
-      site_description_length_check,
-      site_name_length_check,
+    error::{LemmyError, LemmyErrorExt, LemmyErrorType, LemmyResult},
+    utils::{
+        slurs::check_slurs_opt,
+        validation::{
+            build_and_check_regex, check_site_visibility_valid, is_valid_body_field,
+            site_description_length_check, site_name_length_check,
+        },
     },
-  },
 };
 
 #[tracing::instrument(skip(context))]
 pub async fn update_site(
-  data: Json<EditSite>,
-  context: Data<LemmyContext>,
+    data: Json<EditSite>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<SiteResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
-  let site_view = SiteView::read_local(&mut context.pool()).await?;
-  let local_site = site_view.local_site;
-  let site = site_view.site;
+    let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
+    let site_view = SiteView::read_local(&mut context.pool()).await?;
+    let local_site = site_view.local_site;
+    let site = site_view.site;
 
-  // Make sure user is an admin; other types of users should not update site data...
-  is_admin(&local_user_view)?;
+    // Make sure user is an admin; other types of users should not update site data...
+    is_admin(&local_user_view)?;
 
-  validate_update_payload(&local_site, &data)?;
+    validate_update_payload(&local_site, &data)?;
 
-  if let Some(discussion_languages) = data.discussion_languages.clone() {
-    SiteLanguage::update(&mut context.pool(), discussion_languages.clone(), &site).await?;
-  }
+    if let Some(discussion_languages) = data.discussion_languages.clone() {
+        SiteLanguage::update(&mut context.pool(), discussion_languages.clone(), &site).await?;
+    }
 
-  let name = sanitize_html_opt(&data.name);
-  let sidebar = sanitize_html_opt(&data.sidebar);
-  let description = sanitize_html_opt(&data.description);
+    let name = sanitize_html_opt(&data.name);
+    let sidebar = sanitize_html_opt(&data.sidebar);
+    let description = sanitize_html_opt(&data.description);
 
-  let site_form = SiteUpdateForm {
-    name,
-    sidebar: diesel_option_overwrite(sidebar),
-    description: diesel_option_overwrite(description),
-    icon: diesel_option_overwrite_to_url(&data.icon)?,
-    banner: diesel_option_overwrite_to_url(&data.banner)?,
-    updated: Some(Some(naive_now())),
-    ..Default::default()
-  };
+    let site_form = SiteUpdateForm {
+        name,
+        sidebar: diesel_option_overwrite(sidebar),
+        description: diesel_option_overwrite(description),
+        icon: diesel_option_overwrite_to_url(&data.icon)?,
+        banner: diesel_option_overwrite_to_url(&data.banner)?,
+        updated: Some(Some(naive_now())),
+        ..Default::default()
+    };
 
-  Site::update(&mut context.pool(), site.id, &site_form)
-    .await
-    // Ignore errors for all these, so as to not throw errors if no update occurs
-    // Diesel will throw an error for empty update forms
-    .ok();
+    Site::update(&mut context.pool(), site.id, &site_form)
+        .await
+        // Ignore errors for all these, so as to not throw errors if no update occurs
+        // Diesel will throw an error for empty update forms
+        .ok();
 
-  let application_question = sanitize_html_opt(&data.application_question);
-  let default_theme = sanitize_html_opt(&data.default_theme);
-  let legal_information = sanitize_html_opt(&data.legal_information);
+    let application_question = sanitize_html_opt(&data.application_question);
+    let default_theme = sanitize_html_opt(&data.default_theme);
+    let legal_information = sanitize_html_opt(&data.legal_information);
 
-  let local_site_form = LocalSiteUpdateForm {
-    enable_downvotes: data.enable_downvotes,
-    registration_mode: data.registration_mode,
-    enable_nsfw: data.enable_nsfw,
-    community_creation_admin_only: data.community_creation_admin_only,
-    require_email_verification: data.require_email_verification,
-    application_question: diesel_option_overwrite(application_question),
-    private_instance: data.private_instance,
-    default_theme,
-    default_post_listing_type: data.default_post_listing_type,
-    legal_information: diesel_option_overwrite(legal_information),
-    application_email_admins: data.application_email_admins,
-    hide_modlog_mod_names: data.hide_modlog_mod_names,
-    updated: Some(Some(naive_now())),
-    slur_filter_regex: diesel_option_overwrite(data.slur_filter_regex.clone()),
-    actor_name_max_length: data.actor_name_max_length,
-    federation_enabled: data.federation_enabled,
-    captcha_enabled: data.captcha_enabled,
-    captcha_difficulty: data.captcha_difficulty.clone(),
-    reports_email_admins: data.reports_email_admins,
-    ..Default::default()
-  };
+    let local_site_form = LocalSiteUpdateForm {
+        enable_downvotes: data.enable_downvotes,
+        registration_mode: data.registration_mode,
+        enable_nsfw: data.enable_nsfw,
+        community_creation_admin_only: data.community_creation_admin_only,
+        require_email_verification: data.require_email_verification,
+        application_question: diesel_option_overwrite(application_question),
+        private_instance: data.private_instance,
+        default_theme,
+        default_post_listing_type: data.default_post_listing_type,
+        legal_information: diesel_option_overwrite(legal_information),
+        application_email_admins: data.application_email_admins,
+        hide_modlog_mod_names: data.hide_modlog_mod_names,
+        updated: Some(Some(naive_now())),
+        slur_filter_regex: diesel_option_overwrite(data.slur_filter_regex.clone()),
+        actor_name_max_length: data.actor_name_max_length,
+        federation_enabled: data.federation_enabled,
+        captcha_enabled: data.captcha_enabled,
+        captcha_difficulty: data.captcha_difficulty.clone(),
+        reports_email_admins: data.reports_email_admins,
+        ..Default::default()
+    };
 
-  let update_local_site = LocalSite::update(&mut context.pool(), &local_site_form)
-    .await
-    .ok();
+    let update_local_site = LocalSite::update(&mut context.pool(), &local_site_form)
+        .await
+        .ok();
 
-  let local_site_rate_limit_form = LocalSiteRateLimitUpdateForm {
-    message: data.rate_limit_message,
-    message_per_second: data.rate_limit_message_per_second,
-    post: data.rate_limit_post,
-    post_per_second: data.rate_limit_post_per_second,
-    register: data.rate_limit_register,
-    register_per_second: data.rate_limit_register_per_second,
-    image: data.rate_limit_image,
-    image_per_second: data.rate_limit_image_per_second,
-    comment: data.rate_limit_comment,
-    comment_per_second: data.rate_limit_comment_per_second,
-    search: data.rate_limit_search,
-    search_per_second: data.rate_limit_search_per_second,
-    ..Default::default()
-  };
+    let local_site_rate_limit_form = LocalSiteRateLimitUpdateForm {
+        message: data.rate_limit_message,
+        message_per_second: data.rate_limit_message_per_second,
+        post: data.rate_limit_post,
+        post_per_second: data.rate_limit_post_per_second,
+        register: data.rate_limit_register,
+        register_per_second: data.rate_limit_register_per_second,
+        image: data.rate_limit_image,
+        image_per_second: data.rate_limit_image_per_second,
+        comment: data.rate_limit_comment,
+        comment_per_second: data.rate_limit_comment_per_second,
+        search: data.rate_limit_search,
+        search_per_second: data.rate_limit_search_per_second,
+        ..Default::default()
+    };
 
-  LocalSiteRateLimit::update(&mut context.pool(), &local_site_rate_limit_form)
-    .await
-    .ok();
+    LocalSiteRateLimit::update(&mut context.pool(), &local_site_rate_limit_form)
+        .await
+        .ok();
 
-  // Replace the blocked and allowed instances
-  let allowed = data.allowed_instances.clone();
-  FederationAllowList::replace(&mut context.pool(), allowed).await?;
-  let blocked = data.blocked_instances.clone();
-  FederationBlockList::replace(&mut context.pool(), blocked).await?;
+    // Replace the blocked and allowed instances
+    let allowed = data.allowed_instances.clone();
+    FederationAllowList::replace(&mut context.pool(), allowed).await?;
+    let blocked = data.blocked_instances.clone();
+    FederationBlockList::replace(&mut context.pool(), blocked).await?;
 
-  // TODO can't think of a better way to do this.
-  // If the server suddenly requires email verification, or required applications, no old users
-  // will be able to log in. It really only wants this to be a requirement for NEW signups.
-  // So if it was set from false, to true, you need to update all current users columns to be verified.
+    // TODO can't think of a better way to do this.
+    // If the server suddenly requires email verification, or required applications, no old users
+    // will be able to log in. It really only wants this to be a requirement for NEW signups.
+    // So if it was set from false, to true, you need to update all current users columns to be verified.
 
-  let old_require_application =
-    local_site.registration_mode == RegistrationMode::RequireApplication;
-  let new_require_application = update_local_site
-    .as_ref()
-    .map(|ols| ols.registration_mode == RegistrationMode::RequireApplication)
-    .unwrap_or(false);
-  if !old_require_application && new_require_application {
-    LocalUser::set_all_users_registration_applications_accepted(&mut context.pool())
-      .await
-      .with_lemmy_type(LemmyErrorType::CouldntSetAllRegistrationsAccepted)?;
-  }
+    let old_require_application =
+        local_site.registration_mode == RegistrationMode::RequireApplication;
+    let new_require_application = update_local_site
+        .as_ref()
+        .map(|ols| ols.registration_mode == RegistrationMode::RequireApplication)
+        .unwrap_or(false);
+    if !old_require_application && new_require_application {
+        LocalUser::set_all_users_registration_applications_accepted(&mut context.pool())
+            .await
+            .with_lemmy_type(LemmyErrorType::CouldntSetAllRegistrationsAccepted)?;
+    }
 
-  let new_require_email_verification = update_local_site
-    .as_ref()
-    .map(|ols| ols.require_email_verification)
-    .unwrap_or(false);
-  if !local_site.require_email_verification && new_require_email_verification {
-    LocalUser::set_all_users_email_verified(&mut context.pool())
-      .await
-      .with_lemmy_type(LemmyErrorType::CouldntSetAllEmailVerified)?;
-  }
+    let new_require_email_verification = update_local_site
+        .as_ref()
+        .map(|ols| ols.require_email_verification)
+        .unwrap_or(false);
+    if !local_site.require_email_verification && new_require_email_verification {
+        LocalUser::set_all_users_email_verified(&mut context.pool())
+            .await
+            .with_lemmy_type(LemmyErrorType::CouldntSetAllEmailVerified)?;
+    }
 
-  let new_taglines = data.taglines.clone();
-  let taglines = Tagline::replace(&mut context.pool(), local_site.id, new_taglines).await?;
+    let new_taglines = data.taglines.clone();
+    let taglines = Tagline::replace(&mut context.pool(), local_site.id, new_taglines).await?;
 
-  let site_view = SiteView::read_local(&mut context.pool()).await?;
+    let site_view = SiteView::read_local(&mut context.pool()).await?;
 
-  let rate_limit_config =
-    local_site_rate_limit_to_rate_limit_config(&site_view.local_site_rate_limit);
-  context
-    .settings_updated_channel()
-    .send(rate_limit_config)
-    .await?;
+    let rate_limit_config =
+        local_site_rate_limit_to_rate_limit_config(&site_view.local_site_rate_limit);
+    context
+        .settings_updated_channel()
+        .send(rate_limit_config)
+        .await?;
 
-  Ok(Json(SiteResponse {
-    site_view,
-    taglines,
-  }))
+    Ok(Json(SiteResponse {
+        site_view,
+        taglines,
+    }))
 }
 
 fn validate_update_payload(local_site: &LocalSite, edit_site: &EditSite) -> LemmyResult<()> {
-  // Check that the slur regex compiles, and return the regex if valid...
-  // Prioritize using new slur regex from the request; if not provided, use the existing regex.
-  let slur_regex = build_and_check_regex(
-    &edit_site
-      .slur_filter_regex
-      .as_deref()
-      .or(local_site.slur_filter_regex.as_deref()),
-  )?;
+    // Check that the slur regex compiles, and return the regex if valid...
+    // Prioritize using new slur regex from the request; if not provided, use the existing regex.
+    let slur_regex = build_and_check_regex(
+        &edit_site
+            .slur_filter_regex
+            .as_deref()
+            .or(local_site.slur_filter_regex.as_deref()),
+    )?;
 
-  if let Some(name) = &edit_site.name {
-    // The name doesn't need to be updated, but if provided it cannot be blanked out...
-    site_name_length_check(name)?;
-    check_slurs_opt(&edit_site.name, &slur_regex)?;
-  }
+    if let Some(name) = &edit_site.name {
+        // The name doesn't need to be updated, but if provided it cannot be blanked out...
+        site_name_length_check(name)?;
+        check_slurs_opt(&edit_site.name, &slur_regex)?;
+    }
 
-  if let Some(desc) = &edit_site.description {
-    site_description_length_check(desc)?;
-    check_slurs_opt(&edit_site.description, &slur_regex)?;
-  }
+    if let Some(desc) = &edit_site.description {
+        site_description_length_check(desc)?;
+        check_slurs_opt(&edit_site.description, &slur_regex)?;
+    }
 
-  site_default_post_listing_type_check(&edit_site.default_post_listing_type)?;
+    site_default_post_listing_type_check(&edit_site.default_post_listing_type)?;
 
-  check_site_visibility_valid(
-    local_site.private_instance,
-    local_site.federation_enabled,
-    &edit_site.private_instance,
-    &edit_site.federation_enabled,
-  )?;
+    check_site_visibility_valid(
+        local_site.private_instance,
+        local_site.federation_enabled,
+        &edit_site.private_instance,
+        &edit_site.federation_enabled,
+    )?;
 
-  // Ensure that the sidebar has fewer than the max num characters...
-  is_valid_body_field(&edit_site.sidebar, false)?;
+    // Ensure that the sidebar has fewer than the max num characters...
+    is_valid_body_field(&edit_site.sidebar, false)?;
 
-  application_question_check(
-    &local_site.application_question,
-    &edit_site.application_question,
-    edit_site
-      .registration_mode
-      .unwrap_or(local_site.registration_mode),
-  )
+    application_question_check(
+        &local_site.application_question,
+        &edit_site.application_question,
+        edit_site
+            .registration_mode
+            .unwrap_or(local_site.registration_mode),
+    )
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::site::update::validate_update_payload;
-  use lemmy_api_common::site::EditSite;
-  use lemmy_db_schema::{source::local_site::LocalSite, ListingType, RegistrationMode};
-  use lemmy_utils::error::LemmyErrorType;
+    use crate::site::update::validate_update_payload;
+    use lemmy_api_common::site::EditSite;
+    use lemmy_db_schema::{source::local_site::LocalSite, ListingType, RegistrationMode};
+    use lemmy_utils::error::LemmyErrorType;
 
-  #[test]
-  fn test_validate_invalid_update_payload() {
-    let invalid_payloads = [
+    #[test]
+    fn test_validate_invalid_update_payload() {
+        let invalid_payloads = [
       (
         "EditSite name matches LocalSite slur filter",
         LemmyErrorType::Slurs,
@@ -370,7 +365,7 @@ mod tests {
       ),
     ];
 
-    invalid_payloads.iter().enumerate().for_each(
+        invalid_payloads.iter().enumerate().for_each(
       |(
          idx,
          &(reason, ref expected_err, local_site, edit_site),
@@ -395,200 +390,200 @@ mod tests {
         }
       },
     );
-  }
-
-  #[test]
-  fn test_validate_valid_update_payload() {
-    let valid_payloads = [
-      (
-        "No changes between LocalSite and EditSite",
-        &generate_local_site(
-          None::<String>,
-          true,
-          false,
-          None::<String>,
-          RegistrationMode::Open,
-        ),
-        &generate_edit_site(
-          None::<String>,
-          None::<String>,
-          None::<String>,
-          None::<ListingType>,
-          None::<String>,
-          None::<bool>,
-          None::<bool>,
-          None::<String>,
-          None::<RegistrationMode>,
-        ),
-      ),
-      (
-        "EditSite allows clearing and changing values",
-        &generate_local_site(
-          None::<String>,
-          true,
-          false,
-          None::<String>,
-          RegistrationMode::Open,
-        ),
-        &generate_edit_site(
-          Some(String::from("site_name")),
-          Some(String::new()),
-          Some(String::new()),
-          Some(ListingType::All),
-          Some(String::new()),
-          Some(false),
-          Some(true),
-          Some(String::new()),
-          Some(RegistrationMode::Open),
-        ),
-      ),
-      (
-        "EditSite name passes slur filter regex",
-        &generate_local_site(
-          Some(String::from("(foo|bar)")),
-          true,
-          false,
-          None::<String>,
-          RegistrationMode::Open,
-        ),
-        &generate_edit_site(
-          Some(String::from("foo site_name")),
-          None::<String>,
-          None::<String>,
-          None::<ListingType>,
-          Some(String::new()),
-          None::<bool>,
-          None::<bool>,
-          None::<String>,
-          None::<RegistrationMode>,
-        ),
-      ),
-      (
-        "LocalSite has application question and EditSite now requires applications,",
-        &generate_local_site(
-          None::<String>,
-          true,
-          false,
-          Some(String::from("question")),
-          RegistrationMode::Open,
-        ),
-        &generate_edit_site(
-          Some(String::from("site_name")),
-          None::<String>,
-          None::<String>,
-          None::<ListingType>,
-          None::<String>,
-          None::<bool>,
-          None::<bool>,
-          None::<String>,
-          Some(RegistrationMode::RequireApplication),
-        ),
-      ),
-    ];
-
-    valid_payloads
-      .iter()
-      .enumerate()
-      .for_each(|(idx, &(reason, local_site, edit_site))| {
-        assert!(
-          validate_update_payload(local_site, edit_site).is_ok(),
-          "Got Err, but should have got Ok for reason: {}. valid_payloads.nth({})",
-          reason,
-          idx
-        );
-      })
-  }
-
-  fn generate_local_site(
-    site_slur_filter_regex: Option<String>,
-    site_is_private: bool,
-    site_is_federated: bool,
-    site_application_question: Option<String>,
-    site_registration_mode: RegistrationMode,
-  ) -> LocalSite {
-    LocalSite {
-      id: Default::default(),
-      site_id: Default::default(),
-      site_setup: true,
-      enable_downvotes: false,
-      enable_nsfw: false,
-      community_creation_admin_only: false,
-      require_email_verification: false,
-      application_question: site_application_question,
-      private_instance: site_is_private,
-      default_theme: String::new(),
-      default_post_listing_type: ListingType::All,
-      legal_information: None,
-      hide_modlog_mod_names: false,
-      application_email_admins: false,
-      slur_filter_regex: site_slur_filter_regex,
-      actor_name_max_length: 0,
-      federation_enabled: site_is_federated,
-      captcha_enabled: false,
-      captcha_difficulty: String::new(),
-      published: Default::default(),
-      updated: None,
-      registration_mode: site_registration_mode,
-      reports_email_admins: false,
     }
-  }
 
-  // Allow the test helper function to have too many arguments.
-  // It's either this or generate the entire struct each time for testing.
-  #[allow(clippy::too_many_arguments)]
-  fn generate_edit_site(
-    site_name: Option<String>,
-    site_description: Option<String>,
-    site_sidebar: Option<String>,
-    site_listing_type: Option<ListingType>,
-    site_slur_filter_regex: Option<String>,
-    site_is_private: Option<bool>,
-    site_is_federated: Option<bool>,
-    site_application_question: Option<String>,
-    site_registration_mode: Option<RegistrationMode>,
-  ) -> EditSite {
-    EditSite {
-      name: site_name,
-      sidebar: site_sidebar,
-      description: site_description,
-      icon: None,
-      banner: None,
-      enable_downvotes: None,
-      enable_nsfw: None,
-      community_creation_admin_only: None,
-      require_email_verification: None,
-      application_question: site_application_question,
-      private_instance: site_is_private,
-      default_theme: None,
-      default_post_listing_type: site_listing_type,
-      legal_information: None,
-      application_email_admins: None,
-      hide_modlog_mod_names: None,
-      discussion_languages: None,
-      slur_filter_regex: site_slur_filter_regex,
-      actor_name_max_length: None,
-      rate_limit_message: None,
-      rate_limit_message_per_second: None,
-      rate_limit_post: None,
-      rate_limit_post_per_second: None,
-      rate_limit_register: None,
-      rate_limit_register_per_second: None,
-      rate_limit_image: None,
-      rate_limit_image_per_second: None,
-      rate_limit_comment: None,
-      rate_limit_comment_per_second: None,
-      rate_limit_search: None,
-      rate_limit_search_per_second: None,
-      federation_enabled: site_is_federated,
-      federation_debug: None,
-      captcha_enabled: None,
-      captcha_difficulty: None,
-      allowed_instances: None,
-      blocked_instances: None,
-      taglines: None,
-      registration_mode: site_registration_mode,
-      reports_email_admins: None,
-      auth: Default::default(),
+    #[test]
+    fn test_validate_valid_update_payload() {
+        let valid_payloads = [
+            (
+                "No changes between LocalSite and EditSite",
+                &generate_local_site(
+                    None::<String>,
+                    true,
+                    false,
+                    None::<String>,
+                    RegistrationMode::Open,
+                ),
+                &generate_edit_site(
+                    None::<String>,
+                    None::<String>,
+                    None::<String>,
+                    None::<ListingType>,
+                    None::<String>,
+                    None::<bool>,
+                    None::<bool>,
+                    None::<String>,
+                    None::<RegistrationMode>,
+                ),
+            ),
+            (
+                "EditSite allows clearing and changing values",
+                &generate_local_site(
+                    None::<String>,
+                    true,
+                    false,
+                    None::<String>,
+                    RegistrationMode::Open,
+                ),
+                &generate_edit_site(
+                    Some(String::from("site_name")),
+                    Some(String::new()),
+                    Some(String::new()),
+                    Some(ListingType::All),
+                    Some(String::new()),
+                    Some(false),
+                    Some(true),
+                    Some(String::new()),
+                    Some(RegistrationMode::Open),
+                ),
+            ),
+            (
+                "EditSite name passes slur filter regex",
+                &generate_local_site(
+                    Some(String::from("(foo|bar)")),
+                    true,
+                    false,
+                    None::<String>,
+                    RegistrationMode::Open,
+                ),
+                &generate_edit_site(
+                    Some(String::from("foo site_name")),
+                    None::<String>,
+                    None::<String>,
+                    None::<ListingType>,
+                    Some(String::new()),
+                    None::<bool>,
+                    None::<bool>,
+                    None::<String>,
+                    None::<RegistrationMode>,
+                ),
+            ),
+            (
+                "LocalSite has application question and EditSite now requires applications,",
+                &generate_local_site(
+                    None::<String>,
+                    true,
+                    false,
+                    Some(String::from("question")),
+                    RegistrationMode::Open,
+                ),
+                &generate_edit_site(
+                    Some(String::from("site_name")),
+                    None::<String>,
+                    None::<String>,
+                    None::<ListingType>,
+                    None::<String>,
+                    None::<bool>,
+                    None::<bool>,
+                    None::<String>,
+                    Some(RegistrationMode::RequireApplication),
+                ),
+            ),
+        ];
+
+        valid_payloads
+            .iter()
+            .enumerate()
+            .for_each(|(idx, &(reason, local_site, edit_site))| {
+                assert!(
+                    validate_update_payload(local_site, edit_site).is_ok(),
+                    "Got Err, but should have got Ok for reason: {}. valid_payloads.nth({})",
+                    reason,
+                    idx
+                );
+            })
     }
-  }
+
+    fn generate_local_site(
+        site_slur_filter_regex: Option<String>,
+        site_is_private: bool,
+        site_is_federated: bool,
+        site_application_question: Option<String>,
+        site_registration_mode: RegistrationMode,
+    ) -> LocalSite {
+        LocalSite {
+            id: Default::default(),
+            site_id: Default::default(),
+            site_setup: true,
+            enable_downvotes: false,
+            enable_nsfw: false,
+            community_creation_admin_only: false,
+            require_email_verification: false,
+            application_question: site_application_question,
+            private_instance: site_is_private,
+            default_theme: String::new(),
+            default_post_listing_type: ListingType::All,
+            legal_information: None,
+            hide_modlog_mod_names: false,
+            application_email_admins: false,
+            slur_filter_regex: site_slur_filter_regex,
+            actor_name_max_length: 0,
+            federation_enabled: site_is_federated,
+            captcha_enabled: false,
+            captcha_difficulty: String::new(),
+            published: Default::default(),
+            updated: None,
+            registration_mode: site_registration_mode,
+            reports_email_admins: false,
+        }
+    }
+
+    // Allow the test helper function to have too many arguments.
+    // It's either this or generate the entire struct each time for testing.
+    #[allow(clippy::too_many_arguments)]
+    fn generate_edit_site(
+        site_name: Option<String>,
+        site_description: Option<String>,
+        site_sidebar: Option<String>,
+        site_listing_type: Option<ListingType>,
+        site_slur_filter_regex: Option<String>,
+        site_is_private: Option<bool>,
+        site_is_federated: Option<bool>,
+        site_application_question: Option<String>,
+        site_registration_mode: Option<RegistrationMode>,
+    ) -> EditSite {
+        EditSite {
+            name: site_name,
+            sidebar: site_sidebar,
+            description: site_description,
+            icon: None,
+            banner: None,
+            enable_downvotes: None,
+            enable_nsfw: None,
+            community_creation_admin_only: None,
+            require_email_verification: None,
+            application_question: site_application_question,
+            private_instance: site_is_private,
+            default_theme: None,
+            default_post_listing_type: site_listing_type,
+            legal_information: None,
+            application_email_admins: None,
+            hide_modlog_mod_names: None,
+            discussion_languages: None,
+            slur_filter_regex: site_slur_filter_regex,
+            actor_name_max_length: None,
+            rate_limit_message: None,
+            rate_limit_message_per_second: None,
+            rate_limit_post: None,
+            rate_limit_post_per_second: None,
+            rate_limit_register: None,
+            rate_limit_register_per_second: None,
+            rate_limit_image: None,
+            rate_limit_image_per_second: None,
+            rate_limit_comment: None,
+            rate_limit_comment_per_second: None,
+            rate_limit_search: None,
+            rate_limit_search_per_second: None,
+            federation_enabled: site_is_federated,
+            federation_debug: None,
+            captcha_enabled: None,
+            captcha_difficulty: None,
+            allowed_instances: None,
+            blocked_instances: None,
+            taglines: None,
+            registration_mode: site_registration_mode,
+            reports_email_admins: None,
+            auth: Default::default(),
+        }
+    }
 }

--- a/crates/api_crud/src/user/create.rs
+++ b/crates/api_crud/src/user/create.rs
@@ -1,209 +1,202 @@
 use activitypub_federation::{config::Data, http_signatures::generate_actor_keypair};
 use actix_web::web::Json;
 use lemmy_api_common::{
-  context::LemmyContext,
-  person::{LoginResponse, Register},
-  utils::{
-    generate_inbox_url,
-    generate_local_apub_endpoint,
-    generate_shared_inbox_url,
-    honeypot_check,
-    local_site_to_slur_regex,
-    password_length_check,
-    sanitize_html,
-    send_new_applicant_email_to_admins,
-    send_verification_email,
-    EndpointType,
-  },
+    context::LemmyContext,
+    person::{LoginResponse, Register},
+    utils::{
+        generate_inbox_url, generate_local_apub_endpoint, generate_shared_inbox_url,
+        honeypot_check, local_site_to_slur_regex, password_length_check, sanitize_html,
+        send_new_applicant_email_to_admins, send_verification_email, EndpointType,
+    },
 };
 use lemmy_db_schema::{
-  aggregates::structs::PersonAggregates,
-  source::{
-    captcha_answer::{CaptchaAnswer, CheckCaptchaAnswer},
-    local_user::{LocalUser, LocalUserInsertForm},
-    person::{Person, PersonInsertForm},
-    registration_application::{RegistrationApplication, RegistrationApplicationInsertForm},
-  },
-  traits::Crud,
-  RegistrationMode,
+    aggregates::structs::PersonAggregates,
+    source::{
+        captcha_answer::{CaptchaAnswer, CheckCaptchaAnswer},
+        local_user::{LocalUser, LocalUserInsertForm},
+        person::{Person, PersonInsertForm},
+        registration_application::{RegistrationApplication, RegistrationApplicationInsertForm},
+    },
+    traits::Crud,
+    RegistrationMode,
 };
 use lemmy_db_views::structs::{LocalUserView, SiteView};
 use lemmy_utils::{
-  claims::Claims,
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
-  utils::{
-    slurs::{check_slurs, check_slurs_opt},
-    validation::is_valid_actor_name,
-  },
+    claims::Claims,
+    error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+    utils::{
+        slurs::{check_slurs, check_slurs_opt},
+        validation::is_valid_actor_name,
+    },
 };
 
 #[tracing::instrument(skip(context))]
 pub async fn register(
-  data: Json<Register>,
-  context: Data<LemmyContext>,
+    data: Json<Register>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<LoginResponse>, LemmyError> {
-  let site_view = SiteView::read_local(&mut context.pool()).await?;
-  let local_site = site_view.local_site;
-  let require_registration_application =
-    local_site.registration_mode == RegistrationMode::RequireApplication;
+    let site_view = SiteView::read_local(&mut context.pool()).await?;
+    let local_site = site_view.local_site;
+    let require_registration_application =
+        local_site.registration_mode == RegistrationMode::RequireApplication;
 
-  if local_site.registration_mode == RegistrationMode::Closed {
-    Err(LemmyErrorType::RegistrationClosed)?
-  }
-
-  password_length_check(&data.password)?;
-  honeypot_check(&data.honeypot)?;
-
-  if local_site.require_email_verification && data.email.is_none() {
-    Err(LemmyErrorType::EmailRequired)?
-  }
-
-  if local_site.site_setup && require_registration_application && data.answer.is_none() {
-    Err(LemmyErrorType::RegistrationApplicationAnswerRequired)?
-  }
-
-  // Make sure passwords match
-  if data.password != data.password_verify {
-    Err(LemmyErrorType::PasswordsDoNotMatch)?
-  }
-
-  if local_site.site_setup && local_site.captcha_enabled {
-    if let Some(captcha_uuid) = &data.captcha_uuid {
-      let uuid = uuid::Uuid::parse_str(captcha_uuid)?;
-      let check = CaptchaAnswer::check_captcha(
-        &mut context.pool(),
-        CheckCaptchaAnswer {
-          uuid,
-          answer: data.captcha_answer.clone().unwrap_or_default(),
-        },
-      )
-      .await?;
-      if !check {
-        Err(LemmyErrorType::CaptchaIncorrect)?
-      }
-    } else {
-      Err(LemmyErrorType::CaptchaIncorrect)?
+    if local_site.registration_mode == RegistrationMode::Closed {
+        Err(LemmyErrorType::RegistrationClosed)?
     }
-  }
 
-  let slur_regex = local_site_to_slur_regex(&local_site);
-  check_slurs(&data.username, &slur_regex)?;
-  check_slurs_opt(&data.answer, &slur_regex)?;
-  let username = sanitize_html(&data.username);
+    password_length_check(&data.password)?;
+    honeypot_check(&data.honeypot)?;
 
-  let actor_keypair = generate_actor_keypair()?;
-  is_valid_actor_name(&data.username, local_site.actor_name_max_length as usize)?;
-  let actor_id = generate_local_apub_endpoint(
-    EndpointType::Person,
-    &data.username,
-    &context.settings().get_protocol_and_hostname(),
-  )?;
-
-  if let Some(email) = &data.email {
-    if LocalUser::is_email_taken(&mut context.pool(), email).await? {
-      Err(LemmyErrorType::EmailAlreadyExists)?
+    if local_site.require_email_verification && data.email.is_none() {
+        Err(LemmyErrorType::EmailRequired)?
     }
-  }
 
-  // We have to create both a person, and local_user
+    if local_site.site_setup && require_registration_application && data.answer.is_none() {
+        Err(LemmyErrorType::RegistrationApplicationAnswerRequired)?
+    }
 
-  // Register the new person
-  let person_form = PersonInsertForm::builder()
-    .name(username)
-    .actor_id(Some(actor_id.clone()))
-    .private_key(Some(actor_keypair.private_key))
-    .public_key(actor_keypair.public_key)
-    .inbox_url(Some(generate_inbox_url(&actor_id)?))
-    .shared_inbox_url(Some(generate_shared_inbox_url(&actor_id)?))
-    .instance_id(site_view.site.instance_id)
-    .build();
+    // Make sure passwords match
+    if data.password != data.password_verify {
+        Err(LemmyErrorType::PasswordsDoNotMatch)?
+    }
 
-  // insert the person
-  let inserted_person = Person::create(&mut context.pool(), &person_form)
-    .await
-    .with_lemmy_type(LemmyErrorType::UserAlreadyExists)?;
+    if local_site.site_setup && local_site.captcha_enabled {
+        if let Some(captcha_uuid) = &data.captcha_uuid {
+            let uuid = uuid::Uuid::parse_str(captcha_uuid)?;
+            let check = CaptchaAnswer::check_captcha(
+                &mut context.pool(),
+                CheckCaptchaAnswer {
+                    uuid,
+                    answer: data.captcha_answer.clone().unwrap_or_default(),
+                },
+            )
+            .await?;
+            if !check {
+                Err(LemmyErrorType::CaptchaIncorrect)?
+            }
+        } else {
+            Err(LemmyErrorType::CaptchaIncorrect)?
+        }
+    }
 
-  // Automatically set their application as accepted, if they created this with open registration.
-  // Also fixes a bug which allows users to log in when registrations are changed to closed.
-  let accepted_application = Some(!require_registration_application);
+    let slur_regex = local_site_to_slur_regex(&local_site);
+    check_slurs(&data.username, &slur_regex)?;
+    check_slurs_opt(&data.answer, &slur_regex)?;
+    let username = sanitize_html(&data.username);
 
-  // Create the local user
-  let local_user_form = LocalUserInsertForm::builder()
-    .person_id(inserted_person.id)
-    .email(data.email.as_deref().map(str::to_lowercase))
-    .password_encrypted(data.password.to_string())
-    .show_nsfw(Some(data.show_nsfw))
-    .accepted_application(accepted_application)
-    .default_listing_type(Some(local_site.default_post_listing_type))
-    // If its the initial site setup, they are an admin
-    .admin(Some(!local_site.site_setup))
-    .build();
+    let actor_keypair = generate_actor_keypair()?;
+    is_valid_actor_name(&data.username, local_site.actor_name_max_length as usize)?;
+    let actor_id = generate_local_apub_endpoint(
+        EndpointType::Person,
+        &data.username,
+        &context.settings().get_protocol_and_hostname(),
+    )?;
 
-  let inserted_local_user = LocalUser::create(&mut context.pool(), &local_user_form).await?;
+    if let Some(email) = &data.email {
+        if LocalUser::is_email_taken(&mut context.pool(), email).await? {
+            Err(LemmyErrorType::EmailAlreadyExists)?
+        }
+    }
 
-  if local_site.site_setup && require_registration_application {
-    // Create the registration application
-    let form = RegistrationApplicationInsertForm {
-      local_user_id: inserted_local_user.id,
-      // We already made sure answer was not null above
-      answer: data.answer.clone().expect("must have an answer"),
+    // We have to create both a person, and local_user
+
+    // Register the new person
+    let person_form = PersonInsertForm::builder()
+        .name(username)
+        .actor_id(Some(actor_id.clone()))
+        .private_key(Some(actor_keypair.private_key))
+        .public_key(actor_keypair.public_key)
+        .inbox_url(Some(generate_inbox_url(&actor_id)?))
+        .shared_inbox_url(Some(generate_shared_inbox_url(&actor_id)?))
+        .instance_id(site_view.site.instance_id)
+        .build();
+
+    // insert the person
+    let inserted_person = Person::create(&mut context.pool(), &person_form)
+        .await
+        .with_lemmy_type(LemmyErrorType::UserAlreadyExists)?;
+
+    // Automatically set their application as accepted, if they created this with open registration.
+    // Also fixes a bug which allows users to log in when registrations are changed to closed.
+    let accepted_application = Some(!require_registration_application);
+
+    // Create the local user
+    let local_user_form = LocalUserInsertForm::builder()
+        .person_id(inserted_person.id)
+        .email(data.email.as_deref().map(str::to_lowercase))
+        .password_encrypted(data.password.to_string())
+        .show_nsfw(Some(data.show_nsfw))
+        .accepted_application(accepted_application)
+        .default_listing_type(Some(local_site.default_post_listing_type))
+        // If its the initial site setup, they are an admin
+        .admin(Some(!local_site.site_setup))
+        .build();
+
+    let inserted_local_user = LocalUser::create(&mut context.pool(), &local_user_form).await?;
+
+    if local_site.site_setup && require_registration_application {
+        // Create the registration application
+        let form = RegistrationApplicationInsertForm {
+            local_user_id: inserted_local_user.id,
+            // We already made sure answer was not null above
+            answer: data.answer.clone().expect("must have an answer"),
+        };
+
+        RegistrationApplication::create(&mut context.pool(), &form).await?;
+    }
+
+    // Email the admins
+    if local_site.application_email_admins {
+        send_new_applicant_email_to_admins(&data.username, &mut context.pool(), context.settings())
+            .await?;
+    }
+
+    let mut login_response = LoginResponse {
+        jwt: None,
+        registration_created: false,
+        verify_email_sent: false,
     };
 
-    RegistrationApplication::create(&mut context.pool(), &form).await?;
-  }
+    // Log the user in directly if the site is not setup, or email verification and application aren't required
+    if !local_site.site_setup
+        || (!require_registration_application && !local_site.require_email_verification)
+    {
+        login_response.jwt = Some(
+            Claims::jwt(
+                inserted_local_user.id.0,
+                &context.secret().jwt_secret,
+                &context.settings().hostname,
+            )?
+            .into(),
+        );
+    } else {
+        if local_site.require_email_verification {
+            let local_user_view = LocalUserView {
+                local_user: inserted_local_user,
+                person: inserted_person,
+                counts: PersonAggregates::default(),
+            };
+            // we check at the beginning of this method that email is set
+            let email = local_user_view
+                .local_user
+                .email
+                .clone()
+                .expect("email was provided");
 
-  // Email the admins
-  if local_site.application_email_admins {
-    send_new_applicant_email_to_admins(&data.username, &mut context.pool(), context.settings())
-      .await?;
-  }
+            send_verification_email(
+                &local_user_view,
+                &email,
+                &mut context.pool(),
+                context.settings(),
+            )
+            .await?;
+            login_response.verify_email_sent = true;
+        }
 
-  let mut login_response = LoginResponse {
-    jwt: None,
-    registration_created: false,
-    verify_email_sent: false,
-  };
-
-  // Log the user in directly if the site is not setup, or email verification and application aren't required
-  if !local_site.site_setup
-    || (!require_registration_application && !local_site.require_email_verification)
-  {
-    login_response.jwt = Some(
-      Claims::jwt(
-        inserted_local_user.id.0,
-        &context.secret().jwt_secret,
-        &context.settings().hostname,
-      )?
-      .into(),
-    );
-  } else {
-    if local_site.require_email_verification {
-      let local_user_view = LocalUserView {
-        local_user: inserted_local_user,
-        person: inserted_person,
-        counts: PersonAggregates::default(),
-      };
-      // we check at the beginning of this method that email is set
-      let email = local_user_view
-        .local_user
-        .email
-        .clone()
-        .expect("email was provided");
-
-      send_verification_email(
-        &local_user_view,
-        &email,
-        &mut context.pool(),
-        context.settings(),
-      )
-      .await?;
-      login_response.verify_email_sent = true;
+        if require_registration_application {
+            login_response.registration_created = true;
+        }
     }
 
-    if require_registration_application {
-      login_response.registration_created = true;
-    }
-  }
-
-  Ok(Json(login_response))
+    Ok(Json(login_response))
 }

--- a/crates/api_crud/src/user/delete.rs
+++ b/crates/api_crud/src/user/delete.rs
@@ -2,42 +2,42 @@ use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use bcrypt::verify;
 use lemmy_api_common::{
-  context::LemmyContext,
-  person::{DeleteAccount, DeleteAccountResponse},
-  send_activity::{ActivityChannel, SendActivityData},
-  utils::{local_user_view_from_jwt, purge_user_account},
+    context::LemmyContext,
+    person::{DeleteAccount, DeleteAccountResponse},
+    send_activity::{ActivityChannel, SendActivityData},
+    utils::{local_user_view_from_jwt, purge_user_account},
 };
 use lemmy_db_schema::source::person::Person;
 use lemmy_utils::error::{LemmyError, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn delete_account(
-  data: Json<DeleteAccount>,
-  context: Data<LemmyContext>,
+    data: Json<DeleteAccount>,
+    context: Data<LemmyContext>,
 ) -> Result<Json<DeleteAccountResponse>, LemmyError> {
-  let local_user_view = local_user_view_from_jwt(data.auth.as_ref(), &context).await?;
+    let local_user_view = local_user_view_from_jwt(data.auth.as_ref(), &context).await?;
 
-  // Verify the password
-  let valid: bool = verify(
-    &data.password,
-    &local_user_view.local_user.password_encrypted,
-  )
-  .unwrap_or(false);
-  if !valid {
-    Err(LemmyErrorType::IncorrectLogin)?
-  }
+    // Verify the password
+    let valid: bool = verify(
+        &data.password,
+        &local_user_view.local_user.password_encrypted,
+    )
+    .unwrap_or(false);
+    if !valid {
+        Err(LemmyErrorType::IncorrectLogin)?
+    }
 
-  if data.delete_content {
-    purge_user_account(local_user_view.person.id, &context).await?;
-  } else {
-    Person::delete_account(&mut context.pool(), local_user_view.person.id).await?;
-  }
+    if data.delete_content {
+        purge_user_account(local_user_view.person.id, &context).await?;
+    } else {
+        Person::delete_account(&mut context.pool(), local_user_view.person.id).await?;
+    }
 
-  ActivityChannel::submit_activity(
-    SendActivityData::DeleteUser(local_user_view.person, data.delete_content),
-    &context,
-  )
-  .await?;
+    ActivityChannel::submit_activity(
+        SendActivityData::DeleteUser(local_user_view.person, data.delete_content),
+        &context,
+    )
+    .await?;
 
-  Ok(Json(DeleteAccountResponse {}))
+    Ok(Json(DeleteAccountResponse {}))
 }

--- a/crates/apub/src/activities/block/block_user.rs
+++ b/crates/apub/src/activities/block/block_user.rs
@@ -1,219 +1,218 @@
 use crate::{
-  activities::{
-    block::{generate_cc, SiteOrCommunity},
-    community::send_activity_in_community,
-    generate_activity_id,
-    send_lemmy_activity,
-    verify_is_public,
-    verify_mod_action,
-    verify_person_in_community,
-  },
-  activity_lists::AnnouncableActivities,
-  insert_received_activity,
-  objects::{instance::remote_instance_inboxes, person::ApubPerson},
-  protocol::activities::block::block_user::BlockUser,
+    activities::{
+        block::{generate_cc, SiteOrCommunity},
+        community::send_activity_in_community,
+        generate_activity_id, send_lemmy_activity, verify_is_public, verify_mod_action,
+        verify_person_in_community,
+    },
+    activity_lists::AnnouncableActivities,
+    insert_received_activity,
+    objects::{instance::remote_instance_inboxes, person::ApubPerson},
+    protocol::activities::block::block_user::BlockUser,
 };
 use activitypub_federation::{
-  config::Data,
-  kinds::{activity::BlockType, public},
-  protocol::verification::verify_domains_match,
-  traits::{ActivityHandler, Actor},
+    config::Data,
+    kinds::{activity::BlockType, public},
+    protocol::verification::verify_domains_match,
+    traits::{ActivityHandler, Actor},
 };
 use anyhow::anyhow;
 use chrono::{DateTime, Utc};
 use lemmy_api_common::{
-  context::LemmyContext,
-  utils::{remove_user_data, remove_user_data_in_community, sanitize_html_opt},
+    context::LemmyContext,
+    utils::{remove_user_data, remove_user_data_in_community, sanitize_html_opt},
 };
 use lemmy_db_schema::{
-  source::{
-    community::{
-      CommunityFollower,
-      CommunityFollowerForm,
-      CommunityPersonBan,
-      CommunityPersonBanForm,
+    source::{
+        community::{
+            CommunityFollower, CommunityFollowerForm, CommunityPersonBan, CommunityPersonBanForm,
+        },
+        moderator::{ModBan, ModBanForm, ModBanFromCommunity, ModBanFromCommunityForm},
+        person::{Person, PersonUpdateForm},
     },
-    moderator::{ModBan, ModBanForm, ModBanFromCommunity, ModBanFromCommunityForm},
-    person::{Person, PersonUpdateForm},
-  },
-  traits::{Bannable, Crud, Followable},
+    traits::{Bannable, Crud, Followable},
 };
 use lemmy_utils::error::LemmyError;
 use url::Url;
 
 impl BlockUser {
-  pub(in crate::activities::block) async fn new(
-    target: &SiteOrCommunity,
-    user: &ApubPerson,
-    mod_: &ApubPerson,
-    remove_data: Option<bool>,
-    reason: Option<String>,
-    expires: Option<DateTime<Utc>>,
-    context: &Data<LemmyContext>,
-  ) -> Result<BlockUser, LemmyError> {
-    let audience = if let SiteOrCommunity::Community(c) = target {
-      Some(c.id().into())
-    } else {
-      None
-    };
-    Ok(BlockUser {
-      actor: mod_.id().into(),
-      to: vec![public()],
-      object: user.id().into(),
-      cc: generate_cc(target, &mut context.pool()).await?,
-      target: target.id(),
-      kind: BlockType::Block,
-      remove_data,
-      summary: reason,
-      id: generate_activity_id(
-        BlockType::Block,
-        &context.settings().get_protocol_and_hostname(),
-      )?,
-      audience,
-      expires,
-    })
-  }
-
-  #[tracing::instrument(skip_all)]
-  pub async fn send(
-    target: &SiteOrCommunity,
-    user: &ApubPerson,
-    mod_: &ApubPerson,
-    remove_data: bool,
-    reason: Option<String>,
-    expires: Option<DateTime<Utc>>,
-    context: &Data<LemmyContext>,
-  ) -> Result<(), LemmyError> {
-    let block = BlockUser::new(
-      target,
-      user,
-      mod_,
-      Some(remove_data),
-      reason,
-      expires,
-      context,
-    )
-    .await?;
-
-    match target {
-      SiteOrCommunity::Site(_) => {
-        let inboxes = remote_instance_inboxes(&mut context.pool()).await?;
-        send_lemmy_activity(context, block, mod_, inboxes, false).await
-      }
-      SiteOrCommunity::Community(c) => {
-        let activity = AnnouncableActivities::BlockUser(block);
-        let inboxes = vec![user.shared_inbox_or_inbox()];
-        send_activity_in_community(activity, mod_, c, inboxes, true, context).await
-      }
+    pub(in crate::activities::block) async fn new(
+        target: &SiteOrCommunity,
+        user: &ApubPerson,
+        mod_: &ApubPerson,
+        remove_data: Option<bool>,
+        reason: Option<String>,
+        expires: Option<DateTime<Utc>>,
+        context: &Data<LemmyContext>,
+    ) -> Result<BlockUser, LemmyError> {
+        let audience = if let SiteOrCommunity::Community(c) = target {
+            Some(c.id().into())
+        } else {
+            None
+        };
+        Ok(BlockUser {
+            actor: mod_.id().into(),
+            to: vec![public()],
+            object: user.id().into(),
+            cc: generate_cc(target, &mut context.pool()).await?,
+            target: target.id(),
+            kind: BlockType::Block,
+            remove_data,
+            summary: reason,
+            id: generate_activity_id(
+                BlockType::Block,
+                &context.settings().get_protocol_and_hostname(),
+            )?,
+            audience,
+            expires,
+        })
     }
-  }
+
+    #[tracing::instrument(skip_all)]
+    pub async fn send(
+        target: &SiteOrCommunity,
+        user: &ApubPerson,
+        mod_: &ApubPerson,
+        remove_data: bool,
+        reason: Option<String>,
+        expires: Option<DateTime<Utc>>,
+        context: &Data<LemmyContext>,
+    ) -> Result<(), LemmyError> {
+        let block = BlockUser::new(
+            target,
+            user,
+            mod_,
+            Some(remove_data),
+            reason,
+            expires,
+            context,
+        )
+        .await?;
+
+        match target {
+            SiteOrCommunity::Site(_) => {
+                let inboxes = remote_instance_inboxes(&mut context.pool()).await?;
+                send_lemmy_activity(context, block, mod_, inboxes, false).await
+            }
+            SiteOrCommunity::Community(c) => {
+                let activity = AnnouncableActivities::BlockUser(block);
+                let inboxes = vec![user.shared_inbox_or_inbox()];
+                send_activity_in_community(activity, mod_, c, inboxes, true, context).await
+            }
+        }
+    }
 }
 
 #[async_trait::async_trait]
 impl ActivityHandler for BlockUser {
-  type DataType = LemmyContext;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Error = LemmyError;
 
-  fn id(&self) -> &Url {
-    &self.id
-  }
-
-  fn actor(&self) -> &Url {
-    self.actor.inner()
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
-    insert_received_activity(&self.id, context).await?;
-    verify_is_public(&self.to, &self.cc)?;
-    match self.target.dereference(context).await? {
-      SiteOrCommunity::Site(site) => {
-        let domain = self.object.inner().domain().expect("url needs domain");
-        if context.settings().hostname == domain {
-          return Err(
-            anyhow!("Site bans from remote instance can't affect user's home instance").into(),
-          );
-        }
-        // site ban can only target a user who is on the same instance as the actor (admin)
-        verify_domains_match(&site.id(), self.actor.inner())?;
-        verify_domains_match(&site.id(), self.object.inner())?;
-      }
-      SiteOrCommunity::Community(community) => {
-        verify_person_in_community(&self.actor, &community, context).await?;
-        verify_mod_action(&self.actor, self.object.inner(), community.id, context).await?;
-      }
-    }
-    Ok(())
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
-    let expires = self.expires.map(Into::into);
-    let mod_person = self.actor.dereference(context).await?;
-    let blocked_person = self.object.dereference(context).await?;
-    let target = self.target.dereference(context).await?;
-    match target {
-      SiteOrCommunity::Site(_site) => {
-        let blocked_person = Person::update(
-          &mut context.pool(),
-          blocked_person.id,
-          &PersonUpdateForm {
-            banned: Some(true),
-            ban_expires: Some(expires),
-            ..Default::default()
-          },
-        )
-        .await?;
-        if self.remove_data.unwrap_or(false) {
-          remove_user_data(blocked_person.id, context).await?;
-        }
-
-        // write mod log
-        let form = ModBanForm {
-          mod_person_id: mod_person.id,
-          other_person_id: blocked_person.id,
-          reason: sanitize_html_opt(&self.summary),
-          banned: Some(true),
-          expires,
-        };
-        ModBan::create(&mut context.pool(), &form).await?;
-      }
-      SiteOrCommunity::Community(community) => {
-        let community_user_ban_form = CommunityPersonBanForm {
-          community_id: community.id,
-          person_id: blocked_person.id,
-          expires: Some(expires),
-        };
-        CommunityPersonBan::ban(&mut context.pool(), &community_user_ban_form).await?;
-
-        // Also unsubscribe them from the community, if they are subscribed
-        let community_follower_form = CommunityFollowerForm {
-          community_id: community.id,
-          person_id: blocked_person.id,
-          pending: false,
-        };
-        CommunityFollower::unfollow(&mut context.pool(), &community_follower_form)
-          .await
-          .ok();
-
-        if self.remove_data.unwrap_or(false) {
-          remove_user_data_in_community(community.id, blocked_person.id, &mut context.pool())
-            .await?;
-        }
-
-        // write to mod log
-        let form = ModBanFromCommunityForm {
-          mod_person_id: mod_person.id,
-          other_person_id: blocked_person.id,
-          community_id: community.id,
-          reason: sanitize_html_opt(&self.summary),
-          banned: Some(true),
-          expires,
-        };
-        ModBanFromCommunity::create(&mut context.pool(), &form).await?;
-      }
+    fn id(&self) -> &Url {
+        &self.id
     }
 
-    Ok(())
-  }
+    fn actor(&self) -> &Url {
+        self.actor.inner()
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn verify(&self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+        insert_received_activity(&self.id, context).await?;
+        verify_is_public(&self.to, &self.cc)?;
+        match self.target.dereference(context).await? {
+            SiteOrCommunity::Site(site) => {
+                let domain = self.object.inner().domain().expect("url needs domain");
+                if context.settings().hostname == domain {
+                    return Err(anyhow!(
+                        "Site bans from remote instance can't affect user's home instance"
+                    )
+                    .into());
+                }
+                // site ban can only target a user who is on the same instance as the actor (admin)
+                verify_domains_match(&site.id(), self.actor.inner())?;
+                verify_domains_match(&site.id(), self.object.inner())?;
+            }
+            SiteOrCommunity::Community(community) => {
+                verify_person_in_community(&self.actor, &community, context).await?;
+                verify_mod_action(&self.actor, self.object.inner(), community.id, context).await?;
+            }
+        }
+        Ok(())
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+        let expires = self.expires.map(Into::into);
+        let mod_person = self.actor.dereference(context).await?;
+        let blocked_person = self.object.dereference(context).await?;
+        let target = self.target.dereference(context).await?;
+        match target {
+            SiteOrCommunity::Site(_site) => {
+                let blocked_person = Person::update(
+                    &mut context.pool(),
+                    blocked_person.id,
+                    &PersonUpdateForm {
+                        banned: Some(true),
+                        ban_expires: Some(expires),
+                        ..Default::default()
+                    },
+                )
+                .await?;
+                if self.remove_data.unwrap_or(false) {
+                    remove_user_data(blocked_person.id, context).await?;
+                }
+
+                // write mod log
+                let form = ModBanForm {
+                    mod_person_id: mod_person.id,
+                    other_person_id: blocked_person.id,
+                    reason: sanitize_html_opt(&self.summary),
+                    banned: Some(true),
+                    expires,
+                };
+                ModBan::create(&mut context.pool(), &form).await?;
+            }
+            SiteOrCommunity::Community(community) => {
+                let community_user_ban_form = CommunityPersonBanForm {
+                    community_id: community.id,
+                    person_id: blocked_person.id,
+                    expires: Some(expires),
+                };
+                CommunityPersonBan::ban(&mut context.pool(), &community_user_ban_form).await?;
+
+                // Also unsubscribe them from the community, if they are subscribed
+                let community_follower_form = CommunityFollowerForm {
+                    community_id: community.id,
+                    person_id: blocked_person.id,
+                    pending: false,
+                };
+                CommunityFollower::unfollow(&mut context.pool(), &community_follower_form)
+                    .await
+                    .ok();
+
+                if self.remove_data.unwrap_or(false) {
+                    remove_user_data_in_community(
+                        community.id,
+                        blocked_person.id,
+                        &mut context.pool(),
+                    )
+                    .await?;
+                }
+
+                // write to mod log
+                let form = ModBanFromCommunityForm {
+                    mod_person_id: mod_person.id,
+                    other_person_id: blocked_person.id,
+                    community_id: community.id,
+                    reason: sanitize_html_opt(&self.summary),
+                    banned: Some(true),
+                    expires,
+                };
+                ModBanFromCommunity::create(&mut context.pool(), &form).await?;
+            }
+        }
+
+        Ok(())
+    }
 }

--- a/crates/apub/src/activities/block/mod.rs
+++ b/crates/apub/src/activities/block/mod.rs
@@ -1,27 +1,27 @@
 use crate::{
-  objects::{community::ApubCommunity, instance::ApubSite},
-  protocol::{
-    activities::block::{block_user::BlockUser, undo_block_user::UndoBlockUser},
-    objects::{group::Group, instance::Instance},
-  },
+    objects::{community::ApubCommunity, instance::ApubSite},
+    protocol::{
+        activities::block::{block_user::BlockUser, undo_block_user::UndoBlockUser},
+        objects::{group::Group, instance::Instance},
+    },
 };
 use activitypub_federation::{
-  config::Data,
-  fetch::object_id::ObjectId,
-  traits::{Actor, Object},
+    config::Data,
+    fetch::object_id::ObjectId,
+    traits::{Actor, Object},
 };
 use chrono::{DateTime, Utc};
 use lemmy_api_common::{community::BanFromCommunity, context::LemmyContext, person::BanPerson};
 use lemmy_db_schema::{
-  newtypes::CommunityId,
-  source::{community::Community, person::Person, site::Site},
-  traits::Crud,
-  utils::DbPool,
+    newtypes::CommunityId,
+    source::{community::Community, person::Person, site::Site},
+    traits::Crud,
+    utils::DbPool,
 };
 use lemmy_db_views::structs::SiteView;
 use lemmy_utils::{
-  error::{LemmyError, LemmyResult},
-  utils::time::naive_from_unix,
+    error::{LemmyError, LemmyResult},
+    utils::time::naive_from_unix,
 };
 use serde::Deserialize;
 use url::Url;
@@ -31,173 +31,175 @@ pub mod undo_block_user;
 
 #[derive(Clone, Debug)]
 pub enum SiteOrCommunity {
-  Site(ApubSite),
-  Community(ApubCommunity),
+    Site(ApubSite),
+    Community(ApubCommunity),
 }
 
 #[derive(Deserialize)]
 #[serde(untagged)]
 pub enum InstanceOrGroup {
-  Instance(Instance),
-  Group(Group),
+    Instance(Instance),
+    Group(Group),
 }
 
 #[async_trait::async_trait]
 impl Object for SiteOrCommunity {
-  type DataType = LemmyContext;
-  type Kind = InstanceOrGroup;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Kind = InstanceOrGroup;
+    type Error = LemmyError;
 
-  #[tracing::instrument(skip_all)]
-  fn last_refreshed_at(&self) -> Option<DateTime<Utc>> {
-    Some(match self {
-      SiteOrCommunity::Site(i) => i.last_refreshed_at,
-      SiteOrCommunity::Community(c) => c.last_refreshed_at,
-    })
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn read_from_id(
-    object_id: Url,
-    data: &Data<Self::DataType>,
-  ) -> Result<Option<Self>, LemmyError>
-  where
-    Self: Sized,
-  {
-    let site = ApubSite::read_from_id(object_id.clone(), data).await?;
-    Ok(match site {
-      Some(o) => Some(SiteOrCommunity::Site(o)),
-      None => ApubCommunity::read_from_id(object_id, data)
-        .await?
-        .map(SiteOrCommunity::Community),
-    })
-  }
-
-  async fn delete(self, _data: &Data<Self::DataType>) -> Result<(), LemmyError> {
-    unimplemented!()
-  }
-
-  async fn into_json(self, _data: &Data<Self::DataType>) -> Result<Self::Kind, LemmyError> {
-    unimplemented!()
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn verify(
-    apub: &Self::Kind,
-    expected_domain: &Url,
-    data: &Data<Self::DataType>,
-  ) -> Result<(), LemmyError> {
-    match apub {
-      InstanceOrGroup::Instance(i) => ApubSite::verify(i, expected_domain, data).await,
-      InstanceOrGroup::Group(g) => ApubCommunity::verify(g, expected_domain, data).await,
+    #[tracing::instrument(skip_all)]
+    fn last_refreshed_at(&self) -> Option<DateTime<Utc>> {
+        Some(match self {
+            SiteOrCommunity::Site(i) => i.last_refreshed_at,
+            SiteOrCommunity::Community(c) => c.last_refreshed_at,
+        })
     }
-  }
 
-  #[tracing::instrument(skip_all)]
-  async fn from_json(apub: Self::Kind, data: &Data<Self::DataType>) -> Result<Self, LemmyError>
-  where
-    Self: Sized,
-  {
-    Ok(match apub {
-      InstanceOrGroup::Instance(p) => SiteOrCommunity::Site(ApubSite::from_json(p, data).await?),
-      InstanceOrGroup::Group(n) => {
-        SiteOrCommunity::Community(ApubCommunity::from_json(n, data).await?)
-      }
-    })
-  }
+    #[tracing::instrument(skip_all)]
+    async fn read_from_id(
+        object_id: Url,
+        data: &Data<Self::DataType>,
+    ) -> Result<Option<Self>, LemmyError>
+    where
+        Self: Sized,
+    {
+        let site = ApubSite::read_from_id(object_id.clone(), data).await?;
+        Ok(match site {
+            Some(o) => Some(SiteOrCommunity::Site(o)),
+            None => ApubCommunity::read_from_id(object_id, data)
+                .await?
+                .map(SiteOrCommunity::Community),
+        })
+    }
+
+    async fn delete(self, _data: &Data<Self::DataType>) -> Result<(), LemmyError> {
+        unimplemented!()
+    }
+
+    async fn into_json(self, _data: &Data<Self::DataType>) -> Result<Self::Kind, LemmyError> {
+        unimplemented!()
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn verify(
+        apub: &Self::Kind,
+        expected_domain: &Url,
+        data: &Data<Self::DataType>,
+    ) -> Result<(), LemmyError> {
+        match apub {
+            InstanceOrGroup::Instance(i) => ApubSite::verify(i, expected_domain, data).await,
+            InstanceOrGroup::Group(g) => ApubCommunity::verify(g, expected_domain, data).await,
+        }
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn from_json(apub: Self::Kind, data: &Data<Self::DataType>) -> Result<Self, LemmyError>
+    where
+        Self: Sized,
+    {
+        Ok(match apub {
+            InstanceOrGroup::Instance(p) => {
+                SiteOrCommunity::Site(ApubSite::from_json(p, data).await?)
+            }
+            InstanceOrGroup::Group(n) => {
+                SiteOrCommunity::Community(ApubCommunity::from_json(n, data).await?)
+            }
+        })
+    }
 }
 
 impl SiteOrCommunity {
-  fn id(&self) -> ObjectId<SiteOrCommunity> {
-    match self {
-      SiteOrCommunity::Site(s) => ObjectId::from(s.actor_id.clone()),
-      SiteOrCommunity::Community(c) => ObjectId::from(c.actor_id.clone()),
+    fn id(&self) -> ObjectId<SiteOrCommunity> {
+        match self {
+            SiteOrCommunity::Site(s) => ObjectId::from(s.actor_id.clone()),
+            SiteOrCommunity::Community(c) => ObjectId::from(c.actor_id.clone()),
+        }
     }
-  }
 }
 
 async fn generate_cc(
-  target: &SiteOrCommunity,
-  pool: &mut DbPool<'_>,
+    target: &SiteOrCommunity,
+    pool: &mut DbPool<'_>,
 ) -> Result<Vec<Url>, LemmyError> {
-  Ok(match target {
-    SiteOrCommunity::Site(_) => Site::read_remote_sites(pool)
-      .await?
-      .into_iter()
-      .map(|s| s.actor_id.into())
-      .collect(),
-    SiteOrCommunity::Community(c) => vec![c.id()],
-  })
+    Ok(match target {
+        SiteOrCommunity::Site(_) => Site::read_remote_sites(pool)
+            .await?
+            .into_iter()
+            .map(|s| s.actor_id.into())
+            .collect(),
+        SiteOrCommunity::Community(c) => vec![c.id()],
+    })
 }
 
 pub(crate) async fn send_ban_from_site(
-  mod_: Person,
-  banned_user: Person,
-  data: BanPerson,
-  context: Data<LemmyContext>,
+    mod_: Person,
+    banned_user: Person,
+    data: BanPerson,
+    context: Data<LemmyContext>,
 ) -> Result<(), LemmyError> {
-  let site = SiteOrCommunity::Site(SiteView::read_local(&mut context.pool()).await?.site.into());
-  let expires = data.expires.map(naive_from_unix);
+    let site = SiteOrCommunity::Site(SiteView::read_local(&mut context.pool()).await?.site.into());
+    let expires = data.expires.map(naive_from_unix);
 
-  // if the action affects a local user, federate to other instances
-  if banned_user.local {
-    if data.ban {
-      BlockUser::send(
-        &site,
-        &banned_user.into(),
-        &mod_.into(),
-        data.remove_data.unwrap_or(false),
-        data.reason.clone(),
-        expires,
-        &context,
-      )
-      .await
+    // if the action affects a local user, federate to other instances
+    if banned_user.local {
+        if data.ban {
+            BlockUser::send(
+                &site,
+                &banned_user.into(),
+                &mod_.into(),
+                data.remove_data.unwrap_or(false),
+                data.reason.clone(),
+                expires,
+                &context,
+            )
+            .await
+        } else {
+            UndoBlockUser::send(
+                &site,
+                &banned_user.into(),
+                &mod_.into(),
+                data.reason.clone(),
+                &context,
+            )
+            .await
+        }
     } else {
-      UndoBlockUser::send(
-        &site,
-        &banned_user.into(),
-        &mod_.into(),
-        data.reason.clone(),
-        &context,
-      )
-      .await
+        Ok(())
     }
-  } else {
-    Ok(())
-  }
 }
 
 pub(crate) async fn send_ban_from_community(
-  mod_: Person,
-  community_id: CommunityId,
-  banned_person: Person,
-  data: BanFromCommunity,
-  context: Data<LemmyContext>,
+    mod_: Person,
+    community_id: CommunityId,
+    banned_person: Person,
+    data: BanFromCommunity,
+    context: Data<LemmyContext>,
 ) -> LemmyResult<()> {
-  let community: ApubCommunity = Community::read(&mut context.pool(), community_id)
-    .await?
-    .into();
-  let expires = data.expires.map(naive_from_unix);
+    let community: ApubCommunity = Community::read(&mut context.pool(), community_id)
+        .await?
+        .into();
+    let expires = data.expires.map(naive_from_unix);
 
-  if data.ban {
-    BlockUser::send(
-      &SiteOrCommunity::Community(community),
-      &banned_person.into(),
-      &mod_.into(),
-      data.remove_data.unwrap_or(false),
-      data.reason.clone(),
-      expires,
-      &context,
-    )
-    .await
-  } else {
-    UndoBlockUser::send(
-      &SiteOrCommunity::Community(community),
-      &banned_person.into(),
-      &mod_.into(),
-      data.reason.clone(),
-      &context,
-    )
-    .await
-  }
+    if data.ban {
+        BlockUser::send(
+            &SiteOrCommunity::Community(community),
+            &banned_person.into(),
+            &mod_.into(),
+            data.remove_data.unwrap_or(false),
+            data.reason.clone(),
+            expires,
+            &context,
+        )
+        .await
+    } else {
+        UndoBlockUser::send(
+            &SiteOrCommunity::Community(community),
+            &banned_person.into(),
+            &mod_.into(),
+            data.reason.clone(),
+            &context,
+        )
+        .await
+    }
 }

--- a/crates/apub/src/activities/block/undo_block_user.rs
+++ b/crates/apub/src/activities/block/undo_block_user.rs
@@ -1,149 +1,147 @@
 use crate::{
-  activities::{
-    block::{generate_cc, SiteOrCommunity},
-    community::send_activity_in_community,
-    generate_activity_id,
-    send_lemmy_activity,
-    verify_is_public,
-  },
-  activity_lists::AnnouncableActivities,
-  insert_received_activity,
-  objects::{instance::remote_instance_inboxes, person::ApubPerson},
-  protocol::activities::block::{block_user::BlockUser, undo_block_user::UndoBlockUser},
+    activities::{
+        block::{generate_cc, SiteOrCommunity},
+        community::send_activity_in_community,
+        generate_activity_id, send_lemmy_activity, verify_is_public,
+    },
+    activity_lists::AnnouncableActivities,
+    insert_received_activity,
+    objects::{instance::remote_instance_inboxes, person::ApubPerson},
+    protocol::activities::block::{block_user::BlockUser, undo_block_user::UndoBlockUser},
 };
 use activitypub_federation::{
-  config::Data,
-  kinds::{activity::UndoType, public},
-  protocol::verification::verify_domains_match,
-  traits::{ActivityHandler, Actor},
+    config::Data,
+    kinds::{activity::UndoType, public},
+    protocol::verification::verify_domains_match,
+    traits::{ActivityHandler, Actor},
 };
 use lemmy_api_common::{context::LemmyContext, utils::sanitize_html_opt};
 use lemmy_db_schema::{
-  source::{
-    community::{CommunityPersonBan, CommunityPersonBanForm},
-    moderator::{ModBan, ModBanForm, ModBanFromCommunity, ModBanFromCommunityForm},
-    person::{Person, PersonUpdateForm},
-  },
-  traits::{Bannable, Crud},
+    source::{
+        community::{CommunityPersonBan, CommunityPersonBanForm},
+        moderator::{ModBan, ModBanForm, ModBanFromCommunity, ModBanFromCommunityForm},
+        person::{Person, PersonUpdateForm},
+    },
+    traits::{Bannable, Crud},
 };
 use lemmy_utils::error::LemmyError;
 use url::Url;
 
 impl UndoBlockUser {
-  #[tracing::instrument(skip_all)]
-  pub async fn send(
-    target: &SiteOrCommunity,
-    user: &ApubPerson,
-    mod_: &ApubPerson,
-    reason: Option<String>,
-    context: &Data<LemmyContext>,
-  ) -> Result<(), LemmyError> {
-    let block = BlockUser::new(target, user, mod_, None, reason, None, context).await?;
-    let audience = if let SiteOrCommunity::Community(c) = target {
-      Some(c.id().into())
-    } else {
-      None
-    };
+    #[tracing::instrument(skip_all)]
+    pub async fn send(
+        target: &SiteOrCommunity,
+        user: &ApubPerson,
+        mod_: &ApubPerson,
+        reason: Option<String>,
+        context: &Data<LemmyContext>,
+    ) -> Result<(), LemmyError> {
+        let block = BlockUser::new(target, user, mod_, None, reason, None, context).await?;
+        let audience = if let SiteOrCommunity::Community(c) = target {
+            Some(c.id().into())
+        } else {
+            None
+        };
 
-    let id = generate_activity_id(
-      UndoType::Undo,
-      &context.settings().get_protocol_and_hostname(),
-    )?;
-    let undo = UndoBlockUser {
-      actor: mod_.id().into(),
-      to: vec![public()],
-      object: block,
-      cc: generate_cc(target, &mut context.pool()).await?,
-      kind: UndoType::Undo,
-      id: id.clone(),
-      audience,
-    };
+        let id = generate_activity_id(
+            UndoType::Undo,
+            &context.settings().get_protocol_and_hostname(),
+        )?;
+        let undo = UndoBlockUser {
+            actor: mod_.id().into(),
+            to: vec![public()],
+            object: block,
+            cc: generate_cc(target, &mut context.pool()).await?,
+            kind: UndoType::Undo,
+            id: id.clone(),
+            audience,
+        };
 
-    let mut inboxes = vec![user.shared_inbox_or_inbox()];
-    match target {
-      SiteOrCommunity::Site(_) => {
-        inboxes.append(&mut remote_instance_inboxes(&mut context.pool()).await?);
-        send_lemmy_activity(context, undo, mod_, inboxes, false).await
-      }
-      SiteOrCommunity::Community(c) => {
-        let activity = AnnouncableActivities::UndoBlockUser(undo);
-        send_activity_in_community(activity, mod_, c, inboxes, true, context).await
-      }
+        let mut inboxes = vec![user.shared_inbox_or_inbox()];
+        match target {
+            SiteOrCommunity::Site(_) => {
+                inboxes.append(&mut remote_instance_inboxes(&mut context.pool()).await?);
+                send_lemmy_activity(context, undo, mod_, inboxes, false).await
+            }
+            SiteOrCommunity::Community(c) => {
+                let activity = AnnouncableActivities::UndoBlockUser(undo);
+                send_activity_in_community(activity, mod_, c, inboxes, true, context).await
+            }
+        }
     }
-  }
 }
 
 #[async_trait::async_trait]
 impl ActivityHandler for UndoBlockUser {
-  type DataType = LemmyContext;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Error = LemmyError;
 
-  fn id(&self) -> &Url {
-    &self.id
-  }
-
-  fn actor(&self) -> &Url {
-    self.actor.inner()
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
-    insert_received_activity(&self.id, context).await?;
-    verify_is_public(&self.to, &self.cc)?;
-    verify_domains_match(self.actor.inner(), self.object.actor.inner())?;
-    self.object.verify(context).await?;
-    Ok(())
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
-    let expires = self.object.expires.map(Into::into);
-    let mod_person = self.actor.dereference(context).await?;
-    let blocked_person = self.object.object.dereference(context).await?;
-    match self.object.target.dereference(context).await? {
-      SiteOrCommunity::Site(_site) => {
-        let blocked_person = Person::update(
-          &mut context.pool(),
-          blocked_person.id,
-          &PersonUpdateForm {
-            banned: Some(false),
-            ban_expires: Some(expires),
-            ..Default::default()
-          },
-        )
-        .await?;
-
-        // write mod log
-        let form = ModBanForm {
-          mod_person_id: mod_person.id,
-          other_person_id: blocked_person.id,
-          reason: sanitize_html_opt(&self.object.summary),
-          banned: Some(false),
-          expires,
-        };
-        ModBan::create(&mut context.pool(), &form).await?;
-      }
-      SiteOrCommunity::Community(community) => {
-        let community_user_ban_form = CommunityPersonBanForm {
-          community_id: community.id,
-          person_id: blocked_person.id,
-          expires: None,
-        };
-        CommunityPersonBan::unban(&mut context.pool(), &community_user_ban_form).await?;
-
-        // write to mod log
-        let form = ModBanFromCommunityForm {
-          mod_person_id: mod_person.id,
-          other_person_id: blocked_person.id,
-          community_id: community.id,
-          reason: sanitize_html_opt(&self.object.summary),
-          banned: Some(false),
-          expires,
-        };
-        ModBanFromCommunity::create(&mut context.pool(), &form).await?;
-      }
+    fn id(&self) -> &Url {
+        &self.id
     }
 
-    Ok(())
-  }
+    fn actor(&self) -> &Url {
+        self.actor.inner()
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn verify(&self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+        insert_received_activity(&self.id, context).await?;
+        verify_is_public(&self.to, &self.cc)?;
+        verify_domains_match(self.actor.inner(), self.object.actor.inner())?;
+        self.object.verify(context).await?;
+        Ok(())
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+        let expires = self.object.expires.map(Into::into);
+        let mod_person = self.actor.dereference(context).await?;
+        let blocked_person = self.object.object.dereference(context).await?;
+        match self.object.target.dereference(context).await? {
+            SiteOrCommunity::Site(_site) => {
+                let blocked_person = Person::update(
+                    &mut context.pool(),
+                    blocked_person.id,
+                    &PersonUpdateForm {
+                        banned: Some(false),
+                        ban_expires: Some(expires),
+                        ..Default::default()
+                    },
+                )
+                .await?;
+
+                // write mod log
+                let form = ModBanForm {
+                    mod_person_id: mod_person.id,
+                    other_person_id: blocked_person.id,
+                    reason: sanitize_html_opt(&self.object.summary),
+                    banned: Some(false),
+                    expires,
+                };
+                ModBan::create(&mut context.pool(), &form).await?;
+            }
+            SiteOrCommunity::Community(community) => {
+                let community_user_ban_form = CommunityPersonBanForm {
+                    community_id: community.id,
+                    person_id: blocked_person.id,
+                    expires: None,
+                };
+                CommunityPersonBan::unban(&mut context.pool(), &community_user_ban_form).await?;
+
+                // write to mod log
+                let form = ModBanFromCommunityForm {
+                    mod_person_id: mod_person.id,
+                    other_person_id: blocked_person.id,
+                    community_id: community.id,
+                    reason: sanitize_html_opt(&self.object.summary),
+                    banned: Some(false),
+                    expires,
+                };
+                ModBanFromCommunity::create(&mut context.pool(), &form).await?;
+            }
+        }
+
+        Ok(())
+    }
 }

--- a/crates/apub/src/activities/community/announce.rs
+++ b/crates/apub/src/activities/community/announce.rs
@@ -1,24 +1,19 @@
 use crate::{
-  activities::{
-    generate_activity_id,
-    send_lemmy_activity,
-    verify_is_public,
-    verify_person_in_community,
-  },
-  activity_lists::AnnouncableActivities,
-  insert_received_activity,
-  objects::community::ApubCommunity,
-  protocol::{
-    activities::community::announce::{AnnounceActivity, RawAnnouncableActivities},
-    Id,
-    IdOrNestedObject,
-    InCommunity,
-  },
+    activities::{
+        generate_activity_id, send_lemmy_activity, verify_is_public, verify_person_in_community,
+    },
+    activity_lists::AnnouncableActivities,
+    insert_received_activity,
+    objects::community::ApubCommunity,
+    protocol::{
+        activities::community::announce::{AnnounceActivity, RawAnnouncableActivities},
+        Id, IdOrNestedObject, InCommunity,
+    },
 };
 use activitypub_federation::{
-  config::Data,
-  kinds::{activity::AnnounceType, public},
-  traits::{ActivityHandler, Actor},
+    config::Data,
+    kinds::{activity::AnnounceType, public},
+    traits::{ActivityHandler, Actor},
 };
 use lemmy_api_common::context::LemmyContext;
 use lemmy_utils::error::{LemmyError, LemmyErrorType};
@@ -27,155 +22,155 @@ use url::Url;
 
 #[async_trait::async_trait]
 impl ActivityHandler for RawAnnouncableActivities {
-  type DataType = LemmyContext;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Error = LemmyError;
 
-  fn id(&self) -> &Url {
-    &self.id
-  }
-
-  fn actor(&self) -> &Url {
-    &self.actor
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn verify(&self, _data: &Data<Self::DataType>) -> Result<(), Self::Error> {
-    Ok(())
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn receive(self, data: &Data<Self::DataType>) -> Result<(), Self::Error> {
-    let activity: AnnouncableActivities = self.clone().try_into()?;
-    // This is only for sending, not receiving so we reject it.
-    if let AnnouncableActivities::Page(_) = activity {
-      Err(LemmyErrorType::CannotReceivePage)?
+    fn id(&self) -> &Url {
+        &self.id
     }
 
-    // verify and receive activity
-    activity.verify(data).await?;
-    activity.clone().receive(data).await?;
-
-    // if activity is in a community, send to followers
-    let community = activity.community(data).await;
-    if let Ok(community) = community {
-      if community.local {
-        let actor_id = activity.actor().clone().into();
-        verify_person_in_community(&actor_id, &community, data).await?;
-        AnnounceActivity::send(self, &community, data).await?;
-      }
+    fn actor(&self) -> &Url {
+        &self.actor
     }
-    Ok(())
-  }
+
+    #[tracing::instrument(skip_all)]
+    async fn verify(&self, _data: &Data<Self::DataType>) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn receive(self, data: &Data<Self::DataType>) -> Result<(), Self::Error> {
+        let activity: AnnouncableActivities = self.clone().try_into()?;
+        // This is only for sending, not receiving so we reject it.
+        if let AnnouncableActivities::Page(_) = activity {
+            Err(LemmyErrorType::CannotReceivePage)?
+        }
+
+        // verify and receive activity
+        activity.verify(data).await?;
+        activity.clone().receive(data).await?;
+
+        // if activity is in a community, send to followers
+        let community = activity.community(data).await;
+        if let Ok(community) = community {
+            if community.local {
+                let actor_id = activity.actor().clone().into();
+                verify_person_in_community(&actor_id, &community, data).await?;
+                AnnounceActivity::send(self, &community, data).await?;
+            }
+        }
+        Ok(())
+    }
 }
 
 impl AnnounceActivity {
-  pub(crate) fn new(
-    object: RawAnnouncableActivities,
-    community: &ApubCommunity,
-    context: &Data<LemmyContext>,
-  ) -> Result<AnnounceActivity, LemmyError> {
-    Ok(AnnounceActivity {
-      actor: community.id().into(),
-      to: vec![public()],
-      object: IdOrNestedObject::NestedObject(object),
-      cc: vec![community.followers_url.clone().into()],
-      kind: AnnounceType::Announce,
-      id: generate_activity_id(
-        &AnnounceType::Announce,
-        &context.settings().get_protocol_and_hostname(),
-      )?,
-    })
-  }
-
-  #[tracing::instrument(skip_all)]
-  pub async fn send(
-    object: RawAnnouncableActivities,
-    community: &ApubCommunity,
-    context: &Data<LemmyContext>,
-  ) -> Result<(), LemmyError> {
-    let announce = AnnounceActivity::new(object.clone(), community, context)?;
-    let inboxes = community.get_follower_inboxes(context).await?;
-    send_lemmy_activity(context, announce, community, inboxes.clone(), false).await?;
-
-    // Pleroma and Mastodon can't handle activities like Announce/Create/Page. So for
-    // compatibility, we also send Announce/Page so that they can follow Lemmy communities.
-    let object_parsed = object.try_into()?;
-    if let AnnouncableActivities::CreateOrUpdatePost(c) = object_parsed {
-      // Hack: need to convert Page into a format which can be sent as activity, which requires
-      //       adding actor field.
-      let announcable_page = RawAnnouncableActivities {
-        id: generate_activity_id(
-          AnnounceType::Announce,
-          &context.settings().get_protocol_and_hostname(),
-        )?,
-        actor: c.actor.clone().into_inner(),
-        other: serde_json::to_value(c.object)?
-          .as_object()
-          .expect("is object")
-          .clone(),
-      };
-      let announce_compat = AnnounceActivity::new(announcable_page, community, context)?;
-      send_lemmy_activity(context, announce_compat, community, inboxes, false).await?;
+    pub(crate) fn new(
+        object: RawAnnouncableActivities,
+        community: &ApubCommunity,
+        context: &Data<LemmyContext>,
+    ) -> Result<AnnounceActivity, LemmyError> {
+        Ok(AnnounceActivity {
+            actor: community.id().into(),
+            to: vec![public()],
+            object: IdOrNestedObject::NestedObject(object),
+            cc: vec![community.followers_url.clone().into()],
+            kind: AnnounceType::Announce,
+            id: generate_activity_id(
+                &AnnounceType::Announce,
+                &context.settings().get_protocol_and_hostname(),
+            )?,
+        })
     }
-    Ok(())
-  }
+
+    #[tracing::instrument(skip_all)]
+    pub async fn send(
+        object: RawAnnouncableActivities,
+        community: &ApubCommunity,
+        context: &Data<LemmyContext>,
+    ) -> Result<(), LemmyError> {
+        let announce = AnnounceActivity::new(object.clone(), community, context)?;
+        let inboxes = community.get_follower_inboxes(context).await?;
+        send_lemmy_activity(context, announce, community, inboxes.clone(), false).await?;
+
+        // Pleroma and Mastodon can't handle activities like Announce/Create/Page. So for
+        // compatibility, we also send Announce/Page so that they can follow Lemmy communities.
+        let object_parsed = object.try_into()?;
+        if let AnnouncableActivities::CreateOrUpdatePost(c) = object_parsed {
+            // Hack: need to convert Page into a format which can be sent as activity, which requires
+            //       adding actor field.
+            let announcable_page = RawAnnouncableActivities {
+                id: generate_activity_id(
+                    AnnounceType::Announce,
+                    &context.settings().get_protocol_and_hostname(),
+                )?,
+                actor: c.actor.clone().into_inner(),
+                other: serde_json::to_value(c.object)?
+                    .as_object()
+                    .expect("is object")
+                    .clone(),
+            };
+            let announce_compat = AnnounceActivity::new(announcable_page, community, context)?;
+            send_lemmy_activity(context, announce_compat, community, inboxes, false).await?;
+        }
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait]
 impl ActivityHandler for AnnounceActivity {
-  type DataType = LemmyContext;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Error = LemmyError;
 
-  fn id(&self) -> &Url {
-    &self.id
-  }
-
-  fn actor(&self) -> &Url {
-    self.actor.inner()
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
-    insert_received_activity(&self.id, context).await?;
-    verify_is_public(&self.to, &self.cc)?;
-    Ok(())
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
-    let object: AnnouncableActivities = self.object.object(context).await?.try_into()?;
-    // This is only for sending, not receiving so we reject it.
-    if let AnnouncableActivities::Page(_) = object {
-      Err(LemmyErrorType::CannotReceivePage)?
+    fn id(&self) -> &Url {
+        &self.id
     }
 
-    // verify here in order to avoid fetching the object twice over http
-    object.verify(context).await?;
-    object.receive(context).await
-  }
+    fn actor(&self) -> &Url {
+        self.actor.inner()
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn verify(&self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+        insert_received_activity(&self.id, context).await?;
+        verify_is_public(&self.to, &self.cc)?;
+        Ok(())
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn receive(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+        let object: AnnouncableActivities = self.object.object(context).await?.try_into()?;
+        // This is only for sending, not receiving so we reject it.
+        if let AnnouncableActivities::Page(_) = object {
+            Err(LemmyErrorType::CannotReceivePage)?
+        }
+
+        // verify here in order to avoid fetching the object twice over http
+        object.verify(context).await?;
+        object.receive(context).await
+    }
 }
 
 impl Id for RawAnnouncableActivities {
-  fn object_id(&self) -> &Url {
-    ActivityHandler::id(self)
-  }
+    fn object_id(&self) -> &Url {
+        ActivityHandler::id(self)
+    }
 }
 
 impl TryFrom<RawAnnouncableActivities> for AnnouncableActivities {
-  type Error = serde_json::error::Error;
+    type Error = serde_json::error::Error;
 
-  fn try_from(value: RawAnnouncableActivities) -> Result<Self, Self::Error> {
-    let mut map = value.other.clone();
-    map.insert("id".to_string(), Value::String(value.id.to_string()));
-    map.insert("actor".to_string(), Value::String(value.actor.to_string()));
-    serde_json::from_value(Value::Object(map))
-  }
+    fn try_from(value: RawAnnouncableActivities) -> Result<Self, Self::Error> {
+        let mut map = value.other.clone();
+        map.insert("id".to_string(), Value::String(value.id.to_string()));
+        map.insert("actor".to_string(), Value::String(value.actor.to_string()));
+        serde_json::from_value(Value::Object(map))
+    }
 }
 
 impl TryFrom<AnnouncableActivities> for RawAnnouncableActivities {
-  type Error = serde_json::error::Error;
+    type Error = serde_json::error::Error;
 
-  fn try_from(value: AnnouncableActivities) -> Result<Self, Self::Error> {
-    serde_json::from_value(serde_json::to_value(value)?)
-  }
+    fn try_from(value: AnnouncableActivities) -> Result<Self, Self::Error> {
+        serde_json::from_value(serde_json::to_value(value)?)
+    }
 }

--- a/crates/apub/src/activities/community/collection_add.rs
+++ b/crates/apub/src/activities/community/collection_add.rs
@@ -1,204 +1,205 @@
 use crate::{
-  activities::{
-    community::send_activity_in_community,
-    generate_activity_id,
-    verify_is_public,
-    verify_mod_action,
-    verify_person_in_community,
-  },
-  activity_lists::AnnouncableActivities,
-  insert_received_activity,
-  objects::{community::ApubCommunity, person::ApubPerson, post::ApubPost},
-  protocol::{
-    activities::community::{collection_add::CollectionAdd, collection_remove::CollectionRemove},
-    InCommunity,
-  },
+    activities::{
+        community::send_activity_in_community, generate_activity_id, verify_is_public,
+        verify_mod_action, verify_person_in_community,
+    },
+    activity_lists::AnnouncableActivities,
+    insert_received_activity,
+    objects::{community::ApubCommunity, person::ApubPerson, post::ApubPost},
+    protocol::{
+        activities::community::{
+            collection_add::CollectionAdd, collection_remove::CollectionRemove,
+        },
+        InCommunity,
+    },
 };
 use activitypub_federation::{
-  config::Data,
-  fetch::object_id::ObjectId,
-  kinds::{activity::AddType, public},
-  traits::{ActivityHandler, Actor},
+    config::Data,
+    fetch::object_id::ObjectId,
+    kinds::{activity::AddType, public},
+    traits::{ActivityHandler, Actor},
 };
 use lemmy_api_common::{
-  context::LemmyContext,
-  utils::{generate_featured_url, generate_moderators_url},
+    context::LemmyContext,
+    utils::{generate_featured_url, generate_moderators_url},
 };
 use lemmy_db_schema::{
-  impls::community::CollectionType,
-  newtypes::{CommunityId, PersonId},
-  source::{
-    community::{Community, CommunityModerator, CommunityModeratorForm},
-    moderator::{ModAddCommunity, ModAddCommunityForm},
-    person::Person,
-    post::{Post, PostUpdateForm},
-  },
-  traits::{Crud, Joinable},
+    impls::community::CollectionType,
+    newtypes::{CommunityId, PersonId},
+    source::{
+        community::{Community, CommunityModerator, CommunityModeratorForm},
+        moderator::{ModAddCommunity, ModAddCommunityForm},
+        person::Person,
+        post::{Post, PostUpdateForm},
+    },
+    traits::{Crud, Joinable},
 };
 use lemmy_utils::error::LemmyError;
 use url::Url;
 
 impl CollectionAdd {
-  #[tracing::instrument(skip_all)]
-  pub async fn send_add_mod(
-    community: &ApubCommunity,
-    added_mod: &ApubPerson,
-    actor: &ApubPerson,
-    context: &Data<LemmyContext>,
-  ) -> Result<(), LemmyError> {
-    let id = generate_activity_id(
-      AddType::Add,
-      &context.settings().get_protocol_and_hostname(),
-    )?;
-    let add = CollectionAdd {
-      actor: actor.id().into(),
-      to: vec![public()],
-      object: added_mod.id(),
-      target: generate_moderators_url(&community.actor_id)?.into(),
-      cc: vec![community.id()],
-      kind: AddType::Add,
-      id: id.clone(),
-      audience: Some(community.id().into()),
-    };
+    #[tracing::instrument(skip_all)]
+    pub async fn send_add_mod(
+        community: &ApubCommunity,
+        added_mod: &ApubPerson,
+        actor: &ApubPerson,
+        context: &Data<LemmyContext>,
+    ) -> Result<(), LemmyError> {
+        let id = generate_activity_id(
+            AddType::Add,
+            &context.settings().get_protocol_and_hostname(),
+        )?;
+        let add = CollectionAdd {
+            actor: actor.id().into(),
+            to: vec![public()],
+            object: added_mod.id(),
+            target: generate_moderators_url(&community.actor_id)?.into(),
+            cc: vec![community.id()],
+            kind: AddType::Add,
+            id: id.clone(),
+            audience: Some(community.id().into()),
+        };
 
-    let activity = AnnouncableActivities::CollectionAdd(add);
-    let inboxes = vec![added_mod.shared_inbox_or_inbox()];
-    send_activity_in_community(activity, actor, community, inboxes, true, context).await
-  }
+        let activity = AnnouncableActivities::CollectionAdd(add);
+        let inboxes = vec![added_mod.shared_inbox_or_inbox()];
+        send_activity_in_community(activity, actor, community, inboxes, true, context).await
+    }
 
-  pub async fn send_add_featured_post(
-    community: &ApubCommunity,
-    featured_post: &ApubPost,
-    actor: &ApubPerson,
-    context: &Data<LemmyContext>,
-  ) -> Result<(), LemmyError> {
-    let id = generate_activity_id(
-      AddType::Add,
-      &context.settings().get_protocol_and_hostname(),
-    )?;
-    let add = CollectionAdd {
-      actor: actor.id().into(),
-      to: vec![public()],
-      object: featured_post.ap_id.clone().into(),
-      target: generate_featured_url(&community.actor_id)?.into(),
-      cc: vec![community.id()],
-      kind: AddType::Add,
-      id: id.clone(),
-      audience: Some(community.id().into()),
-    };
-    let activity = AnnouncableActivities::CollectionAdd(add);
-    send_activity_in_community(activity, actor, community, vec![], true, context).await
-  }
+    pub async fn send_add_featured_post(
+        community: &ApubCommunity,
+        featured_post: &ApubPost,
+        actor: &ApubPerson,
+        context: &Data<LemmyContext>,
+    ) -> Result<(), LemmyError> {
+        let id = generate_activity_id(
+            AddType::Add,
+            &context.settings().get_protocol_and_hostname(),
+        )?;
+        let add = CollectionAdd {
+            actor: actor.id().into(),
+            to: vec![public()],
+            object: featured_post.ap_id.clone().into(),
+            target: generate_featured_url(&community.actor_id)?.into(),
+            cc: vec![community.id()],
+            kind: AddType::Add,
+            id: id.clone(),
+            audience: Some(community.id().into()),
+        };
+        let activity = AnnouncableActivities::CollectionAdd(add);
+        send_activity_in_community(activity, actor, community, vec![], true, context).await
+    }
 }
 
 #[async_trait::async_trait]
 impl ActivityHandler for CollectionAdd {
-  type DataType = LemmyContext;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Error = LemmyError;
 
-  fn id(&self) -> &Url {
-    &self.id
-  }
-
-  fn actor(&self) -> &Url {
-    self.actor.inner()
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
-    insert_received_activity(&self.id, context).await?;
-    verify_is_public(&self.to, &self.cc)?;
-    let community = self.community(context).await?;
-    verify_person_in_community(&self.actor, &community, context).await?;
-    verify_mod_action(&self.actor, &self.object, community.id, context).await?;
-    Ok(())
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
-    let (community, collection_type) =
-      Community::get_by_collection_url(&mut context.pool(), &self.target.into()).await?;
-    match collection_type {
-      CollectionType::Moderators => {
-        let new_mod = ObjectId::<ApubPerson>::from(self.object)
-          .dereference(context)
-          .await?;
-
-        // If we had to refetch the community while parsing the activity, then the new mod has already
-        // been added. Skip it here as it would result in a duplicate key error.
-        let new_mod_id = new_mod.id;
-        let moderated_communities =
-          CommunityModerator::get_person_moderated_communities(&mut context.pool(), new_mod_id)
-            .await?;
-        if !moderated_communities.contains(&community.id) {
-          let form = CommunityModeratorForm {
-            community_id: community.id,
-            person_id: new_mod.id,
-          };
-          CommunityModerator::join(&mut context.pool(), &form).await?;
-
-          // write mod log
-          let actor = self.actor.dereference(context).await?;
-          let form = ModAddCommunityForm {
-            mod_person_id: actor.id,
-            other_person_id: new_mod.id,
-            community_id: community.id,
-            removed: Some(false),
-          };
-          ModAddCommunity::create(&mut context.pool(), &form).await?;
-        }
-        // TODO: send websocket notification about added mod
-      }
-      CollectionType::Featured => {
-        let post = ObjectId::<ApubPost>::from(self.object)
-          .dereference(context)
-          .await?;
-        let form = PostUpdateForm {
-          featured_community: Some(true),
-          ..Default::default()
-        };
-        Post::update(&mut context.pool(), post.id, &form).await?;
-      }
+    fn id(&self) -> &Url {
+        &self.id
     }
-    Ok(())
-  }
+
+    fn actor(&self) -> &Url {
+        self.actor.inner()
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn verify(&self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+        insert_received_activity(&self.id, context).await?;
+        verify_is_public(&self.to, &self.cc)?;
+        let community = self.community(context).await?;
+        verify_person_in_community(&self.actor, &community, context).await?;
+        verify_mod_action(&self.actor, &self.object, community.id, context).await?;
+        Ok(())
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn receive(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+        let (community, collection_type) =
+            Community::get_by_collection_url(&mut context.pool(), &self.target.into()).await?;
+        match collection_type {
+            CollectionType::Moderators => {
+                let new_mod = ObjectId::<ApubPerson>::from(self.object)
+                    .dereference(context)
+                    .await?;
+
+                // If we had to refetch the community while parsing the activity, then the new mod has already
+                // been added. Skip it here as it would result in a duplicate key error.
+                let new_mod_id = new_mod.id;
+                let moderated_communities = CommunityModerator::get_person_moderated_communities(
+                    &mut context.pool(),
+                    new_mod_id,
+                )
+                .await?;
+                if !moderated_communities.contains(&community.id) {
+                    let form = CommunityModeratorForm {
+                        community_id: community.id,
+                        person_id: new_mod.id,
+                    };
+                    CommunityModerator::join(&mut context.pool(), &form).await?;
+
+                    // write mod log
+                    let actor = self.actor.dereference(context).await?;
+                    let form = ModAddCommunityForm {
+                        mod_person_id: actor.id,
+                        other_person_id: new_mod.id,
+                        community_id: community.id,
+                        removed: Some(false),
+                    };
+                    ModAddCommunity::create(&mut context.pool(), &form).await?;
+                }
+                // TODO: send websocket notification about added mod
+            }
+            CollectionType::Featured => {
+                let post = ObjectId::<ApubPost>::from(self.object)
+                    .dereference(context)
+                    .await?;
+                let form = PostUpdateForm {
+                    featured_community: Some(true),
+                    ..Default::default()
+                };
+                Post::update(&mut context.pool(), post.id, &form).await?;
+            }
+        }
+        Ok(())
+    }
 }
 
 pub(crate) async fn send_add_mod_to_community(
-  actor: Person,
-  community_id: CommunityId,
-  updated_mod_id: PersonId,
-  added: bool,
-  context: Data<LemmyContext>,
+    actor: Person,
+    community_id: CommunityId,
+    updated_mod_id: PersonId,
+    added: bool,
+    context: Data<LemmyContext>,
 ) -> Result<(), LemmyError> {
-  let actor: ApubPerson = actor.into();
-  let community: ApubCommunity = Community::read(&mut context.pool(), community_id)
-    .await?
-    .into();
-  let updated_mod: ApubPerson = Person::read(&mut context.pool(), updated_mod_id)
-    .await?
-    .into();
-  if added {
-    CollectionAdd::send_add_mod(&community, &updated_mod, &actor, &context).await
-  } else {
-    CollectionRemove::send_remove_mod(&community, &updated_mod, &actor, &context).await
-  }
+    let actor: ApubPerson = actor.into();
+    let community: ApubCommunity = Community::read(&mut context.pool(), community_id)
+        .await?
+        .into();
+    let updated_mod: ApubPerson = Person::read(&mut context.pool(), updated_mod_id)
+        .await?
+        .into();
+    if added {
+        CollectionAdd::send_add_mod(&community, &updated_mod, &actor, &context).await
+    } else {
+        CollectionRemove::send_remove_mod(&community, &updated_mod, &actor, &context).await
+    }
 }
 
 pub(crate) async fn send_feature_post(
-  post: Post,
-  actor: Person,
-  featured: bool,
-  context: Data<LemmyContext>,
+    post: Post,
+    actor: Person,
+    featured: bool,
+    context: Data<LemmyContext>,
 ) -> Result<(), LemmyError> {
-  let actor: ApubPerson = actor.into();
-  let post: ApubPost = post.into();
-  let community = Community::read(&mut context.pool(), post.community_id)
-    .await?
-    .into();
-  if featured {
-    CollectionAdd::send_add_featured_post(&community, &post, &actor, &context).await
-  } else {
-    CollectionRemove::send_remove_featured_post(&community, &post, &actor, &context).await
-  }
+    let actor: ApubPerson = actor.into();
+    let post: ApubPost = post.into();
+    let community = Community::read(&mut context.pool(), post.community_id)
+        .await?
+        .into();
+    if featured {
+        CollectionAdd::send_add_featured_post(&community, &post, &actor, &context).await
+    } else {
+        CollectionRemove::send_remove_featured_post(&community, &post, &actor, &context).await
+    }
 }

--- a/crates/apub/src/activities/community/collection_remove.rs
+++ b/crates/apub/src/activities/community/collection_remove.rs
@@ -1,153 +1,150 @@
 use crate::{
-  activities::{
-    community::send_activity_in_community,
-    generate_activity_id,
-    verify_is_public,
-    verify_mod_action,
-    verify_person_in_community,
-  },
-  activity_lists::AnnouncableActivities,
-  insert_received_activity,
-  objects::{community::ApubCommunity, person::ApubPerson, post::ApubPost},
-  protocol::{activities::community::collection_remove::CollectionRemove, InCommunity},
+    activities::{
+        community::send_activity_in_community, generate_activity_id, verify_is_public,
+        verify_mod_action, verify_person_in_community,
+    },
+    activity_lists::AnnouncableActivities,
+    insert_received_activity,
+    objects::{community::ApubCommunity, person::ApubPerson, post::ApubPost},
+    protocol::{activities::community::collection_remove::CollectionRemove, InCommunity},
 };
 use activitypub_federation::{
-  config::Data,
-  fetch::object_id::ObjectId,
-  kinds::{activity::RemoveType, public},
-  traits::{ActivityHandler, Actor},
+    config::Data,
+    fetch::object_id::ObjectId,
+    kinds::{activity::RemoveType, public},
+    traits::{ActivityHandler, Actor},
 };
 use lemmy_api_common::{
-  context::LemmyContext,
-  utils::{generate_featured_url, generate_moderators_url},
+    context::LemmyContext,
+    utils::{generate_featured_url, generate_moderators_url},
 };
 use lemmy_db_schema::{
-  impls::community::CollectionType,
-  source::{
-    community::{Community, CommunityModerator, CommunityModeratorForm},
-    moderator::{ModAddCommunity, ModAddCommunityForm},
-    post::{Post, PostUpdateForm},
-  },
-  traits::{Crud, Joinable},
+    impls::community::CollectionType,
+    source::{
+        community::{Community, CommunityModerator, CommunityModeratorForm},
+        moderator::{ModAddCommunity, ModAddCommunityForm},
+        post::{Post, PostUpdateForm},
+    },
+    traits::{Crud, Joinable},
 };
 use lemmy_utils::error::LemmyError;
 use url::Url;
 
 impl CollectionRemove {
-  #[tracing::instrument(skip_all)]
-  pub async fn send_remove_mod(
-    community: &ApubCommunity,
-    removed_mod: &ApubPerson,
-    actor: &ApubPerson,
-    context: &Data<LemmyContext>,
-  ) -> Result<(), LemmyError> {
-    let id = generate_activity_id(
-      RemoveType::Remove,
-      &context.settings().get_protocol_and_hostname(),
-    )?;
-    let remove = CollectionRemove {
-      actor: actor.id().into(),
-      to: vec![public()],
-      object: removed_mod.id(),
-      target: generate_moderators_url(&community.actor_id)?.into(),
-      id: id.clone(),
-      cc: vec![community.id()],
-      kind: RemoveType::Remove,
-      audience: Some(community.id().into()),
-    };
+    #[tracing::instrument(skip_all)]
+    pub async fn send_remove_mod(
+        community: &ApubCommunity,
+        removed_mod: &ApubPerson,
+        actor: &ApubPerson,
+        context: &Data<LemmyContext>,
+    ) -> Result<(), LemmyError> {
+        let id = generate_activity_id(
+            RemoveType::Remove,
+            &context.settings().get_protocol_and_hostname(),
+        )?;
+        let remove = CollectionRemove {
+            actor: actor.id().into(),
+            to: vec![public()],
+            object: removed_mod.id(),
+            target: generate_moderators_url(&community.actor_id)?.into(),
+            id: id.clone(),
+            cc: vec![community.id()],
+            kind: RemoveType::Remove,
+            audience: Some(community.id().into()),
+        };
 
-    let activity = AnnouncableActivities::CollectionRemove(remove);
-    let inboxes = vec![removed_mod.shared_inbox_or_inbox()];
-    send_activity_in_community(activity, actor, community, inboxes, true, context).await
-  }
+        let activity = AnnouncableActivities::CollectionRemove(remove);
+        let inboxes = vec![removed_mod.shared_inbox_or_inbox()];
+        send_activity_in_community(activity, actor, community, inboxes, true, context).await
+    }
 
-  pub async fn send_remove_featured_post(
-    community: &ApubCommunity,
-    featured_post: &ApubPost,
-    actor: &ApubPerson,
-    context: &Data<LemmyContext>,
-  ) -> Result<(), LemmyError> {
-    let id = generate_activity_id(
-      RemoveType::Remove,
-      &context.settings().get_protocol_and_hostname(),
-    )?;
-    let remove = CollectionRemove {
-      actor: actor.id().into(),
-      to: vec![public()],
-      object: featured_post.ap_id.clone().into(),
-      target: generate_featured_url(&community.actor_id)?.into(),
-      cc: vec![community.id()],
-      kind: RemoveType::Remove,
-      id: id.clone(),
-      audience: Some(community.id().into()),
-    };
-    let activity = AnnouncableActivities::CollectionRemove(remove);
-    send_activity_in_community(activity, actor, community, vec![], true, context).await
-  }
+    pub async fn send_remove_featured_post(
+        community: &ApubCommunity,
+        featured_post: &ApubPost,
+        actor: &ApubPerson,
+        context: &Data<LemmyContext>,
+    ) -> Result<(), LemmyError> {
+        let id = generate_activity_id(
+            RemoveType::Remove,
+            &context.settings().get_protocol_and_hostname(),
+        )?;
+        let remove = CollectionRemove {
+            actor: actor.id().into(),
+            to: vec![public()],
+            object: featured_post.ap_id.clone().into(),
+            target: generate_featured_url(&community.actor_id)?.into(),
+            cc: vec![community.id()],
+            kind: RemoveType::Remove,
+            id: id.clone(),
+            audience: Some(community.id().into()),
+        };
+        let activity = AnnouncableActivities::CollectionRemove(remove);
+        send_activity_in_community(activity, actor, community, vec![], true, context).await
+    }
 }
 
 #[async_trait::async_trait]
 impl ActivityHandler for CollectionRemove {
-  type DataType = LemmyContext;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Error = LemmyError;
 
-  fn id(&self) -> &Url {
-    &self.id
-  }
-
-  fn actor(&self) -> &Url {
-    self.actor.inner()
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
-    insert_received_activity(&self.id, context).await?;
-    verify_is_public(&self.to, &self.cc)?;
-    let community = self.community(context).await?;
-    verify_person_in_community(&self.actor, &community, context).await?;
-    verify_mod_action(&self.actor, &self.object, community.id, context).await?;
-    Ok(())
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
-    let (community, collection_type) =
-      Community::get_by_collection_url(&mut context.pool(), &self.target.into()).await?;
-    match collection_type {
-      CollectionType::Moderators => {
-        let remove_mod = ObjectId::<ApubPerson>::from(self.object)
-          .dereference(context)
-          .await?;
-
-        let form = CommunityModeratorForm {
-          community_id: community.id,
-          person_id: remove_mod.id,
-        };
-        CommunityModerator::leave(&mut context.pool(), &form).await?;
-
-        // write mod log
-        let actor = self.actor.dereference(context).await?;
-        let form = ModAddCommunityForm {
-          mod_person_id: actor.id,
-          other_person_id: remove_mod.id,
-          community_id: community.id,
-          removed: Some(true),
-        };
-        ModAddCommunity::create(&mut context.pool(), &form).await?;
-
-        // TODO: send websocket notification about removed mod
-      }
-      CollectionType::Featured => {
-        let post = ObjectId::<ApubPost>::from(self.object)
-          .dereference(context)
-          .await?;
-        let form = PostUpdateForm {
-          featured_community: Some(false),
-          ..Default::default()
-        };
-        Post::update(&mut context.pool(), post.id, &form).await?;
-      }
+    fn id(&self) -> &Url {
+        &self.id
     }
-    Ok(())
-  }
+
+    fn actor(&self) -> &Url {
+        self.actor.inner()
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn verify(&self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+        insert_received_activity(&self.id, context).await?;
+        verify_is_public(&self.to, &self.cc)?;
+        let community = self.community(context).await?;
+        verify_person_in_community(&self.actor, &community, context).await?;
+        verify_mod_action(&self.actor, &self.object, community.id, context).await?;
+        Ok(())
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn receive(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+        let (community, collection_type) =
+            Community::get_by_collection_url(&mut context.pool(), &self.target.into()).await?;
+        match collection_type {
+            CollectionType::Moderators => {
+                let remove_mod = ObjectId::<ApubPerson>::from(self.object)
+                    .dereference(context)
+                    .await?;
+
+                let form = CommunityModeratorForm {
+                    community_id: community.id,
+                    person_id: remove_mod.id,
+                };
+                CommunityModerator::leave(&mut context.pool(), &form).await?;
+
+                // write mod log
+                let actor = self.actor.dereference(context).await?;
+                let form = ModAddCommunityForm {
+                    mod_person_id: actor.id,
+                    other_person_id: remove_mod.id,
+                    community_id: community.id,
+                    removed: Some(true),
+                };
+                ModAddCommunity::create(&mut context.pool(), &form).await?;
+
+                // TODO: send websocket notification about removed mod
+            }
+            CollectionType::Featured => {
+                let post = ObjectId::<ApubPost>::from(self.object)
+                    .dereference(context)
+                    .await?;
+                let form = PostUpdateForm {
+                    featured_community: Some(false),
+                    ..Default::default()
+                };
+                Post::update(&mut context.pool(), post.id, &form).await?;
+            }
+        }
+        Ok(())
+    }
 }

--- a/crates/apub/src/activities/community/lock_page.rs
+++ b/crates/apub/src/activities/community/lock_page.rs
@@ -1,152 +1,148 @@
 use crate::{
-  activities::{
-    check_community_deleted_or_removed,
-    community::send_activity_in_community,
-    generate_activity_id,
-    verify_is_public,
-    verify_mod_action,
-    verify_person_in_community,
-  },
-  activity_lists::AnnouncableActivities,
-  insert_received_activity,
-  objects::community::ApubCommunity,
-  protocol::{
-    activities::community::lock_page::{LockPage, LockType, UndoLockPage},
-    InCommunity,
-  },
+    activities::{
+        check_community_deleted_or_removed, community::send_activity_in_community,
+        generate_activity_id, verify_is_public, verify_mod_action, verify_person_in_community,
+    },
+    activity_lists::AnnouncableActivities,
+    insert_received_activity,
+    objects::community::ApubCommunity,
+    protocol::{
+        activities::community::lock_page::{LockPage, LockType, UndoLockPage},
+        InCommunity,
+    },
 };
 use activitypub_federation::{
-  config::Data,
-  fetch::object_id::ObjectId,
-  kinds::{activity::UndoType, public},
-  traits::ActivityHandler,
+    config::Data,
+    fetch::object_id::ObjectId,
+    kinds::{activity::UndoType, public},
+    traits::ActivityHandler,
 };
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::{
-  source::{
-    community::Community,
-    person::Person,
-    post::{Post, PostUpdateForm},
-  },
-  traits::Crud,
+    source::{
+        community::Community,
+        person::Person,
+        post::{Post, PostUpdateForm},
+    },
+    traits::Crud,
 };
 use lemmy_utils::error::LemmyError;
 use url::Url;
 
 #[async_trait::async_trait]
 impl ActivityHandler for LockPage {
-  type DataType = LemmyContext;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Error = LemmyError;
 
-  fn id(&self) -> &Url {
-    &self.id
-  }
+    fn id(&self) -> &Url {
+        &self.id
+    }
 
-  fn actor(&self) -> &Url {
-    self.actor.inner()
-  }
+    fn actor(&self) -> &Url {
+        self.actor.inner()
+    }
 
-  async fn verify(&self, context: &Data<Self::DataType>) -> Result<(), Self::Error> {
-    verify_is_public(&self.to, &self.cc)?;
-    let community = self.community(context).await?;
-    verify_person_in_community(&self.actor, &community, context).await?;
-    check_community_deleted_or_removed(&community)?;
-    verify_mod_action(&self.actor, self.object.inner(), community.id, context).await?;
-    Ok(())
-  }
+    async fn verify(&self, context: &Data<Self::DataType>) -> Result<(), Self::Error> {
+        verify_is_public(&self.to, &self.cc)?;
+        let community = self.community(context).await?;
+        verify_person_in_community(&self.actor, &community, context).await?;
+        check_community_deleted_or_removed(&community)?;
+        verify_mod_action(&self.actor, self.object.inner(), community.id, context).await?;
+        Ok(())
+    }
 
-  async fn receive(self, context: &Data<Self::DataType>) -> Result<(), Self::Error> {
-    let form = PostUpdateForm {
-      locked: Some(true),
-      ..Default::default()
-    };
-    let post = self.object.dereference(context).await?;
-    Post::update(&mut context.pool(), post.id, &form).await?;
-    Ok(())
-  }
+    async fn receive(self, context: &Data<Self::DataType>) -> Result<(), Self::Error> {
+        let form = PostUpdateForm {
+            locked: Some(true),
+            ..Default::default()
+        };
+        let post = self.object.dereference(context).await?;
+        Post::update(&mut context.pool(), post.id, &form).await?;
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait]
 impl ActivityHandler for UndoLockPage {
-  type DataType = LemmyContext;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Error = LemmyError;
 
-  fn id(&self) -> &Url {
-    &self.id
-  }
+    fn id(&self) -> &Url {
+        &self.id
+    }
 
-  fn actor(&self) -> &Url {
-    self.actor.inner()
-  }
+    fn actor(&self) -> &Url {
+        self.actor.inner()
+    }
 
-  async fn verify(&self, context: &Data<Self::DataType>) -> Result<(), Self::Error> {
-    insert_received_activity(&self.id, context).await?;
-    verify_is_public(&self.to, &self.cc)?;
-    let community = self.community(context).await?;
-    verify_person_in_community(&self.actor, &community, context).await?;
-    check_community_deleted_or_removed(&community)?;
-    verify_mod_action(
-      &self.actor,
-      self.object.object.inner(),
-      community.id,
-      context,
-    )
-    .await?;
-    Ok(())
-  }
+    async fn verify(&self, context: &Data<Self::DataType>) -> Result<(), Self::Error> {
+        insert_received_activity(&self.id, context).await?;
+        verify_is_public(&self.to, &self.cc)?;
+        let community = self.community(context).await?;
+        verify_person_in_community(&self.actor, &community, context).await?;
+        check_community_deleted_or_removed(&community)?;
+        verify_mod_action(
+            &self.actor,
+            self.object.object.inner(),
+            community.id,
+            context,
+        )
+        .await?;
+        Ok(())
+    }
 
-  async fn receive(self, context: &Data<Self::DataType>) -> Result<(), Self::Error> {
-    let form = PostUpdateForm {
-      locked: Some(false),
-      ..Default::default()
-    };
-    let post = self.object.object.dereference(context).await?;
-    Post::update(&mut context.pool(), post.id, &form).await?;
-    Ok(())
-  }
+    async fn receive(self, context: &Data<Self::DataType>) -> Result<(), Self::Error> {
+        let form = PostUpdateForm {
+            locked: Some(false),
+            ..Default::default()
+        };
+        let post = self.object.object.dereference(context).await?;
+        Post::update(&mut context.pool(), post.id, &form).await?;
+        Ok(())
+    }
 }
 
 pub(crate) async fn send_lock_post(
-  post: Post,
-  actor: Person,
-  locked: bool,
-  context: Data<LemmyContext>,
+    post: Post,
+    actor: Person,
+    locked: bool,
+    context: Data<LemmyContext>,
 ) -> Result<(), LemmyError> {
-  let community: ApubCommunity = Community::read(&mut context.pool(), post.community_id)
-    .await?
-    .into();
-  let id = generate_activity_id(
-    LockType::Lock,
-    &context.settings().get_protocol_and_hostname(),
-  )?;
-  let community_id = community.actor_id.inner().clone();
-  let lock = LockPage {
-    actor: actor.actor_id.clone().into(),
-    to: vec![public()],
-    object: ObjectId::from(post.ap_id),
-    cc: vec![community_id.clone()],
-    kind: LockType::Lock,
-    id,
-    audience: Some(community_id.into()),
-  };
-  let activity = if locked {
-    AnnouncableActivities::LockPost(lock)
-  } else {
+    let community: ApubCommunity = Community::read(&mut context.pool(), post.community_id)
+        .await?
+        .into();
     let id = generate_activity_id(
-      UndoType::Undo,
-      &context.settings().get_protocol_and_hostname(),
+        LockType::Lock,
+        &context.settings().get_protocol_and_hostname(),
     )?;
-    let undo = UndoLockPage {
-      actor: lock.actor.clone(),
-      to: vec![public()],
-      cc: lock.cc.clone(),
-      kind: UndoType::Undo,
-      id,
-      audience: lock.audience.clone(),
-      object: lock,
+    let community_id = community.actor_id.inner().clone();
+    let lock = LockPage {
+        actor: actor.actor_id.clone().into(),
+        to: vec![public()],
+        object: ObjectId::from(post.ap_id),
+        cc: vec![community_id.clone()],
+        kind: LockType::Lock,
+        id,
+        audience: Some(community_id.into()),
     };
-    AnnouncableActivities::UndoLockPost(undo)
-  };
-  send_activity_in_community(activity, &actor.into(), &community, vec![], true, &context).await?;
-  Ok(())
+    let activity = if locked {
+        AnnouncableActivities::LockPost(lock)
+    } else {
+        let id = generate_activity_id(
+            UndoType::Undo,
+            &context.settings().get_protocol_and_hostname(),
+        )?;
+        let undo = UndoLockPage {
+            actor: lock.actor.clone(),
+            to: vec![public()],
+            cc: lock.cc.clone(),
+            kind: UndoType::Undo,
+            id,
+            audience: lock.audience.clone(),
+            object: lock,
+        };
+        AnnouncableActivities::UndoLockPost(undo)
+    };
+    send_activity_in_community(activity, &actor.into(), &community, vec![], true, &context).await?;
+    Ok(())
 }

--- a/crates/apub/src/activities/community/mod.rs
+++ b/crates/apub/src/activities/community/mod.rs
@@ -1,8 +1,8 @@
 use crate::{
-  activities::send_lemmy_activity,
-  activity_lists::AnnouncableActivities,
-  objects::{community::ApubCommunity, person::ApubPerson},
-  protocol::activities::community::announce::AnnounceActivity,
+    activities::send_lemmy_activity,
+    activity_lists::AnnouncableActivities,
+    objects::{community::ApubCommunity, person::ApubPerson},
+    protocol::activities::community::announce::AnnounceActivity,
 };
 use activitypub_federation::{config::Data, traits::Actor};
 use lemmy_api_common::context::LemmyContext;
@@ -31,34 +31,34 @@ pub mod update;
 ///               to the user who is being promoted to moderator)
 /// * `is_mod_activity` - True for things like Add/Mod, these are not sent to user followers
 pub(crate) async fn send_activity_in_community(
-  activity: AnnouncableActivities,
-  actor: &ApubPerson,
-  community: &ApubCommunity,
-  extra_inboxes: Vec<Url>,
-  is_mod_action: bool,
-  context: &Data<LemmyContext>,
+    activity: AnnouncableActivities,
+    actor: &ApubPerson,
+    community: &ApubCommunity,
+    extra_inboxes: Vec<Url>,
+    is_mod_action: bool,
+    context: &Data<LemmyContext>,
 ) -> Result<(), LemmyError> {
-  // send to any users which are mentioned or affected directly
-  let mut inboxes = extra_inboxes;
+    // send to any users which are mentioned or affected directly
+    let mut inboxes = extra_inboxes;
 
-  // send to user followers
-  if !is_mod_action {
-    inboxes.extend(
-      &mut PersonFollower::list_followers(&mut context.pool(), actor.id)
-        .await?
-        .into_iter()
-        .map(|p| ApubPerson(p).shared_inbox_or_inbox()),
-    );
-  }
+    // send to user followers
+    if !is_mod_action {
+        inboxes.extend(
+            &mut PersonFollower::list_followers(&mut context.pool(), actor.id)
+                .await?
+                .into_iter()
+                .map(|p| ApubPerson(p).shared_inbox_or_inbox()),
+        );
+    }
 
-  if community.local {
-    // send directly to community followers
-    AnnounceActivity::send(activity.clone().try_into()?, community, context).await?;
-  } else {
-    // send to the community, which will then forward to followers
-    inboxes.push(community.shared_inbox_or_inbox());
-  }
+    if community.local {
+        // send directly to community followers
+        AnnounceActivity::send(activity.clone().try_into()?, community, context).await?;
+    } else {
+        // send to the community, which will then forward to followers
+        inboxes.push(community.shared_inbox_or_inbox());
+    }
 
-  send_lemmy_activity(context, activity.clone(), actor, inboxes, false).await?;
-  Ok(())
+    send_lemmy_activity(context, activity.clone(), actor, inboxes, false).await?;
+    Ok(())
 }

--- a/crates/apub/src/activities/community/update.rs
+++ b/crates/apub/src/activities/community/update.rs
@@ -1,85 +1,82 @@
 use crate::{
-  activities::{
-    community::send_activity_in_community,
-    generate_activity_id,
-    verify_is_public,
-    verify_mod_action,
-    verify_person_in_community,
-  },
-  activity_lists::AnnouncableActivities,
-  insert_received_activity,
-  objects::{community::ApubCommunity, person::ApubPerson},
-  protocol::{activities::community::update::UpdateCommunity, InCommunity},
+    activities::{
+        community::send_activity_in_community, generate_activity_id, verify_is_public,
+        verify_mod_action, verify_person_in_community,
+    },
+    activity_lists::AnnouncableActivities,
+    insert_received_activity,
+    objects::{community::ApubCommunity, person::ApubPerson},
+    protocol::{activities::community::update::UpdateCommunity, InCommunity},
 };
 use activitypub_federation::{
-  config::Data,
-  kinds::{activity::UpdateType, public},
-  traits::{ActivityHandler, Actor, Object},
+    config::Data,
+    kinds::{activity::UpdateType, public},
+    traits::{ActivityHandler, Actor, Object},
 };
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::{
-  source::{community::Community, person::Person},
-  traits::Crud,
+    source::{community::Community, person::Person},
+    traits::Crud,
 };
 use lemmy_utils::error::LemmyError;
 use url::Url;
 
 pub(crate) async fn send_update_community(
-  community: Community,
-  actor: Person,
-  context: Data<LemmyContext>,
+    community: Community,
+    actor: Person,
+    context: Data<LemmyContext>,
 ) -> Result<(), LemmyError> {
-  let community: ApubCommunity = community.into();
-  let actor: ApubPerson = actor.into();
-  let id = generate_activity_id(
-    UpdateType::Update,
-    &context.settings().get_protocol_and_hostname(),
-  )?;
-  let update = UpdateCommunity {
-    actor: actor.id().into(),
-    to: vec![public()],
-    object: Box::new(community.clone().into_json(&context).await?),
-    cc: vec![community.id()],
-    kind: UpdateType::Update,
-    id: id.clone(),
-    audience: Some(community.id().into()),
-  };
+    let community: ApubCommunity = community.into();
+    let actor: ApubPerson = actor.into();
+    let id = generate_activity_id(
+        UpdateType::Update,
+        &context.settings().get_protocol_and_hostname(),
+    )?;
+    let update = UpdateCommunity {
+        actor: actor.id().into(),
+        to: vec![public()],
+        object: Box::new(community.clone().into_json(&context).await?),
+        cc: vec![community.id()],
+        kind: UpdateType::Update,
+        id: id.clone(),
+        audience: Some(community.id().into()),
+    };
 
-  let activity = AnnouncableActivities::UpdateCommunity(update);
-  send_activity_in_community(activity, &actor, &community, vec![], true, &context).await
+    let activity = AnnouncableActivities::UpdateCommunity(update);
+    send_activity_in_community(activity, &actor, &community, vec![], true, &context).await
 }
 
 #[async_trait::async_trait]
 impl ActivityHandler for UpdateCommunity {
-  type DataType = LemmyContext;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Error = LemmyError;
 
-  fn id(&self) -> &Url {
-    &self.id
-  }
+    fn id(&self) -> &Url {
+        &self.id
+    }
 
-  fn actor(&self) -> &Url {
-    self.actor.inner()
-  }
+    fn actor(&self) -> &Url {
+        self.actor.inner()
+    }
 
-  #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
-    insert_received_activity(&self.id, context).await?;
-    verify_is_public(&self.to, &self.cc)?;
-    let community = self.community(context).await?;
-    verify_person_in_community(&self.actor, &community, context).await?;
-    verify_mod_action(&self.actor, self.object.id.inner(), community.id, context).await?;
-    ApubCommunity::verify(&self.object, &community.actor_id.clone().into(), context).await?;
-    Ok(())
-  }
+    #[tracing::instrument(skip_all)]
+    async fn verify(&self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+        insert_received_activity(&self.id, context).await?;
+        verify_is_public(&self.to, &self.cc)?;
+        let community = self.community(context).await?;
+        verify_person_in_community(&self.actor, &community, context).await?;
+        verify_mod_action(&self.actor, self.object.id.inner(), community.id, context).await?;
+        ApubCommunity::verify(&self.object, &community.actor_id.clone().into(), context).await?;
+        Ok(())
+    }
 
-  #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
-    let community = self.community(context).await?;
+    #[tracing::instrument(skip_all)]
+    async fn receive(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+        let community = self.community(context).await?;
 
-    let community_update_form = self.object.into_update_form();
+        let community_update_form = self.object.into_update_form();
 
-    Community::update(&mut context.pool(), community.id, &community_update_form).await?;
-    Ok(())
-  }
+        Community::update(&mut context.pool(), community.id, &community_update_form).await?;
+        Ok(())
+    }
 }

--- a/crates/apub/src/activities/create_or_update/comment.rs
+++ b/crates/apub/src/activities/create_or_update/comment.rs
@@ -1,174 +1,171 @@
 use crate::{
-  activities::{
-    check_community_deleted_or_removed,
-    community::send_activity_in_community,
-    generate_activity_id,
-    verify_is_public,
-    verify_person_in_community,
-  },
-  activity_lists::AnnouncableActivities,
-  insert_received_activity,
-  mentions::MentionOrValue,
-  objects::{comment::ApubComment, community::ApubCommunity, person::ApubPerson},
-  protocol::{
-    activities::{create_or_update::note::CreateOrUpdateNote, CreateOrUpdateType},
-    InCommunity,
-  },
+    activities::{
+        check_community_deleted_or_removed, community::send_activity_in_community,
+        generate_activity_id, verify_is_public, verify_person_in_community,
+    },
+    activity_lists::AnnouncableActivities,
+    insert_received_activity,
+    mentions::MentionOrValue,
+    objects::{comment::ApubComment, community::ApubCommunity, person::ApubPerson},
+    protocol::{
+        activities::{create_or_update::note::CreateOrUpdateNote, CreateOrUpdateType},
+        InCommunity,
+    },
 };
 use activitypub_federation::{
-  config::Data,
-  fetch::object_id::ObjectId,
-  kinds::public,
-  protocol::verification::verify_domains_match,
-  traits::{ActivityHandler, Actor, Object},
+    config::Data,
+    fetch::object_id::ObjectId,
+    kinds::public,
+    protocol::verification::verify_domains_match,
+    traits::{ActivityHandler, Actor, Object},
 };
 use lemmy_api_common::{
-  build_response::send_local_notifs,
-  context::LemmyContext,
-  utils::{check_post_deleted_or_removed, is_mod_or_admin},
+    build_response::send_local_notifs,
+    context::LemmyContext,
+    utils::{check_post_deleted_or_removed, is_mod_or_admin},
 };
 use lemmy_db_schema::{
-  aggregates::structs::CommentAggregates,
-  newtypes::PersonId,
-  source::{
-    comment::{Comment, CommentLike, CommentLikeForm},
-    community::Community,
-    person::Person,
-    post::Post,
-  },
-  traits::{Crud, Likeable},
+    aggregates::structs::CommentAggregates,
+    newtypes::PersonId,
+    source::{
+        comment::{Comment, CommentLike, CommentLikeForm},
+        community::Community,
+        person::Person,
+        post::Post,
+    },
+    traits::{Crud, Likeable},
 };
 use lemmy_utils::{error::LemmyError, utils::mention::scrape_text_for_mentions};
 use url::Url;
 
 impl CreateOrUpdateNote {
-  #[tracing::instrument(skip(comment, person_id, kind, context))]
-  pub(crate) async fn send(
-    comment: Comment,
-    person_id: PersonId,
-    kind: CreateOrUpdateType,
-    context: Data<LemmyContext>,
-  ) -> Result<(), LemmyError> {
-    // TODO: might be helpful to add a comment method to retrieve community directly
-    let post_id = comment.post_id;
-    let post = Post::read(&mut context.pool(), post_id).await?;
-    let community_id = post.community_id;
-    let person: ApubPerson = Person::read(&mut context.pool(), person_id).await?.into();
-    let community: ApubCommunity = Community::read(&mut context.pool(), community_id)
-      .await?
-      .into();
+    #[tracing::instrument(skip(comment, person_id, kind, context))]
+    pub(crate) async fn send(
+        comment: Comment,
+        person_id: PersonId,
+        kind: CreateOrUpdateType,
+        context: Data<LemmyContext>,
+    ) -> Result<(), LemmyError> {
+        // TODO: might be helpful to add a comment method to retrieve community directly
+        let post_id = comment.post_id;
+        let post = Post::read(&mut context.pool(), post_id).await?;
+        let community_id = post.community_id;
+        let person: ApubPerson = Person::read(&mut context.pool(), person_id).await?.into();
+        let community: ApubCommunity = Community::read(&mut context.pool(), community_id)
+            .await?
+            .into();
 
-    let id = generate_activity_id(
-      kind.clone(),
-      &context.settings().get_protocol_and_hostname(),
-    )?;
-    let note = ApubComment(comment).into_json(&context).await?;
+        let id = generate_activity_id(
+            kind.clone(),
+            &context.settings().get_protocol_and_hostname(),
+        )?;
+        let note = ApubComment(comment).into_json(&context).await?;
 
-    let create_or_update = CreateOrUpdateNote {
-      actor: person.id().into(),
-      to: vec![public()],
-      cc: note.cc.clone(),
-      tag: note.tag.clone(),
-      object: note,
-      kind,
-      id: id.clone(),
-      audience: Some(community.id().into()),
-    };
+        let create_or_update = CreateOrUpdateNote {
+            actor: person.id().into(),
+            to: vec![public()],
+            cc: note.cc.clone(),
+            tag: note.tag.clone(),
+            object: note,
+            kind,
+            id: id.clone(),
+            audience: Some(community.id().into()),
+        };
 
-    let tagged_users: Vec<ObjectId<ApubPerson>> = create_or_update
-      .tag
-      .iter()
-      .filter_map(|t| {
-        if let MentionOrValue::Mention(t) = t {
-          Some(t)
-        } else {
-          None
+        let tagged_users: Vec<ObjectId<ApubPerson>> = create_or_update
+            .tag
+            .iter()
+            .filter_map(|t| {
+                if let MentionOrValue::Mention(t) = t {
+                    Some(t)
+                } else {
+                    None
+                }
+            })
+            .map(|t| t.href.clone())
+            .map(ObjectId::from)
+            .collect();
+        let mut inboxes = vec![];
+        for t in tagged_users {
+            let person = t.dereference(&context).await?;
+            inboxes.push(person.shared_inbox_or_inbox());
         }
-      })
-      .map(|t| t.href.clone())
-      .map(ObjectId::from)
-      .collect();
-    let mut inboxes = vec![];
-    for t in tagged_users {
-      let person = t.dereference(&context).await?;
-      inboxes.push(person.shared_inbox_or_inbox());
-    }
 
-    let activity = AnnouncableActivities::CreateOrUpdateComment(create_or_update);
-    send_activity_in_community(activity, &person, &community, inboxes, false, &context).await
-  }
+        let activity = AnnouncableActivities::CreateOrUpdateComment(create_or_update);
+        send_activity_in_community(activity, &person, &community, inboxes, false, &context).await
+    }
 }
 
 #[async_trait::async_trait]
 impl ActivityHandler for CreateOrUpdateNote {
-  type DataType = LemmyContext;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Error = LemmyError;
 
-  fn id(&self) -> &Url {
-    &self.id
-  }
-
-  fn actor(&self) -> &Url {
-    self.actor.inner()
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
-    insert_received_activity(&self.id, context).await?;
-    verify_is_public(&self.to, &self.cc)?;
-    let post = self.object.get_parents(context).await?.0;
-    let community = self.community(context).await?;
-
-    verify_person_in_community(&self.actor, &community, context).await?;
-    verify_domains_match(self.actor.inner(), self.object.id.inner())?;
-    check_community_deleted_or_removed(&community)?;
-    check_post_deleted_or_removed(&post)?;
-
-    ApubComment::verify(&self.object, self.actor.inner(), context).await?;
-    Ok(())
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
-    // Need to do this check here instead of Note::from_json because we need the person who
-    // send the activity, not the comment author.
-    let existing_comment = self.object.id.dereference_local(context).await.ok();
-    if let (Some(distinguished), Some(existing_comment)) =
-      (self.object.distinguished, existing_comment)
-    {
-      if distinguished != existing_comment.distinguished {
-        let creator = self.actor.dereference(context).await?;
-        let (post, _) = self.object.get_parents(context).await?;
-        is_mod_or_admin(&mut context.pool(), creator.id, post.community_id).await?;
-      }
+    fn id(&self) -> &Url {
+        &self.id
     }
 
-    let comment = ApubComment::from_json(self.object, context).await?;
+    fn actor(&self) -> &Url {
+        self.actor.inner()
+    }
 
-    // author likes their own comment by default
-    let like_form = CommentLikeForm {
-      comment_id: comment.id,
-      post_id: comment.post_id,
-      person_id: comment.creator_id,
-      score: 1,
-    };
-    CommentLike::like(&mut context.pool(), &like_form).await?;
+    #[tracing::instrument(skip_all)]
+    async fn verify(&self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+        insert_received_activity(&self.id, context).await?;
+        verify_is_public(&self.to, &self.cc)?;
+        let post = self.object.get_parents(context).await?.0;
+        let community = self.community(context).await?;
 
-    // Calculate initial hot_rank
-    CommentAggregates::update_hot_rank(&mut context.pool(), comment.id).await?;
+        verify_person_in_community(&self.actor, &community, context).await?;
+        verify_domains_match(self.actor.inner(), self.object.id.inner())?;
+        check_community_deleted_or_removed(&community)?;
+        check_post_deleted_or_removed(&post)?;
 
-    let do_send_email = self.kind == CreateOrUpdateType::Create;
-    let post_id = comment.post_id;
-    let post = Post::read(&mut context.pool(), post_id).await?;
-    let actor = self.actor.dereference(context).await?;
+        ApubComment::verify(&self.object, self.actor.inner(), context).await?;
+        Ok(())
+    }
 
-    // Note:
-    // Although mentions could be gotten from the post tags (they are included there), or the ccs,
-    // Its much easier to scrape them from the comment body, since the API has to do that
-    // anyway.
-    // TODO: for compatibility with other projects, it would be much better to read this from cc or tags
-    let mentions = scrape_text_for_mentions(&comment.content);
-    send_local_notifs(mentions, &comment.0, &actor, &post, do_send_email, context).await?;
-    Ok(())
-  }
+    #[tracing::instrument(skip_all)]
+    async fn receive(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+        // Need to do this check here instead of Note::from_json because we need the person who
+        // send the activity, not the comment author.
+        let existing_comment = self.object.id.dereference_local(context).await.ok();
+        if let (Some(distinguished), Some(existing_comment)) =
+            (self.object.distinguished, existing_comment)
+        {
+            if distinguished != existing_comment.distinguished {
+                let creator = self.actor.dereference(context).await?;
+                let (post, _) = self.object.get_parents(context).await?;
+                is_mod_or_admin(&mut context.pool(), creator.id, post.community_id).await?;
+            }
+        }
+
+        let comment = ApubComment::from_json(self.object, context).await?;
+
+        // author likes their own comment by default
+        let like_form = CommentLikeForm {
+            comment_id: comment.id,
+            post_id: comment.post_id,
+            person_id: comment.creator_id,
+            score: 1,
+        };
+        CommentLike::like(&mut context.pool(), &like_form).await?;
+
+        // Calculate initial hot_rank
+        CommentAggregates::update_hot_rank(&mut context.pool(), comment.id).await?;
+
+        let do_send_email = self.kind == CreateOrUpdateType::Create;
+        let post_id = comment.post_id;
+        let post = Post::read(&mut context.pool(), post_id).await?;
+        let actor = self.actor.dereference(context).await?;
+
+        // Note:
+        // Although mentions could be gotten from the post tags (they are included there), or the ccs,
+        // Its much easier to scrape them from the comment body, since the API has to do that
+        // anyway.
+        // TODO: for compatibility with other projects, it would be much better to read this from cc or tags
+        let mentions = scrape_text_for_mentions(&comment.content);
+        send_local_notifs(mentions, &comment.0, &actor, &post, do_send_email, context).await?;
+        Ok(())
+    }
 }

--- a/crates/apub/src/activities/create_or_update/post.rs
+++ b/crates/apub/src/activities/create_or_update/post.rs
@@ -1,157 +1,154 @@
 use crate::{
-  activities::{
-    check_community_deleted_or_removed,
-    community::send_activity_in_community,
-    generate_activity_id,
-    verify_is_public,
-    verify_mod_action,
-    verify_person_in_community,
-  },
-  activity_lists::AnnouncableActivities,
-  insert_received_activity,
-  objects::{community::ApubCommunity, person::ApubPerson, post::ApubPost},
-  protocol::{
-    activities::{create_or_update::page::CreateOrUpdatePage, CreateOrUpdateType},
-    InCommunity,
-  },
+    activities::{
+        check_community_deleted_or_removed, community::send_activity_in_community,
+        generate_activity_id, verify_is_public, verify_mod_action, verify_person_in_community,
+    },
+    activity_lists::AnnouncableActivities,
+    insert_received_activity,
+    objects::{community::ApubCommunity, person::ApubPerson, post::ApubPost},
+    protocol::{
+        activities::{create_or_update::page::CreateOrUpdatePage, CreateOrUpdateType},
+        InCommunity,
+    },
 };
 use activitypub_federation::{
-  config::Data,
-  kinds::public,
-  protocol::verification::{verify_domains_match, verify_urls_match},
-  traits::{ActivityHandler, Actor, Object},
+    config::Data,
+    kinds::public,
+    protocol::verification::{verify_domains_match, verify_urls_match},
+    traits::{ActivityHandler, Actor, Object},
 };
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::{
-  aggregates::structs::PostAggregates,
-  newtypes::PersonId,
-  source::{
-    community::Community,
-    person::Person,
-    post::{Post, PostLike, PostLikeForm},
-  },
-  traits::{Crud, Likeable},
+    aggregates::structs::PostAggregates,
+    newtypes::PersonId,
+    source::{
+        community::Community,
+        person::Person,
+        post::{Post, PostLike, PostLikeForm},
+    },
+    traits::{Crud, Likeable},
 };
 use lemmy_utils::error::{LemmyError, LemmyErrorType};
 use url::Url;
 
 impl CreateOrUpdatePage {
-  pub(crate) async fn new(
-    post: ApubPost,
-    actor: &ApubPerson,
-    community: &ApubCommunity,
-    kind: CreateOrUpdateType,
-    context: &Data<LemmyContext>,
-  ) -> Result<CreateOrUpdatePage, LemmyError> {
-    let id = generate_activity_id(
-      kind.clone(),
-      &context.settings().get_protocol_and_hostname(),
-    )?;
-    Ok(CreateOrUpdatePage {
-      actor: actor.id().into(),
-      to: vec![public()],
-      object: post.into_json(context).await?,
-      cc: vec![community.id()],
-      kind,
-      id: id.clone(),
-      audience: Some(community.id().into()),
-    })
-  }
+    pub(crate) async fn new(
+        post: ApubPost,
+        actor: &ApubPerson,
+        community: &ApubCommunity,
+        kind: CreateOrUpdateType,
+        context: &Data<LemmyContext>,
+    ) -> Result<CreateOrUpdatePage, LemmyError> {
+        let id = generate_activity_id(
+            kind.clone(),
+            &context.settings().get_protocol_and_hostname(),
+        )?;
+        Ok(CreateOrUpdatePage {
+            actor: actor.id().into(),
+            to: vec![public()],
+            object: post.into_json(context).await?,
+            cc: vec![community.id()],
+            kind,
+            id: id.clone(),
+            audience: Some(community.id().into()),
+        })
+    }
 
-  #[tracing::instrument(skip_all)]
-  pub(crate) async fn send(
-    post: Post,
-    person_id: PersonId,
-    kind: CreateOrUpdateType,
-    context: Data<LemmyContext>,
-  ) -> Result<(), LemmyError> {
-    let post = ApubPost(post);
-    let community_id = post.community_id;
-    let person: ApubPerson = Person::read(&mut context.pool(), person_id).await?.into();
-    let community: ApubCommunity = Community::read(&mut context.pool(), community_id)
-      .await?
-      .into();
+    #[tracing::instrument(skip_all)]
+    pub(crate) async fn send(
+        post: Post,
+        person_id: PersonId,
+        kind: CreateOrUpdateType,
+        context: Data<LemmyContext>,
+    ) -> Result<(), LemmyError> {
+        let post = ApubPost(post);
+        let community_id = post.community_id;
+        let person: ApubPerson = Person::read(&mut context.pool(), person_id).await?.into();
+        let community: ApubCommunity = Community::read(&mut context.pool(), community_id)
+            .await?
+            .into();
 
-    let create_or_update =
-      CreateOrUpdatePage::new(post, &person, &community, kind, &context).await?;
-    let is_mod_action = create_or_update.object.is_mod_action(&context).await?;
-    let activity = AnnouncableActivities::CreateOrUpdatePost(create_or_update);
-    send_activity_in_community(
-      activity,
-      &person,
-      &community,
-      vec![],
-      is_mod_action,
-      &context,
-    )
-    .await?;
-    Ok(())
-  }
+        let create_or_update =
+            CreateOrUpdatePage::new(post, &person, &community, kind, &context).await?;
+        let is_mod_action = create_or_update.object.is_mod_action(&context).await?;
+        let activity = AnnouncableActivities::CreateOrUpdatePost(create_or_update);
+        send_activity_in_community(
+            activity,
+            &person,
+            &community,
+            vec![],
+            is_mod_action,
+            &context,
+        )
+        .await?;
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait]
 impl ActivityHandler for CreateOrUpdatePage {
-  type DataType = LemmyContext;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Error = LemmyError;
 
-  fn id(&self) -> &Url {
-    &self.id
-  }
-
-  fn actor(&self) -> &Url {
-    self.actor.inner()
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
-    insert_received_activity(&self.id, context).await?;
-    verify_is_public(&self.to, &self.cc)?;
-    let community = self.community(context).await?;
-    verify_person_in_community(&self.actor, &community, context).await?;
-    check_community_deleted_or_removed(&community)?;
-
-    match self.kind {
-      CreateOrUpdateType::Create => {
-        verify_domains_match(self.actor.inner(), self.object.id.inner())?;
-        verify_urls_match(self.actor.inner(), self.object.creator()?.inner())?;
-        // Check that the post isnt locked, as that isnt possible for newly created posts.
-        // However, when fetching a remote post we generate a new create activity with the current
-        // locked value, so this check may fail. So only check if its a local community,
-        // because then we will definitely receive all create and update activities separately.
-        let is_locked = self.object.comments_enabled == Some(false);
-        if community.local && is_locked {
-          Err(LemmyErrorType::NewPostCannotBeLocked)?
-        }
-      }
-      CreateOrUpdateType::Update => {
-        let is_mod_action = self.object.is_mod_action(context).await?;
-        if is_mod_action {
-          verify_mod_action(&self.actor, self.object.id.inner(), community.id, context).await?;
-        } else {
-          verify_domains_match(self.actor.inner(), self.object.id.inner())?;
-          verify_urls_match(self.actor.inner(), self.object.creator()?.inner())?;
-        }
-      }
+    fn id(&self) -> &Url {
+        &self.id
     }
-    ApubPost::verify(&self.object, self.actor.inner(), context).await?;
-    Ok(())
-  }
 
-  #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
-    let post = ApubPost::from_json(self.object, context).await?;
+    fn actor(&self) -> &Url {
+        self.actor.inner()
+    }
 
-    // author likes their own post by default
-    let like_form = PostLikeForm {
-      post_id: post.id,
-      person_id: post.creator_id,
-      score: 1,
-    };
-    PostLike::like(&mut context.pool(), &like_form).await?;
+    #[tracing::instrument(skip_all)]
+    async fn verify(&self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+        insert_received_activity(&self.id, context).await?;
+        verify_is_public(&self.to, &self.cc)?;
+        let community = self.community(context).await?;
+        verify_person_in_community(&self.actor, &community, context).await?;
+        check_community_deleted_or_removed(&community)?;
 
-    // Calculate initial hot_rank for post
-    PostAggregates::update_hot_rank(&mut context.pool(), post.id).await?;
+        match self.kind {
+            CreateOrUpdateType::Create => {
+                verify_domains_match(self.actor.inner(), self.object.id.inner())?;
+                verify_urls_match(self.actor.inner(), self.object.creator()?.inner())?;
+                // Check that the post isnt locked, as that isnt possible for newly created posts.
+                // However, when fetching a remote post we generate a new create activity with the current
+                // locked value, so this check may fail. So only check if its a local community,
+                // because then we will definitely receive all create and update activities separately.
+                let is_locked = self.object.comments_enabled == Some(false);
+                if community.local && is_locked {
+                    Err(LemmyErrorType::NewPostCannotBeLocked)?
+                }
+            }
+            CreateOrUpdateType::Update => {
+                let is_mod_action = self.object.is_mod_action(context).await?;
+                if is_mod_action {
+                    verify_mod_action(&self.actor, self.object.id.inner(), community.id, context)
+                        .await?;
+                } else {
+                    verify_domains_match(self.actor.inner(), self.object.id.inner())?;
+                    verify_urls_match(self.actor.inner(), self.object.creator()?.inner())?;
+                }
+            }
+        }
+        ApubPost::verify(&self.object, self.actor.inner(), context).await?;
+        Ok(())
+    }
 
-    Ok(())
-  }
+    #[tracing::instrument(skip_all)]
+    async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+        let post = ApubPost::from_json(self.object, context).await?;
+
+        // author likes their own post by default
+        let like_form = PostLikeForm {
+            post_id: post.id,
+            person_id: post.creator_id,
+            score: 1,
+        };
+        PostLike::like(&mut context.pool(), &like_form).await?;
+
+        // Calculate initial hot_rank for post
+        PostAggregates::update_hot_rank(&mut context.pool(), post.id).await?;
+
+        Ok(())
+    }
 }

--- a/crates/apub/src/activities/create_or_update/private_message.rs
+++ b/crates/apub/src/activities/create_or_update/private_message.rs
@@ -1,16 +1,15 @@
 use crate::{
-  activities::{generate_activity_id, send_lemmy_activity, verify_person},
-  insert_received_activity,
-  objects::{person::ApubPerson, private_message::ApubPrivateMessage},
-  protocol::activities::{
-    create_or_update::chat_message::CreateOrUpdateChatMessage,
-    CreateOrUpdateType,
-  },
+    activities::{generate_activity_id, send_lemmy_activity, verify_person},
+    insert_received_activity,
+    objects::{person::ApubPerson, private_message::ApubPrivateMessage},
+    protocol::activities::{
+        create_or_update::chat_message::CreateOrUpdateChatMessage, CreateOrUpdateType,
+    },
 };
 use activitypub_federation::{
-  config::Data,
-  protocol::verification::verify_domains_match,
-  traits::{ActivityHandler, Actor, Object},
+    config::Data,
+    protocol::verification::verify_domains_match,
+    traits::{ActivityHandler, Actor, Object},
 };
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_views::structs::PrivateMessageView;
@@ -18,56 +17,56 @@ use lemmy_utils::error::LemmyError;
 use url::Url;
 
 pub(crate) async fn send_create_or_update_pm(
-  pm_view: PrivateMessageView,
-  kind: CreateOrUpdateType,
-  context: Data<LemmyContext>,
+    pm_view: PrivateMessageView,
+    kind: CreateOrUpdateType,
+    context: Data<LemmyContext>,
 ) -> Result<(), LemmyError> {
-  let actor: ApubPerson = pm_view.creator.into();
-  let recipient: ApubPerson = pm_view.recipient.into();
+    let actor: ApubPerson = pm_view.creator.into();
+    let recipient: ApubPerson = pm_view.recipient.into();
 
-  let id = generate_activity_id(
-    kind.clone(),
-    &context.settings().get_protocol_and_hostname(),
-  )?;
-  let create_or_update = CreateOrUpdateChatMessage {
-    id: id.clone(),
-    actor: actor.id().into(),
-    to: [recipient.id().into()],
-    object: ApubPrivateMessage(pm_view.private_message.clone())
-      .into_json(&context)
-      .await?,
-    kind,
-  };
-  let inbox = vec![recipient.shared_inbox_or_inbox()];
-  send_lemmy_activity(&context, create_or_update, &actor, inbox, true).await
+    let id = generate_activity_id(
+        kind.clone(),
+        &context.settings().get_protocol_and_hostname(),
+    )?;
+    let create_or_update = CreateOrUpdateChatMessage {
+        id: id.clone(),
+        actor: actor.id().into(),
+        to: [recipient.id().into()],
+        object: ApubPrivateMessage(pm_view.private_message.clone())
+            .into_json(&context)
+            .await?,
+        kind,
+    };
+    let inbox = vec![recipient.shared_inbox_or_inbox()];
+    send_lemmy_activity(&context, create_or_update, &actor, inbox, true).await
 }
 
 #[async_trait::async_trait]
 impl ActivityHandler for CreateOrUpdateChatMessage {
-  type DataType = LemmyContext;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Error = LemmyError;
 
-  fn id(&self) -> &Url {
-    &self.id
-  }
+    fn id(&self) -> &Url {
+        &self.id
+    }
 
-  fn actor(&self) -> &Url {
-    self.actor.inner()
-  }
+    fn actor(&self) -> &Url {
+        self.actor.inner()
+    }
 
-  #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
-    insert_received_activity(&self.id, context).await?;
-    verify_person(&self.actor, context).await?;
-    verify_domains_match(self.actor.inner(), self.object.id.inner())?;
-    verify_domains_match(self.to[0].inner(), self.object.to[0].inner())?;
-    ApubPrivateMessage::verify(&self.object, self.actor.inner(), context).await?;
-    Ok(())
-  }
+    #[tracing::instrument(skip_all)]
+    async fn verify(&self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+        insert_received_activity(&self.id, context).await?;
+        verify_person(&self.actor, context).await?;
+        verify_domains_match(self.actor.inner(), self.object.id.inner())?;
+        verify_domains_match(self.to[0].inner(), self.object.to[0].inner())?;
+        ApubPrivateMessage::verify(&self.object, self.actor.inner(), context).await?;
+        Ok(())
+    }
 
-  #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
-    ApubPrivateMessage::from_json(self.object, context).await?;
-    Ok(())
-  }
+    #[tracing::instrument(skip_all)]
+    async fn receive(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+        ApubPrivateMessage::from_json(self.object, context).await?;
+        Ok(())
+    }
 }

--- a/crates/apub/src/activities/deletion/delete.rs
+++ b/crates/apub/src/activities/deletion/delete.rs
@@ -1,172 +1,168 @@
 use crate::{
-  activities::{
-    deletion::{receive_delete_action, verify_delete_activity, DeletableObjects},
-    generate_activity_id,
-  },
-  insert_received_activity,
-  objects::person::ApubPerson,
-  protocol::{activities::deletion::delete::Delete, IdOrNestedObject},
+    activities::{
+        deletion::{receive_delete_action, verify_delete_activity, DeletableObjects},
+        generate_activity_id,
+    },
+    insert_received_activity,
+    objects::person::ApubPerson,
+    protocol::{activities::deletion::delete::Delete, IdOrNestedObject},
 };
 use activitypub_federation::{config::Data, kinds::activity::DeleteType, traits::ActivityHandler};
 use lemmy_api_common::{context::LemmyContext, utils::sanitize_html_opt};
 use lemmy_db_schema::{
-  source::{
-    comment::{Comment, CommentUpdateForm},
-    community::{Community, CommunityUpdateForm},
-    moderator::{
-      ModRemoveComment,
-      ModRemoveCommentForm,
-      ModRemoveCommunity,
-      ModRemoveCommunityForm,
-      ModRemovePost,
-      ModRemovePostForm,
+    source::{
+        comment::{Comment, CommentUpdateForm},
+        community::{Community, CommunityUpdateForm},
+        moderator::{
+            ModRemoveComment, ModRemoveCommentForm, ModRemoveCommunity, ModRemoveCommunityForm,
+            ModRemovePost, ModRemovePostForm,
+        },
+        post::{Post, PostUpdateForm},
     },
-    post::{Post, PostUpdateForm},
-  },
-  traits::Crud,
+    traits::Crud,
 };
 use lemmy_utils::error::{LemmyError, LemmyErrorType};
 use url::Url;
 
 #[async_trait::async_trait]
 impl ActivityHandler for Delete {
-  type DataType = LemmyContext;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Error = LemmyError;
 
-  fn id(&self) -> &Url {
-    &self.id
-  }
-
-  fn actor(&self) -> &Url {
-    self.actor.inner()
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
-    insert_received_activity(&self.id, context).await?;
-    verify_delete_activity(self, self.summary.is_some(), context).await?;
-    Ok(())
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
-    if let Some(reason) = self.summary {
-      // We set reason to empty string if it doesn't exist, to distinguish between delete and
-      // remove. Here we change it back to option, so we don't write it to db.
-      let reason = if reason.is_empty() {
-        None
-      } else {
-        Some(reason)
-      };
-      receive_remove_action(
-        &self.actor.dereference(context).await?,
-        self.object.id(),
-        reason,
-        context,
-      )
-      .await
-    } else {
-      receive_delete_action(self.object.id(), &self.actor, true, context).await
+    fn id(&self) -> &Url {
+        &self.id
     }
-  }
+
+    fn actor(&self) -> &Url {
+        self.actor.inner()
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn verify(&self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+        insert_received_activity(&self.id, context).await?;
+        verify_delete_activity(self, self.summary.is_some(), context).await?;
+        Ok(())
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+        if let Some(reason) = self.summary {
+            // We set reason to empty string if it doesn't exist, to distinguish between delete and
+            // remove. Here we change it back to option, so we don't write it to db.
+            let reason = if reason.is_empty() {
+                None
+            } else {
+                Some(reason)
+            };
+            receive_remove_action(
+                &self.actor.dereference(context).await?,
+                self.object.id(),
+                reason,
+                context,
+            )
+            .await
+        } else {
+            receive_delete_action(self.object.id(), &self.actor, true, context).await
+        }
+    }
 }
 
 impl Delete {
-  pub(in crate::activities::deletion) fn new(
-    actor: &ApubPerson,
-    object: DeletableObjects,
-    to: Url,
-    community: Option<&Community>,
-    summary: Option<String>,
-    context: &Data<LemmyContext>,
-  ) -> Result<Delete, LemmyError> {
-    let id = generate_activity_id(
-      DeleteType::Delete,
-      &context.settings().get_protocol_and_hostname(),
-    )?;
-    let cc: Option<Url> = community.map(|c| c.actor_id.clone().into());
-    Ok(Delete {
-      actor: actor.actor_id.clone().into(),
-      to: vec![to],
-      object: IdOrNestedObject::Id(object.id()),
-      cc: cc.into_iter().collect(),
-      kind: DeleteType::Delete,
-      summary,
-      id,
-      audience: community.map(|c| c.actor_id.clone().into()),
-    })
-  }
+    pub(in crate::activities::deletion) fn new(
+        actor: &ApubPerson,
+        object: DeletableObjects,
+        to: Url,
+        community: Option<&Community>,
+        summary: Option<String>,
+        context: &Data<LemmyContext>,
+    ) -> Result<Delete, LemmyError> {
+        let id = generate_activity_id(
+            DeleteType::Delete,
+            &context.settings().get_protocol_and_hostname(),
+        )?;
+        let cc: Option<Url> = community.map(|c| c.actor_id.clone().into());
+        Ok(Delete {
+            actor: actor.actor_id.clone().into(),
+            to: vec![to],
+            object: IdOrNestedObject::Id(object.id()),
+            cc: cc.into_iter().collect(),
+            kind: DeleteType::Delete,
+            summary,
+            id,
+            audience: community.map(|c| c.actor_id.clone().into()),
+        })
+    }
 }
 
 #[tracing::instrument(skip_all)]
 pub(in crate::activities) async fn receive_remove_action(
-  actor: &ApubPerson,
-  object: &Url,
-  reason: Option<String>,
-  context: &Data<LemmyContext>,
+    actor: &ApubPerson,
+    object: &Url,
+    reason: Option<String>,
+    context: &Data<LemmyContext>,
 ) -> Result<(), LemmyError> {
-  let reason = sanitize_html_opt(&reason);
+    let reason = sanitize_html_opt(&reason);
 
-  match DeletableObjects::read_from_db(object, context).await? {
-    DeletableObjects::Community(community) => {
-      if community.local {
-        Err(LemmyErrorType::OnlyLocalAdminCanRemoveCommunity)?
-      }
-      let form = ModRemoveCommunityForm {
-        mod_person_id: actor.id,
-        community_id: community.id,
-        removed: Some(true),
-        reason,
-        expires: None,
-      };
-      ModRemoveCommunity::create(&mut context.pool(), &form).await?;
-      Community::update(
-        &mut context.pool(),
-        community.id,
-        &CommunityUpdateForm {
-          removed: Some(true),
-          ..Default::default()
-        },
-      )
-      .await?;
+    match DeletableObjects::read_from_db(object, context).await? {
+        DeletableObjects::Community(community) => {
+            if community.local {
+                Err(LemmyErrorType::OnlyLocalAdminCanRemoveCommunity)?
+            }
+            let form = ModRemoveCommunityForm {
+                mod_person_id: actor.id,
+                community_id: community.id,
+                removed: Some(true),
+                reason,
+                expires: None,
+            };
+            ModRemoveCommunity::create(&mut context.pool(), &form).await?;
+            Community::update(
+                &mut context.pool(),
+                community.id,
+                &CommunityUpdateForm {
+                    removed: Some(true),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        }
+        DeletableObjects::Post(post) => {
+            let form = ModRemovePostForm {
+                mod_person_id: actor.id,
+                post_id: post.id,
+                removed: Some(true),
+                reason,
+            };
+            ModRemovePost::create(&mut context.pool(), &form).await?;
+            Post::update(
+                &mut context.pool(),
+                post.id,
+                &PostUpdateForm {
+                    removed: Some(true),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        }
+        DeletableObjects::Comment(comment) => {
+            let form = ModRemoveCommentForm {
+                mod_person_id: actor.id,
+                comment_id: comment.id,
+                removed: Some(true),
+                reason,
+            };
+            ModRemoveComment::create(&mut context.pool(), &form).await?;
+            Comment::update(
+                &mut context.pool(),
+                comment.id,
+                &CommentUpdateForm {
+                    removed: Some(true),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        }
+        DeletableObjects::PrivateMessage(_) => unimplemented!(),
     }
-    DeletableObjects::Post(post) => {
-      let form = ModRemovePostForm {
-        mod_person_id: actor.id,
-        post_id: post.id,
-        removed: Some(true),
-        reason,
-      };
-      ModRemovePost::create(&mut context.pool(), &form).await?;
-      Post::update(
-        &mut context.pool(),
-        post.id,
-        &PostUpdateForm {
-          removed: Some(true),
-          ..Default::default()
-        },
-      )
-      .await?;
-    }
-    DeletableObjects::Comment(comment) => {
-      let form = ModRemoveCommentForm {
-        mod_person_id: actor.id,
-        comment_id: comment.id,
-        removed: Some(true),
-        reason,
-      };
-      ModRemoveComment::create(&mut context.pool(), &form).await?;
-      Comment::update(
-        &mut context.pool(),
-        comment.id,
-        &CommentUpdateForm {
-          removed: Some(true),
-          ..Default::default()
-        },
-      )
-      .await?;
-    }
-    DeletableObjects::PrivateMessage(_) => unimplemented!(),
-  }
-  Ok(())
+    Ok(())
 }

--- a/crates/apub/src/activities/deletion/delete_user.rs
+++ b/crates/apub/src/activities/deletion/delete_user.rs
@@ -1,14 +1,14 @@
 use crate::{
-  activities::{generate_activity_id, send_lemmy_activity, verify_is_public, verify_person},
-  insert_received_activity,
-  objects::{instance::remote_instance_inboxes, person::ApubPerson},
-  protocol::activities::deletion::delete_user::DeleteUser,
+    activities::{generate_activity_id, send_lemmy_activity, verify_is_public, verify_person},
+    insert_received_activity,
+    objects::{instance::remote_instance_inboxes, person::ApubPerson},
+    protocol::activities::deletion::delete_user::DeleteUser,
 };
 use activitypub_federation::{
-  config::Data,
-  kinds::{activity::DeleteType, public},
-  protocol::verification::verify_urls_match,
-  traits::{ActivityHandler, Actor},
+    config::Data,
+    kinds::{activity::DeleteType, public},
+    protocol::verification::verify_urls_match,
+    traits::{ActivityHandler, Actor},
 };
 use lemmy_api_common::{context::LemmyContext, utils::purge_user_account};
 use lemmy_db_schema::source::person::Person;
@@ -16,61 +16,61 @@ use lemmy_utils::error::LemmyError;
 use url::Url;
 
 pub async fn delete_user(
-  person: Person,
-  delete_content: bool,
-  context: Data<LemmyContext>,
+    person: Person,
+    delete_content: bool,
+    context: Data<LemmyContext>,
 ) -> Result<(), LemmyError> {
-  let actor: ApubPerson = person.into();
+    let actor: ApubPerson = person.into();
 
-  let id = generate_activity_id(
-    DeleteType::Delete,
-    &context.settings().get_protocol_and_hostname(),
-  )?;
-  let delete = DeleteUser {
-    actor: actor.id().into(),
-    to: vec![public()],
-    object: actor.id().into(),
-    kind: DeleteType::Delete,
-    id: id.clone(),
-    cc: vec![],
-    remove_data: Some(delete_content),
-  };
+    let id = generate_activity_id(
+        DeleteType::Delete,
+        &context.settings().get_protocol_and_hostname(),
+    )?;
+    let delete = DeleteUser {
+        actor: actor.id().into(),
+        to: vec![public()],
+        object: actor.id().into(),
+        kind: DeleteType::Delete,
+        id: id.clone(),
+        cc: vec![],
+        remove_data: Some(delete_content),
+    };
 
-  let inboxes = remote_instance_inboxes(&mut context.pool()).await?;
-  send_lemmy_activity(&context, delete, &actor, inboxes, true).await?;
-  Ok(())
+    let inboxes = remote_instance_inboxes(&mut context.pool()).await?;
+    send_lemmy_activity(&context, delete, &actor, inboxes, true).await?;
+    Ok(())
 }
 
 /// This can be separate from Delete activity because it doesn't need to be handled in shared inbox
 /// (cause instance actor doesn't have shared inbox).
 #[async_trait::async_trait]
 impl ActivityHandler for DeleteUser {
-  type DataType = LemmyContext;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Error = LemmyError;
 
-  fn id(&self) -> &Url {
-    &self.id
-  }
-
-  fn actor(&self) -> &Url {
-    self.actor.inner()
-  }
-
-  async fn verify(&self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
-    insert_received_activity(&self.id, context).await?;
-    verify_is_public(&self.to, &[])?;
-    verify_person(&self.actor, context).await?;
-    verify_urls_match(self.actor.inner(), self.object.inner())?;
-    Ok(())
-  }
-
-  async fn receive(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
-    let actor = self.actor.dereference(context).await?;
-    if self.remove_data.unwrap_or(false) {
-      purge_user_account(actor.id, context).await?;
-    } else {
-      Person::delete_account(&mut context.pool(), actor.id).await?;
+    fn id(&self) -> &Url {
+        &self.id
     }
-    Ok(())
-  }
+
+    fn actor(&self) -> &Url {
+        self.actor.inner()
+    }
+
+    async fn verify(&self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+        insert_received_activity(&self.id, context).await?;
+        verify_is_public(&self.to, &[])?;
+        verify_person(&self.actor, context).await?;
+        verify_urls_match(self.actor.inner(), self.object.inner())?;
+        Ok(())
+    }
+
+    async fn receive(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+        let actor = self.actor.dereference(context).await?;
+        if self.remove_data.unwrap_or(false) {
+            purge_user_account(actor.id, context).await?;
+        } else {
+            Person::delete_account(&mut context.pool(), actor.id).await?;
+        }
+        Ok(())
+    }
 }

--- a/crates/apub/src/activities/deletion/mod.rs
+++ b/crates/apub/src/activities/deletion/mod.rs
@@ -1,43 +1,36 @@
 use crate::{
-  activities::{
-    community::send_activity_in_community,
-    send_lemmy_activity,
-    verify_is_public,
-    verify_mod_action,
-    verify_person,
-    verify_person_in_community,
-  },
-  activity_lists::AnnouncableActivities,
-  objects::{
-    comment::ApubComment,
-    community::ApubCommunity,
-    person::ApubPerson,
-    post::ApubPost,
-    private_message::ApubPrivateMessage,
-  },
-  protocol::{
-    activities::deletion::{delete::Delete, undo_delete::UndoDelete},
-    InCommunity,
-  },
+    activities::{
+        community::send_activity_in_community, send_lemmy_activity, verify_is_public,
+        verify_mod_action, verify_person, verify_person_in_community,
+    },
+    activity_lists::AnnouncableActivities,
+    objects::{
+        comment::ApubComment, community::ApubCommunity, person::ApubPerson, post::ApubPost,
+        private_message::ApubPrivateMessage,
+    },
+    protocol::{
+        activities::deletion::{delete::Delete, undo_delete::UndoDelete},
+        InCommunity,
+    },
 };
 use activitypub_federation::{
-  config::Data,
-  fetch::object_id::ObjectId,
-  kinds::public,
-  protocol::verification::verify_domains_match,
-  traits::{Actor, Object},
+    config::Data,
+    fetch::object_id::ObjectId,
+    kinds::public,
+    protocol::verification::verify_domains_match,
+    traits::{Actor, Object},
 };
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::{
-  newtypes::CommunityId,
-  source::{
-    comment::{Comment, CommentUpdateForm},
-    community::{Community, CommunityUpdateForm},
-    person::Person,
-    post::{Post, PostUpdateForm},
-    private_message::{PrivateMessage, PrivateMessageUpdateForm},
-  },
-  traits::Crud,
+    newtypes::CommunityId,
+    source::{
+        comment::{Comment, CommentUpdateForm},
+        community::{Community, CommunityUpdateForm},
+        person::Person,
+        post::{Post, PostUpdateForm},
+        private_message::{PrivateMessage, PrivateMessageUpdateForm},
+    },
+    traits::Crud,
 };
 use lemmy_utils::error::LemmyError;
 use std::ops::Deref;
@@ -51,257 +44,257 @@ pub mod undo_delete;
 /// action was done by a normal user.
 #[tracing::instrument(skip_all)]
 pub(crate) async fn send_apub_delete_in_community(
-  actor: Person,
-  community: Community,
-  object: DeletableObjects,
-  reason: Option<String>,
-  deleted: bool,
-  context: &Data<LemmyContext>,
+    actor: Person,
+    community: Community,
+    object: DeletableObjects,
+    reason: Option<String>,
+    deleted: bool,
+    context: &Data<LemmyContext>,
 ) -> Result<(), LemmyError> {
-  let actor = ApubPerson::from(actor);
-  let is_mod_action = reason.is_some();
-  let activity = if deleted {
-    let delete = Delete::new(&actor, object, public(), Some(&community), reason, context)?;
-    AnnouncableActivities::Delete(delete)
-  } else {
-    let undo = UndoDelete::new(&actor, object, public(), Some(&community), reason, context)?;
-    AnnouncableActivities::UndoDelete(undo)
-  };
-  send_activity_in_community(
-    activity,
-    &actor,
-    &community.into(),
-    vec![],
-    is_mod_action,
-    context,
-  )
-  .await
+    let actor = ApubPerson::from(actor);
+    let is_mod_action = reason.is_some();
+    let activity = if deleted {
+        let delete = Delete::new(&actor, object, public(), Some(&community), reason, context)?;
+        AnnouncableActivities::Delete(delete)
+    } else {
+        let undo = UndoDelete::new(&actor, object, public(), Some(&community), reason, context)?;
+        AnnouncableActivities::UndoDelete(undo)
+    };
+    send_activity_in_community(
+        activity,
+        &actor,
+        &community.into(),
+        vec![],
+        is_mod_action,
+        context,
+    )
+    .await
 }
 
 /// Parameter `reason` being set indicates that this is a removal by a mod. If its unset, this
 /// action was done by a normal user.
 #[tracing::instrument(skip_all)]
 pub(crate) async fn send_apub_delete_in_community_new(
-  actor: Person,
-  community_id: CommunityId,
-  object: DeletableObjects,
-  reason: Option<String>,
-  deleted: bool,
-  context: Data<LemmyContext>,
+    actor: Person,
+    community_id: CommunityId,
+    object: DeletableObjects,
+    reason: Option<String>,
+    deleted: bool,
+    context: Data<LemmyContext>,
 ) -> Result<(), LemmyError> {
-  let community = Community::read(&mut context.pool(), community_id).await?;
-  let actor = ApubPerson::from(actor);
-  let is_mod_action = reason.is_some();
-  let activity = if deleted {
-    let delete = Delete::new(&actor, object, public(), Some(&community), reason, &context)?;
-    AnnouncableActivities::Delete(delete)
-  } else {
-    let undo = UndoDelete::new(&actor, object, public(), Some(&community), reason, &context)?;
-    AnnouncableActivities::UndoDelete(undo)
-  };
-  send_activity_in_community(
-    activity,
-    &actor,
-    &community.into(),
-    vec![],
-    is_mod_action,
-    &context,
-  )
-  .await
+    let community = Community::read(&mut context.pool(), community_id).await?;
+    let actor = ApubPerson::from(actor);
+    let is_mod_action = reason.is_some();
+    let activity = if deleted {
+        let delete = Delete::new(&actor, object, public(), Some(&community), reason, &context)?;
+        AnnouncableActivities::Delete(delete)
+    } else {
+        let undo = UndoDelete::new(&actor, object, public(), Some(&community), reason, &context)?;
+        AnnouncableActivities::UndoDelete(undo)
+    };
+    send_activity_in_community(
+        activity,
+        &actor,
+        &community.into(),
+        vec![],
+        is_mod_action,
+        &context,
+    )
+    .await
 }
 
 #[tracing::instrument(skip_all)]
 pub(crate) async fn send_apub_delete_private_message(
-  actor: &ApubPerson,
-  pm: PrivateMessage,
-  deleted: bool,
-  context: Data<LemmyContext>,
+    actor: &ApubPerson,
+    pm: PrivateMessage,
+    deleted: bool,
+    context: Data<LemmyContext>,
 ) -> Result<(), LemmyError> {
-  let recipient_id = pm.recipient_id;
-  let recipient: ApubPerson = Person::read(&mut context.pool(), recipient_id)
-    .await?
-    .into();
+    let recipient_id = pm.recipient_id;
+    let recipient: ApubPerson = Person::read(&mut context.pool(), recipient_id)
+        .await?
+        .into();
 
-  let deletable = DeletableObjects::PrivateMessage(pm.into());
-  let inbox = vec![recipient.shared_inbox_or_inbox()];
-  if deleted {
-    let delete = Delete::new(actor, deletable, recipient.id(), None, None, &context)?;
-    send_lemmy_activity(&context, delete, actor, inbox, true).await?;
-  } else {
-    let undo = UndoDelete::new(actor, deletable, recipient.id(), None, None, &context)?;
-    send_lemmy_activity(&context, undo, actor, inbox, true).await?;
-  };
-  Ok(())
+    let deletable = DeletableObjects::PrivateMessage(pm.into());
+    let inbox = vec![recipient.shared_inbox_or_inbox()];
+    if deleted {
+        let delete = Delete::new(actor, deletable, recipient.id(), None, None, &context)?;
+        send_lemmy_activity(&context, delete, actor, inbox, true).await?;
+    } else {
+        let undo = UndoDelete::new(actor, deletable, recipient.id(), None, None, &context)?;
+        send_lemmy_activity(&context, undo, actor, inbox, true).await?;
+    };
+    Ok(())
 }
 
 pub enum DeletableObjects {
-  Community(ApubCommunity),
-  Comment(ApubComment),
-  Post(ApubPost),
-  PrivateMessage(ApubPrivateMessage),
+    Community(ApubCommunity),
+    Comment(ApubComment),
+    Post(ApubPost),
+    PrivateMessage(ApubPrivateMessage),
 }
 
 impl DeletableObjects {
-  #[tracing::instrument(skip_all)]
-  pub(crate) async fn read_from_db(
-    ap_id: &Url,
-    context: &Data<LemmyContext>,
-  ) -> Result<DeletableObjects, LemmyError> {
-    if let Some(c) = ApubCommunity::read_from_id(ap_id.clone(), context).await? {
-      return Ok(DeletableObjects::Community(c));
+    #[tracing::instrument(skip_all)]
+    pub(crate) async fn read_from_db(
+        ap_id: &Url,
+        context: &Data<LemmyContext>,
+    ) -> Result<DeletableObjects, LemmyError> {
+        if let Some(c) = ApubCommunity::read_from_id(ap_id.clone(), context).await? {
+            return Ok(DeletableObjects::Community(c));
+        }
+        if let Some(p) = ApubPost::read_from_id(ap_id.clone(), context).await? {
+            return Ok(DeletableObjects::Post(p));
+        }
+        if let Some(c) = ApubComment::read_from_id(ap_id.clone(), context).await? {
+            return Ok(DeletableObjects::Comment(c));
+        }
+        if let Some(p) = ApubPrivateMessage::read_from_id(ap_id.clone(), context).await? {
+            return Ok(DeletableObjects::PrivateMessage(p));
+        }
+        Err(diesel::NotFound.into())
     }
-    if let Some(p) = ApubPost::read_from_id(ap_id.clone(), context).await? {
-      return Ok(DeletableObjects::Post(p));
-    }
-    if let Some(c) = ApubComment::read_from_id(ap_id.clone(), context).await? {
-      return Ok(DeletableObjects::Comment(c));
-    }
-    if let Some(p) = ApubPrivateMessage::read_from_id(ap_id.clone(), context).await? {
-      return Ok(DeletableObjects::PrivateMessage(p));
-    }
-    Err(diesel::NotFound.into())
-  }
 
-  pub(crate) fn id(&self) -> Url {
-    match self {
-      DeletableObjects::Community(c) => c.id(),
-      DeletableObjects::Comment(c) => c.ap_id.clone().into(),
-      DeletableObjects::Post(p) => p.ap_id.clone().into(),
-      DeletableObjects::PrivateMessage(p) => p.ap_id.clone().into(),
+    pub(crate) fn id(&self) -> Url {
+        match self {
+            DeletableObjects::Community(c) => c.id(),
+            DeletableObjects::Comment(c) => c.ap_id.clone().into(),
+            DeletableObjects::Post(p) => p.ap_id.clone().into(),
+            DeletableObjects::PrivateMessage(p) => p.ap_id.clone().into(),
+        }
     }
-  }
 }
 
 #[tracing::instrument(skip_all)]
 pub(in crate::activities) async fn verify_delete_activity(
-  activity: &Delete,
-  is_mod_action: bool,
-  context: &Data<LemmyContext>,
+    activity: &Delete,
+    is_mod_action: bool,
+    context: &Data<LemmyContext>,
 ) -> Result<(), LemmyError> {
-  let object = DeletableObjects::read_from_db(activity.object.id(), context).await?;
-  match object {
-    DeletableObjects::Community(community) => {
-      verify_is_public(&activity.to, &[])?;
-      if community.local {
-        // can only do this check for local community, in remote case it would try to fetch the
-        // deleted community (which fails)
-        verify_person_in_community(&activity.actor, &community, context).await?;
-      }
-      // community deletion is always a mod (or admin) action
-      verify_mod_action(&activity.actor, activity.object.id(), community.id, context).await?;
+    let object = DeletableObjects::read_from_db(activity.object.id(), context).await?;
+    match object {
+        DeletableObjects::Community(community) => {
+            verify_is_public(&activity.to, &[])?;
+            if community.local {
+                // can only do this check for local community, in remote case it would try to fetch the
+                // deleted community (which fails)
+                verify_person_in_community(&activity.actor, &community, context).await?;
+            }
+            // community deletion is always a mod (or admin) action
+            verify_mod_action(&activity.actor, activity.object.id(), community.id, context).await?;
+        }
+        DeletableObjects::Post(p) => {
+            verify_is_public(&activity.to, &[])?;
+            verify_delete_post_or_comment(
+                &activity.actor,
+                &p.ap_id.clone().into(),
+                &activity.community(context).await?,
+                is_mod_action,
+                context,
+            )
+            .await?;
+        }
+        DeletableObjects::Comment(c) => {
+            verify_is_public(&activity.to, &[])?;
+            verify_delete_post_or_comment(
+                &activity.actor,
+                &c.ap_id.clone().into(),
+                &activity.community(context).await?,
+                is_mod_action,
+                context,
+            )
+            .await?;
+        }
+        DeletableObjects::PrivateMessage(_) => {
+            verify_person(&activity.actor, context).await?;
+            verify_domains_match(activity.actor.inner(), activity.object.id())?;
+        }
     }
-    DeletableObjects::Post(p) => {
-      verify_is_public(&activity.to, &[])?;
-      verify_delete_post_or_comment(
-        &activity.actor,
-        &p.ap_id.clone().into(),
-        &activity.community(context).await?,
-        is_mod_action,
-        context,
-      )
-      .await?;
-    }
-    DeletableObjects::Comment(c) => {
-      verify_is_public(&activity.to, &[])?;
-      verify_delete_post_or_comment(
-        &activity.actor,
-        &c.ap_id.clone().into(),
-        &activity.community(context).await?,
-        is_mod_action,
-        context,
-      )
-      .await?;
-    }
-    DeletableObjects::PrivateMessage(_) => {
-      verify_person(&activity.actor, context).await?;
-      verify_domains_match(activity.actor.inner(), activity.object.id())?;
-    }
-  }
-  Ok(())
+    Ok(())
 }
 
 #[tracing::instrument(skip_all)]
 async fn verify_delete_post_or_comment(
-  actor: &ObjectId<ApubPerson>,
-  object_id: &Url,
-  community: &ApubCommunity,
-  is_mod_action: bool,
-  context: &Data<LemmyContext>,
+    actor: &ObjectId<ApubPerson>,
+    object_id: &Url,
+    community: &ApubCommunity,
+    is_mod_action: bool,
+    context: &Data<LemmyContext>,
 ) -> Result<(), LemmyError> {
-  verify_person_in_community(actor, community, context).await?;
-  if is_mod_action {
-    verify_mod_action(actor, object_id, community.id, context).await?;
-  } else {
-    // domain of post ap_id and post.creator ap_id are identical, so we just check the former
-    verify_domains_match(actor.inner(), object_id)?;
-  }
-  Ok(())
+    verify_person_in_community(actor, community, context).await?;
+    if is_mod_action {
+        verify_mod_action(actor, object_id, community.id, context).await?;
+    } else {
+        // domain of post ap_id and post.creator ap_id are identical, so we just check the former
+        verify_domains_match(actor.inner(), object_id)?;
+    }
+    Ok(())
 }
 
 /// Write deletion or restoring of an object to the database, and send websocket message.
 #[tracing::instrument(skip_all)]
 async fn receive_delete_action(
-  object: &Url,
-  actor: &ObjectId<ApubPerson>,
-  deleted: bool,
-  context: &Data<LemmyContext>,
+    object: &Url,
+    actor: &ObjectId<ApubPerson>,
+    deleted: bool,
+    context: &Data<LemmyContext>,
 ) -> Result<(), LemmyError> {
-  match DeletableObjects::read_from_db(object, context).await? {
-    DeletableObjects::Community(community) => {
-      if community.local {
-        let mod_: Person = actor.dereference(context).await?.deref().clone();
-        let object = DeletableObjects::Community(community.clone());
-        let c: Community = community.deref().clone();
-        send_apub_delete_in_community(mod_, c, object, None, true, context).await?;
-      }
+    match DeletableObjects::read_from_db(object, context).await? {
+        DeletableObjects::Community(community) => {
+            if community.local {
+                let mod_: Person = actor.dereference(context).await?.deref().clone();
+                let object = DeletableObjects::Community(community.clone());
+                let c: Community = community.deref().clone();
+                send_apub_delete_in_community(mod_, c, object, None, true, context).await?;
+            }
 
-      Community::update(
-        &mut context.pool(),
-        community.id,
-        &CommunityUpdateForm {
-          deleted: Some(deleted),
-          ..Default::default()
-        },
-      )
-      .await?;
+            Community::update(
+                &mut context.pool(),
+                community.id,
+                &CommunityUpdateForm {
+                    deleted: Some(deleted),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        }
+        DeletableObjects::Post(post) => {
+            if deleted != post.deleted {
+                Post::update(
+                    &mut context.pool(),
+                    post.id,
+                    &PostUpdateForm {
+                        deleted: Some(deleted),
+                        ..Default::default()
+                    },
+                )
+                .await?;
+            }
+        }
+        DeletableObjects::Comment(comment) => {
+            if deleted != comment.deleted {
+                Comment::update(
+                    &mut context.pool(),
+                    comment.id,
+                    &CommentUpdateForm {
+                        deleted: Some(deleted),
+                        ..Default::default()
+                    },
+                )
+                .await?;
+            }
+        }
+        DeletableObjects::PrivateMessage(pm) => {
+            PrivateMessage::update(
+                &mut context.pool(),
+                pm.id,
+                &PrivateMessageUpdateForm {
+                    deleted: Some(deleted),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        }
     }
-    DeletableObjects::Post(post) => {
-      if deleted != post.deleted {
-        Post::update(
-          &mut context.pool(),
-          post.id,
-          &PostUpdateForm {
-            deleted: Some(deleted),
-            ..Default::default()
-          },
-        )
-        .await?;
-      }
-    }
-    DeletableObjects::Comment(comment) => {
-      if deleted != comment.deleted {
-        Comment::update(
-          &mut context.pool(),
-          comment.id,
-          &CommentUpdateForm {
-            deleted: Some(deleted),
-            ..Default::default()
-          },
-        )
-        .await?;
-      }
-    }
-    DeletableObjects::PrivateMessage(pm) => {
-      PrivateMessage::update(
-        &mut context.pool(),
-        pm.id,
-        &PrivateMessageUpdateForm {
-          deleted: Some(deleted),
-          ..Default::default()
-        },
-      )
-      .await?;
-    }
-  }
-  Ok(())
+    Ok(())
 }

--- a/crates/apub/src/activities/deletion/undo_delete.rs
+++ b/crates/apub/src/activities/deletion/undo_delete.rs
@@ -1,163 +1,159 @@
 use crate::{
-  activities::{
-    deletion::{receive_delete_action, verify_delete_activity, DeletableObjects},
-    generate_activity_id,
-  },
-  insert_received_activity,
-  objects::person::ApubPerson,
-  protocol::activities::deletion::{delete::Delete, undo_delete::UndoDelete},
+    activities::{
+        deletion::{receive_delete_action, verify_delete_activity, DeletableObjects},
+        generate_activity_id,
+    },
+    insert_received_activity,
+    objects::person::ApubPerson,
+    protocol::activities::deletion::{delete::Delete, undo_delete::UndoDelete},
 };
 use activitypub_federation::{config::Data, kinds::activity::UndoType, traits::ActivityHandler};
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::{
-  source::{
-    comment::{Comment, CommentUpdateForm},
-    community::{Community, CommunityUpdateForm},
-    moderator::{
-      ModRemoveComment,
-      ModRemoveCommentForm,
-      ModRemoveCommunity,
-      ModRemoveCommunityForm,
-      ModRemovePost,
-      ModRemovePostForm,
+    source::{
+        comment::{Comment, CommentUpdateForm},
+        community::{Community, CommunityUpdateForm},
+        moderator::{
+            ModRemoveComment, ModRemoveCommentForm, ModRemoveCommunity, ModRemoveCommunityForm,
+            ModRemovePost, ModRemovePostForm,
+        },
+        post::{Post, PostUpdateForm},
     },
-    post::{Post, PostUpdateForm},
-  },
-  traits::Crud,
+    traits::Crud,
 };
 use lemmy_utils::error::{LemmyError, LemmyErrorType};
 use url::Url;
 
 #[async_trait::async_trait]
 impl ActivityHandler for UndoDelete {
-  type DataType = LemmyContext;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Error = LemmyError;
 
-  fn id(&self) -> &Url {
-    &self.id
-  }
-
-  fn actor(&self) -> &Url {
-    self.actor.inner()
-  }
-
-  async fn verify(&self, data: &Data<Self::DataType>) -> Result<(), Self::Error> {
-    insert_received_activity(&self.id, data).await?;
-    self.object.verify(data).await?;
-    verify_delete_activity(&self.object, self.object.summary.is_some(), data).await?;
-    Ok(())
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
-    if self.object.summary.is_some() {
-      UndoDelete::receive_undo_remove_action(
-        &self.actor.dereference(context).await?,
-        self.object.object.id(),
-        context,
-      )
-      .await
-    } else {
-      receive_delete_action(self.object.object.id(), &self.actor, false, context).await
+    fn id(&self) -> &Url {
+        &self.id
     }
-  }
+
+    fn actor(&self) -> &Url {
+        self.actor.inner()
+    }
+
+    async fn verify(&self, data: &Data<Self::DataType>) -> Result<(), Self::Error> {
+        insert_received_activity(&self.id, data).await?;
+        self.object.verify(data).await?;
+        verify_delete_activity(&self.object, self.object.summary.is_some(), data).await?;
+        Ok(())
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+        if self.object.summary.is_some() {
+            UndoDelete::receive_undo_remove_action(
+                &self.actor.dereference(context).await?,
+                self.object.object.id(),
+                context,
+            )
+            .await
+        } else {
+            receive_delete_action(self.object.object.id(), &self.actor, false, context).await
+        }
+    }
 }
 
 impl UndoDelete {
-  #[tracing::instrument(skip_all)]
-  pub(in crate::activities::deletion) fn new(
-    actor: &ApubPerson,
-    object: DeletableObjects,
-    to: Url,
-    community: Option<&Community>,
-    summary: Option<String>,
-    context: &Data<LemmyContext>,
-  ) -> Result<UndoDelete, LemmyError> {
-    let object = Delete::new(actor, object, to.clone(), community, summary, context)?;
+    #[tracing::instrument(skip_all)]
+    pub(in crate::activities::deletion) fn new(
+        actor: &ApubPerson,
+        object: DeletableObjects,
+        to: Url,
+        community: Option<&Community>,
+        summary: Option<String>,
+        context: &Data<LemmyContext>,
+    ) -> Result<UndoDelete, LemmyError> {
+        let object = Delete::new(actor, object, to.clone(), community, summary, context)?;
 
-    let id = generate_activity_id(
-      UndoType::Undo,
-      &context.settings().get_protocol_and_hostname(),
-    )?;
-    let cc: Option<Url> = community.map(|c| c.actor_id.clone().into());
-    Ok(UndoDelete {
-      actor: actor.actor_id.clone().into(),
-      to: vec![to],
-      object,
-      cc: cc.into_iter().collect(),
-      kind: UndoType::Undo,
-      id,
-      audience: community.map(|c| c.actor_id.clone().into()),
-    })
-  }
-
-  #[tracing::instrument(skip_all)]
-  pub(in crate::activities) async fn receive_undo_remove_action(
-    actor: &ApubPerson,
-    object: &Url,
-    context: &Data<LemmyContext>,
-  ) -> Result<(), LemmyError> {
-    match DeletableObjects::read_from_db(object, context).await? {
-      DeletableObjects::Community(community) => {
-        if community.local {
-          Err(LemmyErrorType::OnlyLocalAdminCanRestoreCommunity)?
-        }
-        let form = ModRemoveCommunityForm {
-          mod_person_id: actor.id,
-          community_id: community.id,
-          removed: Some(false),
-          reason: None,
-          expires: None,
-        };
-        ModRemoveCommunity::create(&mut context.pool(), &form).await?;
-        Community::update(
-          &mut context.pool(),
-          community.id,
-          &CommunityUpdateForm {
-            removed: Some(false),
-            ..Default::default()
-          },
-        )
-        .await?;
-      }
-      DeletableObjects::Post(post) => {
-        let form = ModRemovePostForm {
-          mod_person_id: actor.id,
-          post_id: post.id,
-          removed: Some(false),
-          reason: None,
-        };
-        ModRemovePost::create(&mut context.pool(), &form).await?;
-        Post::update(
-          &mut context.pool(),
-          post.id,
-          &PostUpdateForm {
-            removed: Some(false),
-            ..Default::default()
-          },
-        )
-        .await?;
-      }
-      DeletableObjects::Comment(comment) => {
-        let form = ModRemoveCommentForm {
-          mod_person_id: actor.id,
-          comment_id: comment.id,
-          removed: Some(false),
-          reason: None,
-        };
-        ModRemoveComment::create(&mut context.pool(), &form).await?;
-        Comment::update(
-          &mut context.pool(),
-          comment.id,
-          &CommentUpdateForm {
-            removed: Some(false),
-            ..Default::default()
-          },
-        )
-        .await?;
-      }
-      DeletableObjects::PrivateMessage(_) => unimplemented!(),
+        let id = generate_activity_id(
+            UndoType::Undo,
+            &context.settings().get_protocol_and_hostname(),
+        )?;
+        let cc: Option<Url> = community.map(|c| c.actor_id.clone().into());
+        Ok(UndoDelete {
+            actor: actor.actor_id.clone().into(),
+            to: vec![to],
+            object,
+            cc: cc.into_iter().collect(),
+            kind: UndoType::Undo,
+            id,
+            audience: community.map(|c| c.actor_id.clone().into()),
+        })
     }
-    Ok(())
-  }
+
+    #[tracing::instrument(skip_all)]
+    pub(in crate::activities) async fn receive_undo_remove_action(
+        actor: &ApubPerson,
+        object: &Url,
+        context: &Data<LemmyContext>,
+    ) -> Result<(), LemmyError> {
+        match DeletableObjects::read_from_db(object, context).await? {
+            DeletableObjects::Community(community) => {
+                if community.local {
+                    Err(LemmyErrorType::OnlyLocalAdminCanRestoreCommunity)?
+                }
+                let form = ModRemoveCommunityForm {
+                    mod_person_id: actor.id,
+                    community_id: community.id,
+                    removed: Some(false),
+                    reason: None,
+                    expires: None,
+                };
+                ModRemoveCommunity::create(&mut context.pool(), &form).await?;
+                Community::update(
+                    &mut context.pool(),
+                    community.id,
+                    &CommunityUpdateForm {
+                        removed: Some(false),
+                        ..Default::default()
+                    },
+                )
+                .await?;
+            }
+            DeletableObjects::Post(post) => {
+                let form = ModRemovePostForm {
+                    mod_person_id: actor.id,
+                    post_id: post.id,
+                    removed: Some(false),
+                    reason: None,
+                };
+                ModRemovePost::create(&mut context.pool(), &form).await?;
+                Post::update(
+                    &mut context.pool(),
+                    post.id,
+                    &PostUpdateForm {
+                        removed: Some(false),
+                        ..Default::default()
+                    },
+                )
+                .await?;
+            }
+            DeletableObjects::Comment(comment) => {
+                let form = ModRemoveCommentForm {
+                    mod_person_id: actor.id,
+                    comment_id: comment.id,
+                    removed: Some(false),
+                    reason: None,
+                };
+                ModRemoveComment::create(&mut context.pool(), &form).await?;
+                Comment::update(
+                    &mut context.pool(),
+                    comment.id,
+                    &CommentUpdateForm {
+                        removed: Some(false),
+                        ..Default::default()
+                    },
+                )
+                .await?;
+            }
+            DeletableObjects::PrivateMessage(_) => unimplemented!(),
+        }
+        Ok(())
+    }
 }

--- a/crates/apub/src/activities/following/accept.rs
+++ b/crates/apub/src/activities/following/accept.rs
@@ -1,13 +1,13 @@
 use crate::{
-  activities::{generate_activity_id, send_lemmy_activity},
-  insert_received_activity,
-  protocol::activities::following::{accept::AcceptFollow, follow::Follow},
+    activities::{generate_activity_id, send_lemmy_activity},
+    insert_received_activity,
+    protocol::activities::following::{accept::AcceptFollow, follow::Follow},
 };
 use activitypub_federation::{
-  config::Data,
-  kinds::activity::AcceptType,
-  protocol::verification::verify_urls_match,
-  traits::{ActivityHandler, Actor},
+    config::Data,
+    kinds::activity::AcceptType,
+    protocol::verification::verify_urls_match,
+    traits::{ActivityHandler, Actor},
 };
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::{source::community::CommunityFollower, traits::Followable};
@@ -15,59 +15,59 @@ use lemmy_utils::error::LemmyError;
 use url::Url;
 
 impl AcceptFollow {
-  #[tracing::instrument(skip_all)]
-  pub async fn send(follow: Follow, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
-    let user_or_community = follow.object.dereference_local(context).await?;
-    let person = follow.actor.clone().dereference(context).await?;
-    let accept = AcceptFollow {
-      actor: user_or_community.id().into(),
-      to: Some([person.id().into()]),
-      object: follow,
-      kind: AcceptType::Accept,
-      id: generate_activity_id(
-        AcceptType::Accept,
-        &context.settings().get_protocol_and_hostname(),
-      )?,
-    };
-    let inbox = vec![person.shared_inbox_or_inbox()];
-    send_lemmy_activity(context, accept, &user_or_community, inbox, true).await
-  }
+    #[tracing::instrument(skip_all)]
+    pub async fn send(follow: Follow, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+        let user_or_community = follow.object.dereference_local(context).await?;
+        let person = follow.actor.clone().dereference(context).await?;
+        let accept = AcceptFollow {
+            actor: user_or_community.id().into(),
+            to: Some([person.id().into()]),
+            object: follow,
+            kind: AcceptType::Accept,
+            id: generate_activity_id(
+                AcceptType::Accept,
+                &context.settings().get_protocol_and_hostname(),
+            )?,
+        };
+        let inbox = vec![person.shared_inbox_or_inbox()];
+        send_lemmy_activity(context, accept, &user_or_community, inbox, true).await
+    }
 }
 
 /// Handle accepted follows
 #[async_trait::async_trait]
 impl ActivityHandler for AcceptFollow {
-  type DataType = LemmyContext;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Error = LemmyError;
 
-  fn id(&self) -> &Url {
-    &self.id
-  }
-
-  fn actor(&self) -> &Url {
-    self.actor.inner()
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
-    insert_received_activity(&self.id, context).await?;
-    verify_urls_match(self.actor.inner(), self.object.object.inner())?;
-    self.object.verify(context).await?;
-    if let Some(to) = &self.to {
-      verify_urls_match(to[0].inner(), self.object.actor.inner())?;
+    fn id(&self) -> &Url {
+        &self.id
     }
-    Ok(())
-  }
 
-  #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
-    let community = self.actor.dereference(context).await?;
-    let person = self.object.actor.dereference(context).await?;
-    // This will throw an error if no follow was requested
-    let community_id = community.id;
-    let person_id = person.id;
-    CommunityFollower::follow_accepted(&mut context.pool(), community_id, person_id).await?;
+    fn actor(&self) -> &Url {
+        self.actor.inner()
+    }
 
-    Ok(())
-  }
+    #[tracing::instrument(skip_all)]
+    async fn verify(&self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+        insert_received_activity(&self.id, context).await?;
+        verify_urls_match(self.actor.inner(), self.object.object.inner())?;
+        self.object.verify(context).await?;
+        if let Some(to) = &self.to {
+            verify_urls_match(to[0].inner(), self.object.actor.inner())?;
+        }
+        Ok(())
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+        let community = self.actor.dereference(context).await?;
+        let person = self.object.actor.dereference(context).await?;
+        // This will throw an error if no follow was requested
+        let community_id = community.id;
+        let person_id = person.id;
+        CommunityFollower::follow_accepted(&mut context.pool(), community_id, person_id).await?;
+
+        Ok(())
+    }
 }

--- a/crates/apub/src/activities/following/follow.rs
+++ b/crates/apub/src/activities/following/follow.rs
@@ -1,121 +1,118 @@
 use crate::{
-  activities::{
-    generate_activity_id,
-    send_lemmy_activity,
-    verify_person,
-    verify_person_in_community,
-  },
-  fetcher::user_or_community::UserOrCommunity,
-  insert_received_activity,
-  objects::{community::ApubCommunity, person::ApubPerson},
-  protocol::activities::following::{accept::AcceptFollow, follow::Follow},
+    activities::{
+        generate_activity_id, send_lemmy_activity, verify_person, verify_person_in_community,
+    },
+    fetcher::user_or_community::UserOrCommunity,
+    insert_received_activity,
+    objects::{community::ApubCommunity, person::ApubPerson},
+    protocol::activities::following::{accept::AcceptFollow, follow::Follow},
 };
 use activitypub_federation::{
-  config::Data,
-  kinds::activity::FollowType,
-  protocol::verification::verify_urls_match,
-  traits::{ActivityHandler, Actor},
+    config::Data,
+    kinds::activity::FollowType,
+    protocol::verification::verify_urls_match,
+    traits::{ActivityHandler, Actor},
 };
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::{
-  source::{
-    community::{CommunityFollower, CommunityFollowerForm},
-    person::{PersonFollower, PersonFollowerForm},
-  },
-  traits::Followable,
+    source::{
+        community::{CommunityFollower, CommunityFollowerForm},
+        person::{PersonFollower, PersonFollowerForm},
+    },
+    traits::Followable,
 };
 use lemmy_utils::error::LemmyError;
 use url::Url;
 
 impl Follow {
-  pub(in crate::activities::following) fn new(
-    actor: &ApubPerson,
-    community: &ApubCommunity,
-    context: &Data<LemmyContext>,
-  ) -> Result<Follow, LemmyError> {
-    Ok(Follow {
-      actor: actor.id().into(),
-      object: community.id().into(),
-      to: Some([community.id().into()]),
-      kind: FollowType::Follow,
-      id: generate_activity_id(
-        FollowType::Follow,
-        &context.settings().get_protocol_and_hostname(),
-      )?,
-    })
-  }
+    pub(in crate::activities::following) fn new(
+        actor: &ApubPerson,
+        community: &ApubCommunity,
+        context: &Data<LemmyContext>,
+    ) -> Result<Follow, LemmyError> {
+        Ok(Follow {
+            actor: actor.id().into(),
+            object: community.id().into(),
+            to: Some([community.id().into()]),
+            kind: FollowType::Follow,
+            id: generate_activity_id(
+                FollowType::Follow,
+                &context.settings().get_protocol_and_hostname(),
+            )?,
+        })
+    }
 
-  #[tracing::instrument(skip_all)]
-  pub async fn send(
-    actor: &ApubPerson,
-    community: &ApubCommunity,
-    context: &Data<LemmyContext>,
-  ) -> Result<(), LemmyError> {
-    let community_follower_form = CommunityFollowerForm {
-      community_id: community.id,
-      person_id: actor.id,
-      pending: true,
-    };
-    CommunityFollower::follow(&mut context.pool(), &community_follower_form)
-      .await
-      .ok();
+    #[tracing::instrument(skip_all)]
+    pub async fn send(
+        actor: &ApubPerson,
+        community: &ApubCommunity,
+        context: &Data<LemmyContext>,
+    ) -> Result<(), LemmyError> {
+        let community_follower_form = CommunityFollowerForm {
+            community_id: community.id,
+            person_id: actor.id,
+            pending: true,
+        };
+        CommunityFollower::follow(&mut context.pool(), &community_follower_form)
+            .await
+            .ok();
 
-    let follow = Follow::new(actor, community, context)?;
-    let inbox = vec![community.shared_inbox_or_inbox()];
-    send_lemmy_activity(context, follow, actor, inbox, true).await
-  }
+        let follow = Follow::new(actor, community, context)?;
+        let inbox = vec![community.shared_inbox_or_inbox()];
+        send_lemmy_activity(context, follow, actor, inbox, true).await
+    }
 }
 
 #[async_trait::async_trait]
 impl ActivityHandler for Follow {
-  type DataType = LemmyContext;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Error = LemmyError;
 
-  fn id(&self) -> &Url {
-    &self.id
-  }
-
-  fn actor(&self) -> &Url {
-    self.actor.inner()
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
-    insert_received_activity(&self.id, context).await?;
-    verify_person(&self.actor, context).await?;
-    let object = self.object.dereference(context).await?;
-    if let UserOrCommunity::Community(c) = object {
-      verify_person_in_community(&self.actor, &c, context).await?;
-    }
-    if let Some(to) = &self.to {
-      verify_urls_match(to[0].inner(), self.object.inner())?;
-    }
-    Ok(())
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
-    let actor = self.actor.dereference(context).await?;
-    let object = self.object.dereference(context).await?;
-    match object {
-      UserOrCommunity::User(u) => {
-        let form = PersonFollowerForm {
-          person_id: u.id,
-          follower_id: actor.id,
-          pending: false,
-        };
-        PersonFollower::follow(&mut context.pool(), &form).await?;
-      }
-      UserOrCommunity::Community(c) => {
-        let form = CommunityFollowerForm {
-          community_id: c.id,
-          person_id: actor.id,
-          pending: false,
-        };
-        CommunityFollower::follow(&mut context.pool(), &form).await?;
-      }
+    fn id(&self) -> &Url {
+        &self.id
     }
 
-    AcceptFollow::send(self, context).await
-  }
+    fn actor(&self) -> &Url {
+        self.actor.inner()
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn verify(&self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+        insert_received_activity(&self.id, context).await?;
+        verify_person(&self.actor, context).await?;
+        let object = self.object.dereference(context).await?;
+        if let UserOrCommunity::Community(c) = object {
+            verify_person_in_community(&self.actor, &c, context).await?;
+        }
+        if let Some(to) = &self.to {
+            verify_urls_match(to[0].inner(), self.object.inner())?;
+        }
+        Ok(())
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+        let actor = self.actor.dereference(context).await?;
+        let object = self.object.dereference(context).await?;
+        match object {
+            UserOrCommunity::User(u) => {
+                let form = PersonFollowerForm {
+                    person_id: u.id,
+                    follower_id: actor.id,
+                    pending: false,
+                };
+                PersonFollower::follow(&mut context.pool(), &form).await?;
+            }
+            UserOrCommunity::Community(c) => {
+                let form = CommunityFollowerForm {
+                    community_id: c.id,
+                    person_id: actor.id,
+                    pending: false,
+                };
+                CommunityFollower::follow(&mut context.pool(), &form).await?;
+            }
+        }
+
+        AcceptFollow::send(self, context).await
+    }
 }

--- a/crates/apub/src/activities/following/mod.rs
+++ b/crates/apub/src/activities/following/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
-  objects::{community::ApubCommunity, person::ApubPerson},
-  protocol::activities::following::{follow::Follow, undo_follow::UndoFollow},
+    objects::{community::ApubCommunity, person::ApubPerson},
+    protocol::activities::following::{follow::Follow, undo_follow::UndoFollow},
 };
 use activitypub_federation::config::Data;
 use lemmy_api_common::context::LemmyContext;
@@ -12,16 +12,16 @@ pub mod follow;
 pub mod undo_follow;
 
 pub async fn send_follow_community(
-  community: Community,
-  person: Person,
-  follow: bool,
-  context: &Data<LemmyContext>,
+    community: Community,
+    person: Person,
+    follow: bool,
+    context: &Data<LemmyContext>,
 ) -> Result<(), LemmyError> {
-  let community: ApubCommunity = community.into();
-  let actor: ApubPerson = person.into();
-  if follow {
-    Follow::send(&actor, &community, context).await
-  } else {
-    UndoFollow::send(&actor, &community, context).await
-  }
+    let community: ApubCommunity = community.into();
+    let actor: ApubPerson = person.into();
+    if follow {
+        Follow::send(&actor, &community, context).await
+    } else {
+        UndoFollow::send(&actor, &community, context).await
+    }
 }

--- a/crates/apub/src/activities/following/undo_follow.rs
+++ b/crates/apub/src/activities/following/undo_follow.rs
@@ -1,99 +1,99 @@
 use crate::{
-  activities::{generate_activity_id, send_lemmy_activity, verify_person},
-  fetcher::user_or_community::UserOrCommunity,
-  insert_received_activity,
-  objects::{community::ApubCommunity, person::ApubPerson},
-  protocol::activities::following::{follow::Follow, undo_follow::UndoFollow},
+    activities::{generate_activity_id, send_lemmy_activity, verify_person},
+    fetcher::user_or_community::UserOrCommunity,
+    insert_received_activity,
+    objects::{community::ApubCommunity, person::ApubPerson},
+    protocol::activities::following::{follow::Follow, undo_follow::UndoFollow},
 };
 use activitypub_federation::{
-  config::Data,
-  kinds::activity::UndoType,
-  protocol::verification::verify_urls_match,
-  traits::{ActivityHandler, Actor},
+    config::Data,
+    kinds::activity::UndoType,
+    protocol::verification::verify_urls_match,
+    traits::{ActivityHandler, Actor},
 };
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::{
-  source::{
-    community::{CommunityFollower, CommunityFollowerForm},
-    person::{PersonFollower, PersonFollowerForm},
-  },
-  traits::Followable,
+    source::{
+        community::{CommunityFollower, CommunityFollowerForm},
+        person::{PersonFollower, PersonFollowerForm},
+    },
+    traits::Followable,
 };
 use lemmy_utils::error::LemmyError;
 use url::Url;
 
 impl UndoFollow {
-  #[tracing::instrument(skip_all)]
-  pub async fn send(
-    actor: &ApubPerson,
-    community: &ApubCommunity,
-    context: &Data<LemmyContext>,
-  ) -> Result<(), LemmyError> {
-    let object = Follow::new(actor, community, context)?;
-    let undo = UndoFollow {
-      actor: actor.id().into(),
-      to: Some([community.id().into()]),
-      object,
-      kind: UndoType::Undo,
-      id: generate_activity_id(
-        UndoType::Undo,
-        &context.settings().get_protocol_and_hostname(),
-      )?,
-    };
-    let inbox = vec![community.shared_inbox_or_inbox()];
-    send_lemmy_activity(context, undo, actor, inbox, true).await
-  }
+    #[tracing::instrument(skip_all)]
+    pub async fn send(
+        actor: &ApubPerson,
+        community: &ApubCommunity,
+        context: &Data<LemmyContext>,
+    ) -> Result<(), LemmyError> {
+        let object = Follow::new(actor, community, context)?;
+        let undo = UndoFollow {
+            actor: actor.id().into(),
+            to: Some([community.id().into()]),
+            object,
+            kind: UndoType::Undo,
+            id: generate_activity_id(
+                UndoType::Undo,
+                &context.settings().get_protocol_and_hostname(),
+            )?,
+        };
+        let inbox = vec![community.shared_inbox_or_inbox()];
+        send_lemmy_activity(context, undo, actor, inbox, true).await
+    }
 }
 
 #[async_trait::async_trait]
 impl ActivityHandler for UndoFollow {
-  type DataType = LemmyContext;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Error = LemmyError;
 
-  fn id(&self) -> &Url {
-    &self.id
-  }
-
-  fn actor(&self) -> &Url {
-    self.actor.inner()
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
-    insert_received_activity(&self.id, context).await?;
-    verify_urls_match(self.actor.inner(), self.object.actor.inner())?;
-    verify_person(&self.actor, context).await?;
-    self.object.verify(context).await?;
-    if let Some(to) = &self.to {
-      verify_urls_match(to[0].inner(), self.object.object.inner())?;
-    }
-    Ok(())
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
-    let person = self.actor.dereference(context).await?;
-    let object = self.object.object.dereference(context).await?;
-
-    match object {
-      UserOrCommunity::User(u) => {
-        let form = PersonFollowerForm {
-          person_id: u.id,
-          follower_id: person.id,
-          pending: false,
-        };
-        PersonFollower::unfollow(&mut context.pool(), &form).await?;
-      }
-      UserOrCommunity::Community(c) => {
-        let form = CommunityFollowerForm {
-          community_id: c.id,
-          person_id: person.id,
-          pending: false,
-        };
-        CommunityFollower::unfollow(&mut context.pool(), &form).await?;
-      }
+    fn id(&self) -> &Url {
+        &self.id
     }
 
-    Ok(())
-  }
+    fn actor(&self) -> &Url {
+        self.actor.inner()
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn verify(&self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+        insert_received_activity(&self.id, context).await?;
+        verify_urls_match(self.actor.inner(), self.object.actor.inner())?;
+        verify_person(&self.actor, context).await?;
+        self.object.verify(context).await?;
+        if let Some(to) = &self.to {
+            verify_urls_match(to[0].inner(), self.object.object.inner())?;
+        }
+        Ok(())
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+        let person = self.actor.dereference(context).await?;
+        let object = self.object.object.dereference(context).await?;
+
+        match object {
+            UserOrCommunity::User(u) => {
+                let form = PersonFollowerForm {
+                    person_id: u.id,
+                    follower_id: person.id,
+                    pending: false,
+                };
+                PersonFollower::unfollow(&mut context.pool(), &form).await?;
+            }
+            UserOrCommunity::Community(c) => {
+                let form = CommunityFollowerForm {
+                    community_id: c.id,
+                    person_id: person.id,
+                    pending: false,
+                };
+                CommunityFollower::unfollow(&mut context.pool(), &form).await?;
+            }
+        }
+
+        Ok(())
+    }
 }

--- a/crates/apub/src/activities/mod.rs
+++ b/crates/apub/src/activities/mod.rs
@@ -1,56 +1,52 @@
 use self::following::send_follow_community;
 use crate::{
-  activities::{
-    block::{send_ban_from_community, send_ban_from_site},
-    community::{
-      collection_add::{send_add_mod_to_community, send_feature_post},
-      lock_page::send_lock_post,
-      update::send_update_community,
+    activities::{
+        block::{send_ban_from_community, send_ban_from_site},
+        community::{
+            collection_add::{send_add_mod_to_community, send_feature_post},
+            lock_page::send_lock_post,
+            update::send_update_community,
+        },
+        create_or_update::private_message::send_create_or_update_pm,
+        deletion::{
+            delete_user::delete_user, send_apub_delete_in_community,
+            send_apub_delete_in_community_new, send_apub_delete_private_message, DeletableObjects,
+        },
+        voting::send_like_activity,
     },
-    create_or_update::private_message::send_create_or_update_pm,
-    deletion::{
-      delete_user::delete_user,
-      send_apub_delete_in_community,
-      send_apub_delete_in_community_new,
-      send_apub_delete_private_message,
-      DeletableObjects,
+    objects::{community::ApubCommunity, person::ApubPerson},
+    protocol::activities::{
+        community::report::Report,
+        create_or_update::{note::CreateOrUpdateNote, page::CreateOrUpdatePage},
+        CreateOrUpdateType,
     },
-    voting::send_like_activity,
-  },
-  objects::{community::ApubCommunity, person::ApubPerson},
-  protocol::activities::{
-    community::report::Report,
-    create_or_update::{note::CreateOrUpdateNote, page::CreateOrUpdatePage},
-    CreateOrUpdateType,
-  },
-  CONTEXT,
+    CONTEXT,
 };
 use activitypub_federation::{
-  activity_queue::send_activity,
-  config::Data,
-  fetch::object_id::ObjectId,
-  kinds::public,
-  protocol::context::WithContext,
-  traits::{ActivityHandler, Actor},
+    activity_queue::send_activity,
+    config::Data,
+    fetch::object_id::ObjectId,
+    kinds::public,
+    protocol::context::WithContext,
+    traits::{ActivityHandler, Actor},
 };
 use anyhow::anyhow;
 use lemmy_api_common::{
-  context::LemmyContext,
-  send_activity::{ActivityChannel, SendActivityData},
+    context::LemmyContext,
+    send_activity::{ActivityChannel, SendActivityData},
 };
 use lemmy_db_schema::{
-  newtypes::CommunityId,
-  source::{
-    activity::{SentActivity, SentActivityForm},
-    community::Community,
-    instance::Instance,
-  },
+    newtypes::CommunityId,
+    source::{
+        activity::{SentActivity, SentActivityForm},
+        community::Community,
+        instance::Instance,
+    },
 };
 use lemmy_db_views_actor::structs::{CommunityPersonBanView, CommunityView};
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType, LemmyResult},
-  spawn_try_task,
-  SYNCHRONOUS_FEDERATION,
+    error::{LemmyError, LemmyErrorExt, LemmyErrorType, LemmyResult},
+    spawn_try_task, SYNCHRONOUS_FEDERATION,
 };
 use moka::future::Cache;
 use once_cell::sync::Lazy;
@@ -75,42 +71,42 @@ pub static DEAD_INSTANCE_LIST_CACHE_DURATION: Duration = Duration::from_secs(30 
 /// doesn't have a site ban.
 #[tracing::instrument(skip_all)]
 async fn verify_person(
-  person_id: &ObjectId<ApubPerson>,
-  context: &Data<LemmyContext>,
+    person_id: &ObjectId<ApubPerson>,
+    context: &Data<LemmyContext>,
 ) -> Result<(), LemmyError> {
-  let person = person_id.dereference(context).await?;
-  if person.banned {
-    Err(anyhow!("Person {} is banned", person_id))
-      .with_lemmy_type(LemmyErrorType::CouldntUpdateComment)
-  } else {
-    Ok(())
-  }
+    let person = person_id.dereference(context).await?;
+    if person.banned {
+        Err(anyhow!("Person {} is banned", person_id))
+            .with_lemmy_type(LemmyErrorType::CouldntUpdateComment)
+    } else {
+        Ok(())
+    }
 }
 
 /// Fetches the person and community to verify their type, then checks if person is banned from site
 /// or community.
 #[tracing::instrument(skip_all)]
 pub(crate) async fn verify_person_in_community(
-  person_id: &ObjectId<ApubPerson>,
-  community: &ApubCommunity,
-  context: &Data<LemmyContext>,
+    person_id: &ObjectId<ApubPerson>,
+    community: &ApubCommunity,
+    context: &Data<LemmyContext>,
 ) -> Result<(), LemmyError> {
-  let person = person_id.dereference(context).await?;
-  if person.banned {
-    Err(LemmyErrorType::PersonIsBannedFromSite(
-      person.actor_id.to_string(),
-    ))?
-  }
-  let person_id = person.id;
-  let community_id = community.id;
-  let is_banned = CommunityPersonBanView::get(&mut context.pool(), person_id, community_id)
-    .await
-    .is_ok();
-  if is_banned {
-    Err(LemmyErrorType::PersonIsBannedFromCommunity)?
-  } else {
-    Ok(())
-  }
+    let person = person_id.dereference(context).await?;
+    if person.banned {
+        Err(LemmyErrorType::PersonIsBannedFromSite(
+            person.actor_id.to_string(),
+        ))?
+    }
+    let person_id = person.id;
+    let community_id = community.id;
+    let is_banned = CommunityPersonBanView::get(&mut context.pool(), person_id, community_id)
+        .await
+        .is_ok();
+    if is_banned {
+        Err(LemmyErrorType::PersonIsBannedFromCommunity)?
+    } else {
+        Ok(())
+    }
 }
 
 /// Verify that mod action in community was performed by a moderator.
@@ -120,233 +116,253 @@ pub(crate) async fn verify_person_in_community(
 /// * `community` - The community inside which moderation is happening
 #[tracing::instrument(skip_all)]
 pub(crate) async fn verify_mod_action(
-  mod_id: &ObjectId<ApubPerson>,
-  object_id: &Url,
-  community_id: CommunityId,
-  context: &Data<LemmyContext>,
+    mod_id: &ObjectId<ApubPerson>,
+    object_id: &Url,
+    community_id: CommunityId,
+    context: &Data<LemmyContext>,
 ) -> Result<(), LemmyError> {
-  let mod_ = mod_id.dereference(context).await?;
+    let mod_ = mod_id.dereference(context).await?;
 
-  let is_mod_or_admin =
-    CommunityView::is_mod_or_admin(&mut context.pool(), mod_.id, community_id).await?;
-  if is_mod_or_admin {
-    return Ok(());
-  }
+    let is_mod_or_admin =
+        CommunityView::is_mod_or_admin(&mut context.pool(), mod_.id, community_id).await?;
+    if is_mod_or_admin {
+        return Ok(());
+    }
 
-  // mod action comes from the same instance as the moderated object, so it was presumably done
-  // by an instance admin.
-  // TODO: federate instance admin status and check it here
-  if mod_id.inner().domain() == object_id.domain() {
-    return Ok(());
-  }
+    // mod action comes from the same instance as the moderated object, so it was presumably done
+    // by an instance admin.
+    // TODO: federate instance admin status and check it here
+    if mod_id.inner().domain() == object_id.domain() {
+        return Ok(());
+    }
 
-  Err(LemmyErrorType::NotAModerator)?
+    Err(LemmyErrorType::NotAModerator)?
 }
 
 pub(crate) fn verify_is_public(to: &[Url], cc: &[Url]) -> Result<(), LemmyError> {
-  if ![to, cc].iter().any(|set| set.contains(&public())) {
-    Err(LemmyErrorType::ObjectIsNotPublic)?
-  } else {
-    Ok(())
-  }
+    if ![to, cc].iter().any(|set| set.contains(&public())) {
+        Err(LemmyErrorType::ObjectIsNotPublic)?
+    } else {
+        Ok(())
+    }
 }
 
 pub(crate) fn verify_community_matches<T>(
-  a: &ObjectId<ApubCommunity>,
-  b: T,
+    a: &ObjectId<ApubCommunity>,
+    b: T,
 ) -> Result<(), LemmyError>
 where
-  T: Into<ObjectId<ApubCommunity>>,
+    T: Into<ObjectId<ApubCommunity>>,
 {
-  let b: ObjectId<ApubCommunity> = b.into();
-  if a != &b {
-    Err(LemmyErrorType::InvalidCommunity)?
-  } else {
-    Ok(())
-  }
+    let b: ObjectId<ApubCommunity> = b.into();
+    if a != &b {
+        Err(LemmyErrorType::InvalidCommunity)?
+    } else {
+        Ok(())
+    }
 }
 
 pub(crate) fn check_community_deleted_or_removed(community: &Community) -> Result<(), LemmyError> {
-  if community.deleted || community.removed {
-    Err(LemmyErrorType::CannotCreatePostOrCommentInDeletedOrRemovedCommunity)?
-  } else {
-    Ok(())
-  }
+    if community.deleted || community.removed {
+        Err(LemmyErrorType::CannotCreatePostOrCommentInDeletedOrRemovedCommunity)?
+    } else {
+        Ok(())
+    }
 }
 
 /// Generate a unique ID for an activity, in the format:
 /// `http(s)://example.com/receive/create/202daf0a-1489-45df-8d2e-c8a3173fed36`
 fn generate_activity_id<T>(kind: T, protocol_and_hostname: &str) -> Result<Url, ParseError>
 where
-  T: ToString,
+    T: ToString,
 {
-  let id = format!(
-    "{}/activities/{}/{}",
-    protocol_and_hostname,
-    kind.to_string().to_lowercase(),
-    Uuid::new_v4()
-  );
-  Url::parse(&id)
+    let id = format!(
+        "{}/activities/{}/{}",
+        protocol_and_hostname,
+        kind.to_string().to_lowercase(),
+        Uuid::new_v4()
+    );
+    Url::parse(&id)
 }
 
 #[tracing::instrument(skip_all)]
 async fn send_lemmy_activity<Activity, ActorT>(
-  data: &Data<LemmyContext>,
-  activity: Activity,
-  actor: &ActorT,
-  mut inbox: Vec<Url>,
-  sensitive: bool,
+    data: &Data<LemmyContext>,
+    activity: Activity,
+    actor: &ActorT,
+    mut inbox: Vec<Url>,
+    sensitive: bool,
 ) -> Result<(), LemmyError>
 where
-  Activity: ActivityHandler + Serialize + Send + Sync + Clone,
-  ActorT: Actor,
-  Activity: ActivityHandler<Error = LemmyError>,
+    Activity: ActivityHandler + Serialize + Send + Sync + Clone,
+    ActorT: Actor,
+    Activity: ActivityHandler<Error = LemmyError>,
 {
-  static CACHE: Lazy<Cache<(), Arc<Vec<String>>>> = Lazy::new(|| {
-    Cache::builder()
-      .max_capacity(1)
-      .time_to_live(DEAD_INSTANCE_LIST_CACHE_DURATION)
-      .build()
-  });
-  let dead_instances = CACHE
-    .try_get_with((), async {
-      Ok::<_, diesel::result::Error>(Arc::new(Instance::dead_instances(&mut data.pool()).await?))
-    })
-    .await?;
+    static CACHE: Lazy<Cache<(), Arc<Vec<String>>>> = Lazy::new(|| {
+        Cache::builder()
+            .max_capacity(1)
+            .time_to_live(DEAD_INSTANCE_LIST_CACHE_DURATION)
+            .build()
+    });
+    let dead_instances = CACHE
+        .try_get_with((), async {
+            Ok::<_, diesel::result::Error>(Arc::new(
+                Instance::dead_instances(&mut data.pool()).await?,
+            ))
+        })
+        .await?;
 
-  inbox.retain(|i| {
-    let domain = i.domain().expect("has domain").to_string();
-    !dead_instances.contains(&domain)
-  });
-  info!("Sending activity {}", activity.id().to_string());
-  let activity = WithContext::new(activity, CONTEXT.deref().clone());
+    inbox.retain(|i| {
+        let domain = i.domain().expect("has domain").to_string();
+        !dead_instances.contains(&domain)
+    });
+    info!("Sending activity {}", activity.id().to_string());
+    let activity = WithContext::new(activity, CONTEXT.deref().clone());
 
-  let form = SentActivityForm {
-    ap_id: activity.id().clone().into(),
-    data: serde_json::to_value(activity.clone())?,
-    sensitive,
-  };
-  SentActivity::create(&mut data.pool(), form).await?;
-  send_activity(activity, actor, inbox, data).await?;
+    let form = SentActivityForm {
+        ap_id: activity.id().clone().into(),
+        data: serde_json::to_value(activity.clone())?,
+        sensitive,
+    };
+    SentActivity::create(&mut data.pool(), form).await?;
+    send_activity(activity, actor, inbox, data).await?;
 
-  Ok(())
+    Ok(())
 }
 
 pub async fn handle_outgoing_activities(context: Data<LemmyContext>) -> LemmyResult<()> {
-  while let Some(data) = ActivityChannel::retrieve_activity().await {
-    match_outgoing_activities(data, &context.reset_request_count()).await?
-  }
-  Ok(())
+    while let Some(data) = ActivityChannel::retrieve_activity().await {
+        match_outgoing_activities(data, &context.reset_request_count()).await?
+    }
+    Ok(())
 }
 
 pub async fn match_outgoing_activities(
-  data: SendActivityData,
-  context: &Data<LemmyContext>,
+    data: SendActivityData,
+    context: &Data<LemmyContext>,
 ) -> LemmyResult<()> {
-  let context = context.reset_request_count();
-  let fed_task = async {
-    use SendActivityData::*;
-    match data {
-      CreatePost(post) => {
-        let creator_id = post.creator_id;
-        CreateOrUpdatePage::send(post, creator_id, CreateOrUpdateType::Create, context).await
-      }
-      UpdatePost(post) => {
-        let creator_id = post.creator_id;
-        CreateOrUpdatePage::send(post, creator_id, CreateOrUpdateType::Update, context).await
-      }
-      DeletePost(post, person, data) => {
-        send_apub_delete_in_community_new(
-          person,
-          post.community_id,
-          DeletableObjects::Post(post.into()),
-          None,
-          data.deleted,
-          context,
-        )
-        .await
-      }
-      RemovePost(post, person, data) => {
-        send_apub_delete_in_community_new(
-          person,
-          post.community_id,
-          DeletableObjects::Post(post.into()),
-          data.reason.or_else(|| Some(String::new())),
-          data.removed,
-          context,
-        )
-        .await
-      }
-      LockPost(post, actor, locked) => send_lock_post(post, actor, locked, context).await,
-      FeaturePost(post, actor, featured) => send_feature_post(post, actor, featured, context).await,
-      CreateComment(comment) => {
-        let creator_id = comment.creator_id;
-        CreateOrUpdateNote::send(comment, creator_id, CreateOrUpdateType::Create, context).await
-      }
-      UpdateComment(comment) => {
-        let creator_id = comment.creator_id;
-        CreateOrUpdateNote::send(comment, creator_id, CreateOrUpdateType::Update, context).await
-      }
-      DeleteComment(comment, actor, community) => {
-        let is_deleted = comment.deleted;
-        let deletable = DeletableObjects::Comment(comment.into());
-        send_apub_delete_in_community(actor, community, deletable, None, is_deleted, &context).await
-      }
-      RemoveComment(comment, actor, community, reason) => {
-        let is_removed = comment.removed;
-        let deletable = DeletableObjects::Comment(comment.into());
-        send_apub_delete_in_community(actor, community, deletable, reason, is_removed, &context)
-          .await
-      }
-      LikePostOrComment(object_id, person, community, score) => {
-        send_like_activity(object_id, person, community, score, context).await
-      }
-      FollowCommunity(community, person, follow) => {
-        send_follow_community(community, person, follow, &context).await
-      }
-      UpdateCommunity(actor, community) => send_update_community(community, actor, context).await,
-      DeleteCommunity(actor, community, removed) => {
-        let deletable = DeletableObjects::Community(community.clone().into());
-        send_apub_delete_in_community(actor, community, deletable, None, removed, &context).await
-      }
-      RemoveCommunity(actor, community, reason, removed) => {
-        let deletable = DeletableObjects::Community(community.clone().into());
-        send_apub_delete_in_community(
-          actor,
-          community,
-          deletable,
-          reason.clone().or_else(|| Some(String::new())),
-          removed,
-          &context,
-        )
-        .await
-      }
-      AddModToCommunity(actor, community_id, updated_mod_id, added) => {
-        send_add_mod_to_community(actor, community_id, updated_mod_id, added, context).await
-      }
-      BanFromCommunity(mod_, community_id, target, data) => {
-        send_ban_from_community(mod_, community_id, target, data, context).await
-      }
-      BanFromSite(mod_, target, data) => send_ban_from_site(mod_, target, data, context).await,
-      CreatePrivateMessage(pm) => {
-        send_create_or_update_pm(pm, CreateOrUpdateType::Create, context).await
-      }
-      UpdatePrivateMessage(pm) => {
-        send_create_or_update_pm(pm, CreateOrUpdateType::Update, context).await
-      }
-      DeletePrivateMessage(person, pm, deleted) => {
-        send_apub_delete_private_message(&person.into(), pm, deleted, context).await
-      }
-      DeleteUser(person, delete_content) => delete_user(person, delete_content, context).await,
-      CreateReport(url, actor, community, reason) => {
-        Report::send(ObjectId::from(url), actor, community, reason, context).await
-      }
+    let context = context.reset_request_count();
+    let fed_task = async {
+        use SendActivityData::*;
+        match data {
+            CreatePost(post) => {
+                let creator_id = post.creator_id;
+                CreateOrUpdatePage::send(post, creator_id, CreateOrUpdateType::Create, context)
+                    .await
+            }
+            UpdatePost(post) => {
+                let creator_id = post.creator_id;
+                CreateOrUpdatePage::send(post, creator_id, CreateOrUpdateType::Update, context)
+                    .await
+            }
+            DeletePost(post, person, data) => {
+                send_apub_delete_in_community_new(
+                    person,
+                    post.community_id,
+                    DeletableObjects::Post(post.into()),
+                    None,
+                    data.deleted,
+                    context,
+                )
+                .await
+            }
+            RemovePost(post, person, data) => {
+                send_apub_delete_in_community_new(
+                    person,
+                    post.community_id,
+                    DeletableObjects::Post(post.into()),
+                    data.reason.or_else(|| Some(String::new())),
+                    data.removed,
+                    context,
+                )
+                .await
+            }
+            LockPost(post, actor, locked) => send_lock_post(post, actor, locked, context).await,
+            FeaturePost(post, actor, featured) => {
+                send_feature_post(post, actor, featured, context).await
+            }
+            CreateComment(comment) => {
+                let creator_id = comment.creator_id;
+                CreateOrUpdateNote::send(comment, creator_id, CreateOrUpdateType::Create, context)
+                    .await
+            }
+            UpdateComment(comment) => {
+                let creator_id = comment.creator_id;
+                CreateOrUpdateNote::send(comment, creator_id, CreateOrUpdateType::Update, context)
+                    .await
+            }
+            DeleteComment(comment, actor, community) => {
+                let is_deleted = comment.deleted;
+                let deletable = DeletableObjects::Comment(comment.into());
+                send_apub_delete_in_community(
+                    actor, community, deletable, None, is_deleted, &context,
+                )
+                .await
+            }
+            RemoveComment(comment, actor, community, reason) => {
+                let is_removed = comment.removed;
+                let deletable = DeletableObjects::Comment(comment.into());
+                send_apub_delete_in_community(
+                    actor, community, deletable, reason, is_removed, &context,
+                )
+                .await
+            }
+            LikePostOrComment(object_id, person, community, score) => {
+                send_like_activity(object_id, person, community, score, context).await
+            }
+            FollowCommunity(community, person, follow) => {
+                send_follow_community(community, person, follow, &context).await
+            }
+            UpdateCommunity(actor, community) => {
+                send_update_community(community, actor, context).await
+            }
+            DeleteCommunity(actor, community, removed) => {
+                let deletable = DeletableObjects::Community(community.clone().into());
+                send_apub_delete_in_community(actor, community, deletable, None, removed, &context)
+                    .await
+            }
+            RemoveCommunity(actor, community, reason, removed) => {
+                let deletable = DeletableObjects::Community(community.clone().into());
+                send_apub_delete_in_community(
+                    actor,
+                    community,
+                    deletable,
+                    reason.clone().or_else(|| Some(String::new())),
+                    removed,
+                    &context,
+                )
+                .await
+            }
+            AddModToCommunity(actor, community_id, updated_mod_id, added) => {
+                send_add_mod_to_community(actor, community_id, updated_mod_id, added, context).await
+            }
+            BanFromCommunity(mod_, community_id, target, data) => {
+                send_ban_from_community(mod_, community_id, target, data, context).await
+            }
+            BanFromSite(mod_, target, data) => {
+                send_ban_from_site(mod_, target, data, context).await
+            }
+            CreatePrivateMessage(pm) => {
+                send_create_or_update_pm(pm, CreateOrUpdateType::Create, context).await
+            }
+            UpdatePrivateMessage(pm) => {
+                send_create_or_update_pm(pm, CreateOrUpdateType::Update, context).await
+            }
+            DeletePrivateMessage(person, pm, deleted) => {
+                send_apub_delete_private_message(&person.into(), pm, deleted, context).await
+            }
+            DeleteUser(person, delete_content) => {
+                delete_user(person, delete_content, context).await
+            }
+            CreateReport(url, actor, community, reason) => {
+                Report::send(ObjectId::from(url), actor, community, reason, context).await
+            }
+        }
+    };
+    if *SYNCHRONOUS_FEDERATION {
+        fed_task.await?;
+    } else {
+        spawn_try_task(fed_task);
     }
-  };
-  if *SYNCHRONOUS_FEDERATION {
-    fed_task.await?;
-  } else {
-    spawn_try_task(fed_task);
-  }
-  Ok(())
+    Ok(())
 }

--- a/crates/apub/src/activities/voting/mod.rs
+++ b/crates/apub/src/activities/voting/mod.rs
@@ -1,24 +1,24 @@
 use crate::{
-  activities::community::send_activity_in_community,
-  activity_lists::AnnouncableActivities,
-  fetcher::post_or_comment::PostOrComment,
-  objects::{comment::ApubComment, community::ApubCommunity, person::ApubPerson, post::ApubPost},
-  protocol::activities::voting::{
-    undo_vote::UndoVote,
-    vote::{Vote, VoteType},
-  },
+    activities::community::send_activity_in_community,
+    activity_lists::AnnouncableActivities,
+    fetcher::post_or_comment::PostOrComment,
+    objects::{comment::ApubComment, community::ApubCommunity, person::ApubPerson, post::ApubPost},
+    protocol::activities::voting::{
+        undo_vote::UndoVote,
+        vote::{Vote, VoteType},
+    },
 };
 use activitypub_federation::{config::Data, fetch::object_id::ObjectId};
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::{
-  newtypes::DbUrl,
-  source::{
-    comment::{CommentLike, CommentLikeForm},
-    community::Community,
-    person::Person,
-    post::{PostLike, PostLikeForm},
-  },
-  traits::Likeable,
+    newtypes::DbUrl,
+    source::{
+        comment::{CommentLike, CommentLikeForm},
+        community::Community,
+        person::Person,
+        post::{PostLike, PostLikeForm},
+    },
+    traits::Likeable,
 };
 use lemmy_utils::error::LemmyError;
 
@@ -26,89 +26,89 @@ pub mod undo_vote;
 pub mod vote;
 
 pub(crate) async fn send_like_activity(
-  object_id: DbUrl,
-  actor: Person,
-  community: Community,
-  score: i16,
-  context: Data<LemmyContext>,
+    object_id: DbUrl,
+    actor: Person,
+    community: Community,
+    score: i16,
+    context: Data<LemmyContext>,
 ) -> Result<(), LemmyError> {
-  let object_id: ObjectId<PostOrComment> = object_id.try_into()?;
-  let actor: ApubPerson = actor.into();
-  let community: ApubCommunity = community.into();
+    let object_id: ObjectId<PostOrComment> = object_id.try_into()?;
+    let actor: ApubPerson = actor.into();
+    let community: ApubCommunity = community.into();
 
-  // score of 1 means upvote, -1 downvote, 0 undo a previous vote
-  if score != 0 {
-    let vote = Vote::new(object_id, &actor, &community, score.try_into()?, &context)?;
-    let activity = AnnouncableActivities::Vote(vote);
-    send_activity_in_community(activity, &actor, &community, vec![], false, &context).await
-  } else {
-    // Lemmy API doesnt distinguish between Undo/Like and Undo/Dislike, so we hardcode it here.
-    let vote = Vote::new(object_id, &actor, &community, VoteType::Like, &context)?;
-    let undo_vote = UndoVote::new(vote, &actor, &community, &context)?;
-    let activity = AnnouncableActivities::UndoVote(undo_vote);
-    send_activity_in_community(activity, &actor, &community, vec![], false, &context).await
-  }
+    // score of 1 means upvote, -1 downvote, 0 undo a previous vote
+    if score != 0 {
+        let vote = Vote::new(object_id, &actor, &community, score.try_into()?, &context)?;
+        let activity = AnnouncableActivities::Vote(vote);
+        send_activity_in_community(activity, &actor, &community, vec![], false, &context).await
+    } else {
+        // Lemmy API doesnt distinguish between Undo/Like and Undo/Dislike, so we hardcode it here.
+        let vote = Vote::new(object_id, &actor, &community, VoteType::Like, &context)?;
+        let undo_vote = UndoVote::new(vote, &actor, &community, &context)?;
+        let activity = AnnouncableActivities::UndoVote(undo_vote);
+        send_activity_in_community(activity, &actor, &community, vec![], false, &context).await
+    }
 }
 
 #[tracing::instrument(skip_all)]
 async fn vote_comment(
-  vote_type: &VoteType,
-  actor: ApubPerson,
-  comment: &ApubComment,
-  context: &Data<LemmyContext>,
+    vote_type: &VoteType,
+    actor: ApubPerson,
+    comment: &ApubComment,
+    context: &Data<LemmyContext>,
 ) -> Result<(), LemmyError> {
-  let comment_id = comment.id;
-  let like_form = CommentLikeForm {
-    comment_id,
-    post_id: comment.post_id,
-    person_id: actor.id,
-    score: vote_type.into(),
-  };
-  let person_id = actor.id;
-  CommentLike::remove(&mut context.pool(), person_id, comment_id).await?;
-  CommentLike::like(&mut context.pool(), &like_form).await?;
-  Ok(())
+    let comment_id = comment.id;
+    let like_form = CommentLikeForm {
+        comment_id,
+        post_id: comment.post_id,
+        person_id: actor.id,
+        score: vote_type.into(),
+    };
+    let person_id = actor.id;
+    CommentLike::remove(&mut context.pool(), person_id, comment_id).await?;
+    CommentLike::like(&mut context.pool(), &like_form).await?;
+    Ok(())
 }
 
 #[tracing::instrument(skip_all)]
 async fn vote_post(
-  vote_type: &VoteType,
-  actor: ApubPerson,
-  post: &ApubPost,
-  context: &Data<LemmyContext>,
+    vote_type: &VoteType,
+    actor: ApubPerson,
+    post: &ApubPost,
+    context: &Data<LemmyContext>,
 ) -> Result<(), LemmyError> {
-  let post_id = post.id;
-  let like_form = PostLikeForm {
-    post_id: post.id,
-    person_id: actor.id,
-    score: vote_type.into(),
-  };
-  let person_id = actor.id;
-  PostLike::remove(&mut context.pool(), person_id, post_id).await?;
-  PostLike::like(&mut context.pool(), &like_form).await?;
-  Ok(())
+    let post_id = post.id;
+    let like_form = PostLikeForm {
+        post_id: post.id,
+        person_id: actor.id,
+        score: vote_type.into(),
+    };
+    let person_id = actor.id;
+    PostLike::remove(&mut context.pool(), person_id, post_id).await?;
+    PostLike::like(&mut context.pool(), &like_form).await?;
+    Ok(())
 }
 
 #[tracing::instrument(skip_all)]
 async fn undo_vote_comment(
-  actor: ApubPerson,
-  comment: &ApubComment,
-  context: &Data<LemmyContext>,
+    actor: ApubPerson,
+    comment: &ApubComment,
+    context: &Data<LemmyContext>,
 ) -> Result<(), LemmyError> {
-  let comment_id = comment.id;
-  let person_id = actor.id;
-  CommentLike::remove(&mut context.pool(), person_id, comment_id).await?;
-  Ok(())
+    let comment_id = comment.id;
+    let person_id = actor.id;
+    CommentLike::remove(&mut context.pool(), person_id, comment_id).await?;
+    Ok(())
 }
 
 #[tracing::instrument(skip_all)]
 async fn undo_vote_post(
-  actor: ApubPerson,
-  post: &ApubPost,
-  context: &Data<LemmyContext>,
+    actor: ApubPerson,
+    post: &ApubPost,
+    context: &Data<LemmyContext>,
 ) -> Result<(), LemmyError> {
-  let post_id = post.id;
-  let person_id = actor.id;
-  PostLike::remove(&mut context.pool(), person_id, post_id).await?;
-  Ok(())
+    let post_id = post.id;
+    let person_id = actor.id;
+    PostLike::remove(&mut context.pool(), person_id, post_id).await?;
+    Ok(())
 }

--- a/crates/apub/src/activities/voting/undo_vote.rs
+++ b/crates/apub/src/activities/voting/undo_vote.rs
@@ -1,77 +1,76 @@
 use crate::{
-  activities::{
-    generate_activity_id,
-    verify_person_in_community,
-    voting::{undo_vote_comment, undo_vote_post},
-  },
-  insert_received_activity,
-  objects::{community::ApubCommunity, person::ApubPerson},
-  protocol::{
-    activities::voting::{undo_vote::UndoVote, vote::Vote},
-    InCommunity,
-  },
-  PostOrComment,
+    activities::{
+        generate_activity_id, verify_person_in_community,
+        voting::{undo_vote_comment, undo_vote_post},
+    },
+    insert_received_activity,
+    objects::{community::ApubCommunity, person::ApubPerson},
+    protocol::{
+        activities::voting::{undo_vote::UndoVote, vote::Vote},
+        InCommunity,
+    },
+    PostOrComment,
 };
 use activitypub_federation::{
-  config::Data,
-  kinds::activity::UndoType,
-  protocol::verification::verify_urls_match,
-  traits::{ActivityHandler, Actor},
+    config::Data,
+    kinds::activity::UndoType,
+    protocol::verification::verify_urls_match,
+    traits::{ActivityHandler, Actor},
 };
 use lemmy_api_common::context::LemmyContext;
 use lemmy_utils::error::LemmyError;
 use url::Url;
 
 impl UndoVote {
-  pub(in crate::activities::voting) fn new(
-    vote: Vote,
-    actor: &ApubPerson,
-    community: &ApubCommunity,
-    context: &Data<LemmyContext>,
-  ) -> Result<Self, LemmyError> {
-    Ok(UndoVote {
-      actor: actor.id().into(),
-      object: vote,
-      kind: UndoType::Undo,
-      id: generate_activity_id(
-        UndoType::Undo,
-        &context.settings().get_protocol_and_hostname(),
-      )?,
-      audience: Some(community.id().into()),
-    })
-  }
+    pub(in crate::activities::voting) fn new(
+        vote: Vote,
+        actor: &ApubPerson,
+        community: &ApubCommunity,
+        context: &Data<LemmyContext>,
+    ) -> Result<Self, LemmyError> {
+        Ok(UndoVote {
+            actor: actor.id().into(),
+            object: vote,
+            kind: UndoType::Undo,
+            id: generate_activity_id(
+                UndoType::Undo,
+                &context.settings().get_protocol_and_hostname(),
+            )?,
+            audience: Some(community.id().into()),
+        })
+    }
 }
 
 #[async_trait::async_trait]
 impl ActivityHandler for UndoVote {
-  type DataType = LemmyContext;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Error = LemmyError;
 
-  fn id(&self) -> &Url {
-    &self.id
-  }
-
-  fn actor(&self) -> &Url {
-    self.actor.inner()
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
-    insert_received_activity(&self.id, context).await?;
-    let community = self.community(context).await?;
-    verify_person_in_community(&self.actor, &community, context).await?;
-    verify_urls_match(self.actor.inner(), self.object.actor.inner())?;
-    self.object.verify(context).await?;
-    Ok(())
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
-    let actor = self.actor.dereference(context).await?;
-    let object = self.object.object.dereference(context).await?;
-    match object {
-      PostOrComment::Post(p) => undo_vote_post(actor, &p, context).await,
-      PostOrComment::Comment(c) => undo_vote_comment(actor, &c, context).await,
+    fn id(&self) -> &Url {
+        &self.id
     }
-  }
+
+    fn actor(&self) -> &Url {
+        self.actor.inner()
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn verify(&self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+        insert_received_activity(&self.id, context).await?;
+        let community = self.community(context).await?;
+        verify_person_in_community(&self.actor, &community, context).await?;
+        verify_urls_match(self.actor.inner(), self.object.actor.inner())?;
+        self.object.verify(context).await?;
+        Ok(())
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+        let actor = self.actor.dereference(context).await?;
+        let object = self.object.object.dereference(context).await?;
+        match object {
+            PostOrComment::Post(p) => undo_vote_post(actor, &p, context).await,
+            PostOrComment::Comment(c) => undo_vote_comment(actor, &c, context).await,
+        }
+    }
 }

--- a/crates/apub/src/activities/voting/vote.rs
+++ b/crates/apub/src/activities/voting/vote.rs
@@ -1,21 +1,20 @@
 use crate::{
-  activities::{
-    generate_activity_id,
-    verify_person_in_community,
-    voting::{vote_comment, vote_post},
-  },
-  insert_received_activity,
-  objects::{community::ApubCommunity, person::ApubPerson},
-  protocol::{
-    activities::voting::vote::{Vote, VoteType},
-    InCommunity,
-  },
-  PostOrComment,
+    activities::{
+        generate_activity_id, verify_person_in_community,
+        voting::{vote_comment, vote_post},
+    },
+    insert_received_activity,
+    objects::{community::ApubCommunity, person::ApubPerson},
+    protocol::{
+        activities::voting::vote::{Vote, VoteType},
+        InCommunity,
+    },
+    PostOrComment,
 };
 use activitypub_federation::{
-  config::Data,
-  fetch::object_id::ObjectId,
-  traits::{ActivityHandler, Actor},
+    config::Data,
+    fetch::object_id::ObjectId,
+    traits::{ActivityHandler, Actor},
 };
 use anyhow::anyhow;
 use lemmy_api_common::context::LemmyContext;
@@ -24,59 +23,59 @@ use lemmy_utils::error::LemmyError;
 use url::Url;
 
 impl Vote {
-  pub(in crate::activities::voting) fn new(
-    object_id: ObjectId<PostOrComment>,
-    actor: &ApubPerson,
-    community: &ApubCommunity,
-    kind: VoteType,
-    context: &Data<LemmyContext>,
-  ) -> Result<Vote, LemmyError> {
-    Ok(Vote {
-      actor: actor.id().into(),
-      object: object_id,
-      kind: kind.clone(),
-      id: generate_activity_id(kind, &context.settings().get_protocol_and_hostname())?,
-      audience: Some(community.id().into()),
-    })
-  }
+    pub(in crate::activities::voting) fn new(
+        object_id: ObjectId<PostOrComment>,
+        actor: &ApubPerson,
+        community: &ApubCommunity,
+        kind: VoteType,
+        context: &Data<LemmyContext>,
+    ) -> Result<Vote, LemmyError> {
+        Ok(Vote {
+            actor: actor.id().into(),
+            object: object_id,
+            kind: kind.clone(),
+            id: generate_activity_id(kind, &context.settings().get_protocol_and_hostname())?,
+            audience: Some(community.id().into()),
+        })
+    }
 }
 
 #[async_trait::async_trait]
 impl ActivityHandler for Vote {
-  type DataType = LemmyContext;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Error = LemmyError;
 
-  fn id(&self) -> &Url {
-    &self.id
-  }
-
-  fn actor(&self) -> &Url {
-    self.actor.inner()
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
-    insert_received_activity(&self.id, context).await?;
-    let community = self.community(context).await?;
-    verify_person_in_community(&self.actor, &community, context).await?;
-    let enable_downvotes = LocalSite::read(&mut context.pool())
-      .await
-      .map(|l| l.enable_downvotes)
-      .unwrap_or(true);
-    if self.kind == VoteType::Dislike && !enable_downvotes {
-      Err(anyhow!("Downvotes disabled").into())
-    } else {
-      Ok(())
+    fn id(&self) -> &Url {
+        &self.id
     }
-  }
 
-  #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
-    let actor = self.actor.dereference(context).await?;
-    let object = self.object.dereference(context).await?;
-    match object {
-      PostOrComment::Post(p) => vote_post(&self.kind, actor, &p, context).await,
-      PostOrComment::Comment(c) => vote_comment(&self.kind, actor, &c, context).await,
+    fn actor(&self) -> &Url {
+        self.actor.inner()
     }
-  }
+
+    #[tracing::instrument(skip_all)]
+    async fn verify(&self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+        insert_received_activity(&self.id, context).await?;
+        let community = self.community(context).await?;
+        verify_person_in_community(&self.actor, &community, context).await?;
+        let enable_downvotes = LocalSite::read(&mut context.pool())
+            .await
+            .map(|l| l.enable_downvotes)
+            .unwrap_or(true);
+        if self.kind == VoteType::Dislike && !enable_downvotes {
+            Err(anyhow!("Downvotes disabled").into())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+        let actor = self.actor.dereference(context).await?;
+        let object = self.object.dereference(context).await?;
+        match object {
+            PostOrComment::Post(p) => vote_post(&self.kind, actor, &p, context).await,
+            PostOrComment::Comment(c) => vote_comment(&self.kind, actor, &c, context).await,
+        }
+    }
 }

--- a/crates/apub/src/activity_lists.rs
+++ b/crates/apub/src/activity_lists.rs
@@ -1,28 +1,27 @@
 use crate::{
-  objects::community::ApubCommunity,
-  protocol::{
-    activities::{
-      block::{block_user::BlockUser, undo_block_user::UndoBlockUser},
-      community::{
-        announce::{AnnounceActivity, RawAnnouncableActivities},
-        collection_add::CollectionAdd,
-        collection_remove::CollectionRemove,
-        lock_page::{LockPage, UndoLockPage},
-        report::Report,
-        update::UpdateCommunity,
-      },
-      create_or_update::{
-        chat_message::CreateOrUpdateChatMessage,
-        note::CreateOrUpdateNote,
-        page::CreateOrUpdatePage,
-      },
-      deletion::{delete::Delete, delete_user::DeleteUser, undo_delete::UndoDelete},
-      following::{accept::AcceptFollow, follow::Follow, undo_follow::UndoFollow},
-      voting::{undo_vote::UndoVote, vote::Vote},
+    objects::community::ApubCommunity,
+    protocol::{
+        activities::{
+            block::{block_user::BlockUser, undo_block_user::UndoBlockUser},
+            community::{
+                announce::{AnnounceActivity, RawAnnouncableActivities},
+                collection_add::CollectionAdd,
+                collection_remove::CollectionRemove,
+                lock_page::{LockPage, UndoLockPage},
+                report::Report,
+                update::UpdateCommunity,
+            },
+            create_or_update::{
+                chat_message::CreateOrUpdateChatMessage, note::CreateOrUpdateNote,
+                page::CreateOrUpdatePage,
+            },
+            deletion::{delete::Delete, delete_user::DeleteUser, undo_delete::UndoDelete},
+            following::{accept::AcceptFollow, follow::Follow, undo_follow::UndoFollow},
+            voting::{undo_vote::UndoVote, vote::Vote},
+        },
+        objects::page::Page,
+        InCommunity,
     },
-    objects::page::Page,
-    InCommunity,
-  },
 };
 use activitypub_federation::{config::Data, traits::ActivityHandler};
 use lemmy_api_common::context::LemmyContext;
@@ -39,14 +38,14 @@ use url::Url;
 #[serde(untagged)]
 #[enum_delegate::implement(ActivityHandler)]
 pub enum SharedInboxActivities {
-  Follow(Follow),
-  AcceptFollow(AcceptFollow),
-  UndoFollow(UndoFollow),
-  CreateOrUpdatePrivateMessage(CreateOrUpdateChatMessage),
-  Report(Report),
-  AnnounceActivity(AnnounceActivity),
-  /// This is a catch-all and needs to be last
-  RawAnnouncableActivities(RawAnnouncableActivities),
+    Follow(Follow),
+    AcceptFollow(AcceptFollow),
+    UndoFollow(UndoFollow),
+    CreateOrUpdatePrivateMessage(CreateOrUpdateChatMessage),
+    Report(Report),
+    AnnounceActivity(AnnounceActivity),
+    /// This is a catch-all and needs to be last
+    RawAnnouncableActivities(RawAnnouncableActivities),
 }
 
 /// List of activities which the group inbox can handle.
@@ -54,11 +53,11 @@ pub enum SharedInboxActivities {
 #[serde(untagged)]
 #[enum_delegate::implement(ActivityHandler)]
 pub enum GroupInboxActivities {
-  Follow(Follow),
-  UndoFollow(UndoFollow),
-  Report(Report),
-  /// This is a catch-all and needs to be last
-  AnnouncableActivities(RawAnnouncableActivities),
+    Follow(Follow),
+    UndoFollow(UndoFollow),
+    Report(Report),
+    /// This is a catch-all and needs to be last
+    AnnouncableActivities(RawAnnouncableActivities),
 }
 
 /// List of activities which the person inbox can handle.
@@ -66,36 +65,36 @@ pub enum GroupInboxActivities {
 #[serde(untagged)]
 #[enum_delegate::implement(ActivityHandler)]
 pub enum PersonInboxActivities {
-  Follow(Follow),
-  AcceptFollow(AcceptFollow),
-  UndoFollow(UndoFollow),
-  CreateOrUpdatePrivateMessage(CreateOrUpdateChatMessage),
-  Delete(Delete),
-  UndoDelete(UndoDelete),
-  AnnounceActivity(AnnounceActivity),
-  /// User can also receive some "announcable" activities, eg a comment mention.
-  AnnouncableActivities(AnnouncableActivities),
+    Follow(Follow),
+    AcceptFollow(AcceptFollow),
+    UndoFollow(UndoFollow),
+    CreateOrUpdatePrivateMessage(CreateOrUpdateChatMessage),
+    Delete(Delete),
+    UndoDelete(UndoDelete),
+    AnnounceActivity(AnnounceActivity),
+    /// User can also receive some "announcable" activities, eg a comment mention.
+    AnnouncableActivities(AnnouncableActivities),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 #[enum_delegate::implement(ActivityHandler)]
 pub enum AnnouncableActivities {
-  CreateOrUpdateComment(CreateOrUpdateNote),
-  CreateOrUpdatePost(CreateOrUpdatePage),
-  Vote(Vote),
-  UndoVote(UndoVote),
-  Delete(Delete),
-  UndoDelete(UndoDelete),
-  UpdateCommunity(UpdateCommunity),
-  BlockUser(BlockUser),
-  UndoBlockUser(UndoBlockUser),
-  CollectionAdd(CollectionAdd),
-  CollectionRemove(CollectionRemove),
-  LockPost(LockPage),
-  UndoLockPost(UndoLockPage),
-  // For compatibility with Pleroma/Mastodon (send only)
-  Page(Page),
+    CreateOrUpdateComment(CreateOrUpdateNote),
+    CreateOrUpdatePost(CreateOrUpdatePage),
+    Vote(Vote),
+    UndoVote(UndoVote),
+    Delete(Delete),
+    UndoDelete(UndoDelete),
+    UpdateCommunity(UpdateCommunity),
+    BlockUser(BlockUser),
+    UndoBlockUser(UndoBlockUser),
+    CollectionAdd(CollectionAdd),
+    CollectionRemove(CollectionRemove),
+    LockPost(LockPage),
+    UndoLockPost(UndoLockPage),
+    // For compatibility with Pleroma/Mastodon (send only)
+    Page(Page),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -103,75 +102,79 @@ pub enum AnnouncableActivities {
 #[enum_delegate::implement(ActivityHandler)]
 #[allow(clippy::enum_variant_names)]
 pub enum SiteInboxActivities {
-  BlockUser(BlockUser),
-  UndoBlockUser(UndoBlockUser),
-  DeleteUser(DeleteUser),
+    BlockUser(BlockUser),
+    UndoBlockUser(UndoBlockUser),
+    DeleteUser(DeleteUser),
 }
 
 #[async_trait::async_trait]
 impl InCommunity for AnnouncableActivities {
-  #[tracing::instrument(skip(self, context))]
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
-    use AnnouncableActivities::*;
-    match self {
-      CreateOrUpdateComment(a) => a.community(context).await,
-      CreateOrUpdatePost(a) => a.community(context).await,
-      Vote(a) => a.community(context).await,
-      UndoVote(a) => a.community(context).await,
-      Delete(a) => a.community(context).await,
-      UndoDelete(a) => a.community(context).await,
-      UpdateCommunity(a) => a.community(context).await,
-      BlockUser(a) => a.community(context).await,
-      UndoBlockUser(a) => a.community(context).await,
-      CollectionAdd(a) => a.community(context).await,
-      CollectionRemove(a) => a.community(context).await,
-      LockPost(a) => a.community(context).await,
-      UndoLockPost(a) => a.community(context).await,
-      Page(_) => unimplemented!(),
+    #[tracing::instrument(skip(self, context))]
+    async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+        use AnnouncableActivities::*;
+        match self {
+            CreateOrUpdateComment(a) => a.community(context).await,
+            CreateOrUpdatePost(a) => a.community(context).await,
+            Vote(a) => a.community(context).await,
+            UndoVote(a) => a.community(context).await,
+            Delete(a) => a.community(context).await,
+            UndoDelete(a) => a.community(context).await,
+            UpdateCommunity(a) => a.community(context).await,
+            BlockUser(a) => a.community(context).await,
+            UndoBlockUser(a) => a.community(context).await,
+            CollectionAdd(a) => a.community(context).await,
+            CollectionRemove(a) => a.community(context).await,
+            LockPost(a) => a.community(context).await,
+            UndoLockPost(a) => a.community(context).await,
+            Page(_) => unimplemented!(),
+        }
     }
-  }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::{
-    activity_lists::{GroupInboxActivities, PersonInboxActivities, SiteInboxActivities},
-    protocol::tests::{test_json, test_parse_lemmy_item},
-  };
+    use crate::{
+        activity_lists::{GroupInboxActivities, PersonInboxActivities, SiteInboxActivities},
+        protocol::tests::{test_json, test_parse_lemmy_item},
+    };
 
-  #[test]
-  fn test_group_inbox() {
-    test_parse_lemmy_item::<GroupInboxActivities>("assets/lemmy/activities/following/follow.json")
-      .unwrap();
-    test_parse_lemmy_item::<GroupInboxActivities>(
-      "assets/lemmy/activities/create_or_update/create_note.json",
-    )
-    .unwrap();
-  }
+    #[test]
+    fn test_group_inbox() {
+        test_parse_lemmy_item::<GroupInboxActivities>(
+            "assets/lemmy/activities/following/follow.json",
+        )
+        .unwrap();
+        test_parse_lemmy_item::<GroupInboxActivities>(
+            "assets/lemmy/activities/create_or_update/create_note.json",
+        )
+        .unwrap();
+    }
 
-  #[test]
-  fn test_person_inbox() {
-    test_parse_lemmy_item::<PersonInboxActivities>("assets/lemmy/activities/following/accept.json")
-      .unwrap();
-    test_parse_lemmy_item::<PersonInboxActivities>(
-      "assets/lemmy/activities/create_or_update/create_note.json",
-    )
-    .unwrap();
-    test_parse_lemmy_item::<PersonInboxActivities>(
-      "assets/lemmy/activities/create_or_update/create_private_message.json",
-    )
-    .unwrap();
-    test_json::<PersonInboxActivities>("assets/mastodon/activities/follow.json").unwrap();
-  }
+    #[test]
+    fn test_person_inbox() {
+        test_parse_lemmy_item::<PersonInboxActivities>(
+            "assets/lemmy/activities/following/accept.json",
+        )
+        .unwrap();
+        test_parse_lemmy_item::<PersonInboxActivities>(
+            "assets/lemmy/activities/create_or_update/create_note.json",
+        )
+        .unwrap();
+        test_parse_lemmy_item::<PersonInboxActivities>(
+            "assets/lemmy/activities/create_or_update/create_private_message.json",
+        )
+        .unwrap();
+        test_json::<PersonInboxActivities>("assets/mastodon/activities/follow.json").unwrap();
+    }
 
-  #[test]
-  fn test_site_inbox() {
-    test_parse_lemmy_item::<SiteInboxActivities>(
-      "assets/lemmy/activities/deletion/delete_user.json",
-    )
-    .unwrap();
-  }
+    #[test]
+    fn test_site_inbox() {
+        test_parse_lemmy_item::<SiteInboxActivities>(
+            "assets/lemmy/activities/deletion/delete_user.json",
+        )
+        .unwrap();
+    }
 }

--- a/crates/apub/src/api/list_comments.rs
+++ b/crates/apub/src/api/list_comments.rs
@@ -1,85 +1,87 @@
 use crate::{
-  api::listing_type_with_default,
-  fetcher::resolve_actor_identifier,
-  objects::community::ApubCommunity,
+    api::listing_type_with_default, fetcher::resolve_actor_identifier,
+    objects::community::ApubCommunity,
 };
 use activitypub_federation::config::Data;
 use actix_web::web::{Json, Query};
 use lemmy_api_common::{
-  comment::{GetComments, GetCommentsResponse},
-  context::LemmyContext,
-  utils::{check_private_instance, local_user_view_from_jwt_opt_new},
+    comment::{GetComments, GetCommentsResponse},
+    context::LemmyContext,
+    utils::{check_private_instance, local_user_view_from_jwt_opt_new},
 };
 use lemmy_db_schema::{
-  source::{comment::Comment, community::Community, local_site::LocalSite},
-  traits::Crud,
+    source::{comment::Comment, community::Community, local_site::LocalSite},
+    traits::Crud,
 };
 use lemmy_db_views::{comment_view::CommentQuery, structs::LocalUserView};
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn list_comments(
-  data: Query<GetComments>,
-  context: Data<LemmyContext>,
-  mut local_user_view: Option<LocalUserView>,
+    data: Query<GetComments>,
+    context: Data<LemmyContext>,
+    mut local_user_view: Option<LocalUserView>,
 ) -> Result<Json<GetCommentsResponse>, LemmyError> {
-  local_user_view_from_jwt_opt_new(&mut local_user_view, data.auth.as_ref(), &context).await;
-  let local_site = LocalSite::read(&mut context.pool()).await?;
-  check_private_instance(&local_user_view, &local_site)?;
+    local_user_view_from_jwt_opt_new(&mut local_user_view, data.auth.as_ref(), &context).await;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
+    check_private_instance(&local_user_view, &local_site)?;
 
-  let community_id = if let Some(name) = &data.community_name {
-    Some(resolve_actor_identifier::<ApubCommunity, Community>(name, &context, &None, true).await?)
-      .map(|c| c.id)
-  } else {
-    data.community_id
-  };
-  let sort = data.sort;
-  let max_depth = data.max_depth;
-  let saved_only = data.saved_only.unwrap_or_default();
+    let community_id = if let Some(name) = &data.community_name {
+        Some(
+            resolve_actor_identifier::<ApubCommunity, Community>(name, &context, &None, true)
+                .await?,
+        )
+        .map(|c| c.id)
+    } else {
+        data.community_id
+    };
+    let sort = data.sort;
+    let max_depth = data.max_depth;
+    let saved_only = data.saved_only.unwrap_or_default();
 
-  let liked_only = data.liked_only.unwrap_or_default();
-  let disliked_only = data.disliked_only.unwrap_or_default();
-  if liked_only && disliked_only {
-    return Err(LemmyError::from(LemmyErrorType::ContradictingFilters));
-  }
+    let liked_only = data.liked_only.unwrap_or_default();
+    let disliked_only = data.disliked_only.unwrap_or_default();
+    if liked_only && disliked_only {
+        return Err(LemmyError::from(LemmyErrorType::ContradictingFilters));
+    }
 
-  let page = data.page;
-  let limit = data.limit;
-  let parent_id = data.parent_id;
+    let page = data.page;
+    let limit = data.limit;
+    let parent_id = data.parent_id;
 
-  let listing_type = Some(listing_type_with_default(
-    data.type_,
-    &local_site,
-    community_id,
-  )?);
+    let listing_type = Some(listing_type_with_default(
+        data.type_,
+        &local_site,
+        community_id,
+    )?);
 
-  // If a parent_id is given, fetch the comment to get the path
-  let parent_path = if let Some(parent_id) = parent_id {
-    Some(Comment::read(&mut context.pool(), parent_id).await?.path)
-  } else {
-    None
-  };
+    // If a parent_id is given, fetch the comment to get the path
+    let parent_path = if let Some(parent_id) = parent_id {
+        Some(Comment::read(&mut context.pool(), parent_id).await?.path)
+    } else {
+        None
+    };
 
-  let parent_path_cloned = parent_path.clone();
-  let post_id = data.post_id;
-  let comments = CommentQuery {
-    listing_type,
-    sort,
-    max_depth,
-    saved_only,
-    liked_only,
-    disliked_only,
-    community_id,
-    parent_path: parent_path_cloned,
-    post_id,
-    local_user: local_user_view.as_ref(),
-    page,
-    limit,
-    ..Default::default()
-  }
-  .list(&mut context.pool())
-  .await
-  .with_lemmy_type(LemmyErrorType::CouldntGetComments)?;
+    let parent_path_cloned = parent_path.clone();
+    let post_id = data.post_id;
+    let comments = CommentQuery {
+        listing_type,
+        sort,
+        max_depth,
+        saved_only,
+        liked_only,
+        disliked_only,
+        community_id,
+        parent_path: parent_path_cloned,
+        post_id,
+        local_user: local_user_view.as_ref(),
+        page,
+        limit,
+        ..Default::default()
+    }
+    .list(&mut context.pool())
+    .await
+    .with_lemmy_type(LemmyErrorType::CouldntGetComments)?;
 
-  Ok(Json(GetCommentsResponse { comments }))
+    Ok(Json(GetCommentsResponse { comments }))
 }

--- a/crates/apub/src/api/list_posts.rs
+++ b/crates/apub/src/api/list_posts.rs
@@ -1,14 +1,13 @@
 use crate::{
-  api::listing_type_with_default,
-  fetcher::resolve_actor_identifier,
-  objects::community::ApubCommunity,
+    api::listing_type_with_default, fetcher::resolve_actor_identifier,
+    objects::community::ApubCommunity,
 };
 use activitypub_federation::config::Data;
 use actix_web::web::{Json, Query};
 use lemmy_api_common::{
-  context::LemmyContext,
-  post::{GetPosts, GetPostsResponse},
-  utils::{check_private_instance, local_user_view_from_jwt_opt_new},
+    context::LemmyContext,
+    post::{GetPosts, GetPostsResponse},
+    utils::{check_private_instance, local_user_view_from_jwt_opt_new},
 };
 use lemmy_db_schema::source::{community::Community, local_site::LocalSite};
 use lemmy_db_views::{post_view::PostQuery, structs::LocalUserView};
@@ -16,54 +15,57 @@ use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn list_posts(
-  data: Query<GetPosts>,
-  context: Data<LemmyContext>,
-  mut local_user_view: Option<LocalUserView>,
+    data: Query<GetPosts>,
+    context: Data<LemmyContext>,
+    mut local_user_view: Option<LocalUserView>,
 ) -> Result<Json<GetPostsResponse>, LemmyError> {
-  local_user_view_from_jwt_opt_new(&mut local_user_view, data.auth.as_ref(), &context).await;
-  let local_site = LocalSite::read(&mut context.pool()).await?;
+    local_user_view_from_jwt_opt_new(&mut local_user_view, data.auth.as_ref(), &context).await;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
 
-  check_private_instance(&local_user_view, &local_site)?;
+    check_private_instance(&local_user_view, &local_site)?;
 
-  let sort = data.sort;
+    let sort = data.sort;
 
-  let page = data.page;
-  let limit = data.limit;
-  let community_id = if let Some(name) = &data.community_name {
-    Some(resolve_actor_identifier::<ApubCommunity, Community>(name, &context, &None, true).await?)
-      .map(|c| c.id)
-  } else {
-    data.community_id
-  };
-  let saved_only = data.saved_only.unwrap_or_default();
+    let page = data.page;
+    let limit = data.limit;
+    let community_id = if let Some(name) = &data.community_name {
+        Some(
+            resolve_actor_identifier::<ApubCommunity, Community>(name, &context, &None, true)
+                .await?,
+        )
+        .map(|c| c.id)
+    } else {
+        data.community_id
+    };
+    let saved_only = data.saved_only.unwrap_or_default();
 
-  let liked_only = data.liked_only.unwrap_or_default();
-  let disliked_only = data.disliked_only.unwrap_or_default();
-  if liked_only && disliked_only {
-    return Err(LemmyError::from(LemmyErrorType::ContradictingFilters));
-  }
+    let liked_only = data.liked_only.unwrap_or_default();
+    let disliked_only = data.disliked_only.unwrap_or_default();
+    if liked_only && disliked_only {
+        return Err(LemmyError::from(LemmyErrorType::ContradictingFilters));
+    }
 
-  let listing_type = Some(listing_type_with_default(
-    data.type_,
-    &local_site,
-    community_id,
-  )?);
+    let listing_type = Some(listing_type_with_default(
+        data.type_,
+        &local_site,
+        community_id,
+    )?);
 
-  let posts = PostQuery {
-    local_user: local_user_view.as_ref(),
-    listing_type,
-    sort,
-    community_id,
-    saved_only,
-    liked_only,
-    disliked_only,
-    page,
-    limit,
-    ..Default::default()
-  }
-  .list(&mut context.pool())
-  .await
-  .with_lemmy_type(LemmyErrorType::CouldntGetPosts)?;
+    let posts = PostQuery {
+        local_user: local_user_view.as_ref(),
+        listing_type,
+        sort,
+        community_id,
+        saved_only,
+        liked_only,
+        disliked_only,
+        page,
+        limit,
+        ..Default::default()
+    }
+    .list(&mut context.pool())
+    .await
+    .with_lemmy_type(LemmyErrorType::CouldntGetPosts)?;
 
-  Ok(Json(GetPostsResponse { posts }))
+    Ok(Json(GetPostsResponse { posts }))
 }

--- a/crates/apub/src/api/mod.rs
+++ b/crates/apub/src/api/mod.rs
@@ -10,16 +10,16 @@ pub mod search;
 
 /// Returns default listing type, depending if the query is for frontpage or community.
 fn listing_type_with_default(
-  type_: Option<ListingType>,
-  local_site: &LocalSite,
-  community_id: Option<CommunityId>,
+    type_: Option<ListingType>,
+    local_site: &LocalSite,
+    community_id: Option<CommunityId>,
 ) -> Result<ListingType, LemmyError> {
-  // On frontpage use listing type from param or admin configured default
-  let listing_type = if community_id.is_none() {
-    type_.unwrap_or(local_site.default_post_listing_type)
-  } else {
-    // inside of community show everything
-    ListingType::All
-  };
-  Ok(listing_type)
+    // On frontpage use listing type from param or admin configured default
+    let listing_type = if community_id.is_none() {
+        type_.unwrap_or(local_site.default_post_listing_type)
+    } else {
+        // inside of community show everything
+        ListingType::All
+    };
+    Ok(listing_type)
 }

--- a/crates/apub/src/api/read_community.rs
+++ b/crates/apub/src/api/read_community.rs
@@ -2,15 +2,12 @@ use crate::{fetcher::resolve_actor_identifier, objects::community::ApubCommunity
 use activitypub_federation::config::Data;
 use actix_web::web::{Json, Query};
 use lemmy_api_common::{
-  community::{GetCommunity, GetCommunityResponse},
-  context::LemmyContext,
-  utils::{check_private_instance, is_mod_or_admin_opt, local_user_view_from_jwt_opt_new},
+    community::{GetCommunity, GetCommunityResponse},
+    context::LemmyContext,
+    utils::{check_private_instance, is_mod_or_admin_opt, local_user_view_from_jwt_opt_new},
 };
 use lemmy_db_schema::source::{
-  actor_language::CommunityLanguage,
-  community::Community,
-  local_site::LocalSite,
-  site::Site,
+    actor_language::CommunityLanguage, community::Community, local_site::LocalSite, site::Site,
 };
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_db_views_actor::structs::{CommunityModeratorView, CommunityView};
@@ -18,70 +15,76 @@ use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorExt2, LemmyErrorTy
 
 #[tracing::instrument(skip(context))]
 pub async fn get_community(
-  data: Query<GetCommunity>,
-  context: Data<LemmyContext>,
-  mut local_user_view: Option<LocalUserView>,
+    data: Query<GetCommunity>,
+    context: Data<LemmyContext>,
+    mut local_user_view: Option<LocalUserView>,
 ) -> Result<Json<GetCommunityResponse>, LemmyError> {
-  local_user_view_from_jwt_opt_new(&mut local_user_view, data.auth.as_ref(), &context).await;
-  let local_site = LocalSite::read(&mut context.pool()).await?;
+    local_user_view_from_jwt_opt_new(&mut local_user_view, data.auth.as_ref(), &context).await;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
 
-  if data.name.is_none() && data.id.is_none() {
-    Err(LemmyErrorType::NoIdGiven)?
-  }
-
-  check_private_instance(&local_user_view, &local_site)?;
-
-  let person_id = local_user_view.as_ref().map(|u| u.person.id);
-
-  let community_id = match data.id {
-    Some(id) => id,
-    None => {
-      let name = data.name.clone().unwrap_or_else(|| "main".to_string());
-      resolve_actor_identifier::<ApubCommunity, Community>(&name, &context, &local_user_view, true)
-        .await
-        .with_lemmy_type(LemmyErrorType::CouldntFindCommunity)?
-        .id
+    if data.name.is_none() && data.id.is_none() {
+        Err(LemmyErrorType::NoIdGiven)?
     }
-  };
 
-  let is_mod_or_admin = is_mod_or_admin_opt(
-    &mut context.pool(),
-    local_user_view.as_ref(),
-    Some(community_id),
-  )
-  .await
-  .is_ok();
+    check_private_instance(&local_user_view, &local_site)?;
 
-  let community_view = CommunityView::read(
-    &mut context.pool(),
-    community_id,
-    person_id,
-    is_mod_or_admin,
-  )
-  .await
-  .with_lemmy_type(LemmyErrorType::CouldntFindCommunity)?;
+    let person_id = local_user_view.as_ref().map(|u| u.person.id);
 
-  let moderators = CommunityModeratorView::for_community(&mut context.pool(), community_id)
+    let community_id = match data.id {
+        Some(id) => id,
+        None => {
+            let name = data.name.clone().unwrap_or_else(|| "main".to_string());
+            resolve_actor_identifier::<ApubCommunity, Community>(
+                &name,
+                &context,
+                &local_user_view,
+                true,
+            )
+            .await
+            .with_lemmy_type(LemmyErrorType::CouldntFindCommunity)?
+            .id
+        }
+    };
+
+    let is_mod_or_admin = is_mod_or_admin_opt(
+        &mut context.pool(),
+        local_user_view.as_ref(),
+        Some(community_id),
+    )
+    .await
+    .is_ok();
+
+    let community_view = CommunityView::read(
+        &mut context.pool(),
+        community_id,
+        person_id,
+        is_mod_or_admin,
+    )
     .await
     .with_lemmy_type(LemmyErrorType::CouldntFindCommunity)?;
 
-  let site_id = Site::instance_actor_id_from_url(community_view.community.actor_id.clone().into());
-  let mut site = Site::read_from_apub_id(&mut context.pool(), &site_id.into()).await?;
-  // no need to include metadata for local site (its already available through other endpoints).
-  // this also prevents us from leaking the federation private key.
-  if let Some(s) = &site {
-    if s.actor_id.domain() == Some(context.settings().hostname.as_ref()) {
-      site = None;
+    let moderators = CommunityModeratorView::for_community(&mut context.pool(), community_id)
+        .await
+        .with_lemmy_type(LemmyErrorType::CouldntFindCommunity)?;
+
+    let site_id =
+        Site::instance_actor_id_from_url(community_view.community.actor_id.clone().into());
+    let mut site = Site::read_from_apub_id(&mut context.pool(), &site_id.into()).await?;
+    // no need to include metadata for local site (its already available through other endpoints).
+    // this also prevents us from leaking the federation private key.
+    if let Some(s) = &site {
+        if s.actor_id.domain() == Some(context.settings().hostname.as_ref()) {
+            site = None;
+        }
     }
-  }
 
-  let community_id = community_view.community.id;
-  let discussion_languages = CommunityLanguage::read(&mut context.pool(), community_id).await?;
+    let community_id = community_view.community.id;
+    let discussion_languages = CommunityLanguage::read(&mut context.pool(), community_id).await?;
 
-  Ok(Json(GetCommunityResponse {
-    community_view,
-    site,
-    moderators,
-    discussion_languages,
-  }))
+    Ok(Json(GetCommunityResponse {
+        community_view,
+        site,
+        moderators,
+        discussion_languages,
+    }))
 }

--- a/crates/apub/src/api/read_person.rs
+++ b/crates/apub/src/api/read_person.rs
@@ -2,13 +2,13 @@ use crate::{fetcher::resolve_actor_identifier, objects::person::ApubPerson};
 use activitypub_federation::config::Data;
 use actix_web::web::{Json, Query};
 use lemmy_api_common::{
-  context::LemmyContext,
-  person::{GetPersonDetails, GetPersonDetailsResponse},
-  utils::{check_private_instance, local_user_view_from_jwt_opt_new},
+    context::LemmyContext,
+    person::{GetPersonDetails, GetPersonDetailsResponse},
+    utils::{check_private_instance, local_user_view_from_jwt_opt_new},
 };
 use lemmy_db_schema::{
-  source::{local_site::LocalSite, person::Person},
-  utils::post_to_comment_sort_type,
+    source::{local_site::LocalSite, person::Person},
+    utils::post_to_comment_sort_type,
 };
 use lemmy_db_views::{comment_view::CommentQuery, post_view::PostQuery, structs::LocalUserView};
 use lemmy_db_views_actor::structs::{CommunityModeratorView, PersonView};
@@ -16,87 +16,92 @@ use lemmy_utils::error::{LemmyError, LemmyErrorExt2, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn read_person(
-  data: Query<GetPersonDetails>,
-  context: Data<LemmyContext>,
-  mut local_user_view: Option<LocalUserView>,
+    data: Query<GetPersonDetails>,
+    context: Data<LemmyContext>,
+    mut local_user_view: Option<LocalUserView>,
 ) -> Result<Json<GetPersonDetailsResponse>, LemmyError> {
-  // Check to make sure a person name or an id is given
-  if data.username.is_none() && data.person_id.is_none() {
-    Err(LemmyErrorType::NoIdGiven)?
-  }
-
-  local_user_view_from_jwt_opt_new(&mut local_user_view, data.auth.as_ref(), &context).await;
-  let local_site = LocalSite::read(&mut context.pool()).await?;
-
-  check_private_instance(&local_user_view, &local_site)?;
-
-  let person_details_id = match data.person_id {
-    Some(id) => id,
-    None => {
-      if let Some(username) = &data.username {
-        resolve_actor_identifier::<ApubPerson, Person>(username, &context, &local_user_view, true)
-          .await
-          .with_lemmy_type(LemmyErrorType::CouldntFindPerson)?
-          .id
-      } else {
-        Err(LemmyErrorType::CouldntFindPerson)?
-      }
+    // Check to make sure a person name or an id is given
+    if data.username.is_none() && data.person_id.is_none() {
+        Err(LemmyErrorType::NoIdGiven)?
     }
-  };
 
-  // You don't need to return settings for the user, since this comes back with GetSite
-  // `my_user`
-  let person_view = PersonView::read(&mut context.pool(), person_details_id).await?;
+    local_user_view_from_jwt_opt_new(&mut local_user_view, data.auth.as_ref(), &context).await;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
 
-  let sort = data.sort;
-  let page = data.page;
-  let limit = data.limit;
-  let saved_only = data.saved_only.unwrap_or_default();
-  let community_id = data.community_id;
-  // If its saved only, you don't care what creator it was
-  // Or, if its not saved, then you only want it for that specific creator
-  let creator_id = if !saved_only {
-    Some(person_details_id)
-  } else {
-    None
-  };
+    check_private_instance(&local_user_view, &local_site)?;
 
-  let posts = PostQuery {
-    sort,
-    saved_only,
-    local_user: local_user_view.as_ref(),
-    community_id,
-    is_profile_view: true,
-    page,
-    limit,
-    creator_id,
-    ..Default::default()
-  }
-  .list(&mut context.pool())
-  .await?;
+    let person_details_id = match data.person_id {
+        Some(id) => id,
+        None => {
+            if let Some(username) = &data.username {
+                resolve_actor_identifier::<ApubPerson, Person>(
+                    username,
+                    &context,
+                    &local_user_view,
+                    true,
+                )
+                .await
+                .with_lemmy_type(LemmyErrorType::CouldntFindPerson)?
+                .id
+            } else {
+                Err(LemmyErrorType::CouldntFindPerson)?
+            }
+        }
+    };
 
-  let comments = CommentQuery {
-    local_user: local_user_view.as_ref(),
-    sort: sort.map(post_to_comment_sort_type),
-    saved_only,
-    community_id,
-    is_profile_view: true,
-    page,
-    limit,
-    creator_id,
-    ..Default::default()
-  }
-  .list(&mut context.pool())
-  .await?;
+    // You don't need to return settings for the user, since this comes back with GetSite
+    // `my_user`
+    let person_view = PersonView::read(&mut context.pool(), person_details_id).await?;
 
-  let moderates =
-    CommunityModeratorView::for_person(&mut context.pool(), person_details_id).await?;
+    let sort = data.sort;
+    let page = data.page;
+    let limit = data.limit;
+    let saved_only = data.saved_only.unwrap_or_default();
+    let community_id = data.community_id;
+    // If its saved only, you don't care what creator it was
+    // Or, if its not saved, then you only want it for that specific creator
+    let creator_id = if !saved_only {
+        Some(person_details_id)
+    } else {
+        None
+    };
 
-  // Return the jwt
-  Ok(Json(GetPersonDetailsResponse {
-    person_view,
-    moderates,
-    comments,
-    posts,
-  }))
+    let posts = PostQuery {
+        sort,
+        saved_only,
+        local_user: local_user_view.as_ref(),
+        community_id,
+        is_profile_view: true,
+        page,
+        limit,
+        creator_id,
+        ..Default::default()
+    }
+    .list(&mut context.pool())
+    .await?;
+
+    let comments = CommentQuery {
+        local_user: local_user_view.as_ref(),
+        sort: sort.map(post_to_comment_sort_type),
+        saved_only,
+        community_id,
+        is_profile_view: true,
+        page,
+        limit,
+        creator_id,
+        ..Default::default()
+    }
+    .list(&mut context.pool())
+    .await?;
+
+    let moderates =
+        CommunityModeratorView::for_person(&mut context.pool(), person_details_id).await?;
+
+    // Return the jwt
+    Ok(Json(GetPersonDetailsResponse {
+        person_view,
+        moderates,
+        comments,
+        posts,
+    }))
 }

--- a/crates/apub/src/api/resolve_object.rs
+++ b/crates/apub/src/api/resolve_object.rs
@@ -1,15 +1,13 @@
 use crate::fetcher::search::{
-  search_query_to_object_id,
-  search_query_to_object_id_local,
-  SearchableObjects,
+    search_query_to_object_id, search_query_to_object_id_local, SearchableObjects,
 };
 use activitypub_federation::config::Data;
 use actix_web::web::{Json, Query};
 use diesel::NotFound;
 use lemmy_api_common::{
-  context::LemmyContext,
-  site::{ResolveObject, ResolveObjectResponse},
-  utils::{check_private_instance, local_user_view_from_jwt_opt_new},
+    context::LemmyContext,
+    site::{ResolveObject, ResolveObjectResponse},
+    utils::{check_private_instance, local_user_view_from_jwt_opt_new},
 };
 use lemmy_db_schema::{newtypes::PersonId, source::local_site::LocalSite, utils::DbPool};
 use lemmy_db_views::structs::{CommentView, LocalUserView, PostView};
@@ -18,62 +16,62 @@ use lemmy_utils::error::{LemmyError, LemmyErrorExt2, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn resolve_object(
-  data: Query<ResolveObject>,
-  context: Data<LemmyContext>,
-  mut local_user_view: Option<LocalUserView>,
+    data: Query<ResolveObject>,
+    context: Data<LemmyContext>,
+    mut local_user_view: Option<LocalUserView>,
 ) -> Result<Json<ResolveObjectResponse>, LemmyError> {
-  local_user_view_from_jwt_opt_new(&mut local_user_view, data.auth.as_ref(), &context).await;
-  let local_site = LocalSite::read(&mut context.pool()).await?;
-  check_private_instance(&local_user_view, &local_site)?;
-  let person_id = local_user_view.map(|v| v.person.id);
-  // If we get a valid personId back we can safely assume that the user is authenticated,
-  // if there's no personId then the JWT was missing or invalid.
-  let is_authenticated = person_id.is_some();
+    local_user_view_from_jwt_opt_new(&mut local_user_view, data.auth.as_ref(), &context).await;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
+    check_private_instance(&local_user_view, &local_site)?;
+    let person_id = local_user_view.map(|v| v.person.id);
+    // If we get a valid personId back we can safely assume that the user is authenticated,
+    // if there's no personId then the JWT was missing or invalid.
+    let is_authenticated = person_id.is_some();
 
-  let res = if is_authenticated {
-    // user is fully authenticated; allow remote lookups as well.
-    search_query_to_object_id(&data.q, &context).await
-  } else {
-    // user isn't authenticated only allow a local search.
-    search_query_to_object_id_local(&data.q, &context).await
-  }
-  .with_lemmy_type(LemmyErrorType::CouldntFindObject)?;
+    let res = if is_authenticated {
+        // user is fully authenticated; allow remote lookups as well.
+        search_query_to_object_id(&data.q, &context).await
+    } else {
+        // user isn't authenticated only allow a local search.
+        search_query_to_object_id_local(&data.q, &context).await
+    }
+    .with_lemmy_type(LemmyErrorType::CouldntFindObject)?;
 
-  convert_response(res, person_id, &mut context.pool())
-    .await
-    .with_lemmy_type(LemmyErrorType::CouldntFindObject)
+    convert_response(res, person_id, &mut context.pool())
+        .await
+        .with_lemmy_type(LemmyErrorType::CouldntFindObject)
 }
 
 async fn convert_response(
-  object: SearchableObjects,
-  user_id: Option<PersonId>,
-  pool: &mut DbPool<'_>,
+    object: SearchableObjects,
+    user_id: Option<PersonId>,
+    pool: &mut DbPool<'_>,
 ) -> Result<Json<ResolveObjectResponse>, LemmyError> {
-  use SearchableObjects::*;
-  let removed_or_deleted;
-  let mut res = ResolveObjectResponse::default();
-  match object {
-    Person(p) => {
-      removed_or_deleted = p.deleted;
-      res.person = Some(PersonView::read(pool, p.id).await?)
+    use SearchableObjects::*;
+    let removed_or_deleted;
+    let mut res = ResolveObjectResponse::default();
+    match object {
+        Person(p) => {
+            removed_or_deleted = p.deleted;
+            res.person = Some(PersonView::read(pool, p.id).await?)
+        }
+        Community(c) => {
+            removed_or_deleted = c.deleted || c.removed;
+            res.community = Some(CommunityView::read(pool, c.id, user_id, false).await?)
+        }
+        Post(p) => {
+            removed_or_deleted = p.deleted || p.removed;
+            res.post = Some(PostView::read(pool, p.id, user_id, false).await?)
+        }
+        Comment(c) => {
+            removed_or_deleted = c.deleted || c.removed;
+            res.comment = Some(CommentView::read(pool, c.id, user_id).await?)
+        }
+    };
+    // if the object was deleted from database, dont return it
+    if removed_or_deleted {
+        Err(NotFound {}.into())
+    } else {
+        Ok(Json(res))
     }
-    Community(c) => {
-      removed_or_deleted = c.deleted || c.removed;
-      res.community = Some(CommunityView::read(pool, c.id, user_id, false).await?)
-    }
-    Post(p) => {
-      removed_or_deleted = p.deleted || p.removed;
-      res.post = Some(PostView::read(pool, p.id, user_id, false).await?)
-    }
-    Comment(c) => {
-      removed_or_deleted = c.deleted || c.removed;
-      res.comment = Some(CommentView::read(pool, c.id, user_id).await?)
-    }
-  };
-  // if the object was deleted from database, dont return it
-  if removed_or_deleted {
-    Err(NotFound {}.into())
-  } else {
-    Ok(Json(res))
-  }
 }

--- a/crates/apub/src/api/search.rs
+++ b/crates/apub/src/api/search.rs
@@ -2,14 +2,14 @@ use crate::{fetcher::resolve_actor_identifier, objects::community::ApubCommunity
 use activitypub_federation::config::Data;
 use actix_web::web::{Json, Query};
 use lemmy_api_common::{
-  context::LemmyContext,
-  site::{Search, SearchResponse},
-  utils::{check_private_instance, is_admin, local_user_view_from_jwt_opt_new},
+    context::LemmyContext,
+    site::{Search, SearchResponse},
+    utils::{check_private_instance, is_admin, local_user_view_from_jwt_opt_new},
 };
 use lemmy_db_schema::{
-  source::{community::Community, local_site::LocalSite},
-  utils::{post_to_comment_sort_type, post_to_person_sort_type},
-  SearchType,
+    source::{community::Community, local_site::LocalSite},
+    utils::{post_to_comment_sort_type, post_to_person_sort_type},
+    SearchType,
 };
 use lemmy_db_views::{comment_view::CommentQuery, post_view::PostQuery, structs::LocalUserView};
 use lemmy_db_views_actor::{community_view::CommunityQuery, person_view::PersonQuery};
@@ -17,192 +17,198 @@ use lemmy_utils::error::LemmyError;
 
 #[tracing::instrument(skip(context))]
 pub async fn search(
-  data: Query<Search>,
-  context: Data<LemmyContext>,
-  mut local_user_view: Option<LocalUserView>,
+    data: Query<Search>,
+    context: Data<LemmyContext>,
+    mut local_user_view: Option<LocalUserView>,
 ) -> Result<Json<SearchResponse>, LemmyError> {
-  local_user_view_from_jwt_opt_new(&mut local_user_view, data.auth.as_ref(), &context).await;
-  let local_site = LocalSite::read(&mut context.pool()).await?;
+    local_user_view_from_jwt_opt_new(&mut local_user_view, data.auth.as_ref(), &context).await;
+    let local_site = LocalSite::read(&mut context.pool()).await?;
 
-  check_private_instance(&local_user_view, &local_site)?;
+    check_private_instance(&local_user_view, &local_site)?;
 
-  let is_admin = local_user_view
-    .as_ref()
-    .map(|luv| is_admin(luv).is_ok())
-    .unwrap_or_default();
+    let is_admin = local_user_view
+        .as_ref()
+        .map(|luv| is_admin(luv).is_ok())
+        .unwrap_or_default();
 
-  let mut posts = Vec::new();
-  let mut comments = Vec::new();
-  let mut communities = Vec::new();
-  let mut users = Vec::new();
+    let mut posts = Vec::new();
+    let mut comments = Vec::new();
+    let mut communities = Vec::new();
+    let mut users = Vec::new();
 
-  // TODO no clean / non-nsfw searching rn
+    // TODO no clean / non-nsfw searching rn
 
-  let q = data.q.clone();
-  let page = data.page;
-  let limit = data.limit;
-  let sort = data.sort;
-  let listing_type = data.listing_type;
-  let search_type = data.type_.unwrap_or(SearchType::All);
-  let community_id = if let Some(name) = &data.community_name {
-    Some(
-      resolve_actor_identifier::<ApubCommunity, Community>(name, &context, &local_user_view, false)
-        .await?,
-    )
-    .map(|c| c.id)
-  } else {
-    data.community_id
-  };
-  let creator_id = data.creator_id;
-  let local_user = local_user_view.as_ref().map(|l| l.local_user.clone());
-  match search_type {
-    SearchType::Posts => {
-      posts = PostQuery {
-        sort: (sort),
-        listing_type: (listing_type),
-        community_id: (community_id),
-        creator_id: (creator_id),
-        local_user: (local_user_view.as_ref()),
-        search_term: (Some(q)),
-        page: (page),
-        limit: (limit),
-        ..Default::default()
-      }
-      .list(&mut context.pool())
-      .await?;
-    }
-    SearchType::Comments => {
-      comments = CommentQuery {
-        sort: (sort.map(post_to_comment_sort_type)),
-        listing_type: (listing_type),
-        search_term: (Some(q)),
-        community_id: (community_id),
-        creator_id: (creator_id),
-        local_user: (local_user_view.as_ref()),
-        page: (page),
-        limit: (limit),
-        ..Default::default()
-      }
-      .list(&mut context.pool())
-      .await?;
-    }
-    SearchType::Communities => {
-      communities = CommunityQuery {
-        sort: (sort),
-        listing_type: (listing_type),
-        search_term: (Some(q)),
-        local_user: (local_user.as_ref()),
-        is_mod_or_admin: (is_admin),
-        page: (page),
-        limit: (limit),
-        ..Default::default()
-      }
-      .list(&mut context.pool())
-      .await?;
-    }
-    SearchType::Users => {
-      users = PersonQuery {
-        sort: (sort.map(post_to_person_sort_type)),
-        search_term: (Some(q)),
-        page: (page),
-        limit: (limit),
-      }
-      .list(&mut context.pool())
-      .await?;
-    }
-    SearchType::All => {
-      // If the community or creator is included, dont search communities or users
-      let community_or_creator_included =
-        data.community_id.is_some() || data.community_name.is_some() || data.creator_id.is_some();
-
-      let q = data.q.clone();
-
-      posts = PostQuery {
-        sort: (sort),
-        listing_type: (listing_type),
-        community_id: (community_id),
-        creator_id: (creator_id),
-        local_user: (local_user_view.as_ref()),
-        search_term: (Some(q)),
-        page: (page),
-        limit: (limit),
-        ..Default::default()
-      }
-      .list(&mut context.pool())
-      .await?;
-
-      let q = data.q.clone();
-
-      comments = CommentQuery {
-        sort: (sort.map(post_to_comment_sort_type)),
-        listing_type: (listing_type),
-        search_term: (Some(q)),
-        community_id: (community_id),
-        creator_id: (creator_id),
-        local_user: (local_user_view.as_ref()),
-        page: (page),
-        limit: (limit),
-        ..Default::default()
-      }
-      .list(&mut context.pool())
-      .await?;
-
-      let q = data.q.clone();
-
-      communities = if community_or_creator_included {
-        vec![]
-      } else {
-        CommunityQuery {
-          sort: (sort),
-          listing_type: (listing_type),
-          search_term: (Some(q)),
-          local_user: (local_user.as_ref()),
-          is_mod_or_admin: (is_admin),
-          page: (page),
-          limit: (limit),
-          ..Default::default()
+    let q = data.q.clone();
+    let page = data.page;
+    let limit = data.limit;
+    let sort = data.sort;
+    let listing_type = data.listing_type;
+    let search_type = data.type_.unwrap_or(SearchType::All);
+    let community_id = if let Some(name) = &data.community_name {
+        Some(
+            resolve_actor_identifier::<ApubCommunity, Community>(
+                name,
+                &context,
+                &local_user_view,
+                false,
+            )
+            .await?,
+        )
+        .map(|c| c.id)
+    } else {
+        data.community_id
+    };
+    let creator_id = data.creator_id;
+    let local_user = local_user_view.as_ref().map(|l| l.local_user.clone());
+    match search_type {
+        SearchType::Posts => {
+            posts = PostQuery {
+                sort: (sort),
+                listing_type: (listing_type),
+                community_id: (community_id),
+                creator_id: (creator_id),
+                local_user: (local_user_view.as_ref()),
+                search_term: (Some(q)),
+                page: (page),
+                limit: (limit),
+                ..Default::default()
+            }
+            .list(&mut context.pool())
+            .await?;
         }
-        .list(&mut context.pool())
-        .await?
-      };
-
-      let q = data.q.clone();
-
-      users = if community_or_creator_included {
-        vec![]
-      } else {
-        PersonQuery {
-          sort: (sort.map(post_to_person_sort_type)),
-          search_term: (Some(q)),
-          page: (page),
-          limit: (limit),
+        SearchType::Comments => {
+            comments = CommentQuery {
+                sort: (sort.map(post_to_comment_sort_type)),
+                listing_type: (listing_type),
+                search_term: (Some(q)),
+                community_id: (community_id),
+                creator_id: (creator_id),
+                local_user: (local_user_view.as_ref()),
+                page: (page),
+                limit: (limit),
+                ..Default::default()
+            }
+            .list(&mut context.pool())
+            .await?;
         }
-        .list(&mut context.pool())
-        .await?
-      };
-    }
-    SearchType::Url => {
-      posts = PostQuery {
-        sort: (sort),
-        listing_type: (listing_type),
-        community_id: (community_id),
-        creator_id: (creator_id),
-        url_search: (Some(q)),
-        page: (page),
-        limit: (limit),
-        ..Default::default()
-      }
-      .list(&mut context.pool())
-      .await?;
-    }
-  };
+        SearchType::Communities => {
+            communities = CommunityQuery {
+                sort: (sort),
+                listing_type: (listing_type),
+                search_term: (Some(q)),
+                local_user: (local_user.as_ref()),
+                is_mod_or_admin: (is_admin),
+                page: (page),
+                limit: (limit),
+                ..Default::default()
+            }
+            .list(&mut context.pool())
+            .await?;
+        }
+        SearchType::Users => {
+            users = PersonQuery {
+                sort: (sort.map(post_to_person_sort_type)),
+                search_term: (Some(q)),
+                page: (page),
+                limit: (limit),
+            }
+            .list(&mut context.pool())
+            .await?;
+        }
+        SearchType::All => {
+            // If the community or creator is included, dont search communities or users
+            let community_or_creator_included = data.community_id.is_some()
+                || data.community_name.is_some()
+                || data.creator_id.is_some();
 
-  // Return the jwt
-  Ok(Json(SearchResponse {
-    type_: search_type,
-    comments,
-    posts,
-    communities,
-    users,
-  }))
+            let q = data.q.clone();
+
+            posts = PostQuery {
+                sort: (sort),
+                listing_type: (listing_type),
+                community_id: (community_id),
+                creator_id: (creator_id),
+                local_user: (local_user_view.as_ref()),
+                search_term: (Some(q)),
+                page: (page),
+                limit: (limit),
+                ..Default::default()
+            }
+            .list(&mut context.pool())
+            .await?;
+
+            let q = data.q.clone();
+
+            comments = CommentQuery {
+                sort: (sort.map(post_to_comment_sort_type)),
+                listing_type: (listing_type),
+                search_term: (Some(q)),
+                community_id: (community_id),
+                creator_id: (creator_id),
+                local_user: (local_user_view.as_ref()),
+                page: (page),
+                limit: (limit),
+                ..Default::default()
+            }
+            .list(&mut context.pool())
+            .await?;
+
+            let q = data.q.clone();
+
+            communities = if community_or_creator_included {
+                vec![]
+            } else {
+                CommunityQuery {
+                    sort: (sort),
+                    listing_type: (listing_type),
+                    search_term: (Some(q)),
+                    local_user: (local_user.as_ref()),
+                    is_mod_or_admin: (is_admin),
+                    page: (page),
+                    limit: (limit),
+                    ..Default::default()
+                }
+                .list(&mut context.pool())
+                .await?
+            };
+
+            let q = data.q.clone();
+
+            users = if community_or_creator_included {
+                vec![]
+            } else {
+                PersonQuery {
+                    sort: (sort.map(post_to_person_sort_type)),
+                    search_term: (Some(q)),
+                    page: (page),
+                    limit: (limit),
+                }
+                .list(&mut context.pool())
+                .await?
+            };
+        }
+        SearchType::Url => {
+            posts = PostQuery {
+                sort: (sort),
+                listing_type: (listing_type),
+                community_id: (community_id),
+                creator_id: (creator_id),
+                url_search: (Some(q)),
+                page: (page),
+                limit: (limit),
+                ..Default::default()
+            }
+            .list(&mut context.pool())
+            .await?;
+        }
+    };
+
+    // Return the jwt
+    Ok(Json(SearchResponse {
+        type_: search_type,
+        comments,
+        posts,
+        communities,
+        users,
+    }))
 }

--- a/crates/apub/src/collections/community_featured.rs
+++ b/crates/apub/src/collections/community_featured.rs
@@ -1,12 +1,12 @@
 use crate::{
-  objects::{community::ApubCommunity, post::ApubPost},
-  protocol::collections::group_featured::GroupFeatured,
+    objects::{community::ApubCommunity, post::ApubPost},
+    protocol::collections::group_featured::GroupFeatured,
 };
 use activitypub_federation::{
-  config::Data,
-  kinds::collection::OrderedCollectionType,
-  protocol::verification::verify_domains_match,
-  traits::{ActivityHandler, Collection, Object},
+    config::Data,
+    kinds::collection::OrderedCollectionType,
+    protocol::verification::verify_domains_match,
+    traits::{ActivityHandler, Collection, Object},
 };
 use futures::future::{join_all, try_join_all};
 use lemmy_api_common::{context::LemmyContext, utils::generate_featured_url};
@@ -19,73 +19,73 @@ pub(crate) struct ApubCommunityFeatured(Vec<ApubPost>);
 
 #[async_trait::async_trait]
 impl Collection for ApubCommunityFeatured {
-  type Owner = ApubCommunity;
-  type DataType = LemmyContext;
-  type Kind = GroupFeatured;
-  type Error = LemmyError;
+    type Owner = ApubCommunity;
+    type DataType = LemmyContext;
+    type Kind = GroupFeatured;
+    type Error = LemmyError;
 
-  async fn read_local(
-    owner: &Self::Owner,
-    data: &Data<Self::DataType>,
-  ) -> Result<Self::Kind, Self::Error> {
-    let ordered_items = try_join_all(
-      Post::list_featured_for_community(&mut data.pool(), owner.id)
-        .await?
-        .into_iter()
-        .map(ApubPost::from)
-        .map(|p| p.into_json(data)),
-    )
-    .await?;
-    Ok(GroupFeatured {
-      r#type: OrderedCollectionType::OrderedCollection,
-      id: generate_featured_url(&owner.actor_id)?.into(),
-      total_items: ordered_items.len() as i32,
-      ordered_items,
-    })
-  }
-
-  async fn verify(
-    apub: &Self::Kind,
-    expected_domain: &Url,
-    _data: &Data<Self::DataType>,
-  ) -> Result<(), Self::Error> {
-    verify_domains_match(expected_domain, &apub.id)?;
-    Ok(())
-  }
-
-  async fn from_json(
-    apub: Self::Kind,
-    _owner: &Self::Owner,
-    data: &Data<Self::DataType>,
-  ) -> Result<Self, Self::Error>
-  where
-    Self: Sized,
-  {
-    let mut posts = apub.ordered_items;
-    if posts.len() as i64 > FETCH_LIMIT_MAX {
-      posts = posts
-        .get(0..(FETCH_LIMIT_MAX as usize))
-        .unwrap_or_default()
-        .to_vec();
+    async fn read_local(
+        owner: &Self::Owner,
+        data: &Data<Self::DataType>,
+    ) -> Result<Self::Kind, Self::Error> {
+        let ordered_items = try_join_all(
+            Post::list_featured_for_community(&mut data.pool(), owner.id)
+                .await?
+                .into_iter()
+                .map(ApubPost::from)
+                .map(|p| p.into_json(data)),
+        )
+        .await?;
+        Ok(GroupFeatured {
+            r#type: OrderedCollectionType::OrderedCollection,
+            id: generate_featured_url(&owner.actor_id)?.into(),
+            total_items: ordered_items.len() as i32,
+            ordered_items,
+        })
     }
 
-    // We intentionally ignore errors here. This is because the outbox might contain posts from old
-    // Lemmy versions, or from other software which we cant parse. In that case, we simply skip the
-    // item and only parse the ones that work.
-    // process items in parallel, to avoid long delay from fetch_site_metadata() and other processing
-    join_all(posts.into_iter().map(|post| {
-      async {
-        // use separate request counter for each item, otherwise there will be problems with
-        // parallel processing
-        let verify = post.verify(data).await;
-        if verify.is_ok() {
-          post.receive(data).await.ok();
-        }
-      }
-    }))
-    .await;
+    async fn verify(
+        apub: &Self::Kind,
+        expected_domain: &Url,
+        _data: &Data<Self::DataType>,
+    ) -> Result<(), Self::Error> {
+        verify_domains_match(expected_domain, &apub.id)?;
+        Ok(())
+    }
 
-    // This return value is unused, so just set an empty vec
-    Ok(ApubCommunityFeatured(Vec::new()))
-  }
+    async fn from_json(
+        apub: Self::Kind,
+        _owner: &Self::Owner,
+        data: &Data<Self::DataType>,
+    ) -> Result<Self, Self::Error>
+    where
+        Self: Sized,
+    {
+        let mut posts = apub.ordered_items;
+        if posts.len() as i64 > FETCH_LIMIT_MAX {
+            posts = posts
+                .get(0..(FETCH_LIMIT_MAX as usize))
+                .unwrap_or_default()
+                .to_vec();
+        }
+
+        // We intentionally ignore errors here. This is because the outbox might contain posts from old
+        // Lemmy versions, or from other software which we cant parse. In that case, we simply skip the
+        // item and only parse the ones that work.
+        // process items in parallel, to avoid long delay from fetch_site_metadata() and other processing
+        join_all(posts.into_iter().map(|post| {
+            async {
+                // use separate request counter for each item, otherwise there will be problems with
+                // parallel processing
+                let verify = post.verify(data).await;
+                if verify.is_ok() {
+                    post.receive(data).await.ok();
+                }
+            }
+        }))
+        .await;
+
+        // This return value is unused, so just set an empty vec
+        Ok(ApubCommunityFeatured(Vec::new()))
+    }
 }

--- a/crates/apub/src/collections/community_moderators.rs
+++ b/crates/apub/src/collections/community_moderators.rs
@@ -1,18 +1,15 @@
 use crate::{
-  objects::{community::ApubCommunity, person::ApubPerson},
-  protocol::collections::group_moderators::GroupModerators,
+    objects::{community::ApubCommunity, person::ApubPerson},
+    protocol::collections::group_moderators::GroupModerators,
 };
 use activitypub_federation::{
-  config::Data,
-  fetch::object_id::ObjectId,
-  kinds::collection::OrderedCollectionType,
-  protocol::verification::verify_domains_match,
-  traits::Collection,
+    config::Data, fetch::object_id::ObjectId, kinds::collection::OrderedCollectionType,
+    protocol::verification::verify_domains_match, traits::Collection,
 };
 use lemmy_api_common::{context::LemmyContext, utils::generate_moderators_url};
 use lemmy_db_schema::{
-  source::community::{CommunityModerator, CommunityModeratorForm},
-  traits::Joinable,
+    source::community::{CommunityModerator, CommunityModeratorForm},
+    traits::Joinable,
 };
 use lemmy_db_views_actor::structs::CommunityModeratorView;
 use lemmy_utils::error::LemmyError;
@@ -23,170 +20,169 @@ pub(crate) struct ApubCommunityModerators(pub(crate) Vec<CommunityModeratorView>
 
 #[async_trait::async_trait]
 impl Collection for ApubCommunityModerators {
-  type Owner = ApubCommunity;
-  type DataType = LemmyContext;
-  type Kind = GroupModerators;
-  type Error = LemmyError;
+    type Owner = ApubCommunity;
+    type DataType = LemmyContext;
+    type Kind = GroupModerators;
+    type Error = LemmyError;
 
-  #[tracing::instrument(skip_all)]
-  async fn read_local(
-    owner: &Self::Owner,
-    data: &Data<Self::DataType>,
-  ) -> Result<Self::Kind, LemmyError> {
-    let moderators = CommunityModeratorView::for_community(&mut data.pool(), owner.id).await?;
-    let ordered_items = moderators
-      .into_iter()
-      .map(|m| ObjectId::<ApubPerson>::from(m.moderator.actor_id))
-      .collect();
-    Ok(GroupModerators {
-      r#type: OrderedCollectionType::OrderedCollection,
-      id: generate_moderators_url(&owner.actor_id)?.into(),
-      ordered_items,
-    })
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn verify(
-    group_moderators: &GroupModerators,
-    expected_domain: &Url,
-    _data: &Data<Self::DataType>,
-  ) -> Result<(), LemmyError> {
-    verify_domains_match(&group_moderators.id, expected_domain)?;
-    Ok(())
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn from_json(
-    apub: Self::Kind,
-    owner: &Self::Owner,
-    data: &Data<Self::DataType>,
-  ) -> Result<Self, LemmyError> {
-    let community_id = owner.id;
-    let current_moderators =
-      CommunityModeratorView::for_community(&mut data.pool(), community_id).await?;
-    // Remove old mods from database which arent in the moderators collection anymore
-    for mod_user in &current_moderators {
-      let mod_id = ObjectId::from(mod_user.moderator.actor_id.clone());
-      if !apub.ordered_items.contains(&mod_id) {
-        let community_moderator_form = CommunityModeratorForm {
-          community_id: mod_user.community.id,
-          person_id: mod_user.moderator.id,
-        };
-        CommunityModerator::leave(&mut data.pool(), &community_moderator_form).await?;
-      }
+    #[tracing::instrument(skip_all)]
+    async fn read_local(
+        owner: &Self::Owner,
+        data: &Data<Self::DataType>,
+    ) -> Result<Self::Kind, LemmyError> {
+        let moderators = CommunityModeratorView::for_community(&mut data.pool(), owner.id).await?;
+        let ordered_items = moderators
+            .into_iter()
+            .map(|m| ObjectId::<ApubPerson>::from(m.moderator.actor_id))
+            .collect();
+        Ok(GroupModerators {
+            r#type: OrderedCollectionType::OrderedCollection,
+            id: generate_moderators_url(&owner.actor_id)?.into(),
+            ordered_items,
+        })
     }
 
-    // Add new mods to database which have been added to moderators collection
-    for mod_id in apub.ordered_items {
-      // Ignore errors as mod accounts might be deleted or instances unavailable.
-      let mod_user: Option<ApubPerson> = mod_id.dereference(data).await.ok();
-      if let Some(mod_user) = mod_user {
-        if !current_moderators
-          .iter()
-          .map(|c| c.moderator.actor_id.clone())
-          .any(|x| x == mod_user.actor_id)
-        {
-          let community_moderator_form = CommunityModeratorForm {
-            community_id: owner.id,
-            person_id: mod_user.id,
-          };
-          CommunityModerator::join(&mut data.pool(), &community_moderator_form).await?;
+    #[tracing::instrument(skip_all)]
+    async fn verify(
+        group_moderators: &GroupModerators,
+        expected_domain: &Url,
+        _data: &Data<Self::DataType>,
+    ) -> Result<(), LemmyError> {
+        verify_domains_match(&group_moderators.id, expected_domain)?;
+        Ok(())
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn from_json(
+        apub: Self::Kind,
+        owner: &Self::Owner,
+        data: &Data<Self::DataType>,
+    ) -> Result<Self, LemmyError> {
+        let community_id = owner.id;
+        let current_moderators =
+            CommunityModeratorView::for_community(&mut data.pool(), community_id).await?;
+        // Remove old mods from database which arent in the moderators collection anymore
+        for mod_user in &current_moderators {
+            let mod_id = ObjectId::from(mod_user.moderator.actor_id.clone());
+            if !apub.ordered_items.contains(&mod_id) {
+                let community_moderator_form = CommunityModeratorForm {
+                    community_id: mod_user.community.id,
+                    person_id: mod_user.moderator.id,
+                };
+                CommunityModerator::leave(&mut data.pool(), &community_moderator_form).await?;
+            }
         }
-      }
-    }
 
-    // This return value is unused, so just set an empty vec
-    Ok(ApubCommunityModerators(Vec::new()))
-  }
+        // Add new mods to database which have been added to moderators collection
+        for mod_id in apub.ordered_items {
+            // Ignore errors as mod accounts might be deleted or instances unavailable.
+            let mod_user: Option<ApubPerson> = mod_id.dereference(data).await.ok();
+            if let Some(mod_user) = mod_user {
+                if !current_moderators
+                    .iter()
+                    .map(|c| c.moderator.actor_id.clone())
+                    .any(|x| x == mod_user.actor_id)
+                {
+                    let community_moderator_form = CommunityModeratorForm {
+                        community_id: owner.id,
+                        person_id: mod_user.id,
+                    };
+                    CommunityModerator::join(&mut data.pool(), &community_moderator_form).await?;
+                }
+            }
+        }
+
+        // This return value is unused, so just set an empty vec
+        Ok(ApubCommunityModerators(Vec::new()))
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use super::*;
-  use crate::{
-    objects::{
-      community::tests::parse_lemmy_community,
-      person::tests::parse_lemmy_person,
-      tests::init_context,
-    },
-    protocol::tests::file_to_json_object,
-  };
-  use lemmy_db_schema::{
-    source::{
-      community::Community,
-      instance::Instance,
-      person::{Person, PersonInsertForm},
-      site::Site,
-    },
-    traits::Crud,
-  };
-  use serial_test::serial;
-
-  #[tokio::test]
-  #[serial]
-  async fn test_parse_lemmy_community_moderators() {
-    let context = init_context().await;
-    let (new_mod, site) = parse_lemmy_person(&context).await;
-    let community = parse_lemmy_community(&context).await;
-    let community_id = community.id;
-
-    let inserted_instance =
-      Instance::read_or_create(&mut context.pool(), "my_domain.tld".to_string())
-        .await
-        .unwrap();
-
-    let old_mod = PersonInsertForm::builder()
-      .name("holly".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let old_mod = Person::create(&mut context.pool(), &old_mod).await.unwrap();
-    let community_moderator_form = CommunityModeratorForm {
-      community_id: community.id,
-      person_id: old_mod.id,
+    use super::*;
+    use crate::{
+        objects::{
+            community::tests::parse_lemmy_community, person::tests::parse_lemmy_person,
+            tests::init_context,
+        },
+        protocol::tests::file_to_json_object,
     };
+    use lemmy_db_schema::{
+        source::{
+            community::Community,
+            instance::Instance,
+            person::{Person, PersonInsertForm},
+            site::Site,
+        },
+        traits::Crud,
+    };
+    use serial_test::serial;
 
-    CommunityModerator::join(&mut context.pool(), &community_moderator_form)
-      .await
-      .unwrap();
+    #[tokio::test]
+    #[serial]
+    async fn test_parse_lemmy_community_moderators() {
+        let context = init_context().await;
+        let (new_mod, site) = parse_lemmy_person(&context).await;
+        let community = parse_lemmy_community(&context).await;
+        let community_id = community.id;
 
-    assert_eq!(site.actor_id.to_string(), "https://enterprise.lemmy.ml/");
+        let inserted_instance =
+            Instance::read_or_create(&mut context.pool(), "my_domain.tld".to_string())
+                .await
+                .unwrap();
 
-    let json: GroupModerators =
-      file_to_json_object("assets/lemmy/collections/group_moderators.json").unwrap();
-    let url = Url::parse("https://enterprise.lemmy.ml/c/tenforward").unwrap();
-    ApubCommunityModerators::verify(&json, &url, &context)
-      .await
-      .unwrap();
-    ApubCommunityModerators::from_json(json, &community, &context)
-      .await
-      .unwrap();
-    assert_eq!(context.request_count(), 0);
+        let old_mod = PersonInsertForm::builder()
+            .name("holly".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let current_moderators =
-      CommunityModeratorView::for_community(&mut context.pool(), community_id)
-        .await
-        .unwrap();
+        let old_mod = Person::create(&mut context.pool(), &old_mod).await.unwrap();
+        let community_moderator_form = CommunityModeratorForm {
+            community_id: community.id,
+            person_id: old_mod.id,
+        };
 
-    assert_eq!(current_moderators.len(), 1);
-    assert_eq!(current_moderators[0].moderator.id, new_mod.id);
+        CommunityModerator::join(&mut context.pool(), &community_moderator_form)
+            .await
+            .unwrap();
 
-    Person::delete(&mut context.pool(), old_mod.id)
-      .await
-      .unwrap();
-    Person::delete(&mut context.pool(), new_mod.id)
-      .await
-      .unwrap();
-    Community::delete(&mut context.pool(), community.id)
-      .await
-      .unwrap();
-    Site::delete(&mut context.pool(), site.id).await.unwrap();
-    Instance::delete(&mut context.pool(), inserted_instance.id)
-      .await
-      .unwrap();
-  }
+        assert_eq!(site.actor_id.to_string(), "https://enterprise.lemmy.ml/");
+
+        let json: GroupModerators =
+            file_to_json_object("assets/lemmy/collections/group_moderators.json").unwrap();
+        let url = Url::parse("https://enterprise.lemmy.ml/c/tenforward").unwrap();
+        ApubCommunityModerators::verify(&json, &url, &context)
+            .await
+            .unwrap();
+        ApubCommunityModerators::from_json(json, &community, &context)
+            .await
+            .unwrap();
+        assert_eq!(context.request_count(), 0);
+
+        let current_moderators =
+            CommunityModeratorView::for_community(&mut context.pool(), community_id)
+                .await
+                .unwrap();
+
+        assert_eq!(current_moderators.len(), 1);
+        assert_eq!(current_moderators[0].moderator.id, new_mod.id);
+
+        Person::delete(&mut context.pool(), old_mod.id)
+            .await
+            .unwrap();
+        Person::delete(&mut context.pool(), new_mod.id)
+            .await
+            .unwrap();
+        Community::delete(&mut context.pool(), community.id)
+            .await
+            .unwrap();
+        Site::delete(&mut context.pool(), site.id).await.unwrap();
+        Instance::delete(&mut context.pool(), inserted_instance.id)
+            .await
+            .unwrap();
+    }
 }

--- a/crates/apub/src/collections/community_outbox.rs
+++ b/crates/apub/src/collections/community_outbox.rs
@@ -1,27 +1,26 @@
 use crate::{
-  activity_lists::AnnouncableActivities,
-  objects::{community::ApubCommunity, post::ApubPost},
-  protocol::{
-    activities::{
-      community::announce::AnnounceActivity,
-      create_or_update::page::CreateOrUpdatePage,
-      CreateOrUpdateType,
+    activity_lists::AnnouncableActivities,
+    objects::{community::ApubCommunity, post::ApubPost},
+    protocol::{
+        activities::{
+            community::announce::AnnounceActivity, create_or_update::page::CreateOrUpdatePage,
+            CreateOrUpdateType,
+        },
+        collections::group_outbox::GroupOutbox,
     },
-    collections::group_outbox::GroupOutbox,
-  },
 };
 use activitypub_federation::{
-  config::Data,
-  kinds::collection::OrderedCollectionType,
-  protocol::verification::verify_domains_match,
-  traits::{ActivityHandler, Collection},
+    config::Data,
+    kinds::collection::OrderedCollectionType,
+    protocol::verification::verify_domains_match,
+    traits::{ActivityHandler, Collection},
 };
 use futures::future::join_all;
 use lemmy_api_common::{context::LemmyContext, utils::generate_outbox_url};
 use lemmy_db_schema::{
-  source::{person::Person, post::Post},
-  traits::Crud,
-  utils::FETCH_LIMIT_MAX,
+    source::{person::Person, post::Post},
+    traits::Crud,
+    utils::FETCH_LIMIT_MAX,
 };
 use lemmy_utils::error::LemmyError;
 use url::Url;
@@ -31,82 +30,83 @@ pub(crate) struct ApubCommunityOutbox(Vec<ApubPost>);
 
 #[async_trait::async_trait]
 impl Collection for ApubCommunityOutbox {
-  type Owner = ApubCommunity;
-  type DataType = LemmyContext;
-  type Kind = GroupOutbox;
-  type Error = LemmyError;
+    type Owner = ApubCommunity;
+    type DataType = LemmyContext;
+    type Kind = GroupOutbox;
+    type Error = LemmyError;
 
-  #[tracing::instrument(skip_all)]
-  async fn read_local(
-    owner: &Self::Owner,
-    data: &Data<Self::DataType>,
-  ) -> Result<Self::Kind, LemmyError> {
-    let post_list: Vec<ApubPost> = Post::list_for_community(&mut data.pool(), owner.id)
-      .await?
-      .into_iter()
-      .map(Into::into)
-      .collect();
-    let mut ordered_items = vec![];
-    for post in post_list {
-      let person = Person::read(&mut data.pool(), post.creator_id)
-        .await?
-        .into();
-      let create =
-        CreateOrUpdatePage::new(post, &person, owner, CreateOrUpdateType::Create, data).await?;
-      let announcable = AnnouncableActivities::CreateOrUpdatePost(create);
-      let announce = AnnounceActivity::new(announcable.try_into()?, owner, data)?;
-      ordered_items.push(announce);
-    }
-
-    Ok(GroupOutbox {
-      r#type: OrderedCollectionType::OrderedCollection,
-      id: generate_outbox_url(&owner.actor_id)?.into(),
-      total_items: ordered_items.len() as i32,
-      ordered_items,
-    })
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn verify(
-    group_outbox: &GroupOutbox,
-    expected_domain: &Url,
-    _data: &Data<Self::DataType>,
-  ) -> Result<(), LemmyError> {
-    verify_domains_match(expected_domain, &group_outbox.id)?;
-    Ok(())
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn from_json(
-    apub: Self::Kind,
-    _owner: &Self::Owner,
-    data: &Data<Self::DataType>,
-  ) -> Result<Self, LemmyError> {
-    let mut outbox_activities = apub.ordered_items;
-    if outbox_activities.len() as i64 > FETCH_LIMIT_MAX {
-      outbox_activities = outbox_activities
-        .get(0..(FETCH_LIMIT_MAX as usize))
-        .unwrap_or_default()
-        .to_vec();
-    }
-
-    // We intentionally ignore errors here. This is because the outbox might contain posts from old
-    // Lemmy versions, or from other software which we cant parse. In that case, we simply skip the
-    // item and only parse the ones that work.
-    // process items in parallel, to avoid long delay from fetch_site_metadata() and other processing
-    join_all(outbox_activities.into_iter().map(|activity| {
-      async {
-        // use separate request counter for each item, otherwise there will be problems with
-        // parallel processing
-        let verify = activity.verify(data).await;
-        if verify.is_ok() {
-          activity.receive(data).await.ok();
+    #[tracing::instrument(skip_all)]
+    async fn read_local(
+        owner: &Self::Owner,
+        data: &Data<Self::DataType>,
+    ) -> Result<Self::Kind, LemmyError> {
+        let post_list: Vec<ApubPost> = Post::list_for_community(&mut data.pool(), owner.id)
+            .await?
+            .into_iter()
+            .map(Into::into)
+            .collect();
+        let mut ordered_items = vec![];
+        for post in post_list {
+            let person = Person::read(&mut data.pool(), post.creator_id)
+                .await?
+                .into();
+            let create =
+                CreateOrUpdatePage::new(post, &person, owner, CreateOrUpdateType::Create, data)
+                    .await?;
+            let announcable = AnnouncableActivities::CreateOrUpdatePost(create);
+            let announce = AnnounceActivity::new(announcable.try_into()?, owner, data)?;
+            ordered_items.push(announce);
         }
-      }
-    }))
-    .await;
 
-    // This return value is unused, so just set an empty vec
-    Ok(ApubCommunityOutbox(Vec::new()))
-  }
+        Ok(GroupOutbox {
+            r#type: OrderedCollectionType::OrderedCollection,
+            id: generate_outbox_url(&owner.actor_id)?.into(),
+            total_items: ordered_items.len() as i32,
+            ordered_items,
+        })
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn verify(
+        group_outbox: &GroupOutbox,
+        expected_domain: &Url,
+        _data: &Data<Self::DataType>,
+    ) -> Result<(), LemmyError> {
+        verify_domains_match(expected_domain, &group_outbox.id)?;
+        Ok(())
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn from_json(
+        apub: Self::Kind,
+        _owner: &Self::Owner,
+        data: &Data<Self::DataType>,
+    ) -> Result<Self, LemmyError> {
+        let mut outbox_activities = apub.ordered_items;
+        if outbox_activities.len() as i64 > FETCH_LIMIT_MAX {
+            outbox_activities = outbox_activities
+                .get(0..(FETCH_LIMIT_MAX as usize))
+                .unwrap_or_default()
+                .to_vec();
+        }
+
+        // We intentionally ignore errors here. This is because the outbox might contain posts from old
+        // Lemmy versions, or from other software which we cant parse. In that case, we simply skip the
+        // item and only parse the ones that work.
+        // process items in parallel, to avoid long delay from fetch_site_metadata() and other processing
+        join_all(outbox_activities.into_iter().map(|activity| {
+            async {
+                // use separate request counter for each item, otherwise there will be problems with
+                // parallel processing
+                let verify = activity.verify(data).await;
+                if verify.is_ok() {
+                    activity.receive(data).await.ok();
+                }
+            }
+        }))
+        .await;
+
+        // This return value is unused, so just set an empty vec
+        Ok(ApubCommunityOutbox(Vec::new()))
+    }
 }

--- a/crates/apub/src/fetcher/mod.rs
+++ b/crates/apub/src/fetcher/mod.rs
@@ -1,7 +1,7 @@
 use activitypub_federation::{
-  config::Data,
-  fetch::webfinger::webfinger_resolve_actor,
-  traits::{Actor, Object},
+    config::Data,
+    fetch::webfinger::webfinger_resolve_actor,
+    traits::{Actor, Object},
 };
 use diesel::NotFound;
 use itertools::Itertools;
@@ -20,45 +20,46 @@ pub mod user_or_community;
 /// to fetch via webfinger from the original instance.
 #[tracing::instrument(skip_all)]
 pub async fn resolve_actor_identifier<ActorType, DbActor>(
-  identifier: &str,
-  context: &Data<LemmyContext>,
-  local_user_view: &Option<LocalUserView>,
-  include_deleted: bool,
+    identifier: &str,
+    context: &Data<LemmyContext>,
+    local_user_view: &Option<LocalUserView>,
+    include_deleted: bool,
 ) -> Result<ActorType, LemmyError>
 where
-  ActorType: Object<DataType = LemmyContext, Error = LemmyError>
-    + Object
-    + Actor
-    + From<DbActor>
-    + Send
-    + 'static,
-  for<'de2> <ActorType as Object>::Kind: serde::Deserialize<'de2>,
-  DbActor: ApubActor + Send + 'static,
+    ActorType: Object<DataType = LemmyContext, Error = LemmyError>
+        + Object
+        + Actor
+        + From<DbActor>
+        + Send
+        + 'static,
+    for<'de2> <ActorType as Object>::Kind: serde::Deserialize<'de2>,
+    DbActor: ApubActor + Send + 'static,
 {
-  // remote actor
-  if identifier.contains('@') {
-    let (name, domain) = identifier
-      .splitn(2, '@')
-      .collect_tuple()
-      .expect("invalid query");
-    let actor = DbActor::read_from_name_and_domain(&mut context.pool(), name, domain).await;
-    if actor.is_ok() {
-      Ok(actor?.into())
-    } else if local_user_view.is_some() {
-      // Fetch the actor from its home instance using webfinger
-      let actor: ActorType = webfinger_resolve_actor(&identifier.to_lowercase(), context).await?;
-      Ok(actor)
-    } else {
-      Err(NotFound.into())
+    // remote actor
+    if identifier.contains('@') {
+        let (name, domain) = identifier
+            .splitn(2, '@')
+            .collect_tuple()
+            .expect("invalid query");
+        let actor = DbActor::read_from_name_and_domain(&mut context.pool(), name, domain).await;
+        if actor.is_ok() {
+            Ok(actor?.into())
+        } else if local_user_view.is_some() {
+            // Fetch the actor from its home instance using webfinger
+            let actor: ActorType =
+                webfinger_resolve_actor(&identifier.to_lowercase(), context).await?;
+            Ok(actor)
+        } else {
+            Err(NotFound.into())
+        }
     }
-  }
-  // local actor
-  else {
-    let identifier = identifier.to_string();
-    Ok(
-      DbActor::read_from_name(&mut context.pool(), &identifier, include_deleted)
-        .await?
-        .into(),
-    )
-  }
+    // local actor
+    else {
+        let identifier = identifier.to_string();
+        Ok(
+            DbActor::read_from_name(&mut context.pool(), &identifier, include_deleted)
+                .await?
+                .into(),
+        )
+    }
 }

--- a/crates/apub/src/fetcher/post_or_comment.rs
+++ b/crates/apub/src/fetcher/post_or_comment.rs
@@ -1,16 +1,16 @@
 use crate::{
-  objects::{comment::ApubComment, community::ApubCommunity, post::ApubPost},
-  protocol::{
-    objects::{note::Note, page::Page},
-    InCommunity,
-  },
+    objects::{comment::ApubComment, community::ApubCommunity, post::ApubPost},
+    protocol::{
+        objects::{note::Note, page::Page},
+        InCommunity,
+    },
 };
 use activitypub_federation::{config::Data, traits::Object};
 use chrono::{DateTime, Utc};
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::{
-  source::{community::Community, post::Post},
-  traits::Crud,
+    source::{community::Community, post::Post},
+    traits::Crud,
 };
 use lemmy_utils::error::LemmyError;
 use serde::Deserialize;
@@ -18,85 +18,87 @@ use url::Url;
 
 #[derive(Clone, Debug)]
 pub enum PostOrComment {
-  Post(ApubPost),
-  Comment(ApubComment),
+    Post(ApubPost),
+    Comment(ApubComment),
 }
 
 #[derive(Deserialize)]
 #[serde(untagged)]
 pub enum PageOrNote {
-  Page(Box<Page>),
-  Note(Note),
+    Page(Box<Page>),
+    Note(Note),
 }
 
 #[async_trait::async_trait]
 impl Object for PostOrComment {
-  type DataType = LemmyContext;
-  type Kind = PageOrNote;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Kind = PageOrNote;
+    type Error = LemmyError;
 
-  fn last_refreshed_at(&self) -> Option<DateTime<Utc>> {
-    None
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn read_from_id(
-    object_id: Url,
-    data: &Data<Self::DataType>,
-  ) -> Result<Option<Self>, LemmyError> {
-    let post = ApubPost::read_from_id(object_id.clone(), data).await?;
-    Ok(match post {
-      Some(o) => Some(PostOrComment::Post(o)),
-      None => ApubComment::read_from_id(object_id, data)
-        .await?
-        .map(PostOrComment::Comment),
-    })
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn delete(self, data: &Data<Self::DataType>) -> Result<(), LemmyError> {
-    match self {
-      PostOrComment::Post(p) => p.delete(data).await,
-      PostOrComment::Comment(c) => c.delete(data).await,
+    fn last_refreshed_at(&self) -> Option<DateTime<Utc>> {
+        None
     }
-  }
 
-  async fn into_json(self, _data: &Data<Self::DataType>) -> Result<Self::Kind, LemmyError> {
-    unimplemented!()
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn verify(
-    apub: &Self::Kind,
-    expected_domain: &Url,
-    data: &Data<Self::DataType>,
-  ) -> Result<(), LemmyError> {
-    match apub {
-      PageOrNote::Page(a) => ApubPost::verify(a, expected_domain, data).await,
-      PageOrNote::Note(a) => ApubComment::verify(a, expected_domain, data).await,
+    #[tracing::instrument(skip_all)]
+    async fn read_from_id(
+        object_id: Url,
+        data: &Data<Self::DataType>,
+    ) -> Result<Option<Self>, LemmyError> {
+        let post = ApubPost::read_from_id(object_id.clone(), data).await?;
+        Ok(match post {
+            Some(o) => Some(PostOrComment::Post(o)),
+            None => ApubComment::read_from_id(object_id, data)
+                .await?
+                .map(PostOrComment::Comment),
+        })
     }
-  }
 
-  #[tracing::instrument(skip_all)]
-  async fn from_json(apub: PageOrNote, context: &Data<LemmyContext>) -> Result<Self, LemmyError> {
-    Ok(match apub {
-      PageOrNote::Page(p) => PostOrComment::Post(ApubPost::from_json(*p, context).await?),
-      PageOrNote::Note(n) => PostOrComment::Comment(ApubComment::from_json(n, context).await?),
-    })
-  }
+    #[tracing::instrument(skip_all)]
+    async fn delete(self, data: &Data<Self::DataType>) -> Result<(), LemmyError> {
+        match self {
+            PostOrComment::Post(p) => p.delete(data).await,
+            PostOrComment::Comment(c) => c.delete(data).await,
+        }
+    }
+
+    async fn into_json(self, _data: &Data<Self::DataType>) -> Result<Self::Kind, LemmyError> {
+        unimplemented!()
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn verify(
+        apub: &Self::Kind,
+        expected_domain: &Url,
+        data: &Data<Self::DataType>,
+    ) -> Result<(), LemmyError> {
+        match apub {
+            PageOrNote::Page(a) => ApubPost::verify(a, expected_domain, data).await,
+            PageOrNote::Note(a) => ApubComment::verify(a, expected_domain, data).await,
+        }
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn from_json(apub: PageOrNote, context: &Data<LemmyContext>) -> Result<Self, LemmyError> {
+        Ok(match apub {
+            PageOrNote::Page(p) => PostOrComment::Post(ApubPost::from_json(*p, context).await?),
+            PageOrNote::Note(n) => {
+                PostOrComment::Comment(ApubComment::from_json(n, context).await?)
+            }
+        })
+    }
 }
 
 #[async_trait::async_trait]
 impl InCommunity for PostOrComment {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
-    let cid = match self {
-      PostOrComment::Post(p) => p.community_id,
-      PostOrComment::Comment(c) => {
-        Post::read(&mut context.pool(), c.post_id)
-          .await?
-          .community_id
-      }
-    };
-    Ok(Community::read(&mut context.pool(), cid).await?.into())
-  }
+    async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+        let cid = match self {
+            PostOrComment::Post(p) => p.community_id,
+            PostOrComment::Comment(c) => {
+                Post::read(&mut context.pool(), c.post_id)
+                    .await?
+                    .community_id
+            }
+        };
+        Ok(Community::read(&mut context.pool(), cid).await?.into())
+    }
 }

--- a/crates/apub/src/fetcher/search.rs
+++ b/crates/apub/src/fetcher/search.rs
@@ -1,11 +1,11 @@
 use crate::{
-  objects::{comment::ApubComment, community::ApubCommunity, person::ApubPerson, post::ApubPost},
-  protocol::objects::{group::Group, note::Note, page::Page, person::Person},
+    objects::{comment::ApubComment, community::ApubCommunity, person::ApubPerson, post::ApubPost},
+    protocol::objects::{group::Group, note::Note, page::Page, person::Person},
 };
 use activitypub_federation::{
-  config::Data,
-  fetch::{object_id::ObjectId, webfinger::webfinger_resolve_actor},
-  traits::Object,
+    config::Data,
+    fetch::{object_id::ObjectId, webfinger::webfinger_resolve_actor},
+    traits::Object,
 };
 use chrono::{DateTime, Utc};
 use lemmy_api_common::context::LemmyContext;
@@ -18,30 +18,32 @@ use url::Url;
 /// which gets resolved to an URL.
 #[tracing::instrument(skip_all)]
 pub(crate) async fn search_query_to_object_id(
-  query: &str,
-  context: &Data<LemmyContext>,
+    query: &str,
+    context: &Data<LemmyContext>,
 ) -> Result<SearchableObjects, LemmyError> {
-  Ok(match Url::parse(query) {
-    Ok(url) => {
-      // its already an url, just go with it
-      ObjectId::from(url).dereference(context).await?
-    }
-    Err(_) => {
-      // not an url, try to resolve via webfinger
-      let mut chars = query.chars();
-      let kind = chars.next();
-      let identifier = chars.as_str();
-      match kind {
-        Some('@') => SearchableObjects::Person(
-          webfinger_resolve_actor::<LemmyContext, ApubPerson>(identifier, context).await?,
-        ),
-        Some('!') => SearchableObjects::Community(
-          webfinger_resolve_actor::<LemmyContext, ApubCommunity>(identifier, context).await?,
-        ),
-        _ => return Err(LemmyErrorType::InvalidQuery)?,
-      }
-    }
-  })
+    Ok(match Url::parse(query) {
+        Ok(url) => {
+            // its already an url, just go with it
+            ObjectId::from(url).dereference(context).await?
+        }
+        Err(_) => {
+            // not an url, try to resolve via webfinger
+            let mut chars = query.chars();
+            let kind = chars.next();
+            let identifier = chars.as_str();
+            match kind {
+                Some('@') => SearchableObjects::Person(
+                    webfinger_resolve_actor::<LemmyContext, ApubPerson>(identifier, context)
+                        .await?,
+                ),
+                Some('!') => SearchableObjects::Community(
+                    webfinger_resolve_actor::<LemmyContext, ApubCommunity>(identifier, context)
+                        .await?,
+                ),
+                _ => return Err(LemmyErrorType::InvalidQuery)?,
+            }
+        }
+    })
 }
 
 /// Converts a search query to an object id.  The query MUST bbe a URL which will bbe treated
@@ -49,112 +51,112 @@ pub(crate) async fn search_query_to_object_id(
 /// !community@example.com) this method will return an error.
 #[tracing::instrument(skip_all)]
 pub(crate) async fn search_query_to_object_id_local(
-  query: &str,
-  context: &Data<LemmyContext>,
+    query: &str,
+    context: &Data<LemmyContext>,
 ) -> Result<SearchableObjects, LemmyError> {
-  let url = Url::parse(query)?;
-  ObjectId::from(url).dereference_local(context).await
+    let url = Url::parse(query)?;
+    ObjectId::from(url).dereference_local(context).await
 }
 
 /// The types of ActivityPub objects that can be fetched directly by searching for their ID.
 #[derive(Debug)]
 pub(crate) enum SearchableObjects {
-  Person(ApubPerson),
-  Community(ApubCommunity),
-  Post(ApubPost),
-  Comment(ApubComment),
+    Person(ApubPerson),
+    Community(ApubCommunity),
+    Post(ApubPost),
+    Comment(ApubComment),
 }
 
 #[derive(Deserialize)]
 #[serde(untagged)]
 pub(crate) enum SearchableKinds {
-  Group(Group),
-  Person(Person),
-  Page(Page),
-  Note(Note),
+    Group(Group),
+    Person(Person),
+    Page(Page),
+    Note(Note),
 }
 
 #[async_trait::async_trait]
 impl Object for SearchableObjects {
-  type DataType = LemmyContext;
-  type Kind = SearchableKinds;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Kind = SearchableKinds;
+    type Error = LemmyError;
 
-  fn last_refreshed_at(&self) -> Option<DateTime<Utc>> {
-    match self {
-      SearchableObjects::Person(p) => p.last_refreshed_at(),
-      SearchableObjects::Community(c) => c.last_refreshed_at(),
-      SearchableObjects::Post(p) => p.last_refreshed_at(),
-      SearchableObjects::Comment(c) => c.last_refreshed_at(),
+    fn last_refreshed_at(&self) -> Option<DateTime<Utc>> {
+        match self {
+            SearchableObjects::Person(p) => p.last_refreshed_at(),
+            SearchableObjects::Community(c) => c.last_refreshed_at(),
+            SearchableObjects::Post(p) => p.last_refreshed_at(),
+            SearchableObjects::Comment(c) => c.last_refreshed_at(),
+        }
     }
-  }
 
-  // TODO: this is inefficient, because if the object is not in local db, it will run 4 db queries
-  //       before finally returning an error. it would be nice if we could check all 4 tables in
-  //       a single query.
-  //       we could skip this and always return an error, but then it would always fetch objects
-  //       over http, and not be able to mark objects as deleted that were deleted by remote server.
-  #[tracing::instrument(skip_all)]
-  async fn read_from_id(
-    object_id: Url,
-    context: &Data<Self::DataType>,
-  ) -> Result<Option<Self>, LemmyError> {
-    let c = ApubCommunity::read_from_id(object_id.clone(), context).await?;
-    if let Some(c) = c {
-      return Ok(Some(SearchableObjects::Community(c)));
+    // TODO: this is inefficient, because if the object is not in local db, it will run 4 db queries
+    //       before finally returning an error. it would be nice if we could check all 4 tables in
+    //       a single query.
+    //       we could skip this and always return an error, but then it would always fetch objects
+    //       over http, and not be able to mark objects as deleted that were deleted by remote server.
+    #[tracing::instrument(skip_all)]
+    async fn read_from_id(
+        object_id: Url,
+        context: &Data<Self::DataType>,
+    ) -> Result<Option<Self>, LemmyError> {
+        let c = ApubCommunity::read_from_id(object_id.clone(), context).await?;
+        if let Some(c) = c {
+            return Ok(Some(SearchableObjects::Community(c)));
+        }
+        let p = ApubPerson::read_from_id(object_id.clone(), context).await?;
+        if let Some(p) = p {
+            return Ok(Some(SearchableObjects::Person(p)));
+        }
+        let p = ApubPost::read_from_id(object_id.clone(), context).await?;
+        if let Some(p) = p {
+            return Ok(Some(SearchableObjects::Post(p)));
+        }
+        let c = ApubComment::read_from_id(object_id, context).await?;
+        if let Some(c) = c {
+            return Ok(Some(SearchableObjects::Comment(c)));
+        }
+        Ok(None)
     }
-    let p = ApubPerson::read_from_id(object_id.clone(), context).await?;
-    if let Some(p) = p {
-      return Ok(Some(SearchableObjects::Person(p)));
-    }
-    let p = ApubPost::read_from_id(object_id.clone(), context).await?;
-    if let Some(p) = p {
-      return Ok(Some(SearchableObjects::Post(p)));
-    }
-    let c = ApubComment::read_from_id(object_id, context).await?;
-    if let Some(c) = c {
-      return Ok(Some(SearchableObjects::Comment(c)));
-    }
-    Ok(None)
-  }
 
-  #[tracing::instrument(skip_all)]
-  async fn delete(self, data: &Data<Self::DataType>) -> Result<(), LemmyError> {
-    match self {
-      SearchableObjects::Person(p) => p.delete(data).await,
-      SearchableObjects::Community(c) => c.delete(data).await,
-      SearchableObjects::Post(p) => p.delete(data).await,
-      SearchableObjects::Comment(c) => c.delete(data).await,
+    #[tracing::instrument(skip_all)]
+    async fn delete(self, data: &Data<Self::DataType>) -> Result<(), LemmyError> {
+        match self {
+            SearchableObjects::Person(p) => p.delete(data).await,
+            SearchableObjects::Community(c) => c.delete(data).await,
+            SearchableObjects::Post(p) => p.delete(data).await,
+            SearchableObjects::Comment(c) => c.delete(data).await,
+        }
     }
-  }
 
-  async fn into_json(self, _data: &Data<Self::DataType>) -> Result<Self::Kind, LemmyError> {
-    unimplemented!()
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn verify(
-    apub: &Self::Kind,
-    expected_domain: &Url,
-    data: &Data<Self::DataType>,
-  ) -> Result<(), LemmyError> {
-    match apub {
-      SearchableKinds::Group(a) => ApubCommunity::verify(a, expected_domain, data).await,
-      SearchableKinds::Person(a) => ApubPerson::verify(a, expected_domain, data).await,
-      SearchableKinds::Page(a) => ApubPost::verify(a, expected_domain, data).await,
-      SearchableKinds::Note(a) => ApubComment::verify(a, expected_domain, data).await,
+    async fn into_json(self, _data: &Data<Self::DataType>) -> Result<Self::Kind, LemmyError> {
+        unimplemented!()
     }
-  }
 
-  #[tracing::instrument(skip_all)]
-  async fn from_json(apub: Self::Kind, context: &Data<LemmyContext>) -> Result<Self, LemmyError> {
-    use SearchableKinds as SAT;
-    use SearchableObjects as SO;
-    Ok(match apub {
-      SAT::Group(g) => SO::Community(ApubCommunity::from_json(g, context).await?),
-      SAT::Person(p) => SO::Person(ApubPerson::from_json(p, context).await?),
-      SAT::Page(p) => SO::Post(ApubPost::from_json(p, context).await?),
-      SAT::Note(n) => SO::Comment(ApubComment::from_json(n, context).await?),
-    })
-  }
+    #[tracing::instrument(skip_all)]
+    async fn verify(
+        apub: &Self::Kind,
+        expected_domain: &Url,
+        data: &Data<Self::DataType>,
+    ) -> Result<(), LemmyError> {
+        match apub {
+            SearchableKinds::Group(a) => ApubCommunity::verify(a, expected_domain, data).await,
+            SearchableKinds::Person(a) => ApubPerson::verify(a, expected_domain, data).await,
+            SearchableKinds::Page(a) => ApubPost::verify(a, expected_domain, data).await,
+            SearchableKinds::Note(a) => ApubComment::verify(a, expected_domain, data).await,
+        }
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn from_json(apub: Self::Kind, context: &Data<LemmyContext>) -> Result<Self, LemmyError> {
+        use SearchableKinds as SAT;
+        use SearchableObjects as SO;
+        Ok(match apub {
+            SAT::Group(g) => SO::Community(ApubCommunity::from_json(g, context).await?),
+            SAT::Person(p) => SO::Person(ApubPerson::from_json(p, context).await?),
+            SAT::Page(p) => SO::Post(ApubPost::from_json(p, context).await?),
+            SAT::Note(n) => SO::Comment(ApubComment::from_json(n, context).await?),
+        })
+    }
 }

--- a/crates/apub/src/fetcher/user_or_community.rs
+++ b/crates/apub/src/fetcher/user_or_community.rs
@@ -1,10 +1,10 @@
 use crate::{
-  objects::{community::ApubCommunity, person::ApubPerson},
-  protocol::objects::{group::Group, person::Person},
+    objects::{community::ApubCommunity, person::ApubPerson},
+    protocol::objects::{group::Group, person::Person},
 };
 use activitypub_federation::{
-  config::Data,
-  traits::{Actor, Object},
+    config::Data,
+    traits::{Actor, Object},
 };
 use chrono::{DateTime, Utc};
 use lemmy_api_common::context::LemmyContext;
@@ -14,108 +14,110 @@ use url::Url;
 
 #[derive(Clone, Debug)]
 pub enum UserOrCommunity {
-  User(ApubPerson),
-  Community(ApubCommunity),
+    User(ApubPerson),
+    Community(ApubCommunity),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum PersonOrGroup {
-  Person(Person),
-  Group(Group),
+    Person(Person),
+    Group(Group),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub enum PersonOrGroupType {
-  Person,
-  Group,
+    Person,
+    Group,
 }
 
 #[async_trait::async_trait]
 impl Object for UserOrCommunity {
-  type DataType = LemmyContext;
-  type Kind = PersonOrGroup;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Kind = PersonOrGroup;
+    type Error = LemmyError;
 
-  fn last_refreshed_at(&self) -> Option<DateTime<Utc>> {
-    Some(match self {
-      UserOrCommunity::User(p) => p.last_refreshed_at,
-      UserOrCommunity::Community(p) => p.last_refreshed_at,
-    })
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn read_from_id(
-    object_id: Url,
-    data: &Data<Self::DataType>,
-  ) -> Result<Option<Self>, LemmyError> {
-    let person = ApubPerson::read_from_id(object_id.clone(), data).await?;
-    Ok(match person {
-      Some(o) => Some(UserOrCommunity::User(o)),
-      None => ApubCommunity::read_from_id(object_id, data)
-        .await?
-        .map(UserOrCommunity::Community),
-    })
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn delete(self, data: &Data<Self::DataType>) -> Result<(), LemmyError> {
-    match self {
-      UserOrCommunity::User(p) => p.delete(data).await,
-      UserOrCommunity::Community(p) => p.delete(data).await,
+    fn last_refreshed_at(&self) -> Option<DateTime<Utc>> {
+        Some(match self {
+            UserOrCommunity::User(p) => p.last_refreshed_at,
+            UserOrCommunity::Community(p) => p.last_refreshed_at,
+        })
     }
-  }
 
-  async fn into_json(self, _data: &Data<Self::DataType>) -> Result<Self::Kind, LemmyError> {
-    unimplemented!()
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn verify(
-    apub: &Self::Kind,
-    expected_domain: &Url,
-    data: &Data<Self::DataType>,
-  ) -> Result<(), LemmyError> {
-    match apub {
-      PersonOrGroup::Person(a) => ApubPerson::verify(a, expected_domain, data).await,
-      PersonOrGroup::Group(a) => ApubCommunity::verify(a, expected_domain, data).await,
+    #[tracing::instrument(skip_all)]
+    async fn read_from_id(
+        object_id: Url,
+        data: &Data<Self::DataType>,
+    ) -> Result<Option<Self>, LemmyError> {
+        let person = ApubPerson::read_from_id(object_id.clone(), data).await?;
+        Ok(match person {
+            Some(o) => Some(UserOrCommunity::User(o)),
+            None => ApubCommunity::read_from_id(object_id, data)
+                .await?
+                .map(UserOrCommunity::Community),
+        })
     }
-  }
 
-  #[tracing::instrument(skip_all)]
-  async fn from_json(apub: Self::Kind, data: &Data<Self::DataType>) -> Result<Self, LemmyError> {
-    Ok(match apub {
-      PersonOrGroup::Person(p) => UserOrCommunity::User(ApubPerson::from_json(p, data).await?),
-      PersonOrGroup::Group(p) => {
-        UserOrCommunity::Community(ApubCommunity::from_json(p, data).await?)
-      }
-    })
-  }
+    #[tracing::instrument(skip_all)]
+    async fn delete(self, data: &Data<Self::DataType>) -> Result<(), LemmyError> {
+        match self {
+            UserOrCommunity::User(p) => p.delete(data).await,
+            UserOrCommunity::Community(p) => p.delete(data).await,
+        }
+    }
+
+    async fn into_json(self, _data: &Data<Self::DataType>) -> Result<Self::Kind, LemmyError> {
+        unimplemented!()
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn verify(
+        apub: &Self::Kind,
+        expected_domain: &Url,
+        data: &Data<Self::DataType>,
+    ) -> Result<(), LemmyError> {
+        match apub {
+            PersonOrGroup::Person(a) => ApubPerson::verify(a, expected_domain, data).await,
+            PersonOrGroup::Group(a) => ApubCommunity::verify(a, expected_domain, data).await,
+        }
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn from_json(apub: Self::Kind, data: &Data<Self::DataType>) -> Result<Self, LemmyError> {
+        Ok(match apub {
+            PersonOrGroup::Person(p) => {
+                UserOrCommunity::User(ApubPerson::from_json(p, data).await?)
+            }
+            PersonOrGroup::Group(p) => {
+                UserOrCommunity::Community(ApubCommunity::from_json(p, data).await?)
+            }
+        })
+    }
 }
 
 impl Actor for UserOrCommunity {
-  fn id(&self) -> Url {
-    match self {
-      UserOrCommunity::User(u) => u.id(),
-      UserOrCommunity::Community(c) => c.id(),
+    fn id(&self) -> Url {
+        match self {
+            UserOrCommunity::User(u) => u.id(),
+            UserOrCommunity::Community(c) => c.id(),
+        }
     }
-  }
 
-  fn public_key_pem(&self) -> &str {
-    match self {
-      UserOrCommunity::User(p) => p.public_key_pem(),
-      UserOrCommunity::Community(p) => p.public_key_pem(),
+    fn public_key_pem(&self) -> &str {
+        match self {
+            UserOrCommunity::User(p) => p.public_key_pem(),
+            UserOrCommunity::Community(p) => p.public_key_pem(),
+        }
     }
-  }
 
-  fn private_key_pem(&self) -> Option<String> {
-    match self {
-      UserOrCommunity::User(p) => p.private_key_pem(),
-      UserOrCommunity::Community(p) => p.private_key_pem(),
+    fn private_key_pem(&self) -> Option<String> {
+        match self {
+            UserOrCommunity::User(p) => p.private_key_pem(),
+            UserOrCommunity::Community(p) => p.private_key_pem(),
+        }
     }
-  }
 
-  fn inbox(&self) -> Url {
-    unimplemented!()
-  }
+    fn inbox(&self) -> Url {
+        unimplemented!()
+    }
 }

--- a/crates/apub/src/http/comment.rs
+++ b/crates/apub/src/http/comment.rs
@@ -1,6 +1,6 @@
 use crate::{
-  http::{create_apub_response, create_apub_tombstone_response, err_object_not_local},
-  objects::comment::ApubComment,
+    http::{create_apub_response, create_apub_tombstone_response, err_object_not_local},
+    objects::comment::ApubComment,
 };
 use activitypub_federation::{config::Data, traits::Object};
 use actix_web::{web::Path, HttpResponse};
@@ -11,22 +11,22 @@ use serde::Deserialize;
 
 #[derive(Deserialize)]
 pub(crate) struct CommentQuery {
-  comment_id: String,
+    comment_id: String,
 }
 
 /// Return the ActivityPub json representation of a local comment over HTTP.
 #[tracing::instrument(skip_all)]
 pub(crate) async fn get_apub_comment(
-  info: Path<CommentQuery>,
-  context: Data<LemmyContext>,
+    info: Path<CommentQuery>,
+    context: Data<LemmyContext>,
 ) -> Result<HttpResponse, LemmyError> {
-  let id = CommentId(info.comment_id.parse::<i32>()?);
-  let comment: ApubComment = Comment::read(&mut context.pool(), id).await?.into();
-  if !comment.local {
-    Err(err_object_not_local())
-  } else if !comment.deleted && !comment.removed {
-    create_apub_response(&comment.into_json(&context).await?)
-  } else {
-    create_apub_tombstone_response(comment.ap_id.clone())
-  }
+    let id = CommentId(info.comment_id.parse::<i32>()?);
+    let comment: ApubComment = Comment::read(&mut context.pool(), id).await?.into();
+    if !comment.local {
+        Err(err_object_not_local())
+    } else if !comment.deleted && !comment.removed {
+        create_apub_response(&comment.into_json(&context).await?)
+    } else {
+        create_apub_tombstone_response(comment.ap_id.clone())
+    }
 }

--- a/crates/apub/src/http/community.rs
+++ b/crates/apub/src/http/community.rs
@@ -1,19 +1,18 @@
 use crate::{
-  activity_lists::GroupInboxActivities,
-  collections::{
-    community_featured::ApubCommunityFeatured,
-    community_moderators::ApubCommunityModerators,
-    community_outbox::ApubCommunityOutbox,
-  },
-  http::{create_apub_response, create_apub_tombstone_response},
-  objects::{community::ApubCommunity, person::ApubPerson},
-  protocol::collections::group_followers::GroupFollowers,
+    activity_lists::GroupInboxActivities,
+    collections::{
+        community_featured::ApubCommunityFeatured, community_moderators::ApubCommunityModerators,
+        community_outbox::ApubCommunityOutbox,
+    },
+    http::{create_apub_response, create_apub_tombstone_response},
+    objects::{community::ApubCommunity, person::ApubPerson},
+    protocol::collections::group_followers::GroupFollowers,
 };
 use activitypub_federation::{
-  actix_web::inbox::receive_activity,
-  config::Data,
-  protocol::context::WithContext,
-  traits::{Collection, Object},
+    actix_web::inbox::receive_activity,
+    config::Data,
+    protocol::context::WithContext,
+    traits::{Collection, Object},
 };
 use actix_web::{web, web::Bytes, HttpRequest, HttpResponse};
 use lemmy_api_common::context::LemmyContext;
@@ -23,98 +22,98 @@ use serde::Deserialize;
 
 #[derive(Deserialize)]
 pub(crate) struct CommunityQuery {
-  community_name: String,
+    community_name: String,
 }
 
 /// Return the ActivityPub json representation of a local community over HTTP.
 #[tracing::instrument(skip_all)]
 pub(crate) async fn get_apub_community_http(
-  info: web::Path<CommunityQuery>,
-  context: Data<LemmyContext>,
+    info: web::Path<CommunityQuery>,
+    context: Data<LemmyContext>,
 ) -> Result<HttpResponse, LemmyError> {
-  let community: ApubCommunity =
-    Community::read_from_name(&mut context.pool(), &info.community_name, true)
-      .await?
-      .into();
+    let community: ApubCommunity =
+        Community::read_from_name(&mut context.pool(), &info.community_name, true)
+            .await?
+            .into();
 
-  if !community.deleted && !community.removed {
-    let apub = community.into_json(&context).await?;
+    if !community.deleted && !community.removed {
+        let apub = community.into_json(&context).await?;
 
-    create_apub_response(&apub)
-  } else {
-    create_apub_tombstone_response(community.actor_id.clone())
-  }
+        create_apub_response(&apub)
+    } else {
+        create_apub_tombstone_response(community.actor_id.clone())
+    }
 }
 
 /// Handler for all incoming receive to community inboxes.
 #[tracing::instrument(skip_all)]
 pub async fn community_inbox(
-  request: HttpRequest,
-  body: Bytes,
-  data: Data<LemmyContext>,
+    request: HttpRequest,
+    body: Bytes,
+    data: Data<LemmyContext>,
 ) -> Result<HttpResponse, LemmyError> {
-  receive_activity::<WithContext<GroupInboxActivities>, ApubPerson, LemmyContext>(
-    request, body, &data,
-  )
-  .await
+    receive_activity::<WithContext<GroupInboxActivities>, ApubPerson, LemmyContext>(
+        request, body, &data,
+    )
+    .await
 }
 
 /// Returns an empty followers collection, only populating the size (for privacy).
 pub(crate) async fn get_apub_community_followers(
-  info: web::Path<CommunityQuery>,
-  context: Data<LemmyContext>,
+    info: web::Path<CommunityQuery>,
+    context: Data<LemmyContext>,
 ) -> Result<HttpResponse, LemmyError> {
-  let community =
-    Community::read_from_name(&mut context.pool(), &info.community_name, false).await?;
-  let followers = GroupFollowers::new(community, &context).await?;
-  create_apub_response(&followers)
+    let community =
+        Community::read_from_name(&mut context.pool(), &info.community_name, false).await?;
+    let followers = GroupFollowers::new(community, &context).await?;
+    create_apub_response(&followers)
 }
 
 /// Returns the community outbox, which is populated by a maximum of 20 posts (but no other
 /// activites like votes or comments).
 pub(crate) async fn get_apub_community_outbox(
-  info: web::Path<CommunityQuery>,
-  context: Data<LemmyContext>,
+    info: web::Path<CommunityQuery>,
+    context: Data<LemmyContext>,
 ) -> Result<HttpResponse, LemmyError> {
-  let community: ApubCommunity =
-    Community::read_from_name(&mut context.pool(), &info.community_name, false)
-      .await?
-      .into();
-  if community.deleted || community.removed {
-    Err(LemmyErrorType::Deleted)?
-  }
-  let outbox = ApubCommunityOutbox::read_local(&community, &context).await?;
-  create_apub_response(&outbox)
+    let community: ApubCommunity =
+        Community::read_from_name(&mut context.pool(), &info.community_name, false)
+            .await?
+            .into();
+    if community.deleted || community.removed {
+        Err(LemmyErrorType::Deleted)?
+    }
+    let outbox = ApubCommunityOutbox::read_local(&community, &context).await?;
+    create_apub_response(&outbox)
 }
 
 #[tracing::instrument(skip_all)]
 pub(crate) async fn get_apub_community_moderators(
-  info: web::Path<CommunityQuery>,
-  context: Data<LemmyContext>,
+    info: web::Path<CommunityQuery>,
+    context: Data<LemmyContext>,
 ) -> Result<HttpResponse, LemmyError> {
-  let community: ApubCommunity =
-    Community::read_from_name(&mut context.pool(), &info.community_name, false)
-      .await?
-      .into();
-  if community.deleted || community.removed {
-    Err(LemmyErrorType::Deleted)?
-  }
-  let moderators = ApubCommunityModerators::read_local(&community, &context).await?;
-  create_apub_response(&moderators)
+    let community: ApubCommunity =
+        Community::read_from_name(&mut context.pool(), &info.community_name, false)
+            .await?
+            .into();
+    if community.deleted || community.removed {
+        Err(LemmyErrorType::Deleted)?
+    }
+    let moderators = ApubCommunityModerators::read_local(&community, &context).await?;
+    create_apub_response(&moderators)
 }
 
 /// Returns collection of featured (stickied) posts.
 pub(crate) async fn get_apub_community_featured(
-  info: web::Path<CommunityQuery>,
-  context: Data<LemmyContext>,
+    info: web::Path<CommunityQuery>,
+    context: Data<LemmyContext>,
 ) -> Result<HttpResponse, LemmyError> {
-  let community: ApubCommunity =
-    Community::read_from_name(&mut context.pool(), &info.community_name, false)
-      .await?
-      .into();
-  if community.deleted || community.removed {
-    Err(LemmyErrorType::Deleted)?
-  }
-  let featured = ApubCommunityFeatured::read_local(&community, &context).await?;
-  create_apub_response(&featured)
+    let community: ApubCommunity =
+        Community::read_from_name(&mut context.pool(), &info.community_name, false)
+            .await?
+            .into();
+    if community.deleted || community.removed {
+        Err(LemmyErrorType::Deleted)?
+    }
+    let featured = ApubCommunityFeatured::read_local(&community, &context).await?;
+    create_apub_response(&featured)
 }

--- a/crates/apub/src/http/mod.rs
+++ b/crates/apub/src/http/mod.rs
@@ -1,14 +1,10 @@
 use crate::{
-  activity_lists::SharedInboxActivities,
-  fetcher::user_or_community::UserOrCommunity,
-  protocol::objects::tombstone::Tombstone,
-  CONTEXT,
+    activity_lists::SharedInboxActivities, fetcher::user_or_community::UserOrCommunity,
+    protocol::objects::tombstone::Tombstone, CONTEXT,
 };
 use activitypub_federation::{
-  actix_web::inbox::receive_activity,
-  config::Data,
-  protocol::context::WithContext,
-  FEDERATION_CONTENT_TYPE,
+    actix_web::inbox::receive_activity, config::Data, protocol::context::WithContext,
+    FEDERATION_CONTENT_TYPE,
 };
 use actix_web::{web, web::Bytes, HttpRequest, HttpResponse};
 use http::StatusCode;
@@ -27,12 +23,12 @@ pub mod routes;
 pub mod site;
 
 pub async fn shared_inbox(
-  request: HttpRequest,
-  body: Bytes,
-  data: Data<LemmyContext>,
+    request: HttpRequest,
+    body: Bytes,
+    data: Data<LemmyContext>,
 ) -> LemmyResult<HttpResponse> {
-  receive_activity::<SharedInboxActivities, UserOrCommunity, LemmyContext>(request, body, &data)
-    .await
+    receive_activity::<SharedInboxActivities, UserOrCommunity, LemmyContext>(request, body, &data)
+        .await
 }
 
 /// Convert the data to json and turn it into an HTTP Response with the correct ActivityPub
@@ -41,59 +37,55 @@ pub async fn shared_inbox(
 /// actix-web doesn't allow pretty-print for json so we need to do this manually.
 fn create_apub_response<T>(data: &T) -> LemmyResult<HttpResponse>
 where
-  T: Serialize,
+    T: Serialize,
 {
-  let json = serde_json::to_string_pretty(&WithContext::new(data, CONTEXT.clone()))?;
+    let json = serde_json::to_string_pretty(&WithContext::new(data, CONTEXT.clone()))?;
 
-  Ok(
-    HttpResponse::Ok()
-      .content_type(FEDERATION_CONTENT_TYPE)
-      .body(json),
-  )
+    Ok(HttpResponse::Ok()
+        .content_type(FEDERATION_CONTENT_TYPE)
+        .body(json))
 }
 
 fn create_apub_tombstone_response<T: Into<Url>>(id: T) -> LemmyResult<HttpResponse> {
-  let tombstone = Tombstone::new(id.into());
-  let json = serde_json::to_string_pretty(&WithContext::new(tombstone, CONTEXT.deref().clone()))?;
+    let tombstone = Tombstone::new(id.into());
+    let json = serde_json::to_string_pretty(&WithContext::new(tombstone, CONTEXT.deref().clone()))?;
 
-  Ok(
-    HttpResponse::Gone()
-      .content_type(FEDERATION_CONTENT_TYPE)
-      .status(StatusCode::GONE)
-      .body(json),
-  )
+    Ok(HttpResponse::Gone()
+        .content_type(FEDERATION_CONTENT_TYPE)
+        .status(StatusCode::GONE)
+        .body(json))
 }
 
 fn err_object_not_local() -> LemmyError {
-  LemmyErrorType::ObjectNotLocal.into()
+    LemmyErrorType::ObjectNotLocal.into()
 }
 
 #[derive(Deserialize)]
 pub struct ActivityQuery {
-  type_: String,
-  id: String,
+    type_: String,
+    id: String,
 }
 
 /// Return the ActivityPub json representation of a local activity over HTTP.
 #[tracing::instrument(skip_all)]
 pub(crate) async fn get_activity(
-  info: web::Path<ActivityQuery>,
-  context: web::Data<LemmyContext>,
+    info: web::Path<ActivityQuery>,
+    context: web::Data<LemmyContext>,
 ) -> Result<HttpResponse, LemmyError> {
-  let settings = context.settings();
-  let activity_id = Url::parse(&format!(
-    "{}/activities/{}/{}",
-    settings.get_protocol_and_hostname(),
-    info.type_,
-    info.id
-  ))?
-  .into();
-  let activity = SentActivity::read_from_apub_id(&mut context.pool(), &activity_id).await?;
+    let settings = context.settings();
+    let activity_id = Url::parse(&format!(
+        "{}/activities/{}/{}",
+        settings.get_protocol_and_hostname(),
+        info.type_,
+        info.id
+    ))?
+    .into();
+    let activity = SentActivity::read_from_apub_id(&mut context.pool(), &activity_id).await?;
 
-  let sensitive = activity.sensitive;
-  if sensitive {
-    Ok(HttpResponse::Forbidden().finish())
-  } else {
-    create_apub_response(&activity.data)
-  }
+    let sensitive = activity.sensitive;
+    if sensitive {
+        Ok(HttpResponse::Forbidden().finish())
+    } else {
+        create_apub_response(&activity.data)
+    }
 }

--- a/crates/apub/src/http/person.rs
+++ b/crates/apub/src/http/person.rs
@@ -1,15 +1,13 @@
 use crate::{
-  activity_lists::PersonInboxActivities,
-  fetcher::user_or_community::UserOrCommunity,
-  http::{create_apub_response, create_apub_tombstone_response},
-  objects::person::ApubPerson,
-  protocol::collections::empty_outbox::EmptyOutbox,
+    activity_lists::PersonInboxActivities,
+    fetcher::user_or_community::UserOrCommunity,
+    http::{create_apub_response, create_apub_tombstone_response},
+    objects::person::ApubPerson,
+    protocol::collections::empty_outbox::EmptyOutbox,
 };
 use activitypub_federation::{
-  actix_web::inbox::receive_activity,
-  config::Data,
-  protocol::context::WithContext,
-  traits::Object,
+    actix_web::inbox::receive_activity, config::Data, protocol::context::WithContext,
+    traits::Object,
 };
 use actix_web::{web, web::Bytes, HttpRequest, HttpResponse};
 use lemmy_api_common::{context::LemmyContext, utils::generate_outbox_url};
@@ -19,49 +17,49 @@ use serde::Deserialize;
 
 #[derive(Deserialize)]
 pub struct PersonQuery {
-  user_name: String,
+    user_name: String,
 }
 
 /// Return the ActivityPub json representation of a local person over HTTP.
 #[tracing::instrument(skip_all)]
 pub(crate) async fn get_apub_person_http(
-  info: web::Path<PersonQuery>,
-  context: Data<LemmyContext>,
+    info: web::Path<PersonQuery>,
+    context: Data<LemmyContext>,
 ) -> Result<HttpResponse, LemmyError> {
-  let user_name = info.into_inner().user_name;
-  // TODO: this needs to be able to read deleted persons, so that it can send tombstones
-  let person: ApubPerson = Person::read_from_name(&mut context.pool(), &user_name, true)
-    .await?
-    .into();
+    let user_name = info.into_inner().user_name;
+    // TODO: this needs to be able to read deleted persons, so that it can send tombstones
+    let person: ApubPerson = Person::read_from_name(&mut context.pool(), &user_name, true)
+        .await?
+        .into();
 
-  if !person.deleted {
-    let apub = person.into_json(&context).await?;
+    if !person.deleted {
+        let apub = person.into_json(&context).await?;
 
-    create_apub_response(&apub)
-  } else {
-    create_apub_tombstone_response(person.actor_id.clone())
-  }
+        create_apub_response(&apub)
+    } else {
+        create_apub_tombstone_response(person.actor_id.clone())
+    }
 }
 
 #[tracing::instrument(skip_all)]
 pub async fn person_inbox(
-  request: HttpRequest,
-  body: Bytes,
-  data: Data<LemmyContext>,
+    request: HttpRequest,
+    body: Bytes,
+    data: Data<LemmyContext>,
 ) -> Result<HttpResponse, LemmyError> {
-  receive_activity::<WithContext<PersonInboxActivities>, UserOrCommunity, LemmyContext>(
-    request, body, &data,
-  )
-  .await
+    receive_activity::<WithContext<PersonInboxActivities>, UserOrCommunity, LemmyContext>(
+        request, body, &data,
+    )
+    .await
 }
 
 #[tracing::instrument(skip_all)]
 pub(crate) async fn get_apub_person_outbox(
-  info: web::Path<PersonQuery>,
-  context: Data<LemmyContext>,
+    info: web::Path<PersonQuery>,
+    context: Data<LemmyContext>,
 ) -> Result<HttpResponse, LemmyError> {
-  let person = Person::read_from_name(&mut context.pool(), &info.user_name, false).await?;
-  let outbox_id = generate_outbox_url(&person.actor_id)?.into();
-  let outbox = EmptyOutbox::new(outbox_id)?;
-  create_apub_response(&outbox)
+    let person = Person::read_from_name(&mut context.pool(), &info.user_name, false).await?;
+    let outbox_id = generate_outbox_url(&person.actor_id)?.into();
+    let outbox = EmptyOutbox::new(outbox_id)?;
+    create_apub_response(&outbox)
 }

--- a/crates/apub/src/http/post.rs
+++ b/crates/apub/src/http/post.rs
@@ -1,6 +1,6 @@
 use crate::{
-  http::{create_apub_response, create_apub_tombstone_response, err_object_not_local},
-  objects::post::ApubPost,
+    http::{create_apub_response, create_apub_tombstone_response, err_object_not_local},
+    objects::post::ApubPost,
 };
 use activitypub_federation::{config::Data, traits::Object};
 use actix_web::{web, HttpResponse};
@@ -11,22 +11,22 @@ use serde::Deserialize;
 
 #[derive(Deserialize)]
 pub(crate) struct PostQuery {
-  post_id: String,
+    post_id: String,
 }
 
 /// Return the ActivityPub json representation of a local post over HTTP.
 #[tracing::instrument(skip_all)]
 pub(crate) async fn get_apub_post(
-  info: web::Path<PostQuery>,
-  context: Data<LemmyContext>,
+    info: web::Path<PostQuery>,
+    context: Data<LemmyContext>,
 ) -> Result<HttpResponse, LemmyError> {
-  let id = PostId(info.post_id.parse::<i32>()?);
-  let post: ApubPost = Post::read(&mut context.pool(), id).await?.into();
-  if !post.local {
-    Err(err_object_not_local())
-  } else if !post.deleted && !post.removed {
-    create_apub_response(&post.into_json(&context).await?)
-  } else {
-    create_apub_tombstone_response(post.ap_id.clone())
-  }
+    let id = PostId(info.post_id.parse::<i32>()?);
+    let post: ApubPost = Post::read(&mut context.pool(), id).await?.into();
+    if !post.local {
+        Err(err_object_not_local())
+    } else if !post.deleted && !post.removed {
+        create_apub_response(&post.into_json(&context).await?)
+    } else {
+        create_apub_tombstone_response(post.ap_id.clone())
+    }
 }

--- a/crates/apub/src/http/routes.rs
+++ b/crates/apub/src/http/routes.rs
@@ -1,66 +1,61 @@
 use crate::http::{
-  comment::get_apub_comment,
-  community::{
-    community_inbox,
-    get_apub_community_featured,
-    get_apub_community_followers,
-    get_apub_community_http,
-    get_apub_community_moderators,
-    get_apub_community_outbox,
-  },
-  get_activity,
-  person::{get_apub_person_http, get_apub_person_outbox, person_inbox},
-  post::get_apub_post,
-  shared_inbox,
-  site::{get_apub_site_http, get_apub_site_inbox, get_apub_site_outbox},
+    comment::get_apub_comment,
+    community::{
+        community_inbox, get_apub_community_featured, get_apub_community_followers,
+        get_apub_community_http, get_apub_community_moderators, get_apub_community_outbox,
+    },
+    get_activity,
+    person::{get_apub_person_http, get_apub_person_outbox, person_inbox},
+    post::get_apub_post,
+    shared_inbox,
+    site::{get_apub_site_http, get_apub_site_inbox, get_apub_site_outbox},
 };
 use actix_web::{
-  guard::{Guard, GuardContext},
-  http::{header, Method},
-  web,
+    guard::{Guard, GuardContext},
+    http::{header, Method},
+    web,
 };
 
 pub fn config(cfg: &mut web::ServiceConfig) {
-  cfg
-    .route("/", web::get().to(get_apub_site_http))
-    .route("/site_outbox", web::get().to(get_apub_site_outbox))
-    .route(
-      "/c/{community_name}",
-      web::get().to(get_apub_community_http),
-    )
-    .route(
-      "/c/{community_name}/followers",
-      web::get().to(get_apub_community_followers),
-    )
-    .route(
-      "/c/{community_name}/outbox",
-      web::get().to(get_apub_community_outbox),
-    )
-    .route(
-      "/c/{community_name}/featured",
-      web::get().to(get_apub_community_featured),
-    )
-    .route(
-      "/c/{community_name}/moderators",
-      web::get().to(get_apub_community_moderators),
-    )
-    .route("/u/{user_name}", web::get().to(get_apub_person_http))
-    .route(
-      "/u/{user_name}/outbox",
-      web::get().to(get_apub_person_outbox),
-    )
-    .route("/post/{post_id}", web::get().to(get_apub_post))
-    .route("/comment/{comment_id}", web::get().to(get_apub_comment))
-    .route("/activities/{type_}/{id}", web::get().to(get_activity));
+    cfg.route("/", web::get().to(get_apub_site_http))
+        .route("/site_outbox", web::get().to(get_apub_site_outbox))
+        .route(
+            "/c/{community_name}",
+            web::get().to(get_apub_community_http),
+        )
+        .route(
+            "/c/{community_name}/followers",
+            web::get().to(get_apub_community_followers),
+        )
+        .route(
+            "/c/{community_name}/outbox",
+            web::get().to(get_apub_community_outbox),
+        )
+        .route(
+            "/c/{community_name}/featured",
+            web::get().to(get_apub_community_featured),
+        )
+        .route(
+            "/c/{community_name}/moderators",
+            web::get().to(get_apub_community_moderators),
+        )
+        .route("/u/{user_name}", web::get().to(get_apub_person_http))
+        .route(
+            "/u/{user_name}/outbox",
+            web::get().to(get_apub_person_outbox),
+        )
+        .route("/post/{post_id}", web::get().to(get_apub_post))
+        .route("/comment/{comment_id}", web::get().to(get_apub_comment))
+        .route("/activities/{type_}/{id}", web::get().to(get_activity));
 
-  cfg.service(
-    web::scope("")
-      .guard(InboxRequestGuard)
-      .route("/c/{community_name}/inbox", web::post().to(community_inbox))
-      .route("/u/{user_name}/inbox", web::post().to(person_inbox))
-      .route("/inbox", web::post().to(shared_inbox))
-      .route("/site_inbox", web::post().to(get_apub_site_inbox)),
-  );
+    cfg.service(
+        web::scope("")
+            .guard(InboxRequestGuard)
+            .route("/c/{community_name}/inbox", web::post().to(community_inbox))
+            .route("/u/{user_name}/inbox", web::post().to(person_inbox))
+            .route("/inbox", web::post().to(shared_inbox))
+            .route("/site_inbox", web::post().to(get_apub_site_inbox)),
+    );
 }
 
 /// Without this, things like webfinger or RSS feeds stop working, as all requests seem to get
@@ -69,13 +64,13 @@ pub fn config(cfg: &mut web::ServiceConfig) {
 struct InboxRequestGuard;
 
 impl Guard for InboxRequestGuard {
-  fn check(&self, ctx: &GuardContext) -> bool {
-    if ctx.head().method != Method::POST {
-      return false;
+    fn check(&self, ctx: &GuardContext) -> bool {
+        if ctx.head().method != Method::POST {
+            return false;
+        }
+        if let Some(val) = ctx.head().headers.get(header::CONTENT_TYPE) {
+            return val.as_bytes().starts_with(b"application/");
+        }
+        false
     }
-    if let Some(val) = ctx.head().headers.get(header::CONTENT_TYPE) {
-      return val.as_bytes().starts_with(b"application/");
-    }
-    false
-  }
 }

--- a/crates/apub/src/http/site.rs
+++ b/crates/apub/src/http/site.rs
@@ -1,14 +1,12 @@
 use crate::{
-  activity_lists::SiteInboxActivities,
-  http::create_apub_response,
-  objects::{instance::ApubSite, person::ApubPerson},
-  protocol::collections::empty_outbox::EmptyOutbox,
+    activity_lists::SiteInboxActivities,
+    http::create_apub_response,
+    objects::{instance::ApubSite, person::ApubPerson},
+    protocol::collections::empty_outbox::EmptyOutbox,
 };
 use activitypub_federation::{
-  actix_web::inbox::receive_activity,
-  config::Data,
-  protocol::context::WithContext,
-  traits::Object,
+    actix_web::inbox::receive_activity, config::Data, protocol::context::WithContext,
+    traits::Object,
 };
 use actix_web::{web::Bytes, HttpRequest, HttpResponse};
 use lemmy_api_common::context::LemmyContext;
@@ -17,34 +15,34 @@ use lemmy_utils::error::LemmyError;
 use url::Url;
 
 pub(crate) async fn get_apub_site_http(
-  context: Data<LemmyContext>,
+    context: Data<LemmyContext>,
 ) -> Result<HttpResponse, LemmyError> {
-  let site: ApubSite = SiteView::read_local(&mut context.pool()).await?.site.into();
+    let site: ApubSite = SiteView::read_local(&mut context.pool()).await?.site.into();
 
-  let apub = site.into_json(&context).await?;
-  create_apub_response(&apub)
+    let apub = site.into_json(&context).await?;
+    create_apub_response(&apub)
 }
 
 #[tracing::instrument(skip_all)]
 pub(crate) async fn get_apub_site_outbox(
-  context: Data<LemmyContext>,
+    context: Data<LemmyContext>,
 ) -> Result<HttpResponse, LemmyError> {
-  let outbox_id = format!(
-    "{}/site_outbox",
-    context.settings().get_protocol_and_hostname()
-  );
-  let outbox = EmptyOutbox::new(Url::parse(&outbox_id)?)?;
-  create_apub_response(&outbox)
+    let outbox_id = format!(
+        "{}/site_outbox",
+        context.settings().get_protocol_and_hostname()
+    );
+    let outbox = EmptyOutbox::new(Url::parse(&outbox_id)?)?;
+    create_apub_response(&outbox)
 }
 
 #[tracing::instrument(skip_all)]
 pub async fn get_apub_site_inbox(
-  request: HttpRequest,
-  body: Bytes,
-  data: Data<LemmyContext>,
+    request: HttpRequest,
+    body: Bytes,
+    data: Data<LemmyContext>,
 ) -> Result<HttpResponse, LemmyError> {
-  receive_activity::<WithContext<SiteInboxActivities>, ApubPerson, LemmyContext>(
-    request, body, &data,
-  )
-  .await
+    receive_activity::<WithContext<SiteInboxActivities>, ApubPerson, LemmyContext>(
+        request, body, &data,
+    )
+    .await
 }

--- a/crates/apub/src/lib.rs
+++ b/crates/apub/src/lib.rs
@@ -4,8 +4,8 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::{
-  source::{activity::ReceivedActivity, instance::Instance, local_site::LocalSite},
-  utils::{ActualDbPool, DbPool},
+    source::{activity::ReceivedActivity, instance::Instance, local_site::LocalSite},
+    utils::{ActualDbPool, DbPool},
 };
 use lemmy_utils::error::{LemmyError, LemmyErrorType, LemmyResult};
 use moka::future::Cache;
@@ -31,7 +31,7 @@ pub const FEDERATION_HTTP_FETCH_LIMIT: u32 = 50;
 const BLOCKLIST_CACHE_DURATION: Duration = Duration::from_secs(60);
 
 static CONTEXT: Lazy<Vec<serde_json::Value>> = Lazy::new(|| {
-  serde_json::from_str(include_str!("../assets/lemmy/context.json")).expect("parse context")
+    serde_json::from_str(include_str!("../assets/lemmy/context.json")).expect("parse context")
 });
 
 #[derive(Clone)]
@@ -39,27 +39,27 @@ pub struct VerifyUrlData(pub ActualDbPool);
 
 #[async_trait]
 impl UrlVerifier for VerifyUrlData {
-  async fn verify(&self, url: &Url) -> Result<(), anyhow::Error> {
-    let local_site_data = local_site_data_cached(&mut (&self.0).into())
-      .await
-      .expect("read local site data");
-    check_apub_id_valid(url, &local_site_data).map_err(|err| match err {
-      LemmyError {
-        error_type: LemmyErrorType::FederationDisabled,
-        ..
-      } => anyhow!("Federation disabled"),
-      LemmyError {
-        error_type: LemmyErrorType::DomainBlocked(_),
-        ..
-      } => anyhow!("Domain is blocked"),
-      LemmyError {
-        error_type: LemmyErrorType::DomainNotInAllowList(_),
-        ..
-      } => anyhow!("Domain is not in allowlist"),
-      _ => anyhow!("Failed validating apub id"),
-    })?;
-    Ok(())
-  }
+    async fn verify(&self, url: &Url) -> Result<(), anyhow::Error> {
+        let local_site_data = local_site_data_cached(&mut (&self.0).into())
+            .await
+            .expect("read local site data");
+        check_apub_id_valid(url, &local_site_data).map_err(|err| match err {
+            LemmyError {
+                error_type: LemmyErrorType::FederationDisabled,
+                ..
+            } => anyhow!("Federation disabled"),
+            LemmyError {
+                error_type: LemmyErrorType::DomainBlocked(_),
+                ..
+            } => anyhow!("Domain is blocked"),
+            LemmyError {
+                error_type: LemmyErrorType::DomainNotInAllowList(_),
+                ..
+            } => anyhow!("Domain is not in allowlist"),
+            _ => anyhow!("Failed validating apub id"),
+        })?;
+        Ok(())
+    }
 }
 
 /// Checks if the ID is allowed for sending or receiving.
@@ -71,55 +71,55 @@ impl UrlVerifier for VerifyUrlData {
 /// - URL not being in the blocklist (if it is active)
 #[tracing::instrument(skip(local_site_data))]
 fn check_apub_id_valid(apub_id: &Url, local_site_data: &LocalSiteData) -> Result<(), LemmyError> {
-  let domain = apub_id.domain().expect("apud id has domain").to_string();
+    let domain = apub_id.domain().expect("apud id has domain").to_string();
 
-  if !local_site_data
-    .local_site
-    .as_ref()
-    .map(|l| l.federation_enabled)
-    .unwrap_or(true)
-  {
-    Err(LemmyErrorType::FederationDisabled)?
-  }
+    if !local_site_data
+        .local_site
+        .as_ref()
+        .map(|l| l.federation_enabled)
+        .unwrap_or(true)
+    {
+        Err(LemmyErrorType::FederationDisabled)?
+    }
 
-  if local_site_data
-    .blocked_instances
-    .iter()
-    .any(|i| domain.to_lowercase().eq(&i.domain.to_lowercase()))
-  {
-    Err(LemmyErrorType::DomainBlocked(domain.clone()))?
-  }
+    if local_site_data
+        .blocked_instances
+        .iter()
+        .any(|i| domain.to_lowercase().eq(&i.domain.to_lowercase()))
+    {
+        Err(LemmyErrorType::DomainBlocked(domain.clone()))?
+    }
 
-  // Only check this if there are instances in the allowlist
-  if !local_site_data.allowed_instances.is_empty()
-    && !local_site_data
-      .allowed_instances
-      .iter()
-      .any(|i| domain.to_lowercase().eq(&i.domain.to_lowercase()))
-  {
-    Err(LemmyErrorType::DomainNotInAllowList(domain))?
-  }
+    // Only check this if there are instances in the allowlist
+    if !local_site_data.allowed_instances.is_empty()
+        && !local_site_data
+            .allowed_instances
+            .iter()
+            .any(|i| domain.to_lowercase().eq(&i.domain.to_lowercase()))
+    {
+        Err(LemmyErrorType::DomainNotInAllowList(domain))?
+    }
 
-  Ok(())
+    Ok(())
 }
 
 #[derive(Clone)]
 pub(crate) struct LocalSiteData {
-  local_site: Option<LocalSite>,
-  allowed_instances: Vec<Instance>,
-  blocked_instances: Vec<Instance>,
+    local_site: Option<LocalSite>,
+    allowed_instances: Vec<Instance>,
+    blocked_instances: Vec<Instance>,
 }
 
 pub(crate) async fn local_site_data_cached(
-  pool: &mut DbPool<'_>,
+    pool: &mut DbPool<'_>,
 ) -> LemmyResult<Arc<LocalSiteData>> {
-  static CACHE: Lazy<Cache<(), Arc<LocalSiteData>>> = Lazy::new(|| {
-    Cache::builder()
-      .max_capacity(1)
-      .time_to_live(BLOCKLIST_CACHE_DURATION)
-      .build()
-  });
-  Ok(
+    static CACHE: Lazy<Cache<(), Arc<LocalSiteData>>> = Lazy::new(|| {
+        Cache::builder()
+            .max_capacity(1)
+            .time_to_live(BLOCKLIST_CACHE_DURATION)
+            .build()
+    });
+    Ok(
     CACHE
       .try_get_with((), async {
         let (local_site, allowed_instances, blocked_instances) =
@@ -143,43 +143,43 @@ pub(crate) async fn local_site_data_cached(
 }
 
 pub(crate) async fn check_apub_id_valid_with_strictness(
-  apub_id: &Url,
-  is_strict: bool,
-  context: &LemmyContext,
+    apub_id: &Url,
+    is_strict: bool,
+    context: &LemmyContext,
 ) -> Result<(), LemmyError> {
-  let domain = apub_id.domain().expect("apud id has domain").to_string();
-  let local_instance = context
-    .settings()
-    .get_hostname_without_port()
-    .expect("local hostname is valid");
-  if domain == local_instance {
-    return Ok(());
-  }
-
-  let local_site_data = local_site_data_cached(&mut context.pool()).await?;
-  check_apub_id_valid(apub_id, &local_site_data)?;
-
-  // Only check allowlist if this is a community, and there are instances in the allowlist
-  if is_strict && !local_site_data.allowed_instances.is_empty() {
-    // need to allow this explicitly because apub receive might contain objects from our local
-    // instance.
-    let mut allowed_and_local = local_site_data
-      .allowed_instances
-      .iter()
-      .map(|i| i.domain.clone())
-      .collect::<Vec<String>>();
-    let local_instance = context
-      .settings()
-      .get_hostname_without_port()
-      .expect("local hostname is valid");
-    allowed_and_local.push(local_instance);
-
     let domain = apub_id.domain().expect("apud id has domain").to_string();
-    if !allowed_and_local.contains(&domain) {
-      Err(LemmyErrorType::FederationDisabledByStrictAllowList)?
+    let local_instance = context
+        .settings()
+        .get_hostname_without_port()
+        .expect("local hostname is valid");
+    if domain == local_instance {
+        return Ok(());
     }
-  }
-  Ok(())
+
+    let local_site_data = local_site_data_cached(&mut context.pool()).await?;
+    check_apub_id_valid(apub_id, &local_site_data)?;
+
+    // Only check allowlist if this is a community, and there are instances in the allowlist
+    if is_strict && !local_site_data.allowed_instances.is_empty() {
+        // need to allow this explicitly because apub receive might contain objects from our local
+        // instance.
+        let mut allowed_and_local = local_site_data
+            .allowed_instances
+            .iter()
+            .map(|i| i.domain.clone())
+            .collect::<Vec<String>>();
+        let local_instance = context
+            .settings()
+            .get_hostname_without_port()
+            .expect("local hostname is valid");
+        allowed_and_local.push(local_instance);
+
+        let domain = apub_id.domain().expect("apud id has domain").to_string();
+        if !allowed_and_local.contains(&domain) {
+            Err(LemmyErrorType::FederationDisabledByStrictAllowList)?
+        }
+    }
+    Ok(())
 }
 
 /// Store received activities in the database.
@@ -188,9 +188,9 @@ pub(crate) async fn check_apub_id_valid_with_strictness(
 /// would be a waste of resources.
 #[tracing::instrument(skip(data))]
 async fn insert_received_activity(
-  ap_id: &Url,
-  data: &Data<LemmyContext>,
+    ap_id: &Url,
+    data: &Data<LemmyContext>,
 ) -> Result<(), LemmyError> {
-  ReceivedActivity::create(&mut data.pool(), &ap_id.clone().into()).await?;
-  Ok(())
+    ReceivedActivity::create(&mut data.pool(), &ap_id.clone().into()).await?;
+    Ok(())
 }

--- a/crates/apub/src/mentions.rs
+++ b/crates/apub/src/mentions.rs
@@ -1,15 +1,15 @@
 use crate::objects::{comment::ApubComment, community::ApubCommunity, person::ApubPerson};
 use activitypub_federation::{
-  config::Data,
-  fetch::{object_id::ObjectId, webfinger::webfinger_resolve_actor},
-  kinds::link::MentionType,
-  traits::Actor,
+    config::Data,
+    fetch::{object_id::ObjectId, webfinger::webfinger_resolve_actor},
+    kinds::link::MentionType,
+    traits::Actor,
 };
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::{
-  source::{comment::Comment, person::Person, post::Post},
-  traits::Crud,
-  utils::DbPool,
+    source::{comment::Comment, person::Person, post::Post},
+    traits::Crud,
+    utils::DbPool,
 };
 use lemmy_utils::{error::LemmyError, utils::mention::scrape_text_for_mentions};
 use serde::{Deserialize, Serialize};
@@ -19,21 +19,21 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum MentionOrValue {
-  Mention(Mention),
-  Value(Value),
+    Mention(Mention),
+    Value(Value),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Mention {
-  pub href: Url,
-  name: Option<String>,
-  #[serde(rename = "type")]
-  pub kind: MentionType,
+    pub href: Url,
+    name: Option<String>,
+    #[serde(rename = "type")]
+    pub kind: MentionType,
 }
 
 pub struct MentionsAndAddresses {
-  pub ccs: Vec<Url>,
-  pub tags: Vec<MentionOrValue>,
+    pub ccs: Vec<Url>,
+    pub tags: Vec<MentionOrValue>,
 }
 
 /// This takes a comment, and builds a list of to_addresses, inboxes,
@@ -41,67 +41,68 @@ pub struct MentionsAndAddresses {
 /// Addresses are the persons / addresses that go in the cc field.
 #[tracing::instrument(skip(comment, community_id, context))]
 pub async fn collect_non_local_mentions(
-  comment: &ApubComment,
-  community_id: ObjectId<ApubCommunity>,
-  context: &Data<LemmyContext>,
+    comment: &ApubComment,
+    community_id: ObjectId<ApubCommunity>,
+    context: &Data<LemmyContext>,
 ) -> Result<MentionsAndAddresses, LemmyError> {
-  let parent_creator = get_comment_parent_creator(&mut context.pool(), comment).await?;
-  let mut addressed_ccs: Vec<Url> = vec![community_id.into(), parent_creator.id()];
+    let parent_creator = get_comment_parent_creator(&mut context.pool(), comment).await?;
+    let mut addressed_ccs: Vec<Url> = vec![community_id.into(), parent_creator.id()];
 
-  // Add the mention tag
-  let parent_creator_tag = Mention {
-    href: parent_creator.actor_id.clone().into(),
-    name: Some(format!(
-      "@{}@{}",
-      &parent_creator.name,
-      &parent_creator.id().domain().expect("has domain")
-    )),
-    kind: MentionType::Mention,
-  };
-  let mut tags = vec![parent_creator_tag];
-
-  // Get the person IDs for any mentions
-  let mentions = scrape_text_for_mentions(&comment.content)
-    .into_iter()
-    // Filter only the non-local ones
-    .filter(|m| !m.is_local(&context.settings().hostname));
-
-  for mention in mentions {
-    let identifier = format!("{}@{}", mention.name, mention.domain);
-    let person = webfinger_resolve_actor::<LemmyContext, ApubPerson>(&identifier, context).await;
-    if let Ok(person) = person {
-      addressed_ccs.push(person.actor_id.to_string().parse()?);
-
-      let mention_tag = Mention {
-        href: person.id(),
-        name: Some(mention.full_name()),
+    // Add the mention tag
+    let parent_creator_tag = Mention {
+        href: parent_creator.actor_id.clone().into(),
+        name: Some(format!(
+            "@{}@{}",
+            &parent_creator.name,
+            &parent_creator.id().domain().expect("has domain")
+        )),
         kind: MentionType::Mention,
-      };
-      tags.push(mention_tag);
-    }
-  }
+    };
+    let mut tags = vec![parent_creator_tag];
 
-  let tags = tags.into_iter().map(MentionOrValue::Mention).collect();
-  Ok(MentionsAndAddresses {
-    ccs: addressed_ccs,
-    tags,
-  })
+    // Get the person IDs for any mentions
+    let mentions = scrape_text_for_mentions(&comment.content)
+        .into_iter()
+        // Filter only the non-local ones
+        .filter(|m| !m.is_local(&context.settings().hostname));
+
+    for mention in mentions {
+        let identifier = format!("{}@{}", mention.name, mention.domain);
+        let person =
+            webfinger_resolve_actor::<LemmyContext, ApubPerson>(&identifier, context).await;
+        if let Ok(person) = person {
+            addressed_ccs.push(person.actor_id.to_string().parse()?);
+
+            let mention_tag = Mention {
+                href: person.id(),
+                name: Some(mention.full_name()),
+                kind: MentionType::Mention,
+            };
+            tags.push(mention_tag);
+        }
+    }
+
+    let tags = tags.into_iter().map(MentionOrValue::Mention).collect();
+    Ok(MentionsAndAddresses {
+        ccs: addressed_ccs,
+        tags,
+    })
 }
 
 /// Returns the apub ID of the person this comment is responding to. Meaning, in case this is a
 /// top-level comment, the creator of the post, otherwise the creator of the parent comment.
 #[tracing::instrument(skip(pool, comment))]
 async fn get_comment_parent_creator(
-  pool: &mut DbPool<'_>,
-  comment: &Comment,
+    pool: &mut DbPool<'_>,
+    comment: &Comment,
 ) -> Result<ApubPerson, LemmyError> {
-  let parent_creator_id = if let Some(parent_comment_id) = comment.parent_comment_id() {
-    let parent_comment = Comment::read(pool, parent_comment_id).await?;
-    parent_comment.creator_id
-  } else {
-    let parent_post_id = comment.post_id;
-    let parent_post = Post::read(pool, parent_post_id).await?;
-    parent_post.creator_id
-  };
-  Ok(Person::read(pool, parent_creator_id).await?.into())
+    let parent_creator_id = if let Some(parent_comment_id) = comment.parent_comment_id() {
+        let parent_comment = Comment::read(pool, parent_comment_id).await?;
+        parent_comment.creator_id
+    } else {
+        let parent_post_id = comment.post_id;
+        let parent_post = Post::read(pool, parent_post_id).await?;
+        parent_post.creator_id
+    };
+    Ok(Person::read(pool, parent_creator_id).await?.into())
 }

--- a/crates/apub/src/objects/comment.rs
+++ b/crates/apub/src/objects/comment.rs
@@ -1,38 +1,37 @@
 use crate::{
-  activities::{verify_is_public, verify_person_in_community},
-  check_apub_id_valid_with_strictness,
-  mentions::collect_non_local_mentions,
-  objects::{read_from_string_or_source, verify_is_remote_object},
-  protocol::{
-    objects::{note::Note, LanguageTag},
-    InCommunity,
-    Source,
-  },
+    activities::{verify_is_public, verify_person_in_community},
+    check_apub_id_valid_with_strictness,
+    mentions::collect_non_local_mentions,
+    objects::{read_from_string_or_source, verify_is_remote_object},
+    protocol::{
+        objects::{note::Note, LanguageTag},
+        InCommunity, Source,
+    },
 };
 use activitypub_federation::{
-  config::Data,
-  kinds::{object::NoteType, public},
-  protocol::{values::MediaTypeMarkdownOrHtml, verification::verify_domains_match},
-  traits::Object,
+    config::Data,
+    kinds::{object::NoteType, public},
+    protocol::{values::MediaTypeMarkdownOrHtml, verification::verify_domains_match},
+    traits::Object,
 };
 use chrono::{DateTime, Utc};
 use lemmy_api_common::{
-  context::LemmyContext,
-  utils::{local_site_opt_to_slur_regex, sanitize_html},
+    context::LemmyContext,
+    utils::{local_site_opt_to_slur_regex, sanitize_html},
 };
 use lemmy_db_schema::{
-  source::{
-    comment::{Comment, CommentInsertForm, CommentUpdateForm},
-    community::Community,
-    local_site::LocalSite,
-    person::Person,
-    post::Post,
-  },
-  traits::Crud,
+    source::{
+        comment::{Comment, CommentInsertForm, CommentUpdateForm},
+        community::Community,
+        local_site::LocalSite,
+        person::Person,
+        post::Post,
+    },
+    traits::Crud,
 };
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorType},
-  utils::{markdown::markdown_to_html, slurs::remove_slurs, time::convert_datetime},
+    error::{LemmyError, LemmyErrorType},
+    utils::{markdown::markdown_to_html, slurs::remove_slurs, time::convert_datetime},
 };
 use std::ops::Deref;
 use url::Url;
@@ -41,261 +40,267 @@ use url::Url;
 pub struct ApubComment(pub(crate) Comment);
 
 impl Deref for ApubComment {
-  type Target = Comment;
-  fn deref(&self) -> &Self::Target {
-    &self.0
-  }
+    type Target = Comment;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 impl From<Comment> for ApubComment {
-  fn from(c: Comment) -> Self {
-    ApubComment(c)
-  }
+    fn from(c: Comment) -> Self {
+        ApubComment(c)
+    }
 }
 
 #[async_trait::async_trait]
 impl Object for ApubComment {
-  type DataType = LemmyContext;
-  type Kind = Note;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Kind = Note;
+    type Error = LemmyError;
 
-  fn last_refreshed_at(&self) -> Option<DateTime<Utc>> {
-    None
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn read_from_id(
-    object_id: Url,
-    context: &Data<Self::DataType>,
-  ) -> Result<Option<Self>, LemmyError> {
-    Ok(
-      Comment::read_from_apub_id(&mut context.pool(), object_id)
-        .await?
-        .map(Into::into),
-    )
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn delete(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
-    if !self.deleted {
-      let form = CommentUpdateForm {
-        deleted: Some(true),
-        ..Default::default()
-      };
-      Comment::update(&mut context.pool(), self.id, &form).await?;
+    fn last_refreshed_at(&self) -> Option<DateTime<Utc>> {
+        None
     }
-    Ok(())
-  }
 
-  #[tracing::instrument(skip_all)]
-  async fn into_json(self, context: &Data<Self::DataType>) -> Result<Note, LemmyError> {
-    let creator_id = self.creator_id;
-    let creator = Person::read(&mut context.pool(), creator_id).await?;
-
-    let post_id = self.post_id;
-    let post = Post::read(&mut context.pool(), post_id).await?;
-    let community_id = post.community_id;
-    let community = Community::read(&mut context.pool(), community_id).await?;
-
-    let in_reply_to = if let Some(comment_id) = self.parent_comment_id() {
-      let parent_comment = Comment::read(&mut context.pool(), comment_id).await?;
-      parent_comment.ap_id.into()
-    } else {
-      post.ap_id.into()
-    };
-    let language = LanguageTag::new_single(self.language_id, &mut context.pool()).await?;
-    let maa = collect_non_local_mentions(&self, community.actor_id.clone().into(), context).await?;
-
-    let note = Note {
-      r#type: NoteType::Note,
-      id: self.ap_id.clone().into(),
-      attributed_to: creator.actor_id.into(),
-      to: vec![public()],
-      cc: maa.ccs,
-      content: markdown_to_html(&self.content),
-      media_type: Some(MediaTypeMarkdownOrHtml::Html),
-      source: Some(Source::new(self.content.clone())),
-      in_reply_to,
-      published: Some(convert_datetime(self.published)),
-      updated: self.updated.map(convert_datetime),
-      tag: maa.tags,
-      distinguished: Some(self.distinguished),
-      language,
-      audience: Some(community.actor_id.into()),
-    };
-
-    Ok(note)
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn verify(
-    note: &Note,
-    expected_domain: &Url,
-    context: &Data<LemmyContext>,
-  ) -> Result<(), LemmyError> {
-    verify_domains_match(note.id.inner(), expected_domain)?;
-    verify_domains_match(note.attributed_to.inner(), note.id.inner())?;
-    verify_is_public(&note.to, &note.cc)?;
-    let community = note.community(context).await?;
-
-    check_apub_id_valid_with_strictness(note.id.inner(), community.local, context).await?;
-    verify_is_remote_object(note.id.inner(), context.settings())?;
-    verify_person_in_community(&note.attributed_to, &community, context).await?;
-    let (post, _) = note.get_parents(context).await?;
-    if post.locked {
-      Err(LemmyErrorType::PostIsLocked)?
-    } else {
-      Ok(())
+    #[tracing::instrument(skip_all)]
+    async fn read_from_id(
+        object_id: Url,
+        context: &Data<Self::DataType>,
+    ) -> Result<Option<Self>, LemmyError> {
+        Ok(Comment::read_from_apub_id(&mut context.pool(), object_id)
+            .await?
+            .map(Into::into))
     }
-  }
 
-  /// Converts a `Note` to `Comment`.
-  ///
-  /// If the parent community, post and comment(s) are not known locally, these are also fetched.
-  #[tracing::instrument(skip_all)]
-  async fn from_json(note: Note, context: &Data<LemmyContext>) -> Result<ApubComment, LemmyError> {
-    let creator = note.attributed_to.dereference(context).await?;
-    let (post, parent_comment) = note.get_parents(context).await?;
+    #[tracing::instrument(skip_all)]
+    async fn delete(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+        if !self.deleted {
+            let form = CommentUpdateForm {
+                deleted: Some(true),
+                ..Default::default()
+            };
+            Comment::update(&mut context.pool(), self.id, &form).await?;
+        }
+        Ok(())
+    }
 
-    let content = read_from_string_or_source(&note.content, &note.media_type, &note.source);
+    #[tracing::instrument(skip_all)]
+    async fn into_json(self, context: &Data<Self::DataType>) -> Result<Note, LemmyError> {
+        let creator_id = self.creator_id;
+        let creator = Person::read(&mut context.pool(), creator_id).await?;
 
-    let local_site = LocalSite::read(&mut context.pool()).await.ok();
-    let slur_regex = &local_site_opt_to_slur_regex(&local_site);
-    let content = remove_slurs(&content, slur_regex);
-    let content = sanitize_html(&content);
-    let language_id =
-      LanguageTag::to_language_id_single(note.language, &mut context.pool()).await?;
+        let post_id = self.post_id;
+        let post = Post::read(&mut context.pool(), post_id).await?;
+        let community_id = post.community_id;
+        let community = Community::read(&mut context.pool(), community_id).await?;
 
-    let form = CommentInsertForm {
-      creator_id: creator.id,
-      post_id: post.id,
-      content,
-      removed: None,
-      published: note.published.map(Into::into),
-      updated: note.updated.map(Into::into),
-      deleted: Some(false),
-      ap_id: Some(note.id.into()),
-      distinguished: note.distinguished,
-      local: Some(false),
-      language_id,
-    };
-    let parent_comment_path = parent_comment.map(|t| t.0.path);
-    let comment = Comment::create(&mut context.pool(), &form, parent_comment_path.as_ref()).await?;
-    Ok(comment.into())
-  }
+        let in_reply_to = if let Some(comment_id) = self.parent_comment_id() {
+            let parent_comment = Comment::read(&mut context.pool(), comment_id).await?;
+            parent_comment.ap_id.into()
+        } else {
+            post.ap_id.into()
+        };
+        let language = LanguageTag::new_single(self.language_id, &mut context.pool()).await?;
+        let maa =
+            collect_non_local_mentions(&self, community.actor_id.clone().into(), context).await?;
+
+        let note = Note {
+            r#type: NoteType::Note,
+            id: self.ap_id.clone().into(),
+            attributed_to: creator.actor_id.into(),
+            to: vec![public()],
+            cc: maa.ccs,
+            content: markdown_to_html(&self.content),
+            media_type: Some(MediaTypeMarkdownOrHtml::Html),
+            source: Some(Source::new(self.content.clone())),
+            in_reply_to,
+            published: Some(convert_datetime(self.published)),
+            updated: self.updated.map(convert_datetime),
+            tag: maa.tags,
+            distinguished: Some(self.distinguished),
+            language,
+            audience: Some(community.actor_id.into()),
+        };
+
+        Ok(note)
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn verify(
+        note: &Note,
+        expected_domain: &Url,
+        context: &Data<LemmyContext>,
+    ) -> Result<(), LemmyError> {
+        verify_domains_match(note.id.inner(), expected_domain)?;
+        verify_domains_match(note.attributed_to.inner(), note.id.inner())?;
+        verify_is_public(&note.to, &note.cc)?;
+        let community = note.community(context).await?;
+
+        check_apub_id_valid_with_strictness(note.id.inner(), community.local, context).await?;
+        verify_is_remote_object(note.id.inner(), context.settings())?;
+        verify_person_in_community(&note.attributed_to, &community, context).await?;
+        let (post, _) = note.get_parents(context).await?;
+        if post.locked {
+            Err(LemmyErrorType::PostIsLocked)?
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Converts a `Note` to `Comment`.
+    ///
+    /// If the parent community, post and comment(s) are not known locally, these are also fetched.
+    #[tracing::instrument(skip_all)]
+    async fn from_json(
+        note: Note,
+        context: &Data<LemmyContext>,
+    ) -> Result<ApubComment, LemmyError> {
+        let creator = note.attributed_to.dereference(context).await?;
+        let (post, parent_comment) = note.get_parents(context).await?;
+
+        let content = read_from_string_or_source(&note.content, &note.media_type, &note.source);
+
+        let local_site = LocalSite::read(&mut context.pool()).await.ok();
+        let slur_regex = &local_site_opt_to_slur_regex(&local_site);
+        let content = remove_slurs(&content, slur_regex);
+        let content = sanitize_html(&content);
+        let language_id =
+            LanguageTag::to_language_id_single(note.language, &mut context.pool()).await?;
+
+        let form = CommentInsertForm {
+            creator_id: creator.id,
+            post_id: post.id,
+            content,
+            removed: None,
+            published: note.published.map(Into::into),
+            updated: note.updated.map(Into::into),
+            deleted: Some(false),
+            ap_id: Some(note.id.into()),
+            distinguished: note.distinguished,
+            local: Some(false),
+            language_id,
+        };
+        let parent_comment_path = parent_comment.map(|t| t.0.path);
+        let comment =
+            Comment::create(&mut context.pool(), &form, parent_comment_path.as_ref()).await?;
+        Ok(comment.into())
+    }
 }
 
 #[cfg(test)]
 pub(crate) mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use super::*;
-  use crate::{
-    objects::{
-      community::{tests::parse_lemmy_community, ApubCommunity},
-      instance::ApubSite,
-      person::{tests::parse_lemmy_person, ApubPerson},
-      post::ApubPost,
-      tests::init_context,
-    },
-    protocol::tests::file_to_json_object,
-  };
-  use assert_json_diff::assert_json_include;
-  use html2md::parse_html;
-  use lemmy_db_schema::source::site::Site;
-  use serial_test::serial;
+    use super::*;
+    use crate::{
+        objects::{
+            community::{tests::parse_lemmy_community, ApubCommunity},
+            instance::ApubSite,
+            person::{tests::parse_lemmy_person, ApubPerson},
+            post::ApubPost,
+            tests::init_context,
+        },
+        protocol::tests::file_to_json_object,
+    };
+    use assert_json_diff::assert_json_include;
+    use html2md::parse_html;
+    use lemmy_db_schema::source::site::Site;
+    use serial_test::serial;
 
-  async fn prepare_comment_test(
-    url: &Url,
-    context: &Data<LemmyContext>,
-  ) -> (ApubPerson, ApubCommunity, ApubPost, ApubSite) {
-    // use separate counter so this doesnt affect tests
-    let context2 = context.reset_request_count();
-    let (person, site) = parse_lemmy_person(&context2).await;
-    let community = parse_lemmy_community(&context2).await;
-    let post_json = file_to_json_object("assets/lemmy/objects/page.json").unwrap();
-    ApubPost::verify(&post_json, url, &context2).await.unwrap();
-    let post = ApubPost::from_json(post_json, &context2).await.unwrap();
-    (person, community, post, site)
-  }
+    async fn prepare_comment_test(
+        url: &Url,
+        context: &Data<LemmyContext>,
+    ) -> (ApubPerson, ApubCommunity, ApubPost, ApubSite) {
+        // use separate counter so this doesnt affect tests
+        let context2 = context.reset_request_count();
+        let (person, site) = parse_lemmy_person(&context2).await;
+        let community = parse_lemmy_community(&context2).await;
+        let post_json = file_to_json_object("assets/lemmy/objects/page.json").unwrap();
+        ApubPost::verify(&post_json, url, &context2).await.unwrap();
+        let post = ApubPost::from_json(post_json, &context2).await.unwrap();
+        (person, community, post, site)
+    }
 
-  async fn cleanup(data: (ApubPerson, ApubCommunity, ApubPost, ApubSite), context: &LemmyContext) {
-    Post::delete(&mut context.pool(), data.2.id).await.unwrap();
-    Community::delete(&mut context.pool(), data.1.id)
-      .await
-      .unwrap();
-    Person::delete(&mut context.pool(), data.0.id)
-      .await
-      .unwrap();
-    Site::delete(&mut context.pool(), data.3.id).await.unwrap();
-    LocalSite::delete(&mut context.pool()).await.unwrap();
-  }
+    async fn cleanup(
+        data: (ApubPerson, ApubCommunity, ApubPost, ApubSite),
+        context: &LemmyContext,
+    ) {
+        Post::delete(&mut context.pool(), data.2.id).await.unwrap();
+        Community::delete(&mut context.pool(), data.1.id)
+            .await
+            .unwrap();
+        Person::delete(&mut context.pool(), data.0.id)
+            .await
+            .unwrap();
+        Site::delete(&mut context.pool(), data.3.id).await.unwrap();
+        LocalSite::delete(&mut context.pool()).await.unwrap();
+    }
 
-  #[tokio::test]
-  #[serial]
-  pub(crate) async fn test_parse_lemmy_comment() {
-    let context = init_context().await;
-    let url = Url::parse("https://enterprise.lemmy.ml/comment/38741").unwrap();
-    let data = prepare_comment_test(&url, &context).await;
+    #[tokio::test]
+    #[serial]
+    pub(crate) async fn test_parse_lemmy_comment() {
+        let context = init_context().await;
+        let url = Url::parse("https://enterprise.lemmy.ml/comment/38741").unwrap();
+        let data = prepare_comment_test(&url, &context).await;
 
-    let json: Note = file_to_json_object("assets/lemmy/objects/note.json").unwrap();
-    ApubComment::verify(&json, &url, &context).await.unwrap();
-    let comment = ApubComment::from_json(json.clone(), &context)
-      .await
-      .unwrap();
+        let json: Note = file_to_json_object("assets/lemmy/objects/note.json").unwrap();
+        ApubComment::verify(&json, &url, &context).await.unwrap();
+        let comment = ApubComment::from_json(json.clone(), &context)
+            .await
+            .unwrap();
 
-    assert_eq!(comment.ap_id, url.into());
-    assert_eq!(comment.content.len(), 14);
-    assert!(!comment.local);
-    assert_eq!(context.request_count(), 0);
+        assert_eq!(comment.ap_id, url.into());
+        assert_eq!(comment.content.len(), 14);
+        assert!(!comment.local);
+        assert_eq!(context.request_count(), 0);
 
-    let comment_id = comment.id;
-    let to_apub = comment.into_json(&context).await.unwrap();
-    assert_json_include!(actual: json, expected: to_apub);
+        let comment_id = comment.id;
+        let to_apub = comment.into_json(&context).await.unwrap();
+        assert_json_include!(actual: json, expected: to_apub);
 
-    Comment::delete(&mut context.pool(), comment_id)
-      .await
-      .unwrap();
-    cleanup(data, &context).await;
-  }
+        Comment::delete(&mut context.pool(), comment_id)
+            .await
+            .unwrap();
+        cleanup(data, &context).await;
+    }
 
-  #[tokio::test]
-  #[serial]
-  async fn test_parse_pleroma_comment() {
-    let context = init_context().await;
-    let url = Url::parse("https://enterprise.lemmy.ml/comment/38741").unwrap();
-    let data = prepare_comment_test(&url, &context).await;
+    #[tokio::test]
+    #[serial]
+    async fn test_parse_pleroma_comment() {
+        let context = init_context().await;
+        let url = Url::parse("https://enterprise.lemmy.ml/comment/38741").unwrap();
+        let data = prepare_comment_test(&url, &context).await;
 
-    let pleroma_url =
-      Url::parse("https://queer.hacktivis.me/objects/8d4973f4-53de-49cd-8c27-df160e16a9c2")
-        .unwrap();
-    let person_json = file_to_json_object("assets/pleroma/objects/person.json").unwrap();
-    ApubPerson::verify(&person_json, &pleroma_url, &context)
-      .await
-      .unwrap();
-    ApubPerson::from_json(person_json, &context).await.unwrap();
-    let json = file_to_json_object("assets/pleroma/objects/note.json").unwrap();
-    ApubComment::verify(&json, &pleroma_url, &context)
-      .await
-      .unwrap();
-    let comment = ApubComment::from_json(json, &context).await.unwrap();
+        let pleroma_url =
+            Url::parse("https://queer.hacktivis.me/objects/8d4973f4-53de-49cd-8c27-df160e16a9c2")
+                .unwrap();
+        let person_json = file_to_json_object("assets/pleroma/objects/person.json").unwrap();
+        ApubPerson::verify(&person_json, &pleroma_url, &context)
+            .await
+            .unwrap();
+        ApubPerson::from_json(person_json, &context).await.unwrap();
+        let json = file_to_json_object("assets/pleroma/objects/note.json").unwrap();
+        ApubComment::verify(&json, &pleroma_url, &context)
+            .await
+            .unwrap();
+        let comment = ApubComment::from_json(json, &context).await.unwrap();
 
-    assert_eq!(comment.ap_id, pleroma_url.into());
-    assert_eq!(comment.content.len(), 64);
-    assert!(!comment.local);
-    assert_eq!(context.request_count(), 1);
+        assert_eq!(comment.ap_id, pleroma_url.into());
+        assert_eq!(comment.content.len(), 64);
+        assert!(!comment.local);
+        assert_eq!(context.request_count(), 1);
 
-    Comment::delete(&mut context.pool(), comment.id)
-      .await
-      .unwrap();
-    cleanup(data, &context).await;
-  }
+        Comment::delete(&mut context.pool(), comment.id)
+            .await
+            .unwrap();
+        cleanup(data, &context).await;
+    }
 
-  #[tokio::test]
-  #[serial]
-  async fn test_html_to_markdown_sanitize() {
-    let parsed = parse_html("<script></script><b>hello</b>");
-    assert_eq!(parsed, "**hello**");
-  }
+    #[tokio::test]
+    #[serial]
+    async fn test_html_to_markdown_sanitize() {
+        let parsed = parse_html("<script></script><b>hello</b>");
+        assert_eq!(parsed, "**hello**");
+    }
 }

--- a/crates/apub/src/objects/community.rs
+++ b/crates/apub/src/objects/community.rs
@@ -1,34 +1,32 @@
 use crate::{
-  check_apub_id_valid,
-  local_site_data_cached,
-  objects::instance::fetch_instance_actor_for_object,
-  protocol::{
-    objects::{group::Group, Endpoints, LanguageTag},
-    ImageObject,
-    Source,
-  },
+    check_apub_id_valid, local_site_data_cached,
+    objects::instance::fetch_instance_actor_for_object,
+    protocol::{
+        objects::{group::Group, Endpoints, LanguageTag},
+        ImageObject, Source,
+    },
 };
 use activitypub_federation::{
-  config::Data,
-  kinds::actor::GroupType,
-  traits::{Actor, Object},
+    config::Data,
+    kinds::actor::GroupType,
+    traits::{Actor, Object},
 };
 use chrono::{DateTime, Utc};
 use lemmy_api_common::{
-  context::LemmyContext,
-  utils::{generate_featured_url, generate_moderators_url, generate_outbox_url},
+    context::LemmyContext,
+    utils::{generate_featured_url, generate_moderators_url, generate_outbox_url},
 };
 use lemmy_db_schema::{
-  source::{
-    actor_language::CommunityLanguage,
-    community::{Community, CommunityUpdateForm},
-  },
-  traits::{ApubActor, Crud},
+    source::{
+        actor_language::CommunityLanguage,
+        community::{Community, CommunityUpdateForm},
+    },
+    traits::{ApubActor, Crud},
 };
 use lemmy_db_views_actor::structs::CommunityFollowerView;
 use lemmy_utils::{
-  error::LemmyError,
-  utils::{markdown::markdown_to_html, time::convert_datetime},
+    error::LemmyError,
+    utils::{markdown::markdown_to_html, time::convert_datetime},
 };
 use std::ops::Deref;
 use tracing::debug;
@@ -38,218 +36,218 @@ use url::Url;
 pub struct ApubCommunity(Community);
 
 impl Deref for ApubCommunity {
-  type Target = Community;
-  fn deref(&self) -> &Self::Target {
-    &self.0
-  }
+    type Target = Community;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 impl From<Community> for ApubCommunity {
-  fn from(c: Community) -> Self {
-    ApubCommunity(c)
-  }
+    fn from(c: Community) -> Self {
+        ApubCommunity(c)
+    }
 }
 
 #[async_trait::async_trait]
 impl Object for ApubCommunity {
-  type DataType = LemmyContext;
-  type Kind = Group;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Kind = Group;
+    type Error = LemmyError;
 
-  fn last_refreshed_at(&self) -> Option<DateTime<Utc>> {
-    Some(self.last_refreshed_at)
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn read_from_id(
-    object_id: Url,
-    context: &Data<Self::DataType>,
-  ) -> Result<Option<Self>, LemmyError> {
-    Ok(
-      Community::read_from_apub_id(&mut context.pool(), &object_id.into())
-        .await?
-        .map(Into::into),
-    )
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn delete(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
-    let form = CommunityUpdateForm {
-      deleted: Some(true),
-      ..Default::default()
-    };
-    Community::update(&mut context.pool(), self.id, &form).await?;
-    Ok(())
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn into_json(self, data: &Data<Self::DataType>) -> Result<Group, LemmyError> {
-    let community_id = self.id;
-    let langs = CommunityLanguage::read(&mut data.pool(), community_id).await?;
-    let language = LanguageTag::new_multiple(langs, &mut data.pool()).await?;
-
-    let group = Group {
-      kind: GroupType::Group,
-      id: self.id().into(),
-      preferred_username: self.name.clone(),
-      name: Some(self.title.clone()),
-      summary: self.description.as_ref().map(|b| markdown_to_html(b)),
-      source: self.description.clone().map(Source::new),
-      icon: self.icon.clone().map(ImageObject::new),
-      image: self.banner.clone().map(ImageObject::new),
-      sensitive: Some(self.nsfw),
-      featured: Some(generate_featured_url(&self.actor_id)?.into()),
-      inbox: self.inbox_url.clone().into(),
-      outbox: generate_outbox_url(&self.actor_id)?.into(),
-      followers: self.followers_url.clone().into(),
-      endpoints: self.shared_inbox_url.clone().map(|s| Endpoints {
-        shared_inbox: s.into(),
-      }),
-      public_key: self.public_key(),
-      language,
-      published: Some(convert_datetime(self.published)),
-      updated: self.updated.map(convert_datetime),
-      posting_restricted_to_mods: Some(self.posting_restricted_to_mods),
-      attributed_to: Some(generate_moderators_url(&self.actor_id)?.into()),
-    };
-    Ok(group)
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn verify(
-    group: &Group,
-    expected_domain: &Url,
-    context: &Data<Self::DataType>,
-  ) -> Result<(), LemmyError> {
-    group.verify(expected_domain, context).await
-  }
-
-  /// Converts a `Group` to `Community`, inserts it into the database and updates moderators.
-  #[tracing::instrument(skip_all)]
-  async fn from_json(
-    group: Group,
-    context: &Data<Self::DataType>,
-  ) -> Result<ApubCommunity, LemmyError> {
-    let instance_id = fetch_instance_actor_for_object(&group.id, context).await?;
-
-    let form = Group::into_insert_form(group.clone(), instance_id);
-    let languages =
-      LanguageTag::to_language_id_multiple(group.language, &mut context.pool()).await?;
-
-    let community = Community::create(&mut context.pool(), &form).await?;
-    CommunityLanguage::update(&mut context.pool(), languages, community.id).await?;
-
-    let community: ApubCommunity = community.into();
-
-    // Fetching mods and outbox is not necessary for Lemmy to work, so ignore errors. Besides,
-    // we need to ignore these errors so that tests can work entirely offline.
-    let fetch_outbox = group.outbox.dereference(&community, context);
-
-    if let Some(moderators) = group.attributed_to {
-      let fetch_moderators = moderators.dereference(&community, context);
-      // Fetch mods and outbox in parallel
-      let res = tokio::join!(fetch_outbox, fetch_moderators);
-      res.0.map_err(|e| debug!("{}", e)).ok();
-      res.1.map_err(|e| debug!("{}", e)).ok();
-    } else {
-      fetch_outbox.await.map_err(|e| debug!("{}", e)).ok();
+    fn last_refreshed_at(&self) -> Option<DateTime<Utc>> {
+        Some(self.last_refreshed_at)
     }
 
-    Ok(community)
-  }
+    #[tracing::instrument(skip_all)]
+    async fn read_from_id(
+        object_id: Url,
+        context: &Data<Self::DataType>,
+    ) -> Result<Option<Self>, LemmyError> {
+        Ok(
+            Community::read_from_apub_id(&mut context.pool(), &object_id.into())
+                .await?
+                .map(Into::into),
+        )
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn delete(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+        let form = CommunityUpdateForm {
+            deleted: Some(true),
+            ..Default::default()
+        };
+        Community::update(&mut context.pool(), self.id, &form).await?;
+        Ok(())
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn into_json(self, data: &Data<Self::DataType>) -> Result<Group, LemmyError> {
+        let community_id = self.id;
+        let langs = CommunityLanguage::read(&mut data.pool(), community_id).await?;
+        let language = LanguageTag::new_multiple(langs, &mut data.pool()).await?;
+
+        let group = Group {
+            kind: GroupType::Group,
+            id: self.id().into(),
+            preferred_username: self.name.clone(),
+            name: Some(self.title.clone()),
+            summary: self.description.as_ref().map(|b| markdown_to_html(b)),
+            source: self.description.clone().map(Source::new),
+            icon: self.icon.clone().map(ImageObject::new),
+            image: self.banner.clone().map(ImageObject::new),
+            sensitive: Some(self.nsfw),
+            featured: Some(generate_featured_url(&self.actor_id)?.into()),
+            inbox: self.inbox_url.clone().into(),
+            outbox: generate_outbox_url(&self.actor_id)?.into(),
+            followers: self.followers_url.clone().into(),
+            endpoints: self.shared_inbox_url.clone().map(|s| Endpoints {
+                shared_inbox: s.into(),
+            }),
+            public_key: self.public_key(),
+            language,
+            published: Some(convert_datetime(self.published)),
+            updated: self.updated.map(convert_datetime),
+            posting_restricted_to_mods: Some(self.posting_restricted_to_mods),
+            attributed_to: Some(generate_moderators_url(&self.actor_id)?.into()),
+        };
+        Ok(group)
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn verify(
+        group: &Group,
+        expected_domain: &Url,
+        context: &Data<Self::DataType>,
+    ) -> Result<(), LemmyError> {
+        group.verify(expected_domain, context).await
+    }
+
+    /// Converts a `Group` to `Community`, inserts it into the database and updates moderators.
+    #[tracing::instrument(skip_all)]
+    async fn from_json(
+        group: Group,
+        context: &Data<Self::DataType>,
+    ) -> Result<ApubCommunity, LemmyError> {
+        let instance_id = fetch_instance_actor_for_object(&group.id, context).await?;
+
+        let form = Group::into_insert_form(group.clone(), instance_id);
+        let languages =
+            LanguageTag::to_language_id_multiple(group.language, &mut context.pool()).await?;
+
+        let community = Community::create(&mut context.pool(), &form).await?;
+        CommunityLanguage::update(&mut context.pool(), languages, community.id).await?;
+
+        let community: ApubCommunity = community.into();
+
+        // Fetching mods and outbox is not necessary for Lemmy to work, so ignore errors. Besides,
+        // we need to ignore these errors so that tests can work entirely offline.
+        let fetch_outbox = group.outbox.dereference(&community, context);
+
+        if let Some(moderators) = group.attributed_to {
+            let fetch_moderators = moderators.dereference(&community, context);
+            // Fetch mods and outbox in parallel
+            let res = tokio::join!(fetch_outbox, fetch_moderators);
+            res.0.map_err(|e| debug!("{}", e)).ok();
+            res.1.map_err(|e| debug!("{}", e)).ok();
+        } else {
+            fetch_outbox.await.map_err(|e| debug!("{}", e)).ok();
+        }
+
+        Ok(community)
+    }
 }
 
 impl Actor for ApubCommunity {
-  fn id(&self) -> Url {
-    self.actor_id.inner().clone()
-  }
+    fn id(&self) -> Url {
+        self.actor_id.inner().clone()
+    }
 
-  fn public_key_pem(&self) -> &str {
-    &self.public_key
-  }
+    fn public_key_pem(&self) -> &str {
+        &self.public_key
+    }
 
-  fn private_key_pem(&self) -> Option<String> {
-    self.private_key.clone()
-  }
+    fn private_key_pem(&self) -> Option<String> {
+        self.private_key.clone()
+    }
 
-  fn inbox(&self) -> Url {
-    self.inbox_url.clone().into()
-  }
+    fn inbox(&self) -> Url {
+        self.inbox_url.clone().into()
+    }
 
-  fn shared_inbox(&self) -> Option<Url> {
-    self.shared_inbox_url.clone().map(Into::into)
-  }
+    fn shared_inbox(&self) -> Option<Url> {
+        self.shared_inbox_url.clone().map(Into::into)
+    }
 }
 
 impl ApubCommunity {
-  /// For a given community, returns the inboxes of all followers.
-  #[tracing::instrument(skip_all)]
-  pub(crate) async fn get_follower_inboxes(
-    &self,
-    context: &LemmyContext,
-  ) -> Result<Vec<Url>, LemmyError> {
-    let id = self.id;
+    /// For a given community, returns the inboxes of all followers.
+    #[tracing::instrument(skip_all)]
+    pub(crate) async fn get_follower_inboxes(
+        &self,
+        context: &LemmyContext,
+    ) -> Result<Vec<Url>, LemmyError> {
+        let id = self.id;
 
-    let local_site_data = local_site_data_cached(&mut context.pool()).await?;
-    let follows =
-      CommunityFollowerView::get_community_follower_inboxes(&mut context.pool(), id).await?;
-    let inboxes: Vec<Url> = follows
-      .into_iter()
-      .map(Into::into)
-      .filter(|inbox: &Url| inbox.host_str() != Some(&context.settings().hostname))
-      // Don't send to blocked instances
-      .filter(|inbox| check_apub_id_valid(inbox, &local_site_data).is_ok())
-      .collect();
+        let local_site_data = local_site_data_cached(&mut context.pool()).await?;
+        let follows =
+            CommunityFollowerView::get_community_follower_inboxes(&mut context.pool(), id).await?;
+        let inboxes: Vec<Url> = follows
+            .into_iter()
+            .map(Into::into)
+            .filter(|inbox: &Url| inbox.host_str() != Some(&context.settings().hostname))
+            // Don't send to blocked instances
+            .filter(|inbox| check_apub_id_valid(inbox, &local_site_data).is_ok())
+            .collect();
 
-    Ok(inboxes)
-  }
+        Ok(inboxes)
+    }
 }
 
 #[cfg(test)]
 pub(crate) mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use super::*;
-  use crate::{
-    objects::{instance::tests::parse_lemmy_instance, tests::init_context},
-    protocol::tests::file_to_json_object,
-  };
-  use activitypub_federation::fetch::collection_id::CollectionId;
-  use lemmy_db_schema::{source::site::Site, traits::Crud};
-  use serial_test::serial;
+    use super::*;
+    use crate::{
+        objects::{instance::tests::parse_lemmy_instance, tests::init_context},
+        protocol::tests::file_to_json_object,
+    };
+    use activitypub_federation::fetch::collection_id::CollectionId;
+    use lemmy_db_schema::{source::site::Site, traits::Crud};
+    use serial_test::serial;
 
-  pub(crate) async fn parse_lemmy_community(context: &Data<LemmyContext>) -> ApubCommunity {
-    // use separate counter so this doesnt affect tests
-    let context2 = context.reset_request_count();
-    let mut json: Group = file_to_json_object("assets/lemmy/objects/group.json").unwrap();
-    // change these links so they dont fetch over the network
-    json.attributed_to = None;
-    json.outbox =
-      CollectionId::parse("https://enterprise.lemmy.ml/c/tenforward/not_outbox").unwrap();
+    pub(crate) async fn parse_lemmy_community(context: &Data<LemmyContext>) -> ApubCommunity {
+        // use separate counter so this doesnt affect tests
+        let context2 = context.reset_request_count();
+        let mut json: Group = file_to_json_object("assets/lemmy/objects/group.json").unwrap();
+        // change these links so they dont fetch over the network
+        json.attributed_to = None;
+        json.outbox =
+            CollectionId::parse("https://enterprise.lemmy.ml/c/tenforward/not_outbox").unwrap();
 
-    let url = Url::parse("https://enterprise.lemmy.ml/c/tenforward").unwrap();
-    ApubCommunity::verify(&json, &url, &context2).await.unwrap();
-    let community = ApubCommunity::from_json(json, &context2).await.unwrap();
-    // this makes one requests to the (intentionally broken) outbox collection
-    assert_eq!(context2.request_count(), 1);
-    community
-  }
+        let url = Url::parse("https://enterprise.lemmy.ml/c/tenforward").unwrap();
+        ApubCommunity::verify(&json, &url, &context2).await.unwrap();
+        let community = ApubCommunity::from_json(json, &context2).await.unwrap();
+        // this makes one requests to the (intentionally broken) outbox collection
+        assert_eq!(context2.request_count(), 1);
+        community
+    }
 
-  #[tokio::test]
-  #[serial]
-  async fn test_parse_lemmy_community() {
-    let context = init_context().await;
-    let site = parse_lemmy_instance(&context).await;
-    let community = parse_lemmy_community(&context).await;
+    #[tokio::test]
+    #[serial]
+    async fn test_parse_lemmy_community() {
+        let context = init_context().await;
+        let site = parse_lemmy_instance(&context).await;
+        let community = parse_lemmy_community(&context).await;
 
-    assert_eq!(community.title, "Ten Forward");
-    assert!(!community.local);
-    assert_eq!(community.description.as_ref().unwrap().len(), 132);
+        assert_eq!(community.title, "Ten Forward");
+        assert!(!community.local);
+        assert_eq!(community.description.as_ref().unwrap().len(), 132);
 
-    Community::delete(&mut context.pool(), community.id)
-      .await
-      .unwrap();
-    Site::delete(&mut context.pool(), site.id).await.unwrap();
-  }
+        Community::delete(&mut context.pool(), community.id)
+            .await
+            .unwrap();
+        Site::delete(&mut context.pool(), site.id).await.unwrap();
+    }
 }

--- a/crates/apub/src/objects/instance.rs
+++ b/crates/apub/src/objects/instance.rs
@@ -1,42 +1,40 @@
 use crate::{
-  check_apub_id_valid_with_strictness,
-  local_site_data_cached,
-  objects::read_from_string_or_source_opt,
-  protocol::{
-    objects::{instance::Instance, LanguageTag},
-    ImageObject,
-    Source,
-  },
+    check_apub_id_valid_with_strictness, local_site_data_cached,
+    objects::read_from_string_or_source_opt,
+    protocol::{
+        objects::{instance::Instance, LanguageTag},
+        ImageObject, Source,
+    },
 };
 use activitypub_federation::{
-  config::Data,
-  fetch::object_id::ObjectId,
-  kinds::actor::ApplicationType,
-  protocol::{values::MediaTypeHtml, verification::verify_domains_match},
-  traits::{Actor, Object},
+    config::Data,
+    fetch::object_id::ObjectId,
+    kinds::actor::ApplicationType,
+    protocol::{values::MediaTypeHtml, verification::verify_domains_match},
+    traits::{Actor, Object},
 };
 use chrono::{DateTime, Utc};
 use lemmy_api_common::{
-  context::LemmyContext,
-  utils::{local_site_opt_to_slur_regex, sanitize_html_opt},
+    context::LemmyContext,
+    utils::{local_site_opt_to_slur_regex, sanitize_html_opt},
 };
 use lemmy_db_schema::{
-  newtypes::InstanceId,
-  source::{
-    actor_language::SiteLanguage,
-    instance::Instance as DbInstance,
-    site::{Site, SiteInsertForm},
-  },
-  traits::Crud,
-  utils::{naive_now, DbPool},
+    newtypes::InstanceId,
+    source::{
+        actor_language::SiteLanguage,
+        instance::Instance as DbInstance,
+        site::{Site, SiteInsertForm},
+    },
+    traits::Crud,
+    utils::{naive_now, DbPool},
 };
 use lemmy_utils::{
-  error::LemmyError,
-  utils::{
-    markdown::markdown_to_html,
-    slurs::{check_slurs, check_slurs_opt},
-    time::convert_datetime,
-  },
+    error::LemmyError,
+    utils::{
+        markdown::markdown_to_html,
+        slurs::{check_slurs, check_slurs_opt},
+        time::convert_datetime,
+    },
 };
 use std::ops::Deref;
 use tracing::debug;
@@ -46,199 +44,196 @@ use url::Url;
 pub struct ApubSite(Site);
 
 impl Deref for ApubSite {
-  type Target = Site;
-  fn deref(&self) -> &Self::Target {
-    &self.0
-  }
+    type Target = Site;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 impl From<Site> for ApubSite {
-  fn from(s: Site) -> Self {
-    ApubSite(s)
-  }
+    fn from(s: Site) -> Self {
+        ApubSite(s)
+    }
 }
 
 #[async_trait::async_trait]
 impl Object for ApubSite {
-  type DataType = LemmyContext;
-  type Kind = Instance;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Kind = Instance;
+    type Error = LemmyError;
 
-  fn last_refreshed_at(&self) -> Option<DateTime<Utc>> {
-    Some(self.last_refreshed_at)
-  }
+    fn last_refreshed_at(&self) -> Option<DateTime<Utc>> {
+        Some(self.last_refreshed_at)
+    }
 
-  #[tracing::instrument(skip_all)]
-  async fn read_from_id(
-    object_id: Url,
-    data: &Data<Self::DataType>,
-  ) -> Result<Option<Self>, LemmyError> {
-    Ok(
-      Site::read_from_apub_id(&mut data.pool(), &object_id.into())
-        .await?
-        .map(Into::into),
-    )
-  }
+    #[tracing::instrument(skip_all)]
+    async fn read_from_id(
+        object_id: Url,
+        data: &Data<Self::DataType>,
+    ) -> Result<Option<Self>, LemmyError> {
+        Ok(Site::read_from_apub_id(&mut data.pool(), &object_id.into())
+            .await?
+            .map(Into::into))
+    }
 
-  async fn delete(self, _data: &Data<Self::DataType>) -> Result<(), LemmyError> {
-    unimplemented!()
-  }
+    async fn delete(self, _data: &Data<Self::DataType>) -> Result<(), LemmyError> {
+        unimplemented!()
+    }
 
-  #[tracing::instrument(skip_all)]
-  async fn into_json(self, data: &Data<Self::DataType>) -> Result<Self::Kind, LemmyError> {
-    let site_id = self.id;
-    let langs = SiteLanguage::read(&mut data.pool(), site_id).await?;
-    let language = LanguageTag::new_multiple(langs, &mut data.pool()).await?;
+    #[tracing::instrument(skip_all)]
+    async fn into_json(self, data: &Data<Self::DataType>) -> Result<Self::Kind, LemmyError> {
+        let site_id = self.id;
+        let langs = SiteLanguage::read(&mut data.pool(), site_id).await?;
+        let language = LanguageTag::new_multiple(langs, &mut data.pool()).await?;
 
-    let instance = Instance {
-      kind: ApplicationType::Application,
-      id: self.id().into(),
-      name: self.name.clone(),
-      content: self.sidebar.as_ref().map(|d| markdown_to_html(d)),
-      source: self.sidebar.clone().map(Source::new),
-      summary: self.description.clone(),
-      media_type: self.sidebar.as_ref().map(|_| MediaTypeHtml::Html),
-      icon: self.icon.clone().map(ImageObject::new),
-      image: self.banner.clone().map(ImageObject::new),
-      inbox: self.inbox_url.clone().into(),
-      outbox: Url::parse(&format!("{}/site_outbox", self.actor_id))?,
-      public_key: self.public_key(),
-      language,
-      published: convert_datetime(self.published),
-      updated: self.updated.map(convert_datetime),
-    };
-    Ok(instance)
-  }
+        let instance = Instance {
+            kind: ApplicationType::Application,
+            id: self.id().into(),
+            name: self.name.clone(),
+            content: self.sidebar.as_ref().map(|d| markdown_to_html(d)),
+            source: self.sidebar.clone().map(Source::new),
+            summary: self.description.clone(),
+            media_type: self.sidebar.as_ref().map(|_| MediaTypeHtml::Html),
+            icon: self.icon.clone().map(ImageObject::new),
+            image: self.banner.clone().map(ImageObject::new),
+            inbox: self.inbox_url.clone().into(),
+            outbox: Url::parse(&format!("{}/site_outbox", self.actor_id))?,
+            public_key: self.public_key(),
+            language,
+            published: convert_datetime(self.published),
+            updated: self.updated.map(convert_datetime),
+        };
+        Ok(instance)
+    }
 
-  #[tracing::instrument(skip_all)]
-  async fn verify(
-    apub: &Self::Kind,
-    expected_domain: &Url,
-    data: &Data<Self::DataType>,
-  ) -> Result<(), LemmyError> {
-    check_apub_id_valid_with_strictness(apub.id.inner(), true, data).await?;
-    verify_domains_match(expected_domain, apub.id.inner())?;
+    #[tracing::instrument(skip_all)]
+    async fn verify(
+        apub: &Self::Kind,
+        expected_domain: &Url,
+        data: &Data<Self::DataType>,
+    ) -> Result<(), LemmyError> {
+        check_apub_id_valid_with_strictness(apub.id.inner(), true, data).await?;
+        verify_domains_match(expected_domain, apub.id.inner())?;
 
-    let local_site_data = local_site_data_cached(&mut data.pool()).await?;
-    let slur_regex = &local_site_opt_to_slur_regex(&local_site_data.local_site);
-    check_slurs(&apub.name, slur_regex)?;
-    check_slurs_opt(&apub.summary, slur_regex)?;
+        let local_site_data = local_site_data_cached(&mut data.pool()).await?;
+        let slur_regex = &local_site_opt_to_slur_regex(&local_site_data.local_site);
+        check_slurs(&apub.name, slur_regex)?;
+        check_slurs_opt(&apub.summary, slur_regex)?;
 
-    Ok(())
-  }
+        Ok(())
+    }
 
-  #[tracing::instrument(skip_all)]
-  async fn from_json(apub: Self::Kind, data: &Data<Self::DataType>) -> Result<Self, LemmyError> {
-    let domain = apub.id.inner().domain().expect("group id has domain");
-    let instance = DbInstance::read_or_create(&mut data.pool(), domain.to_string()).await?;
+    #[tracing::instrument(skip_all)]
+    async fn from_json(apub: Self::Kind, data: &Data<Self::DataType>) -> Result<Self, LemmyError> {
+        let domain = apub.id.inner().domain().expect("group id has domain");
+        let instance = DbInstance::read_or_create(&mut data.pool(), domain.to_string()).await?;
 
-    let sidebar = read_from_string_or_source_opt(&apub.content, &None, &apub.source);
-    let sidebar = sanitize_html_opt(&sidebar);
-    let description = sanitize_html_opt(&apub.summary);
+        let sidebar = read_from_string_or_source_opt(&apub.content, &None, &apub.source);
+        let sidebar = sanitize_html_opt(&sidebar);
+        let description = sanitize_html_opt(&apub.summary);
 
-    let site_form = SiteInsertForm {
-      name: apub.name.clone(),
-      sidebar,
-      updated: apub.updated,
-      icon: apub.icon.clone().map(|i| i.url.into()),
-      banner: apub.image.clone().map(|i| i.url.into()),
-      description,
-      actor_id: Some(apub.id.clone().into()),
-      last_refreshed_at: Some(naive_now()),
-      inbox_url: Some(apub.inbox.clone().into()),
-      public_key: Some(apub.public_key.public_key_pem.clone()),
-      private_key: None,
-      instance_id: instance.id,
-    };
-    let languages = LanguageTag::to_language_id_multiple(apub.language, &mut data.pool()).await?;
+        let site_form = SiteInsertForm {
+            name: apub.name.clone(),
+            sidebar,
+            updated: apub.updated,
+            icon: apub.icon.clone().map(|i| i.url.into()),
+            banner: apub.image.clone().map(|i| i.url.into()),
+            description,
+            actor_id: Some(apub.id.clone().into()),
+            last_refreshed_at: Some(naive_now()),
+            inbox_url: Some(apub.inbox.clone().into()),
+            public_key: Some(apub.public_key.public_key_pem.clone()),
+            private_key: None,
+            instance_id: instance.id,
+        };
+        let languages =
+            LanguageTag::to_language_id_multiple(apub.language, &mut data.pool()).await?;
 
-    let site = Site::create(&mut data.pool(), &site_form).await?;
-    SiteLanguage::update(&mut data.pool(), languages, &site).await?;
-    Ok(site.into())
-  }
+        let site = Site::create(&mut data.pool(), &site_form).await?;
+        SiteLanguage::update(&mut data.pool(), languages, &site).await?;
+        Ok(site.into())
+    }
 }
 
 impl Actor for ApubSite {
-  fn id(&self) -> Url {
-    self.actor_id.inner().clone()
-  }
+    fn id(&self) -> Url {
+        self.actor_id.inner().clone()
+    }
 
-  fn public_key_pem(&self) -> &str {
-    &self.public_key
-  }
+    fn public_key_pem(&self) -> &str {
+        &self.public_key
+    }
 
-  fn private_key_pem(&self) -> Option<String> {
-    self.private_key.clone()
-  }
+    fn private_key_pem(&self) -> Option<String> {
+        self.private_key.clone()
+    }
 
-  fn inbox(&self) -> Url {
-    self.inbox_url.clone().into()
-  }
+    fn inbox(&self) -> Url {
+        self.inbox_url.clone().into()
+    }
 }
 
 /// Try to fetch the instance actor (to make things like instance rules available).
 pub(in crate::objects) async fn fetch_instance_actor_for_object<T: Into<Url> + Clone>(
-  object_id: &T,
-  context: &Data<LemmyContext>,
+    object_id: &T,
+    context: &Data<LemmyContext>,
 ) -> Result<InstanceId, LemmyError> {
-  let object_id: Url = object_id.clone().into();
-  let instance_id = Site::instance_actor_id_from_url(object_id);
-  let site = ObjectId::<ApubSite>::from(instance_id.clone())
-    .dereference(context)
-    .await;
-  match site {
-    Ok(s) => Ok(s.instance_id),
-    Err(e) => {
-      // Failed to fetch instance actor, its probably not a lemmy instance
-      debug!("Failed to dereference site for {}: {}", &instance_id, e);
-      let domain = instance_id.domain().expect("has domain");
-      Ok(
-        DbInstance::read_or_create(&mut context.pool(), domain.to_string())
-          .await?
-          .id,
-      )
+    let object_id: Url = object_id.clone().into();
+    let instance_id = Site::instance_actor_id_from_url(object_id);
+    let site = ObjectId::<ApubSite>::from(instance_id.clone())
+        .dereference(context)
+        .await;
+    match site {
+        Ok(s) => Ok(s.instance_id),
+        Err(e) => {
+            // Failed to fetch instance actor, its probably not a lemmy instance
+            debug!("Failed to dereference site for {}: {}", &instance_id, e);
+            let domain = instance_id.domain().expect("has domain");
+            Ok(
+                DbInstance::read_or_create(&mut context.pool(), domain.to_string())
+                    .await?
+                    .id,
+            )
+        }
     }
-  }
 }
 
 pub(crate) async fn remote_instance_inboxes(pool: &mut DbPool<'_>) -> Result<Vec<Url>, LemmyError> {
-  Ok(
-    Site::read_remote_sites(pool)
-      .await?
-      .into_iter()
-      .map(|s| ApubSite::from(s).shared_inbox_or_inbox())
-      .collect(),
-  )
+    Ok(Site::read_remote_sites(pool)
+        .await?
+        .into_iter()
+        .map(|s| ApubSite::from(s).shared_inbox_or_inbox())
+        .collect())
 }
 
 #[cfg(test)]
 pub(crate) mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use super::*;
-  use crate::{objects::tests::init_context, protocol::tests::file_to_json_object};
-  use lemmy_db_schema::traits::Crud;
-  use serial_test::serial;
+    use super::*;
+    use crate::{objects::tests::init_context, protocol::tests::file_to_json_object};
+    use lemmy_db_schema::traits::Crud;
+    use serial_test::serial;
 
-  pub(crate) async fn parse_lemmy_instance(context: &Data<LemmyContext>) -> ApubSite {
-    let json: Instance = file_to_json_object("assets/lemmy/objects/instance.json").unwrap();
-    let id = Url::parse("https://enterprise.lemmy.ml/").unwrap();
-    ApubSite::verify(&json, &id, context).await.unwrap();
-    let site = ApubSite::from_json(json, context).await.unwrap();
-    assert_eq!(context.request_count(), 0);
-    site
-  }
+    pub(crate) async fn parse_lemmy_instance(context: &Data<LemmyContext>) -> ApubSite {
+        let json: Instance = file_to_json_object("assets/lemmy/objects/instance.json").unwrap();
+        let id = Url::parse("https://enterprise.lemmy.ml/").unwrap();
+        ApubSite::verify(&json, &id, context).await.unwrap();
+        let site = ApubSite::from_json(json, context).await.unwrap();
+        assert_eq!(context.request_count(), 0);
+        site
+    }
 
-  #[tokio::test]
-  #[serial]
-  async fn test_parse_lemmy_instance() {
-    let context = init_context().await;
-    let site = parse_lemmy_instance(&context).await;
+    #[tokio::test]
+    #[serial]
+    async fn test_parse_lemmy_instance() {
+        let context = init_context().await;
+        let site = parse_lemmy_instance(&context).await;
 
-    assert_eq!(site.name, "Enterprise");
-    assert_eq!(site.description.as_ref().unwrap().len(), 15);
+        assert_eq!(site.name, "Enterprise");
+        assert_eq!(site.description.as_ref().unwrap().len(), 15);
 
-    Site::delete(&mut context.pool(), site.id).await.unwrap();
-  }
+        Site::delete(&mut context.pool(), site.id).await.unwrap();
+    }
 }

--- a/crates/apub/src/objects/mod.rs
+++ b/crates/apub/src/objects/mod.rs
@@ -13,30 +13,30 @@ pub mod post;
 pub mod private_message;
 
 pub(crate) fn read_from_string_or_source(
-  content: &str,
-  media_type: &Option<MediaTypeMarkdownOrHtml>,
-  source: &Option<Source>,
+    content: &str,
+    media_type: &Option<MediaTypeMarkdownOrHtml>,
+    source: &Option<Source>,
 ) -> String {
-  if let Some(s) = source {
-    // markdown sent by lemmy in source field
-    s.content.clone()
-  } else if media_type == &Some(MediaTypeMarkdownOrHtml::Markdown) {
-    // markdown sent by peertube in content field
-    content.to_string()
-  } else {
-    // otherwise, convert content html to markdown
-    parse_html(content)
-  }
+    if let Some(s) = source {
+        // markdown sent by lemmy in source field
+        s.content.clone()
+    } else if media_type == &Some(MediaTypeMarkdownOrHtml::Markdown) {
+        // markdown sent by peertube in content field
+        content.to_string()
+    } else {
+        // otherwise, convert content html to markdown
+        parse_html(content)
+    }
 }
 
 pub(crate) fn read_from_string_or_source_opt(
-  content: &Option<String>,
-  media_type: &Option<MediaTypeMarkdownOrHtml>,
-  source: &Option<Source>,
+    content: &Option<String>,
+    media_type: &Option<MediaTypeMarkdownOrHtml>,
+    source: &Option<Source>,
 ) -> Option<String> {
-  content
-    .as_ref()
-    .map(|content| read_from_string_or_source(content, media_type, source))
+    content
+        .as_ref()
+        .map(|content| read_from_string_or_source(content, media_type, source))
 }
 
 /// When for example a Post is made in a remote community, the community will send it back,
@@ -44,73 +44,73 @@ pub(crate) fn read_from_string_or_source_opt(
 /// existing, local Post. In particular, it will set the field local = false, so that the object
 /// can't be fetched from the Activitypub HTTP endpoint anymore (which only serves local objects).
 pub(crate) fn verify_is_remote_object(id: &Url, settings: &Settings) -> Result<(), LemmyError> {
-  let local_domain = settings.get_hostname_without_port()?;
-  if id.domain() == Some(&local_domain) {
-    Err(anyhow!("cant accept local object from remote instance").into())
-  } else {
-    Ok(())
-  }
+    let local_domain = settings.get_hostname_without_port()?;
+    if id.domain() == Some(&local_domain) {
+        Err(anyhow!("cant accept local object from remote instance").into())
+    } else {
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 pub(crate) mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use activitypub_federation::config::{Data, FederationConfig};
-  use anyhow::anyhow;
-  use lemmy_api_common::{context::LemmyContext, request::build_user_agent};
-  use lemmy_db_schema::{source::secret::Secret, utils::build_db_pool_for_tests};
-  use lemmy_utils::{
-    rate_limit::{RateLimitCell, RateLimitConfig},
-    settings::SETTINGS,
-  };
-  use reqwest::{Client, Request, Response};
-  use reqwest_middleware::{ClientBuilder, Middleware, Next};
-  use task_local_extensions::Extensions;
-
-  struct BlockedMiddleware;
-
-  /// A reqwest middleware which blocks all requests
-  #[async_trait::async_trait]
-  impl Middleware for BlockedMiddleware {
-    async fn handle(
-      &self,
-      _req: Request,
-      _extensions: &mut Extensions,
-      _next: Next<'_>,
-    ) -> reqwest_middleware::Result<Response> {
-      Err(anyhow!("Network requests not allowed").into())
-    }
-  }
-
-  // TODO: would be nice if we didnt have to use a full context for tests.
-  pub(crate) async fn init_context() -> Data<LemmyContext> {
-    // call this to run migrations
-    let pool = build_db_pool_for_tests().await;
-
-    let settings = SETTINGS.clone();
-    let client = Client::builder()
-      .user_agent(build_user_agent(&settings))
-      .build()
-      .unwrap();
-
-    let client = ClientBuilder::new(client).with(BlockedMiddleware).build();
-    let secret = Secret {
-      id: 0,
-      jwt_secret: String::new(),
+    use activitypub_federation::config::{Data, FederationConfig};
+    use anyhow::anyhow;
+    use lemmy_api_common::{context::LemmyContext, request::build_user_agent};
+    use lemmy_db_schema::{source::secret::Secret, utils::build_db_pool_for_tests};
+    use lemmy_utils::{
+        rate_limit::{RateLimitCell, RateLimitConfig},
+        settings::SETTINGS,
     };
+    use reqwest::{Client, Request, Response};
+    use reqwest_middleware::{ClientBuilder, Middleware, Next};
+    use task_local_extensions::Extensions;
 
-    let rate_limit_config = RateLimitConfig::builder().build();
-    let rate_limit_cell = RateLimitCell::new(rate_limit_config).await;
+    struct BlockedMiddleware;
 
-    let context = LemmyContext::create(pool, client, secret, rate_limit_cell.clone());
-    let config = FederationConfig::builder()
-      .domain("example.com")
-      .app_data(context)
-      .build()
-      .await
-      .unwrap();
-    config.to_request_data()
-  }
+    /// A reqwest middleware which blocks all requests
+    #[async_trait::async_trait]
+    impl Middleware for BlockedMiddleware {
+        async fn handle(
+            &self,
+            _req: Request,
+            _extensions: &mut Extensions,
+            _next: Next<'_>,
+        ) -> reqwest_middleware::Result<Response> {
+            Err(anyhow!("Network requests not allowed").into())
+        }
+    }
+
+    // TODO: would be nice if we didnt have to use a full context for tests.
+    pub(crate) async fn init_context() -> Data<LemmyContext> {
+        // call this to run migrations
+        let pool = build_db_pool_for_tests().await;
+
+        let settings = SETTINGS.clone();
+        let client = Client::builder()
+            .user_agent(build_user_agent(&settings))
+            .build()
+            .unwrap();
+
+        let client = ClientBuilder::new(client).with(BlockedMiddleware).build();
+        let secret = Secret {
+            id: 0,
+            jwt_secret: String::new(),
+        };
+
+        let rate_limit_config = RateLimitConfig::builder().build();
+        let rate_limit_cell = RateLimitCell::new(rate_limit_config).await;
+
+        let context = LemmyContext::create(pool, client, secret, rate_limit_cell.clone());
+        let config = FederationConfig::builder()
+            .domain("example.com")
+            .app_data(context)
+            .build()
+            .await
+            .unwrap();
+        config.to_request_data()
+    }
 }

--- a/crates/apub/src/objects/person.rs
+++ b/crates/apub/src/objects/person.rs
@@ -1,38 +1,36 @@
 use crate::{
-  check_apub_id_valid_with_strictness,
-  local_site_data_cached,
-  objects::{instance::fetch_instance_actor_for_object, read_from_string_or_source_opt},
-  protocol::{
-    objects::{
-      person::{Person, UserTypes},
-      Endpoints,
+    check_apub_id_valid_with_strictness, local_site_data_cached,
+    objects::{instance::fetch_instance_actor_for_object, read_from_string_or_source_opt},
+    protocol::{
+        objects::{
+            person::{Person, UserTypes},
+            Endpoints,
+        },
+        ImageObject, Source,
     },
-    ImageObject,
-    Source,
-  },
 };
 use activitypub_federation::{
-  config::Data,
-  protocol::verification::verify_domains_match,
-  traits::{Actor, Object},
+    config::Data,
+    protocol::verification::verify_domains_match,
+    traits::{Actor, Object},
 };
 use chrono::{DateTime, Utc};
 use lemmy_api_common::{
-  context::LemmyContext,
-  utils::{generate_outbox_url, local_site_opt_to_slur_regex, sanitize_html, sanitize_html_opt},
+    context::LemmyContext,
+    utils::{generate_outbox_url, local_site_opt_to_slur_regex, sanitize_html, sanitize_html_opt},
 };
 use lemmy_db_schema::{
-  source::person::{Person as DbPerson, PersonInsertForm, PersonUpdateForm},
-  traits::{ApubActor, Crud},
-  utils::naive_now,
+    source::person::{Person as DbPerson, PersonInsertForm, PersonUpdateForm},
+    traits::{ApubActor, Crud},
+    utils::naive_now,
 };
 use lemmy_utils::{
-  error::LemmyError,
-  utils::{
-    markdown::markdown_to_html,
-    slurs::{check_slurs, check_slurs_opt},
-    time::convert_datetime,
-  },
+    error::LemmyError,
+    utils::{
+        markdown::markdown_to_html,
+        slurs::{check_slurs, check_slurs_opt},
+        time::convert_datetime,
+    },
 };
 use std::ops::Deref;
 use url::Url;
@@ -41,234 +39,234 @@ use url::Url;
 pub struct ApubPerson(pub(crate) DbPerson);
 
 impl Deref for ApubPerson {
-  type Target = DbPerson;
-  fn deref(&self) -> &Self::Target {
-    &self.0
-  }
+    type Target = DbPerson;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 impl From<DbPerson> for ApubPerson {
-  fn from(p: DbPerson) -> Self {
-    ApubPerson(p)
-  }
+    fn from(p: DbPerson) -> Self {
+        ApubPerson(p)
+    }
 }
 
 #[async_trait::async_trait]
 impl Object for ApubPerson {
-  type DataType = LemmyContext;
-  type Kind = Person;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Kind = Person;
+    type Error = LemmyError;
 
-  fn last_refreshed_at(&self) -> Option<DateTime<Utc>> {
-    Some(self.last_refreshed_at)
-  }
+    fn last_refreshed_at(&self) -> Option<DateTime<Utc>> {
+        Some(self.last_refreshed_at)
+    }
 
-  #[tracing::instrument(skip_all)]
-  async fn read_from_id(
-    object_id: Url,
-    context: &Data<Self::DataType>,
-  ) -> Result<Option<Self>, LemmyError> {
-    Ok(
-      DbPerson::read_from_apub_id(&mut context.pool(), &object_id.into())
-        .await?
-        .map(Into::into),
-    )
-  }
+    #[tracing::instrument(skip_all)]
+    async fn read_from_id(
+        object_id: Url,
+        context: &Data<Self::DataType>,
+    ) -> Result<Option<Self>, LemmyError> {
+        Ok(
+            DbPerson::read_from_apub_id(&mut context.pool(), &object_id.into())
+                .await?
+                .map(Into::into),
+        )
+    }
 
-  #[tracing::instrument(skip_all)]
-  async fn delete(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
-    let form = PersonUpdateForm {
-      deleted: Some(true),
-      ..Default::default()
-    };
-    DbPerson::update(&mut context.pool(), self.id, &form).await?;
-    Ok(())
-  }
+    #[tracing::instrument(skip_all)]
+    async fn delete(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+        let form = PersonUpdateForm {
+            deleted: Some(true),
+            ..Default::default()
+        };
+        DbPerson::update(&mut context.pool(), self.id, &form).await?;
+        Ok(())
+    }
 
-  #[tracing::instrument(skip_all)]
-  async fn into_json(self, _context: &Data<Self::DataType>) -> Result<Person, LemmyError> {
-    let kind = if self.bot_account {
-      UserTypes::Service
-    } else {
-      UserTypes::Person
-    };
+    #[tracing::instrument(skip_all)]
+    async fn into_json(self, _context: &Data<Self::DataType>) -> Result<Person, LemmyError> {
+        let kind = if self.bot_account {
+            UserTypes::Service
+        } else {
+            UserTypes::Person
+        };
 
-    let person = Person {
-      kind,
-      id: self.actor_id.clone().into(),
-      preferred_username: self.name.clone(),
-      name: self.display_name.clone(),
-      summary: self.bio.as_ref().map(|b| markdown_to_html(b)),
-      source: self.bio.clone().map(Source::new),
-      icon: self.avatar.clone().map(ImageObject::new),
-      image: self.banner.clone().map(ImageObject::new),
-      matrix_user_id: self.matrix_user_id.clone(),
-      published: Some(convert_datetime(self.published)),
-      outbox: generate_outbox_url(&self.actor_id)?.into(),
-      endpoints: self.shared_inbox_url.clone().map(|s| Endpoints {
-        shared_inbox: s.into(),
-      }),
-      public_key: self.public_key(),
-      updated: self.updated.map(convert_datetime),
-      inbox: self.inbox_url.clone().into(),
-    };
-    Ok(person)
-  }
+        let person = Person {
+            kind,
+            id: self.actor_id.clone().into(),
+            preferred_username: self.name.clone(),
+            name: self.display_name.clone(),
+            summary: self.bio.as_ref().map(|b| markdown_to_html(b)),
+            source: self.bio.clone().map(Source::new),
+            icon: self.avatar.clone().map(ImageObject::new),
+            image: self.banner.clone().map(ImageObject::new),
+            matrix_user_id: self.matrix_user_id.clone(),
+            published: Some(convert_datetime(self.published)),
+            outbox: generate_outbox_url(&self.actor_id)?.into(),
+            endpoints: self.shared_inbox_url.clone().map(|s| Endpoints {
+                shared_inbox: s.into(),
+            }),
+            public_key: self.public_key(),
+            updated: self.updated.map(convert_datetime),
+            inbox: self.inbox_url.clone().into(),
+        };
+        Ok(person)
+    }
 
-  #[tracing::instrument(skip_all)]
-  async fn verify(
-    person: &Person,
-    expected_domain: &Url,
-    context: &Data<Self::DataType>,
-  ) -> Result<(), LemmyError> {
-    let local_site_data = local_site_data_cached(&mut context.pool()).await?;
-    let slur_regex = &local_site_opt_to_slur_regex(&local_site_data.local_site);
-    check_slurs(&person.preferred_username, slur_regex)?;
-    check_slurs_opt(&person.name, slur_regex)?;
+    #[tracing::instrument(skip_all)]
+    async fn verify(
+        person: &Person,
+        expected_domain: &Url,
+        context: &Data<Self::DataType>,
+    ) -> Result<(), LemmyError> {
+        let local_site_data = local_site_data_cached(&mut context.pool()).await?;
+        let slur_regex = &local_site_opt_to_slur_regex(&local_site_data.local_site);
+        check_slurs(&person.preferred_username, slur_regex)?;
+        check_slurs_opt(&person.name, slur_regex)?;
 
-    verify_domains_match(person.id.inner(), expected_domain)?;
-    check_apub_id_valid_with_strictness(person.id.inner(), false, context).await?;
+        verify_domains_match(person.id.inner(), expected_domain)?;
+        check_apub_id_valid_with_strictness(person.id.inner(), false, context).await?;
 
-    let bio = read_from_string_or_source_opt(&person.summary, &None, &person.source);
-    check_slurs_opt(&bio, slur_regex)?;
-    Ok(())
-  }
+        let bio = read_from_string_or_source_opt(&person.summary, &None, &person.source);
+        check_slurs_opt(&bio, slur_regex)?;
+        Ok(())
+    }
 
-  #[tracing::instrument(skip_all)]
-  async fn from_json(
-    person: Person,
-    context: &Data<Self::DataType>,
-  ) -> Result<ApubPerson, LemmyError> {
-    let instance_id = fetch_instance_actor_for_object(&person.id, context).await?;
+    #[tracing::instrument(skip_all)]
+    async fn from_json(
+        person: Person,
+        context: &Data<Self::DataType>,
+    ) -> Result<ApubPerson, LemmyError> {
+        let instance_id = fetch_instance_actor_for_object(&person.id, context).await?;
 
-    let name = sanitize_html(&person.preferred_username);
-    let display_name = sanitize_html_opt(&person.name);
-    let bio = read_from_string_or_source_opt(&person.summary, &None, &person.source);
-    let bio = sanitize_html_opt(&bio);
+        let name = sanitize_html(&person.preferred_username);
+        let display_name = sanitize_html_opt(&person.name);
+        let bio = read_from_string_or_source_opt(&person.summary, &None, &person.source);
+        let bio = sanitize_html_opt(&bio);
 
-    // Some Mastodon users have `name: ""` (empty string), need to convert that to `None`
-    // https://github.com/mastodon/mastodon/issues/25233
-    let display_name = display_name.filter(|n| !n.is_empty());
+        // Some Mastodon users have `name: ""` (empty string), need to convert that to `None`
+        // https://github.com/mastodon/mastodon/issues/25233
+        let display_name = display_name.filter(|n| !n.is_empty());
 
-    let person_form = PersonInsertForm {
-      name,
-      display_name,
-      banned: None,
-      ban_expires: None,
-      deleted: Some(false),
-      avatar: person.icon.map(|i| i.url.into()),
-      banner: person.image.map(|i| i.url.into()),
-      published: person.published.map(Into::into),
-      updated: person.updated.map(Into::into),
-      actor_id: Some(person.id.into()),
-      bio,
-      local: Some(false),
-      bot_account: Some(person.kind == UserTypes::Service),
-      private_key: None,
-      public_key: person.public_key.public_key_pem,
-      last_refreshed_at: Some(naive_now()),
-      inbox_url: Some(person.inbox.into()),
-      shared_inbox_url: person.endpoints.map(|e| e.shared_inbox.into()),
-      matrix_user_id: person.matrix_user_id,
-      instance_id,
-    };
-    let person = DbPerson::upsert(&mut context.pool(), &person_form).await?;
+        let person_form = PersonInsertForm {
+            name,
+            display_name,
+            banned: None,
+            ban_expires: None,
+            deleted: Some(false),
+            avatar: person.icon.map(|i| i.url.into()),
+            banner: person.image.map(|i| i.url.into()),
+            published: person.published.map(Into::into),
+            updated: person.updated.map(Into::into),
+            actor_id: Some(person.id.into()),
+            bio,
+            local: Some(false),
+            bot_account: Some(person.kind == UserTypes::Service),
+            private_key: None,
+            public_key: person.public_key.public_key_pem,
+            last_refreshed_at: Some(naive_now()),
+            inbox_url: Some(person.inbox.into()),
+            shared_inbox_url: person.endpoints.map(|e| e.shared_inbox.into()),
+            matrix_user_id: person.matrix_user_id,
+            instance_id,
+        };
+        let person = DbPerson::upsert(&mut context.pool(), &person_form).await?;
 
-    Ok(person.into())
-  }
+        Ok(person.into())
+    }
 }
 
 impl Actor for ApubPerson {
-  fn id(&self) -> Url {
-    self.actor_id.inner().clone()
-  }
+    fn id(&self) -> Url {
+        self.actor_id.inner().clone()
+    }
 
-  fn public_key_pem(&self) -> &str {
-    &self.public_key
-  }
+    fn public_key_pem(&self) -> &str {
+        &self.public_key
+    }
 
-  fn private_key_pem(&self) -> Option<String> {
-    self.private_key.clone()
-  }
+    fn private_key_pem(&self) -> Option<String> {
+        self.private_key.clone()
+    }
 
-  fn inbox(&self) -> Url {
-    self.inbox_url.clone().into()
-  }
+    fn inbox(&self) -> Url {
+        self.inbox_url.clone().into()
+    }
 
-  fn shared_inbox(&self) -> Option<Url> {
-    self.shared_inbox_url.clone().map(Into::into)
-  }
+    fn shared_inbox(&self) -> Option<Url> {
+        self.shared_inbox_url.clone().map(Into::into)
+    }
 }
 
 #[cfg(test)]
 pub(crate) mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use super::*;
-  use crate::{
-    objects::{
-      instance::{tests::parse_lemmy_instance, ApubSite},
-      tests::init_context,
-    },
-    protocol::{objects::instance::Instance, tests::file_to_json_object},
-  };
-  use activitypub_federation::fetch::object_id::ObjectId;
-  use lemmy_db_schema::{source::site::Site, traits::Crud};
-  use serial_test::serial;
+    use super::*;
+    use crate::{
+        objects::{
+            instance::{tests::parse_lemmy_instance, ApubSite},
+            tests::init_context,
+        },
+        protocol::{objects::instance::Instance, tests::file_to_json_object},
+    };
+    use activitypub_federation::fetch::object_id::ObjectId;
+    use lemmy_db_schema::{source::site::Site, traits::Crud};
+    use serial_test::serial;
 
-  pub(crate) async fn parse_lemmy_person(context: &Data<LemmyContext>) -> (ApubPerson, ApubSite) {
-    let site = parse_lemmy_instance(context).await;
-    let json = file_to_json_object("assets/lemmy/objects/person.json").unwrap();
-    let url = Url::parse("https://enterprise.lemmy.ml/u/picard").unwrap();
-    ApubPerson::verify(&json, &url, context).await.unwrap();
-    let person = ApubPerson::from_json(json, context).await.unwrap();
-    assert_eq!(context.request_count(), 0);
-    (person, site)
-  }
+    pub(crate) async fn parse_lemmy_person(context: &Data<LemmyContext>) -> (ApubPerson, ApubSite) {
+        let site = parse_lemmy_instance(context).await;
+        let json = file_to_json_object("assets/lemmy/objects/person.json").unwrap();
+        let url = Url::parse("https://enterprise.lemmy.ml/u/picard").unwrap();
+        ApubPerson::verify(&json, &url, context).await.unwrap();
+        let person = ApubPerson::from_json(json, context).await.unwrap();
+        assert_eq!(context.request_count(), 0);
+        (person, site)
+    }
 
-  #[tokio::test]
-  #[serial]
-  async fn test_parse_lemmy_person() {
-    let context = init_context().await;
-    let (person, site) = parse_lemmy_person(&context).await;
+    #[tokio::test]
+    #[serial]
+    async fn test_parse_lemmy_person() {
+        let context = init_context().await;
+        let (person, site) = parse_lemmy_person(&context).await;
 
-    assert_eq!(person.display_name, Some("Jean-Luc Picard".to_string()));
-    assert!(!person.local);
-    assert_eq!(person.bio.as_ref().unwrap().len(), 39);
+        assert_eq!(person.display_name, Some("Jean-Luc Picard".to_string()));
+        assert!(!person.local);
+        assert_eq!(person.bio.as_ref().unwrap().len(), 39);
 
-    cleanup((person, site), &context).await;
-  }
+        cleanup((person, site), &context).await;
+    }
 
-  #[tokio::test]
-  #[serial]
-  async fn test_parse_pleroma_person() {
-    let context = init_context().await;
+    #[tokio::test]
+    #[serial]
+    async fn test_parse_pleroma_person() {
+        let context = init_context().await;
 
-    // create and parse a fake pleroma instance actor, to avoid network request during test
-    let mut json: Instance = file_to_json_object("assets/lemmy/objects/instance.json").unwrap();
-    json.id = ObjectId::parse("https://queer.hacktivis.me/").unwrap();
-    let url = Url::parse("https://queer.hacktivis.me/users/lanodan").unwrap();
-    ApubSite::verify(&json, &url, &context).await.unwrap();
-    let site = ApubSite::from_json(json, &context).await.unwrap();
+        // create and parse a fake pleroma instance actor, to avoid network request during test
+        let mut json: Instance = file_to_json_object("assets/lemmy/objects/instance.json").unwrap();
+        json.id = ObjectId::parse("https://queer.hacktivis.me/").unwrap();
+        let url = Url::parse("https://queer.hacktivis.me/users/lanodan").unwrap();
+        ApubSite::verify(&json, &url, &context).await.unwrap();
+        let site = ApubSite::from_json(json, &context).await.unwrap();
 
-    let json = file_to_json_object("assets/pleroma/objects/person.json").unwrap();
-    ApubPerson::verify(&json, &url, &context).await.unwrap();
-    let person = ApubPerson::from_json(json, &context).await.unwrap();
+        let json = file_to_json_object("assets/pleroma/objects/person.json").unwrap();
+        ApubPerson::verify(&json, &url, &context).await.unwrap();
+        let person = ApubPerson::from_json(json, &context).await.unwrap();
 
-    assert_eq!(person.actor_id, url.into());
-    assert_eq!(person.name, "lanodan");
-    assert!(!person.local);
-    assert_eq!(context.request_count(), 0);
-    assert_eq!(person.bio.as_ref().unwrap().len(), 873);
+        assert_eq!(person.actor_id, url.into());
+        assert_eq!(person.name, "lanodan");
+        assert!(!person.local);
+        assert_eq!(context.request_count(), 0);
+        assert_eq!(person.bio.as_ref().unwrap().len(), 873);
 
-    cleanup((person, site), &context).await;
-  }
+        cleanup((person, site), &context).await;
+    }
 
-  async fn cleanup(data: (ApubPerson, ApubSite), context: &LemmyContext) {
-    DbPerson::delete(&mut context.pool(), data.0.id)
-      .await
-      .unwrap();
-    Site::delete(&mut context.pool(), data.1.id).await.unwrap();
-  }
+    async fn cleanup(data: (ApubPerson, ApubSite), context: &LemmyContext) {
+        DbPerson::delete(&mut context.pool(), data.0.id)
+            .await
+            .unwrap();
+        Site::delete(&mut context.pool(), data.1.id).await.unwrap();
+    }
 }

--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -1,57 +1,51 @@
 use crate::{
-  activities::{verify_is_public, verify_person_in_community},
-  check_apub_id_valid_with_strictness,
-  local_site_data_cached,
-  objects::{read_from_string_or_source_opt, verify_is_remote_object},
-  protocol::{
-    objects::{
-      page::{Attachment, AttributedTo, Page, PageType},
-      LanguageTag,
+    activities::{verify_is_public, verify_person_in_community},
+    check_apub_id_valid_with_strictness, local_site_data_cached,
+    objects::{read_from_string_or_source_opt, verify_is_remote_object},
+    protocol::{
+        objects::{
+            page::{Attachment, AttributedTo, Page, PageType},
+            LanguageTag,
+        },
+        ImageObject, InCommunity, Source,
     },
-    ImageObject,
-    InCommunity,
-    Source,
-  },
 };
 use activitypub_federation::{
-  config::Data,
-  kinds::public,
-  protocol::{values::MediaTypeMarkdownOrHtml, verification::verify_domains_match},
-  traits::Object,
+    config::Data,
+    kinds::public,
+    protocol::{values::MediaTypeMarkdownOrHtml, verification::verify_domains_match},
+    traits::Object,
 };
 use anyhow::anyhow;
 use chrono::{DateTime, Utc};
 use html2md::parse_html;
 use lemmy_api_common::{
-  context::LemmyContext,
-  request::fetch_site_data,
-  utils::{
-    is_mod_or_admin,
-    local_site_opt_to_sensitive,
-    local_site_opt_to_slur_regex,
-    sanitize_html,
-    sanitize_html_opt,
-  },
+    context::LemmyContext,
+    request::fetch_site_data,
+    utils::{
+        is_mod_or_admin, local_site_opt_to_sensitive, local_site_opt_to_slur_regex, sanitize_html,
+        sanitize_html_opt,
+    },
 };
 use lemmy_db_schema::{
-  self,
-  source::{
-    community::Community,
-    local_site::LocalSite,
-    moderator::{ModLockPost, ModLockPostForm},
-    person::Person,
-    post::{Post, PostInsertForm, PostUpdateForm},
-  },
-  traits::Crud,
+    self,
+    source::{
+        community::Community,
+        local_site::LocalSite,
+        moderator::{ModLockPost, ModLockPostForm},
+        person::Person,
+        post::{Post, PostInsertForm, PostUpdateForm},
+    },
+    traits::Crud,
 };
 use lemmy_utils::{
-  error::LemmyError,
-  utils::{
-    markdown::markdown_to_html,
-    slurs::{check_slurs_opt, remove_slurs},
-    time::convert_datetime,
-    validation::check_url_scheme,
-  },
+    error::LemmyError,
+    utils::{
+        markdown::markdown_to_html,
+        slurs::{check_slurs_opt, remove_slurs},
+        time::convert_datetime,
+        validation::check_url_scheme,
+    },
 };
 use std::ops::Deref;
 use url::Url;
@@ -62,280 +56,275 @@ const MAX_TITLE_LENGTH: usize = 200;
 pub struct ApubPost(pub(crate) Post);
 
 impl Deref for ApubPost {
-  type Target = Post;
-  fn deref(&self) -> &Self::Target {
-    &self.0
-  }
+    type Target = Post;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 impl From<Post> for ApubPost {
-  fn from(p: Post) -> Self {
-    ApubPost(p)
-  }
+    fn from(p: Post) -> Self {
+        ApubPost(p)
+    }
 }
 
 #[async_trait::async_trait]
 impl Object for ApubPost {
-  type DataType = LemmyContext;
-  type Kind = Page;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Kind = Page;
+    type Error = LemmyError;
 
-  fn last_refreshed_at(&self) -> Option<DateTime<Utc>> {
-    None
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn read_from_id(
-    object_id: Url,
-    context: &Data<Self::DataType>,
-  ) -> Result<Option<Self>, LemmyError> {
-    Ok(
-      Post::read_from_apub_id(&mut context.pool(), object_id)
-        .await?
-        .map(Into::into),
-    )
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn delete(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
-    if !self.deleted {
-      let form = PostUpdateForm {
-        deleted: Some(true),
-        ..Default::default()
-      };
-      Post::update(&mut context.pool(), self.id, &form).await?;
-    }
-    Ok(())
-  }
-
-  // Turn a Lemmy post into an ActivityPub page that can be sent out over the network.
-  #[tracing::instrument(skip_all)]
-  async fn into_json(self, context: &Data<Self::DataType>) -> Result<Page, LemmyError> {
-    let creator_id = self.creator_id;
-    let creator = Person::read(&mut context.pool(), creator_id).await?;
-    let community_id = self.community_id;
-    let community = Community::read(&mut context.pool(), community_id).await?;
-    let language = LanguageTag::new_single(self.language_id, &mut context.pool()).await?;
-
-    let page = Page {
-      kind: PageType::Page,
-      id: self.ap_id.clone().into(),
-      attributed_to: AttributedTo::Lemmy(creator.actor_id.into()),
-      to: vec![community.actor_id.clone().into(), public()],
-      cc: vec![],
-      name: Some(self.name.clone()),
-      content: self.body.as_ref().map(|b| markdown_to_html(b)),
-      media_type: Some(MediaTypeMarkdownOrHtml::Html),
-      source: self.body.clone().map(Source::new),
-      attachment: self.url.clone().map(Attachment::new).into_iter().collect(),
-      image: self.thumbnail_url.clone().map(ImageObject::new),
-      comments_enabled: Some(!self.locked),
-      sensitive: Some(self.nsfw),
-      language,
-      published: Some(convert_datetime(self.published)),
-      updated: self.updated.map(convert_datetime),
-      audience: Some(community.actor_id.into()),
-      in_reply_to: None,
-    };
-    Ok(page)
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn verify(
-    page: &Page,
-    expected_domain: &Url,
-    context: &Data<Self::DataType>,
-  ) -> Result<(), LemmyError> {
-    // We can't verify the domain in case of mod action, because the mod may be on a different
-    // instance from the post author.
-    if !page.is_mod_action(context).await? {
-      verify_domains_match(page.id.inner(), expected_domain)?;
-      verify_is_remote_object(page.id.inner(), context.settings())?;
-    };
-
-    let community = page.community(context).await?;
-    check_apub_id_valid_with_strictness(page.id.inner(), community.local, context).await?;
-    verify_person_in_community(&page.creator()?, &community, context).await?;
-
-    let local_site_data = local_site_data_cached(&mut context.pool()).await?;
-    let slur_regex = &local_site_opt_to_slur_regex(&local_site_data.local_site);
-    check_slurs_opt(&page.name, slur_regex)?;
-
-    verify_domains_match(page.creator()?.inner(), page.id.inner())?;
-    verify_is_public(&page.to, &page.cc)?;
-    Ok(())
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn from_json(page: Page, context: &Data<Self::DataType>) -> Result<ApubPost, LemmyError> {
-    let creator = page.creator()?.dereference(context).await?;
-    let community = page.community(context).await?;
-    if community.posting_restricted_to_mods {
-      is_mod_or_admin(&mut context.pool(), creator.id, community.id).await?;
-    }
-    let mut name = page
-      .name
-      .clone()
-      .or_else(|| {
-        page
-          .content
-          .clone()
-          .as_ref()
-          .and_then(|c| parse_html(c).lines().next().map(ToString::to_string))
-      })
-      .ok_or_else(|| anyhow!("Object must have name or content"))?;
-    if name.chars().count() > MAX_TITLE_LENGTH {
-      name = name.chars().take(MAX_TITLE_LENGTH).collect();
-    }
-
-    // read existing, local post if any (for generating mod log)
-    let old_post = page.id.dereference_local(context).await;
-
-    let form = if !page.is_mod_action(context).await? {
-      let first_attachment = page.attachment.into_iter().map(Attachment::url).next();
-      let url = if first_attachment.is_some() {
-        first_attachment
-      } else if page.kind == PageType::Video {
-        // we cant display videos directly, so insert a link to external video page
-        Some(page.id.inner().clone())
-      } else {
+    fn last_refreshed_at(&self) -> Option<DateTime<Utc>> {
         None
-      };
-      check_url_scheme(&url)?;
-
-      let local_site = LocalSite::read(&mut context.pool()).await.ok();
-      let allow_sensitive = local_site_opt_to_sensitive(&local_site);
-      let page_is_sensitive = page.sensitive.unwrap_or(false);
-      let include_image = allow_sensitive || !page_is_sensitive;
-
-      // Only fetch metadata if the post has a url and was not seen previously. We dont want to
-      // waste resources by fetching metadata for the same post multiple times.
-      // Additionally, only fetch image if content is not sensitive or is allowed on local site.
-      let (metadata_res, thumbnail) = match &url {
-        Some(url) if old_post.is_err() => {
-          fetch_site_data(
-            context.client(),
-            context.settings(),
-            Some(url),
-            include_image,
-          )
-          .await
-        }
-        _ => (None, None),
-      };
-      // If no image was included with metadata, use post image instead when available.
-      let thumbnail_url = thumbnail.or_else(|| page.image.map(|i| i.url.into()));
-
-      let (embed_title, embed_description, embed_video_url) = metadata_res
-        .map(|u| (u.title, u.description, u.embed_video_url))
-        .unwrap_or_default();
-      let slur_regex = &local_site_opt_to_slur_regex(&local_site);
-
-      let body_slurs_removed =
-        read_from_string_or_source_opt(&page.content, &page.media_type, &page.source)
-          .map(|s| remove_slurs(&s, slur_regex));
-      let language_id =
-        LanguageTag::to_language_id_single(page.language, &mut context.pool()).await?;
-
-      let name = sanitize_html(&name);
-      let embed_title = sanitize_html_opt(&embed_title);
-      let embed_description = sanitize_html_opt(&embed_description);
-
-      PostInsertForm {
-        name,
-        url: url.map(Into::into),
-        body: body_slurs_removed,
-        creator_id: creator.id,
-        community_id: community.id,
-        removed: None,
-        locked: page.comments_enabled.map(|e| !e),
-        published: page.published.map(Into::into),
-        updated: page.updated.map(Into::into),
-        deleted: Some(false),
-        nsfw: page.sensitive,
-        embed_title,
-        embed_description,
-        embed_video_url,
-        thumbnail_url,
-        ap_id: Some(page.id.clone().into()),
-        local: Some(false),
-        language_id,
-        featured_community: None,
-        featured_local: None,
-      }
-    } else {
-      // if is mod action, only update locked/stickied fields, nothing else
-      PostInsertForm::builder()
-        .name(name)
-        .creator_id(creator.id)
-        .community_id(community.id)
-        .ap_id(Some(page.id.clone().into()))
-        .locked(page.comments_enabled.map(|e| !e))
-        .updated(page.updated.map(Into::into))
-        .build()
-    };
-
-    let post = Post::create(&mut context.pool(), &form).await?;
-
-    // write mod log entry for lock
-    if Page::is_locked_changed(&old_post, &page.comments_enabled) {
-      let form = ModLockPostForm {
-        mod_person_id: creator.id,
-        post_id: post.id,
-        locked: Some(post.locked),
-      };
-      ModLockPost::create(&mut context.pool(), &form).await?;
     }
 
-    Ok(post.into())
-  }
+    #[tracing::instrument(skip_all)]
+    async fn read_from_id(
+        object_id: Url,
+        context: &Data<Self::DataType>,
+    ) -> Result<Option<Self>, LemmyError> {
+        Ok(Post::read_from_apub_id(&mut context.pool(), object_id)
+            .await?
+            .map(Into::into))
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn delete(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+        if !self.deleted {
+            let form = PostUpdateForm {
+                deleted: Some(true),
+                ..Default::default()
+            };
+            Post::update(&mut context.pool(), self.id, &form).await?;
+        }
+        Ok(())
+    }
+
+    // Turn a Lemmy post into an ActivityPub page that can be sent out over the network.
+    #[tracing::instrument(skip_all)]
+    async fn into_json(self, context: &Data<Self::DataType>) -> Result<Page, LemmyError> {
+        let creator_id = self.creator_id;
+        let creator = Person::read(&mut context.pool(), creator_id).await?;
+        let community_id = self.community_id;
+        let community = Community::read(&mut context.pool(), community_id).await?;
+        let language = LanguageTag::new_single(self.language_id, &mut context.pool()).await?;
+
+        let page = Page {
+            kind: PageType::Page,
+            id: self.ap_id.clone().into(),
+            attributed_to: AttributedTo::Lemmy(creator.actor_id.into()),
+            to: vec![community.actor_id.clone().into(), public()],
+            cc: vec![],
+            name: Some(self.name.clone()),
+            content: self.body.as_ref().map(|b| markdown_to_html(b)),
+            media_type: Some(MediaTypeMarkdownOrHtml::Html),
+            source: self.body.clone().map(Source::new),
+            attachment: self.url.clone().map(Attachment::new).into_iter().collect(),
+            image: self.thumbnail_url.clone().map(ImageObject::new),
+            comments_enabled: Some(!self.locked),
+            sensitive: Some(self.nsfw),
+            language,
+            published: Some(convert_datetime(self.published)),
+            updated: self.updated.map(convert_datetime),
+            audience: Some(community.actor_id.into()),
+            in_reply_to: None,
+        };
+        Ok(page)
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn verify(
+        page: &Page,
+        expected_domain: &Url,
+        context: &Data<Self::DataType>,
+    ) -> Result<(), LemmyError> {
+        // We can't verify the domain in case of mod action, because the mod may be on a different
+        // instance from the post author.
+        if !page.is_mod_action(context).await? {
+            verify_domains_match(page.id.inner(), expected_domain)?;
+            verify_is_remote_object(page.id.inner(), context.settings())?;
+        };
+
+        let community = page.community(context).await?;
+        check_apub_id_valid_with_strictness(page.id.inner(), community.local, context).await?;
+        verify_person_in_community(&page.creator()?, &community, context).await?;
+
+        let local_site_data = local_site_data_cached(&mut context.pool()).await?;
+        let slur_regex = &local_site_opt_to_slur_regex(&local_site_data.local_site);
+        check_slurs_opt(&page.name, slur_regex)?;
+
+        verify_domains_match(page.creator()?.inner(), page.id.inner())?;
+        verify_is_public(&page.to, &page.cc)?;
+        Ok(())
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn from_json(page: Page, context: &Data<Self::DataType>) -> Result<ApubPost, LemmyError> {
+        let creator = page.creator()?.dereference(context).await?;
+        let community = page.community(context).await?;
+        if community.posting_restricted_to_mods {
+            is_mod_or_admin(&mut context.pool(), creator.id, community.id).await?;
+        }
+        let mut name = page
+            .name
+            .clone()
+            .or_else(|| {
+                page.content
+                    .clone()
+                    .as_ref()
+                    .and_then(|c| parse_html(c).lines().next().map(ToString::to_string))
+            })
+            .ok_or_else(|| anyhow!("Object must have name or content"))?;
+        if name.chars().count() > MAX_TITLE_LENGTH {
+            name = name.chars().take(MAX_TITLE_LENGTH).collect();
+        }
+
+        // read existing, local post if any (for generating mod log)
+        let old_post = page.id.dereference_local(context).await;
+
+        let form = if !page.is_mod_action(context).await? {
+            let first_attachment = page.attachment.into_iter().map(Attachment::url).next();
+            let url = if first_attachment.is_some() {
+                first_attachment
+            } else if page.kind == PageType::Video {
+                // we cant display videos directly, so insert a link to external video page
+                Some(page.id.inner().clone())
+            } else {
+                None
+            };
+            check_url_scheme(&url)?;
+
+            let local_site = LocalSite::read(&mut context.pool()).await.ok();
+            let allow_sensitive = local_site_opt_to_sensitive(&local_site);
+            let page_is_sensitive = page.sensitive.unwrap_or(false);
+            let include_image = allow_sensitive || !page_is_sensitive;
+
+            // Only fetch metadata if the post has a url and was not seen previously. We dont want to
+            // waste resources by fetching metadata for the same post multiple times.
+            // Additionally, only fetch image if content is not sensitive or is allowed on local site.
+            let (metadata_res, thumbnail) = match &url {
+                Some(url) if old_post.is_err() => {
+                    fetch_site_data(
+                        context.client(),
+                        context.settings(),
+                        Some(url),
+                        include_image,
+                    )
+                    .await
+                }
+                _ => (None, None),
+            };
+            // If no image was included with metadata, use post image instead when available.
+            let thumbnail_url = thumbnail.or_else(|| page.image.map(|i| i.url.into()));
+
+            let (embed_title, embed_description, embed_video_url) = metadata_res
+                .map(|u| (u.title, u.description, u.embed_video_url))
+                .unwrap_or_default();
+            let slur_regex = &local_site_opt_to_slur_regex(&local_site);
+
+            let body_slurs_removed =
+                read_from_string_or_source_opt(&page.content, &page.media_type, &page.source)
+                    .map(|s| remove_slurs(&s, slur_regex));
+            let language_id =
+                LanguageTag::to_language_id_single(page.language, &mut context.pool()).await?;
+
+            let name = sanitize_html(&name);
+            let embed_title = sanitize_html_opt(&embed_title);
+            let embed_description = sanitize_html_opt(&embed_description);
+
+            PostInsertForm {
+                name,
+                url: url.map(Into::into),
+                body: body_slurs_removed,
+                creator_id: creator.id,
+                community_id: community.id,
+                removed: None,
+                locked: page.comments_enabled.map(|e| !e),
+                published: page.published.map(Into::into),
+                updated: page.updated.map(Into::into),
+                deleted: Some(false),
+                nsfw: page.sensitive,
+                embed_title,
+                embed_description,
+                embed_video_url,
+                thumbnail_url,
+                ap_id: Some(page.id.clone().into()),
+                local: Some(false),
+                language_id,
+                featured_community: None,
+                featured_local: None,
+            }
+        } else {
+            // if is mod action, only update locked/stickied fields, nothing else
+            PostInsertForm::builder()
+                .name(name)
+                .creator_id(creator.id)
+                .community_id(community.id)
+                .ap_id(Some(page.id.clone().into()))
+                .locked(page.comments_enabled.map(|e| !e))
+                .updated(page.updated.map(Into::into))
+                .build()
+        };
+
+        let post = Post::create(&mut context.pool(), &form).await?;
+
+        // write mod log entry for lock
+        if Page::is_locked_changed(&old_post, &page.comments_enabled) {
+            let form = ModLockPostForm {
+                mod_person_id: creator.id,
+                post_id: post.id,
+                locked: Some(post.locked),
+            };
+            ModLockPost::create(&mut context.pool(), &form).await?;
+        }
+
+        Ok(post.into())
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use super::*;
-  use crate::{
-    objects::{
-      community::tests::parse_lemmy_community,
-      person::tests::parse_lemmy_person,
-      post::ApubPost,
-      tests::init_context,
-    },
-    protocol::tests::file_to_json_object,
-  };
-  use lemmy_db_schema::source::site::Site;
-  use serial_test::serial;
+    use super::*;
+    use crate::{
+        objects::{
+            community::tests::parse_lemmy_community, person::tests::parse_lemmy_person,
+            post::ApubPost, tests::init_context,
+        },
+        protocol::tests::file_to_json_object,
+    };
+    use lemmy_db_schema::source::site::Site;
+    use serial_test::serial;
 
-  #[tokio::test]
-  #[serial]
-  async fn test_parse_lemmy_post() {
-    let context = init_context().await;
-    let (person, site) = parse_lemmy_person(&context).await;
-    let community = parse_lemmy_community(&context).await;
+    #[tokio::test]
+    #[serial]
+    async fn test_parse_lemmy_post() {
+        let context = init_context().await;
+        let (person, site) = parse_lemmy_person(&context).await;
+        let community = parse_lemmy_community(&context).await;
 
-    let json = file_to_json_object("assets/lemmy/objects/page.json").unwrap();
-    let url = Url::parse("https://enterprise.lemmy.ml/post/55143").unwrap();
-    ApubPost::verify(&json, &url, &context).await.unwrap();
-    let post = ApubPost::from_json(json, &context).await.unwrap();
+        let json = file_to_json_object("assets/lemmy/objects/page.json").unwrap();
+        let url = Url::parse("https://enterprise.lemmy.ml/post/55143").unwrap();
+        ApubPost::verify(&json, &url, &context).await.unwrap();
+        let post = ApubPost::from_json(json, &context).await.unwrap();
 
-    assert_eq!(post.ap_id, url.into());
-    assert_eq!(post.name, "Post title");
-    assert!(post.body.is_some());
-    assert_eq!(post.body.as_ref().unwrap().len(), 45);
-    assert!(!post.locked);
-    assert!(!post.featured_community);
-    assert_eq!(context.request_count(), 0);
+        assert_eq!(post.ap_id, url.into());
+        assert_eq!(post.name, "Post title");
+        assert!(post.body.is_some());
+        assert_eq!(post.body.as_ref().unwrap().len(), 45);
+        assert!(!post.locked);
+        assert!(!post.featured_community);
+        assert_eq!(context.request_count(), 0);
 
-    Post::delete(&mut context.pool(), post.id).await.unwrap();
-    Person::delete(&mut context.pool(), person.id)
-      .await
-      .unwrap();
-    Community::delete(&mut context.pool(), community.id)
-      .await
-      .unwrap();
-    Site::delete(&mut context.pool(), site.id).await.unwrap();
-  }
+        Post::delete(&mut context.pool(), post.id).await.unwrap();
+        Person::delete(&mut context.pool(), person.id)
+            .await
+            .unwrap();
+        Community::delete(&mut context.pool(), community.id)
+            .await
+            .unwrap();
+        Site::delete(&mut context.pool(), site.id).await.unwrap();
+    }
 }

--- a/crates/apub/src/objects/private_message.rs
+++ b/crates/apub/src/objects/private_message.rs
@@ -1,31 +1,31 @@
 use crate::{
-  check_apub_id_valid_with_strictness,
-  objects::read_from_string_or_source,
-  protocol::{
-    objects::chat_message::{ChatMessage, ChatMessageType},
-    Source,
-  },
+    check_apub_id_valid_with_strictness,
+    objects::read_from_string_or_source,
+    protocol::{
+        objects::chat_message::{ChatMessage, ChatMessageType},
+        Source,
+    },
 };
 use activitypub_federation::{
-  config::Data,
-  protocol::{values::MediaTypeHtml, verification::verify_domains_match},
-  traits::Object,
+    config::Data,
+    protocol::{values::MediaTypeHtml, verification::verify_domains_match},
+    traits::Object,
 };
 use chrono::{DateTime, Utc};
 use lemmy_api_common::{
-  context::LemmyContext,
-  utils::{check_person_block, sanitize_html},
+    context::LemmyContext,
+    utils::{check_person_block, sanitize_html},
 };
 use lemmy_db_schema::{
-  source::{
-    person::Person,
-    private_message::{PrivateMessage, PrivateMessageInsertForm},
-  },
-  traits::Crud,
+    source::{
+        person::Person,
+        private_message::{PrivateMessage, PrivateMessageInsertForm},
+    },
+    traits::Crud,
 };
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorType},
-  utils::{markdown::markdown_to_html, time::convert_datetime},
+    error::{LemmyError, LemmyErrorType},
+    utils::{markdown::markdown_to_html, time::convert_datetime},
 };
 use std::ops::Deref;
 use url::Url;
@@ -34,215 +34,216 @@ use url::Url;
 pub struct ApubPrivateMessage(pub(crate) PrivateMessage);
 
 impl Deref for ApubPrivateMessage {
-  type Target = PrivateMessage;
-  fn deref(&self) -> &Self::Target {
-    &self.0
-  }
+    type Target = PrivateMessage;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 impl From<PrivateMessage> for ApubPrivateMessage {
-  fn from(pm: PrivateMessage) -> Self {
-    ApubPrivateMessage(pm)
-  }
+    fn from(pm: PrivateMessage) -> Self {
+        ApubPrivateMessage(pm)
+    }
 }
 
 #[async_trait::async_trait]
 impl Object for ApubPrivateMessage {
-  type DataType = LemmyContext;
-  type Kind = ChatMessage;
-  type Error = LemmyError;
+    type DataType = LemmyContext;
+    type Kind = ChatMessage;
+    type Error = LemmyError;
 
-  fn last_refreshed_at(&self) -> Option<DateTime<Utc>> {
-    None
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn read_from_id(
-    object_id: Url,
-    context: &Data<Self::DataType>,
-  ) -> Result<Option<Self>, LemmyError> {
-    Ok(
-      PrivateMessage::read_from_apub_id(&mut context.pool(), object_id)
-        .await?
-        .map(Into::into),
-    )
-  }
-
-  async fn delete(self, _context: &Data<Self::DataType>) -> Result<(), LemmyError> {
-    // do nothing, because pm can't be fetched over http
-    unimplemented!()
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn into_json(self, context: &Data<Self::DataType>) -> Result<ChatMessage, LemmyError> {
-    let creator_id = self.creator_id;
-    let creator = Person::read(&mut context.pool(), creator_id).await?;
-
-    let recipient_id = self.recipient_id;
-    let recipient = Person::read(&mut context.pool(), recipient_id).await?;
-
-    let note = ChatMessage {
-      r#type: ChatMessageType::ChatMessage,
-      id: self.ap_id.clone().into(),
-      attributed_to: creator.actor_id.into(),
-      to: [recipient.actor_id.into()],
-      content: markdown_to_html(&self.content),
-      media_type: Some(MediaTypeHtml::Html),
-      source: Some(Source::new(self.content.clone())),
-      published: Some(convert_datetime(self.published)),
-      updated: self.updated.map(convert_datetime),
-    };
-    Ok(note)
-  }
-
-  #[tracing::instrument(skip_all)]
-  async fn verify(
-    note: &ChatMessage,
-    expected_domain: &Url,
-    context: &Data<Self::DataType>,
-  ) -> Result<(), LemmyError> {
-    verify_domains_match(note.id.inner(), expected_domain)?;
-    verify_domains_match(note.attributed_to.inner(), note.id.inner())?;
-
-    check_apub_id_valid_with_strictness(note.id.inner(), false, context).await?;
-    let person = note.attributed_to.dereference(context).await?;
-    if person.banned {
-      Err(LemmyErrorType::PersonIsBannedFromSite(
-        person.actor_id.to_string(),
-      ))?
-    } else {
-      Ok(())
+    fn last_refreshed_at(&self) -> Option<DateTime<Utc>> {
+        None
     }
-  }
 
-  #[tracing::instrument(skip_all)]
-  async fn from_json(
-    note: ChatMessage,
-    context: &Data<Self::DataType>,
-  ) -> Result<ApubPrivateMessage, LemmyError> {
-    let creator = note.attributed_to.dereference(context).await?;
-    let recipient = note.to[0].dereference(context).await?;
-    check_person_block(creator.id, recipient.id, &mut context.pool()).await?;
+    #[tracing::instrument(skip_all)]
+    async fn read_from_id(
+        object_id: Url,
+        context: &Data<Self::DataType>,
+    ) -> Result<Option<Self>, LemmyError> {
+        Ok(
+            PrivateMessage::read_from_apub_id(&mut context.pool(), object_id)
+                .await?
+                .map(Into::into),
+        )
+    }
 
-    let content = read_from_string_or_source(&note.content, &None, &note.source);
-    let content = sanitize_html(&content);
+    async fn delete(self, _context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+        // do nothing, because pm can't be fetched over http
+        unimplemented!()
+    }
 
-    let form = PrivateMessageInsertForm {
-      creator_id: creator.id,
-      recipient_id: recipient.id,
-      content,
-      published: note.published.map(Into::into),
-      updated: note.updated.map(Into::into),
-      deleted: Some(false),
-      read: None,
-      ap_id: Some(note.id.into()),
-      local: Some(false),
-    };
-    let pm = PrivateMessage::create(&mut context.pool(), &form).await?;
-    Ok(pm.into())
-  }
+    #[tracing::instrument(skip_all)]
+    async fn into_json(self, context: &Data<Self::DataType>) -> Result<ChatMessage, LemmyError> {
+        let creator_id = self.creator_id;
+        let creator = Person::read(&mut context.pool(), creator_id).await?;
+
+        let recipient_id = self.recipient_id;
+        let recipient = Person::read(&mut context.pool(), recipient_id).await?;
+
+        let note = ChatMessage {
+            r#type: ChatMessageType::ChatMessage,
+            id: self.ap_id.clone().into(),
+            attributed_to: creator.actor_id.into(),
+            to: [recipient.actor_id.into()],
+            content: markdown_to_html(&self.content),
+            media_type: Some(MediaTypeHtml::Html),
+            source: Some(Source::new(self.content.clone())),
+            published: Some(convert_datetime(self.published)),
+            updated: self.updated.map(convert_datetime),
+        };
+        Ok(note)
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn verify(
+        note: &ChatMessage,
+        expected_domain: &Url,
+        context: &Data<Self::DataType>,
+    ) -> Result<(), LemmyError> {
+        verify_domains_match(note.id.inner(), expected_domain)?;
+        verify_domains_match(note.attributed_to.inner(), note.id.inner())?;
+
+        check_apub_id_valid_with_strictness(note.id.inner(), false, context).await?;
+        let person = note.attributed_to.dereference(context).await?;
+        if person.banned {
+            Err(LemmyErrorType::PersonIsBannedFromSite(
+                person.actor_id.to_string(),
+            ))?
+        } else {
+            Ok(())
+        }
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn from_json(
+        note: ChatMessage,
+        context: &Data<Self::DataType>,
+    ) -> Result<ApubPrivateMessage, LemmyError> {
+        let creator = note.attributed_to.dereference(context).await?;
+        let recipient = note.to[0].dereference(context).await?;
+        check_person_block(creator.id, recipient.id, &mut context.pool()).await?;
+
+        let content = read_from_string_or_source(&note.content, &None, &note.source);
+        let content = sanitize_html(&content);
+
+        let form = PrivateMessageInsertForm {
+            creator_id: creator.id,
+            recipient_id: recipient.id,
+            content,
+            published: note.published.map(Into::into),
+            updated: note.updated.map(Into::into),
+            deleted: Some(false),
+            read: None,
+            ap_id: Some(note.id.into()),
+            local: Some(false),
+        };
+        let pm = PrivateMessage::create(&mut context.pool(), &form).await?;
+        Ok(pm.into())
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use super::*;
-  use crate::{
-    objects::{
-      instance::{tests::parse_lemmy_instance, ApubSite},
-      person::ApubPerson,
-      tests::init_context,
-    },
-    protocol::tests::file_to_json_object,
-  };
-  use assert_json_diff::assert_json_include;
-  use lemmy_db_schema::source::site::Site;
-  use serial_test::serial;
+    use super::*;
+    use crate::{
+        objects::{
+            instance::{tests::parse_lemmy_instance, ApubSite},
+            person::ApubPerson,
+            tests::init_context,
+        },
+        protocol::tests::file_to_json_object,
+    };
+    use assert_json_diff::assert_json_include;
+    use lemmy_db_schema::source::site::Site;
+    use serial_test::serial;
 
-  async fn prepare_comment_test(
-    url: &Url,
-    context: &Data<LemmyContext>,
-  ) -> (ApubPerson, ApubPerson, ApubSite) {
-    let context2 = context.reset_request_count();
-    let lemmy_person = file_to_json_object("assets/lemmy/objects/person.json").unwrap();
-    let site = parse_lemmy_instance(&context2).await;
-    ApubPerson::verify(&lemmy_person, url, &context2)
-      .await
-      .unwrap();
-    let person1 = ApubPerson::from_json(lemmy_person, &context2)
-      .await
-      .unwrap();
-    let pleroma_person = file_to_json_object("assets/pleroma/objects/person.json").unwrap();
-    let pleroma_url = Url::parse("https://queer.hacktivis.me/users/lanodan").unwrap();
-    ApubPerson::verify(&pleroma_person, &pleroma_url, &context2)
-      .await
-      .unwrap();
-    let person2 = ApubPerson::from_json(pleroma_person, &context2)
-      .await
-      .unwrap();
-    (person1, person2, site)
-  }
+    async fn prepare_comment_test(
+        url: &Url,
+        context: &Data<LemmyContext>,
+    ) -> (ApubPerson, ApubPerson, ApubSite) {
+        let context2 = context.reset_request_count();
+        let lemmy_person = file_to_json_object("assets/lemmy/objects/person.json").unwrap();
+        let site = parse_lemmy_instance(&context2).await;
+        ApubPerson::verify(&lemmy_person, url, &context2)
+            .await
+            .unwrap();
+        let person1 = ApubPerson::from_json(lemmy_person, &context2)
+            .await
+            .unwrap();
+        let pleroma_person = file_to_json_object("assets/pleroma/objects/person.json").unwrap();
+        let pleroma_url = Url::parse("https://queer.hacktivis.me/users/lanodan").unwrap();
+        ApubPerson::verify(&pleroma_person, &pleroma_url, &context2)
+            .await
+            .unwrap();
+        let person2 = ApubPerson::from_json(pleroma_person, &context2)
+            .await
+            .unwrap();
+        (person1, person2, site)
+    }
 
-  async fn cleanup(data: (ApubPerson, ApubPerson, ApubSite), context: &Data<LemmyContext>) {
-    Person::delete(&mut context.pool(), data.0.id)
-      .await
-      .unwrap();
-    Person::delete(&mut context.pool(), data.1.id)
-      .await
-      .unwrap();
-    Site::delete(&mut context.pool(), data.2.id).await.unwrap();
-  }
+    async fn cleanup(data: (ApubPerson, ApubPerson, ApubSite), context: &Data<LemmyContext>) {
+        Person::delete(&mut context.pool(), data.0.id)
+            .await
+            .unwrap();
+        Person::delete(&mut context.pool(), data.1.id)
+            .await
+            .unwrap();
+        Site::delete(&mut context.pool(), data.2.id).await.unwrap();
+    }
 
-  #[tokio::test]
-  #[serial]
-  async fn test_parse_lemmy_pm() {
-    let context = init_context().await;
-    let url = Url::parse("https://enterprise.lemmy.ml/private_message/1621").unwrap();
-    let data = prepare_comment_test(&url, &context).await;
-    let json: ChatMessage = file_to_json_object("assets/lemmy/objects/chat_message.json").unwrap();
-    ApubPrivateMessage::verify(&json, &url, &context)
-      .await
-      .unwrap();
-    let pm = ApubPrivateMessage::from_json(json.clone(), &context)
-      .await
-      .unwrap();
+    #[tokio::test]
+    #[serial]
+    async fn test_parse_lemmy_pm() {
+        let context = init_context().await;
+        let url = Url::parse("https://enterprise.lemmy.ml/private_message/1621").unwrap();
+        let data = prepare_comment_test(&url, &context).await;
+        let json: ChatMessage =
+            file_to_json_object("assets/lemmy/objects/chat_message.json").unwrap();
+        ApubPrivateMessage::verify(&json, &url, &context)
+            .await
+            .unwrap();
+        let pm = ApubPrivateMessage::from_json(json.clone(), &context)
+            .await
+            .unwrap();
 
-    assert_eq!(pm.ap_id.clone(), url.into());
-    assert_eq!(pm.content.len(), 20);
-    assert_eq!(context.request_count(), 0);
+        assert_eq!(pm.ap_id.clone(), url.into());
+        assert_eq!(pm.content.len(), 20);
+        assert_eq!(context.request_count(), 0);
 
-    let pm_id = pm.id;
-    let to_apub = pm.into_json(&context).await.unwrap();
-    assert_json_include!(actual: json, expected: to_apub);
+        let pm_id = pm.id;
+        let to_apub = pm.into_json(&context).await.unwrap();
+        assert_json_include!(actual: json, expected: to_apub);
 
-    PrivateMessage::delete(&mut context.pool(), pm_id)
-      .await
-      .unwrap();
-    cleanup(data, &context).await;
-  }
+        PrivateMessage::delete(&mut context.pool(), pm_id)
+            .await
+            .unwrap();
+        cleanup(data, &context).await;
+    }
 
-  #[tokio::test]
-  #[serial]
-  async fn test_parse_pleroma_pm() {
-    let context = init_context().await;
-    let url = Url::parse("https://enterprise.lemmy.ml/private_message/1621").unwrap();
-    let data = prepare_comment_test(&url, &context).await;
-    let pleroma_url = Url::parse("https://queer.hacktivis.me/objects/2").unwrap();
-    let json = file_to_json_object("assets/pleroma/objects/chat_message.json").unwrap();
-    ApubPrivateMessage::verify(&json, &pleroma_url, &context)
-      .await
-      .unwrap();
-    let pm = ApubPrivateMessage::from_json(json, &context).await.unwrap();
+    #[tokio::test]
+    #[serial]
+    async fn test_parse_pleroma_pm() {
+        let context = init_context().await;
+        let url = Url::parse("https://enterprise.lemmy.ml/private_message/1621").unwrap();
+        let data = prepare_comment_test(&url, &context).await;
+        let pleroma_url = Url::parse("https://queer.hacktivis.me/objects/2").unwrap();
+        let json = file_to_json_object("assets/pleroma/objects/chat_message.json").unwrap();
+        ApubPrivateMessage::verify(&json, &pleroma_url, &context)
+            .await
+            .unwrap();
+        let pm = ApubPrivateMessage::from_json(json, &context).await.unwrap();
 
-    assert_eq!(pm.ap_id, pleroma_url.into());
-    assert_eq!(pm.content.len(), 3);
-    assert_eq!(context.request_count(), 0);
+        assert_eq!(pm.ap_id, pleroma_url.into());
+        assert_eq!(pm.content.len(), 3);
+        assert_eq!(context.request_count(), 0);
 
-    PrivateMessage::delete(&mut context.pool(), pm.id)
-      .await
-      .unwrap();
-    cleanup(data, &context).await;
-  }
+        PrivateMessage::delete(&mut context.pool(), pm.id)
+            .await
+            .unwrap();
+        cleanup(data, &context).await;
+    }
 }

--- a/crates/apub/src/protocol/activities/block/block_user.rs
+++ b/crates/apub/src/protocol/activities/block/block_user.rs
@@ -1,13 +1,11 @@
 use crate::{
-  activities::{block::SiteOrCommunity, verify_community_matches},
-  objects::{community::ApubCommunity, person::ApubPerson},
-  protocol::InCommunity,
+    activities::{block::SiteOrCommunity, verify_community_matches},
+    objects::{community::ApubCommunity, person::ApubPerson},
+    protocol::InCommunity,
 };
 use activitypub_federation::{
-  config::Data,
-  fetch::object_id::ObjectId,
-  kinds::activity::BlockType,
-  protocol::helpers::deserialize_one_or_many,
+    config::Data, fetch::object_id::ObjectId, kinds::activity::BlockType,
+    protocol::helpers::deserialize_one_or_many,
 };
 use anyhow::anyhow;
 use chrono::{DateTime, Utc};
@@ -21,37 +19,37 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BlockUser {
-  pub(crate) actor: ObjectId<ApubPerson>,
-  #[serde(deserialize_with = "deserialize_one_or_many")]
-  pub(crate) to: Vec<Url>,
-  pub(crate) object: ObjectId<ApubPerson>,
-  #[serde(deserialize_with = "deserialize_one_or_many")]
-  pub(crate) cc: Vec<Url>,
-  pub(crate) target: ObjectId<SiteOrCommunity>,
-  #[serde(rename = "type")]
-  pub(crate) kind: BlockType,
-  pub(crate) id: Url,
-  pub(crate) audience: Option<ObjectId<ApubCommunity>>,
+    pub(crate) actor: ObjectId<ApubPerson>,
+    #[serde(deserialize_with = "deserialize_one_or_many")]
+    pub(crate) to: Vec<Url>,
+    pub(crate) object: ObjectId<ApubPerson>,
+    #[serde(deserialize_with = "deserialize_one_or_many")]
+    pub(crate) cc: Vec<Url>,
+    pub(crate) target: ObjectId<SiteOrCommunity>,
+    #[serde(rename = "type")]
+    pub(crate) kind: BlockType,
+    pub(crate) id: Url,
+    pub(crate) audience: Option<ObjectId<ApubCommunity>>,
 
-  /// Quick and dirty solution.
-  /// TODO: send a separate Delete activity instead
-  pub(crate) remove_data: Option<bool>,
-  /// block reason, written to mod log
-  pub(crate) summary: Option<String>,
-  pub(crate) expires: Option<DateTime<Utc>>,
+    /// Quick and dirty solution.
+    /// TODO: send a separate Delete activity instead
+    pub(crate) remove_data: Option<bool>,
+    /// block reason, written to mod log
+    pub(crate) summary: Option<String>,
+    pub(crate) expires: Option<DateTime<Utc>>,
 }
 
 #[async_trait::async_trait]
 impl InCommunity for BlockUser {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
-    let target = self.target.dereference(context).await?;
-    let community = match target {
-      SiteOrCommunity::Community(c) => c,
-      SiteOrCommunity::Site(_) => return Err(anyhow!("activity is not in community").into()),
-    };
-    if let Some(audience) = &self.audience {
-      verify_community_matches(audience, community.actor_id.clone())?;
+    async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+        let target = self.target.dereference(context).await?;
+        let community = match target {
+            SiteOrCommunity::Community(c) => c,
+            SiteOrCommunity::Site(_) => return Err(anyhow!("activity is not in community").into()),
+        };
+        if let Some(audience) = &self.audience {
+            verify_community_matches(audience, community.actor_id.clone())?;
+        }
+        Ok(community)
     }
-    Ok(community)
-  }
 }

--- a/crates/apub/src/protocol/activities/block/mod.rs
+++ b/crates/apub/src/protocol/activities/block/mod.rs
@@ -3,18 +3,21 @@ pub mod undo_block_user;
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::protocol::{
-    activities::block::{block_user::BlockUser, undo_block_user::UndoBlockUser},
-    tests::test_parse_lemmy_item,
-  };
+    use crate::protocol::{
+        activities::block::{block_user::BlockUser, undo_block_user::UndoBlockUser},
+        tests::test_parse_lemmy_item,
+    };
 
-  #[test]
-  fn test_parse_lemmy_block() {
-    test_parse_lemmy_item::<BlockUser>("assets/lemmy/activities/block/block_user.json").unwrap();
-    test_parse_lemmy_item::<UndoBlockUser>("assets/lemmy/activities/block/undo_block_user.json")
-      .unwrap();
-  }
+    #[test]
+    fn test_parse_lemmy_block() {
+        test_parse_lemmy_item::<BlockUser>("assets/lemmy/activities/block/block_user.json")
+            .unwrap();
+        test_parse_lemmy_item::<UndoBlockUser>(
+            "assets/lemmy/activities/block/undo_block_user.json",
+        )
+        .unwrap();
+    }
 }

--- a/crates/apub/src/protocol/activities/block/undo_block_user.rs
+++ b/crates/apub/src/protocol/activities/block/undo_block_user.rs
@@ -1,13 +1,11 @@
 use crate::{
-  activities::verify_community_matches,
-  objects::{community::ApubCommunity, person::ApubPerson},
-  protocol::{activities::block::block_user::BlockUser, InCommunity},
+    activities::verify_community_matches,
+    objects::{community::ApubCommunity, person::ApubPerson},
+    protocol::{activities::block::block_user::BlockUser, InCommunity},
 };
 use activitypub_federation::{
-  config::Data,
-  fetch::object_id::ObjectId,
-  kinds::activity::UndoType,
-  protocol::helpers::deserialize_one_or_many,
+    config::Data, fetch::object_id::ObjectId, kinds::activity::UndoType,
+    protocol::helpers::deserialize_one_or_many,
 };
 use lemmy_api_common::context::LemmyContext;
 use lemmy_utils::error::LemmyError;
@@ -19,25 +17,25 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UndoBlockUser {
-  pub(crate) actor: ObjectId<ApubPerson>,
-  #[serde(deserialize_with = "deserialize_one_or_many")]
-  pub(crate) to: Vec<Url>,
-  pub(crate) object: BlockUser,
-  #[serde(deserialize_with = "deserialize_one_or_many")]
-  pub(crate) cc: Vec<Url>,
-  #[serde(rename = "type")]
-  pub(crate) kind: UndoType,
-  pub(crate) id: Url,
-  pub(crate) audience: Option<ObjectId<ApubCommunity>>,
+    pub(crate) actor: ObjectId<ApubPerson>,
+    #[serde(deserialize_with = "deserialize_one_or_many")]
+    pub(crate) to: Vec<Url>,
+    pub(crate) object: BlockUser,
+    #[serde(deserialize_with = "deserialize_one_or_many")]
+    pub(crate) cc: Vec<Url>,
+    #[serde(rename = "type")]
+    pub(crate) kind: UndoType,
+    pub(crate) id: Url,
+    pub(crate) audience: Option<ObjectId<ApubCommunity>>,
 }
 
 #[async_trait::async_trait]
 impl InCommunity for UndoBlockUser {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
-    let community = self.object.community(context).await?;
-    if let Some(audience) = &self.audience {
-      verify_community_matches(audience, community.actor_id.clone())?;
+    async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+        let community = self.object.community(context).await?;
+        if let Some(audience) = &self.audience {
+            verify_community_matches(audience, community.actor_id.clone())?;
+        }
+        Ok(community)
     }
-    Ok(community)
-  }
 }

--- a/crates/apub/src/protocol/activities/community/announce.rs
+++ b/crates/apub/src/protocol/activities/community/announce.rs
@@ -1,8 +1,7 @@
 use crate::{objects::community::ApubCommunity, protocol::IdOrNestedObject};
 use activitypub_federation::{
-  fetch::object_id::ObjectId,
-  kinds::activity::AnnounceType,
-  protocol::helpers::deserialize_one_or_many,
+    fetch::object_id::ObjectId, kinds::activity::AnnounceType,
+    protocol::helpers::deserialize_one_or_many,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -11,23 +10,23 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AnnounceActivity {
-  pub(crate) actor: ObjectId<ApubCommunity>,
-  #[serde(deserialize_with = "deserialize_one_or_many")]
-  pub(crate) to: Vec<Url>,
-  pub(crate) object: IdOrNestedObject<RawAnnouncableActivities>,
-  #[serde(deserialize_with = "deserialize_one_or_many")]
-  pub(crate) cc: Vec<Url>,
-  #[serde(rename = "type")]
-  pub(crate) kind: AnnounceType,
-  pub(crate) id: Url,
+    pub(crate) actor: ObjectId<ApubCommunity>,
+    #[serde(deserialize_with = "deserialize_one_or_many")]
+    pub(crate) to: Vec<Url>,
+    pub(crate) object: IdOrNestedObject<RawAnnouncableActivities>,
+    #[serde(deserialize_with = "deserialize_one_or_many")]
+    pub(crate) cc: Vec<Url>,
+    #[serde(rename = "type")]
+    pub(crate) kind: AnnounceType,
+    pub(crate) id: Url,
 }
 
 /// Use this to receive community inbox activities, and then announce them if valid. This
 /// ensures that all json fields are kept, even if Lemmy doesnt understand them.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RawAnnouncableActivities {
-  pub(crate) id: Url,
-  pub(crate) actor: Url,
-  #[serde(flatten)]
-  pub(crate) other: Map<String, Value>,
+    pub(crate) id: Url,
+    pub(crate) actor: Url,
+    #[serde(flatten)]
+    pub(crate) other: Map<String, Value>,
 }

--- a/crates/apub/src/protocol/activities/community/collection_add.rs
+++ b/crates/apub/src/protocol/activities/community/collection_add.rs
@@ -1,13 +1,11 @@
 use crate::{
-  activities::verify_community_matches,
-  objects::{community::ApubCommunity, person::ApubPerson},
-  protocol::InCommunity,
+    activities::verify_community_matches,
+    objects::{community::ApubCommunity, person::ApubPerson},
+    protocol::InCommunity,
 };
 use activitypub_federation::{
-  config::Data,
-  fetch::object_id::ObjectId,
-  kinds::activity::AddType,
-  protocol::helpers::deserialize_one_or_many,
+    config::Data, fetch::object_id::ObjectId, kinds::activity::AddType,
+    protocol::helpers::deserialize_one_or_many,
 };
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::source::community::Community;
@@ -18,27 +16,28 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CollectionAdd {
-  pub(crate) actor: ObjectId<ApubPerson>,
-  #[serde(deserialize_with = "deserialize_one_or_many")]
-  pub(crate) to: Vec<Url>,
-  pub(crate) object: Url,
-  pub(crate) target: Url,
-  #[serde(deserialize_with = "deserialize_one_or_many")]
-  pub(crate) cc: Vec<Url>,
-  #[serde(rename = "type")]
-  pub(crate) kind: AddType,
-  pub(crate) id: Url,
-  pub(crate) audience: Option<ObjectId<ApubCommunity>>,
+    pub(crate) actor: ObjectId<ApubPerson>,
+    #[serde(deserialize_with = "deserialize_one_or_many")]
+    pub(crate) to: Vec<Url>,
+    pub(crate) object: Url,
+    pub(crate) target: Url,
+    #[serde(deserialize_with = "deserialize_one_or_many")]
+    pub(crate) cc: Vec<Url>,
+    #[serde(rename = "type")]
+    pub(crate) kind: AddType,
+    pub(crate) id: Url,
+    pub(crate) audience: Option<ObjectId<ApubCommunity>>,
 }
 
 #[async_trait::async_trait]
 impl InCommunity for CollectionAdd {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
-    let (community, _) =
-      Community::get_by_collection_url(&mut context.pool(), &self.clone().target.into()).await?;
-    if let Some(audience) = &self.audience {
-      verify_community_matches(audience, community.actor_id.clone())?;
+    async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+        let (community, _) =
+            Community::get_by_collection_url(&mut context.pool(), &self.clone().target.into())
+                .await?;
+        if let Some(audience) = &self.audience {
+            verify_community_matches(audience, community.actor_id.clone())?;
+        }
+        Ok(community.into())
     }
-    Ok(community.into())
-  }
 }

--- a/crates/apub/src/protocol/activities/community/collection_remove.rs
+++ b/crates/apub/src/protocol/activities/community/collection_remove.rs
@@ -1,13 +1,11 @@
 use crate::{
-  activities::verify_community_matches,
-  objects::{community::ApubCommunity, person::ApubPerson},
-  protocol::InCommunity,
+    activities::verify_community_matches,
+    objects::{community::ApubCommunity, person::ApubPerson},
+    protocol::InCommunity,
 };
 use activitypub_federation::{
-  config::Data,
-  fetch::object_id::ObjectId,
-  kinds::activity::RemoveType,
-  protocol::helpers::deserialize_one_or_many,
+    config::Data, fetch::object_id::ObjectId, kinds::activity::RemoveType,
+    protocol::helpers::deserialize_one_or_many,
 };
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::source::community::Community;
@@ -18,27 +16,28 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CollectionRemove {
-  pub(crate) actor: ObjectId<ApubPerson>,
-  #[serde(deserialize_with = "deserialize_one_or_many")]
-  pub(crate) to: Vec<Url>,
-  pub(crate) object: Url,
-  #[serde(deserialize_with = "deserialize_one_or_many")]
-  pub(crate) cc: Vec<Url>,
-  #[serde(rename = "type")]
-  pub(crate) kind: RemoveType,
-  pub(crate) target: Url,
-  pub(crate) id: Url,
-  pub(crate) audience: Option<ObjectId<ApubCommunity>>,
+    pub(crate) actor: ObjectId<ApubPerson>,
+    #[serde(deserialize_with = "deserialize_one_or_many")]
+    pub(crate) to: Vec<Url>,
+    pub(crate) object: Url,
+    #[serde(deserialize_with = "deserialize_one_or_many")]
+    pub(crate) cc: Vec<Url>,
+    #[serde(rename = "type")]
+    pub(crate) kind: RemoveType,
+    pub(crate) target: Url,
+    pub(crate) id: Url,
+    pub(crate) audience: Option<ObjectId<ApubCommunity>>,
 }
 
 #[async_trait::async_trait]
 impl InCommunity for CollectionRemove {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
-    let (community, _) =
-      Community::get_by_collection_url(&mut context.pool(), &self.clone().target.into()).await?;
-    if let Some(audience) = &self.audience {
-      verify_community_matches(audience, community.actor_id.clone())?;
+    async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+        let (community, _) =
+            Community::get_by_collection_url(&mut context.pool(), &self.clone().target.into())
+                .await?;
+        if let Some(audience) = &self.audience {
+            verify_community_matches(audience, community.actor_id.clone())?;
+        }
+        Ok(community.into())
     }
-    Ok(community.into())
-  }
 }

--- a/crates/apub/src/protocol/activities/community/lock_page.rs
+++ b/crates/apub/src/protocol/activities/community/lock_page.rs
@@ -1,13 +1,11 @@
 use crate::{
-  activities::verify_community_matches,
-  objects::{community::ApubCommunity, person::ApubPerson, post::ApubPost},
-  protocol::InCommunity,
+    activities::verify_community_matches,
+    objects::{community::ApubCommunity, person::ApubPerson, post::ApubPost},
+    protocol::InCommunity,
 };
 use activitypub_federation::{
-  config::Data,
-  fetch::object_id::ObjectId,
-  kinds::activity::UndoType,
-  protocol::helpers::deserialize_one_or_many,
+    config::Data, fetch::object_id::ObjectId, kinds::activity::UndoType,
+    protocol::helpers::deserialize_one_or_many,
 };
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::{source::community::Community, traits::Crud};
@@ -18,58 +16,58 @@ use url::Url;
 
 #[derive(Clone, Debug, Deserialize, Serialize, Display)]
 pub enum LockType {
-  Lock,
+    Lock,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LockPage {
-  pub(crate) actor: ObjectId<ApubPerson>,
-  #[serde(deserialize_with = "deserialize_one_or_many")]
-  pub(crate) to: Vec<Url>,
-  pub(crate) object: ObjectId<ApubPost>,
-  #[serde(deserialize_with = "deserialize_one_or_many")]
-  pub(crate) cc: Vec<Url>,
-  #[serde(rename = "type")]
-  pub(crate) kind: LockType,
-  pub(crate) id: Url,
-  pub(crate) audience: Option<ObjectId<ApubCommunity>>,
+    pub(crate) actor: ObjectId<ApubPerson>,
+    #[serde(deserialize_with = "deserialize_one_or_many")]
+    pub(crate) to: Vec<Url>,
+    pub(crate) object: ObjectId<ApubPost>,
+    #[serde(deserialize_with = "deserialize_one_or_many")]
+    pub(crate) cc: Vec<Url>,
+    #[serde(rename = "type")]
+    pub(crate) kind: LockType,
+    pub(crate) id: Url,
+    pub(crate) audience: Option<ObjectId<ApubCommunity>>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UndoLockPage {
-  pub(crate) actor: ObjectId<ApubPerson>,
-  #[serde(deserialize_with = "deserialize_one_or_many")]
-  pub(crate) to: Vec<Url>,
-  pub(crate) object: LockPage,
-  #[serde(deserialize_with = "deserialize_one_or_many")]
-  pub(crate) cc: Vec<Url>,
-  #[serde(rename = "type")]
-  pub(crate) kind: UndoType,
-  pub(crate) id: Url,
-  pub(crate) audience: Option<ObjectId<ApubCommunity>>,
+    pub(crate) actor: ObjectId<ApubPerson>,
+    #[serde(deserialize_with = "deserialize_one_or_many")]
+    pub(crate) to: Vec<Url>,
+    pub(crate) object: LockPage,
+    #[serde(deserialize_with = "deserialize_one_or_many")]
+    pub(crate) cc: Vec<Url>,
+    #[serde(rename = "type")]
+    pub(crate) kind: UndoType,
+    pub(crate) id: Url,
+    pub(crate) audience: Option<ObjectId<ApubCommunity>>,
 }
 
 #[async_trait::async_trait]
 impl InCommunity for LockPage {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
-    let post = self.object.dereference(context).await?;
-    let community = Community::read(&mut context.pool(), post.community_id).await?;
-    if let Some(audience) = &self.audience {
-      verify_community_matches(audience, community.actor_id.clone())?;
+    async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+        let post = self.object.dereference(context).await?;
+        let community = Community::read(&mut context.pool(), post.community_id).await?;
+        if let Some(audience) = &self.audience {
+            verify_community_matches(audience, community.actor_id.clone())?;
+        }
+        Ok(community.into())
     }
-    Ok(community.into())
-  }
 }
 
 #[async_trait::async_trait]
 impl InCommunity for UndoLockPage {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
-    let community = self.object.community(context).await?;
-    if let Some(audience) = &self.audience {
-      verify_community_matches(audience, community.actor_id.clone())?;
+    async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+        let community = self.object.community(context).await?;
+        if let Some(audience) = &self.audience {
+            verify_community_matches(audience, community.actor_id.clone())?;
+        }
+        Ok(community)
     }
-    Ok(community)
-  }
 }

--- a/crates/apub/src/protocol/activities/community/mod.rs
+++ b/crates/apub/src/protocol/activities/community/mod.rs
@@ -7,51 +7,57 @@ pub mod update;
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::protocol::{
-    activities::community::{
-      announce::AnnounceActivity,
-      collection_add::CollectionAdd,
-      collection_remove::CollectionRemove,
-      lock_page::{LockPage, UndoLockPage},
-      report::Report,
-      update::UpdateCommunity,
-    },
-    tests::test_parse_lemmy_item,
-  };
+    use crate::protocol::{
+        activities::community::{
+            announce::AnnounceActivity,
+            collection_add::CollectionAdd,
+            collection_remove::CollectionRemove,
+            lock_page::{LockPage, UndoLockPage},
+            report::Report,
+            update::UpdateCommunity,
+        },
+        tests::test_parse_lemmy_item,
+    };
 
-  #[test]
-  fn test_parse_lemmy_community_activities() {
-    test_parse_lemmy_item::<AnnounceActivity>(
-      "assets/lemmy/activities/community/announce_create_page.json",
-    )
-    .unwrap();
+    #[test]
+    fn test_parse_lemmy_community_activities() {
+        test_parse_lemmy_item::<AnnounceActivity>(
+            "assets/lemmy/activities/community/announce_create_page.json",
+        )
+        .unwrap();
 
-    test_parse_lemmy_item::<CollectionAdd>("assets/lemmy/activities/community/add_mod.json")
-      .unwrap();
-    test_parse_lemmy_item::<CollectionRemove>("assets/lemmy/activities/community/remove_mod.json")
-      .unwrap();
+        test_parse_lemmy_item::<CollectionAdd>("assets/lemmy/activities/community/add_mod.json")
+            .unwrap();
+        test_parse_lemmy_item::<CollectionRemove>(
+            "assets/lemmy/activities/community/remove_mod.json",
+        )
+        .unwrap();
 
-    test_parse_lemmy_item::<CollectionAdd>(
-      "assets/lemmy/activities/community/add_featured_post.json",
-    )
-    .unwrap();
-    test_parse_lemmy_item::<CollectionRemove>(
-      "assets/lemmy/activities/community/remove_featured_post.json",
-    )
-    .unwrap();
+        test_parse_lemmy_item::<CollectionAdd>(
+            "assets/lemmy/activities/community/add_featured_post.json",
+        )
+        .unwrap();
+        test_parse_lemmy_item::<CollectionRemove>(
+            "assets/lemmy/activities/community/remove_featured_post.json",
+        )
+        .unwrap();
 
-    test_parse_lemmy_item::<LockPage>("assets/lemmy/activities/community/lock_page.json").unwrap();
-    test_parse_lemmy_item::<UndoLockPage>("assets/lemmy/activities/community/undo_lock_page.json")
-      .unwrap();
+        test_parse_lemmy_item::<LockPage>("assets/lemmy/activities/community/lock_page.json")
+            .unwrap();
+        test_parse_lemmy_item::<UndoLockPage>(
+            "assets/lemmy/activities/community/undo_lock_page.json",
+        )
+        .unwrap();
 
-    test_parse_lemmy_item::<UpdateCommunity>(
-      "assets/lemmy/activities/community/update_community.json",
-    )
-    .unwrap();
+        test_parse_lemmy_item::<UpdateCommunity>(
+            "assets/lemmy/activities/community/update_community.json",
+        )
+        .unwrap();
 
-    test_parse_lemmy_item::<Report>("assets/lemmy/activities/community/report_page.json").unwrap();
-  }
+        test_parse_lemmy_item::<Report>("assets/lemmy/activities/community/report_page.json")
+            .unwrap();
+    }
 }

--- a/crates/apub/src/protocol/activities/community/report.rs
+++ b/crates/apub/src/protocol/activities/community/report.rs
@@ -1,14 +1,12 @@
 use crate::{
-  activities::verify_community_matches,
-  fetcher::post_or_comment::PostOrComment,
-  objects::{community::ApubCommunity, person::ApubPerson},
-  protocol::InCommunity,
+    activities::verify_community_matches,
+    fetcher::post_or_comment::PostOrComment,
+    objects::{community::ApubCommunity, person::ApubPerson},
+    protocol::InCommunity,
 };
 use activitypub_federation::{
-  config::Data,
-  fetch::object_id::ObjectId,
-  kinds::activity::FlagType,
-  protocol::helpers::deserialize_one,
+    config::Data, fetch::object_id::ObjectId, kinds::activity::FlagType,
+    protocol::helpers::deserialize_one,
 };
 use lemmy_api_common::context::LemmyContext;
 use lemmy_utils::error::LemmyError;
@@ -18,24 +16,24 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Report {
-  pub(crate) actor: ObjectId<ApubPerson>,
-  #[serde(deserialize_with = "deserialize_one")]
-  pub(crate) to: [ObjectId<ApubCommunity>; 1],
-  pub(crate) object: ObjectId<PostOrComment>,
-  pub(crate) summary: String,
-  #[serde(rename = "type")]
-  pub(crate) kind: FlagType,
-  pub(crate) id: Url,
-  pub(crate) audience: Option<ObjectId<ApubCommunity>>,
+    pub(crate) actor: ObjectId<ApubPerson>,
+    #[serde(deserialize_with = "deserialize_one")]
+    pub(crate) to: [ObjectId<ApubCommunity>; 1],
+    pub(crate) object: ObjectId<PostOrComment>,
+    pub(crate) summary: String,
+    #[serde(rename = "type")]
+    pub(crate) kind: FlagType,
+    pub(crate) id: Url,
+    pub(crate) audience: Option<ObjectId<ApubCommunity>>,
 }
 
 #[async_trait::async_trait]
 impl InCommunity for Report {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
-    let community = self.to[0].dereference(context).await?;
-    if let Some(audience) = &self.audience {
-      verify_community_matches(audience, community.actor_id.clone())?;
+    async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+        let community = self.to[0].dereference(context).await?;
+        if let Some(audience) = &self.audience {
+            verify_community_matches(audience, community.actor_id.clone())?;
+        }
+        Ok(community)
     }
-    Ok(community)
-  }
 }

--- a/crates/apub/src/protocol/activities/community/update.rs
+++ b/crates/apub/src/protocol/activities/community/update.rs
@@ -1,13 +1,11 @@
 use crate::{
-  activities::verify_community_matches,
-  objects::{community::ApubCommunity, person::ApubPerson},
-  protocol::{objects::group::Group, InCommunity},
+    activities::verify_community_matches,
+    objects::{community::ApubCommunity, person::ApubPerson},
+    protocol::{objects::group::Group, InCommunity},
 };
 use activitypub_federation::{
-  config::Data,
-  fetch::object_id::ObjectId,
-  kinds::activity::UpdateType,
-  protocol::helpers::deserialize_one_or_many,
+    config::Data, fetch::object_id::ObjectId, kinds::activity::UpdateType,
+    protocol::helpers::deserialize_one_or_many,
 };
 use lemmy_api_common::context::LemmyContext;
 use lemmy_utils::error::LemmyError;
@@ -19,26 +17,26 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateCommunity {
-  pub(crate) actor: ObjectId<ApubPerson>,
-  #[serde(deserialize_with = "deserialize_one_or_many")]
-  pub(crate) to: Vec<Url>,
-  // TODO: would be nice to use a separate struct here, which only contains the fields updated here
-  pub(crate) object: Box<Group>,
-  #[serde(deserialize_with = "deserialize_one_or_many")]
-  pub(crate) cc: Vec<Url>,
-  #[serde(rename = "type")]
-  pub(crate) kind: UpdateType,
-  pub(crate) id: Url,
-  pub(crate) audience: Option<ObjectId<ApubCommunity>>,
+    pub(crate) actor: ObjectId<ApubPerson>,
+    #[serde(deserialize_with = "deserialize_one_or_many")]
+    pub(crate) to: Vec<Url>,
+    // TODO: would be nice to use a separate struct here, which only contains the fields updated here
+    pub(crate) object: Box<Group>,
+    #[serde(deserialize_with = "deserialize_one_or_many")]
+    pub(crate) cc: Vec<Url>,
+    #[serde(rename = "type")]
+    pub(crate) kind: UpdateType,
+    pub(crate) id: Url,
+    pub(crate) audience: Option<ObjectId<ApubCommunity>>,
 }
 
 #[async_trait::async_trait]
 impl InCommunity for UpdateCommunity {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
-    let community: ApubCommunity = self.object.id.clone().dereference(context).await?;
-    if let Some(audience) = &self.audience {
-      verify_community_matches(audience, community.actor_id.clone())?;
+    async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+        let community: ApubCommunity = self.object.id.clone().dereference(context).await?;
+        if let Some(audience) = &self.audience {
+            verify_community_matches(audience, community.actor_id.clone())?;
+        }
+        Ok(community)
     }
-    Ok(community)
-  }
 }

--- a/crates/apub/src/protocol/activities/create_or_update/chat_message.rs
+++ b/crates/apub/src/protocol/activities/create_or_update/chat_message.rs
@@ -1,6 +1,6 @@
 use crate::{
-  objects::person::ApubPerson,
-  protocol::{activities::CreateOrUpdateType, objects::chat_message::ChatMessage},
+    objects::person::ApubPerson,
+    protocol::{activities::CreateOrUpdateType, objects::chat_message::ChatMessage},
 };
 use activitypub_federation::{fetch::object_id::ObjectId, protocol::helpers::deserialize_one};
 use serde::{Deserialize, Serialize};
@@ -9,11 +9,11 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateOrUpdateChatMessage {
-  pub(crate) id: Url,
-  pub(crate) actor: ObjectId<ApubPerson>,
-  #[serde(deserialize_with = "deserialize_one")]
-  pub(crate) to: [ObjectId<ApubPerson>; 1],
-  pub(crate) object: ChatMessage,
-  #[serde(rename = "type")]
-  pub(crate) kind: CreateOrUpdateType,
+    pub(crate) id: Url,
+    pub(crate) actor: ObjectId<ApubPerson>,
+    #[serde(deserialize_with = "deserialize_one")]
+    pub(crate) to: [ObjectId<ApubPerson>; 1],
+    pub(crate) object: ChatMessage,
+    #[serde(rename = "type")]
+    pub(crate) kind: CreateOrUpdateType,
 }

--- a/crates/apub/src/protocol/activities/create_or_update/mod.rs
+++ b/crates/apub/src/protocol/activities/create_or_update/mod.rs
@@ -4,35 +4,34 @@ pub mod page;
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::protocol::{
-    activities::create_or_update::{
-      chat_message::CreateOrUpdateChatMessage,
-      note::CreateOrUpdateNote,
-      page::CreateOrUpdatePage,
-    },
-    tests::test_parse_lemmy_item,
-  };
+    use crate::protocol::{
+        activities::create_or_update::{
+            chat_message::CreateOrUpdateChatMessage, note::CreateOrUpdateNote,
+            page::CreateOrUpdatePage,
+        },
+        tests::test_parse_lemmy_item,
+    };
 
-  #[test]
-  fn test_parse_lemmy_create_or_update() {
-    test_parse_lemmy_item::<CreateOrUpdatePage>(
-      "assets/lemmy/activities/create_or_update/create_page.json",
-    )
-    .unwrap();
-    test_parse_lemmy_item::<CreateOrUpdatePage>(
-      "assets/lemmy/activities/create_or_update/update_page.json",
-    )
-    .unwrap();
-    test_parse_lemmy_item::<CreateOrUpdateNote>(
-      "assets/lemmy/activities/create_or_update/create_note.json",
-    )
-    .unwrap();
-    test_parse_lemmy_item::<CreateOrUpdateChatMessage>(
-      "assets/lemmy/activities/create_or_update/create_private_message.json",
-    )
-    .unwrap();
-  }
+    #[test]
+    fn test_parse_lemmy_create_or_update() {
+        test_parse_lemmy_item::<CreateOrUpdatePage>(
+            "assets/lemmy/activities/create_or_update/create_page.json",
+        )
+        .unwrap();
+        test_parse_lemmy_item::<CreateOrUpdatePage>(
+            "assets/lemmy/activities/create_or_update/update_page.json",
+        )
+        .unwrap();
+        test_parse_lemmy_item::<CreateOrUpdateNote>(
+            "assets/lemmy/activities/create_or_update/create_note.json",
+        )
+        .unwrap();
+        test_parse_lemmy_item::<CreateOrUpdateChatMessage>(
+            "assets/lemmy/activities/create_or_update/create_private_message.json",
+        )
+        .unwrap();
+    }
 }

--- a/crates/apub/src/protocol/activities/create_or_update/note.rs
+++ b/crates/apub/src/protocol/activities/create_or_update/note.rs
@@ -1,13 +1,11 @@
 use crate::{
-  activities::verify_community_matches,
-  mentions::MentionOrValue,
-  objects::{community::ApubCommunity, person::ApubPerson},
-  protocol::{activities::CreateOrUpdateType, objects::note::Note, InCommunity},
+    activities::verify_community_matches,
+    mentions::MentionOrValue,
+    objects::{community::ApubCommunity, person::ApubPerson},
+    protocol::{activities::CreateOrUpdateType, objects::note::Note, InCommunity},
 };
 use activitypub_federation::{
-  config::Data,
-  fetch::object_id::ObjectId,
-  protocol::helpers::deserialize_one_or_many,
+    config::Data, fetch::object_id::ObjectId, protocol::helpers::deserialize_one_or_many,
 };
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::{source::community::Community, traits::Crud};
@@ -18,28 +16,28 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateOrUpdateNote {
-  pub(crate) actor: ObjectId<ApubPerson>,
-  #[serde(deserialize_with = "deserialize_one_or_many")]
-  pub(crate) to: Vec<Url>,
-  pub(crate) object: Note,
-  #[serde(deserialize_with = "deserialize_one_or_many")]
-  pub(crate) cc: Vec<Url>,
-  #[serde(default)]
-  pub(crate) tag: Vec<MentionOrValue>,
-  #[serde(rename = "type")]
-  pub(crate) kind: CreateOrUpdateType,
-  pub(crate) id: Url,
-  pub(crate) audience: Option<ObjectId<ApubCommunity>>,
+    pub(crate) actor: ObjectId<ApubPerson>,
+    #[serde(deserialize_with = "deserialize_one_or_many")]
+    pub(crate) to: Vec<Url>,
+    pub(crate) object: Note,
+    #[serde(deserialize_with = "deserialize_one_or_many")]
+    pub(crate) cc: Vec<Url>,
+    #[serde(default)]
+    pub(crate) tag: Vec<MentionOrValue>,
+    #[serde(rename = "type")]
+    pub(crate) kind: CreateOrUpdateType,
+    pub(crate) id: Url,
+    pub(crate) audience: Option<ObjectId<ApubCommunity>>,
 }
 
 #[async_trait::async_trait]
 impl InCommunity for CreateOrUpdateNote {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
-    let post = self.object.get_parents(context).await?.0;
-    let community = Community::read(&mut context.pool(), post.community_id).await?;
-    if let Some(audience) = &self.audience {
-      verify_community_matches(audience, community.actor_id.clone())?;
+    async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+        let post = self.object.get_parents(context).await?.0;
+        let community = Community::read(&mut context.pool(), post.community_id).await?;
+        if let Some(audience) = &self.audience {
+            verify_community_matches(audience, community.actor_id.clone())?;
+        }
+        Ok(community.into())
     }
-    Ok(community.into())
-  }
 }

--- a/crates/apub/src/protocol/activities/create_or_update/page.rs
+++ b/crates/apub/src/protocol/activities/create_or_update/page.rs
@@ -1,12 +1,10 @@
 use crate::{
-  activities::verify_community_matches,
-  objects::{community::ApubCommunity, person::ApubPerson},
-  protocol::{activities::CreateOrUpdateType, objects::page::Page, InCommunity},
+    activities::verify_community_matches,
+    objects::{community::ApubCommunity, person::ApubPerson},
+    protocol::{activities::CreateOrUpdateType, objects::page::Page, InCommunity},
 };
 use activitypub_federation::{
-  config::Data,
-  fetch::object_id::ObjectId,
-  protocol::helpers::deserialize_one_or_many,
+    config::Data, fetch::object_id::ObjectId, protocol::helpers::deserialize_one_or_many,
 };
 use lemmy_api_common::context::LemmyContext;
 use lemmy_utils::error::LemmyError;
@@ -16,25 +14,25 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateOrUpdatePage {
-  pub(crate) actor: ObjectId<ApubPerson>,
-  #[serde(deserialize_with = "deserialize_one_or_many")]
-  pub(crate) to: Vec<Url>,
-  pub(crate) object: Page,
-  #[serde(deserialize_with = "deserialize_one_or_many")]
-  pub(crate) cc: Vec<Url>,
-  #[serde(rename = "type")]
-  pub(crate) kind: CreateOrUpdateType,
-  pub(crate) id: Url,
-  pub(crate) audience: Option<ObjectId<ApubCommunity>>,
+    pub(crate) actor: ObjectId<ApubPerson>,
+    #[serde(deserialize_with = "deserialize_one_or_many")]
+    pub(crate) to: Vec<Url>,
+    pub(crate) object: Page,
+    #[serde(deserialize_with = "deserialize_one_or_many")]
+    pub(crate) cc: Vec<Url>,
+    #[serde(rename = "type")]
+    pub(crate) kind: CreateOrUpdateType,
+    pub(crate) id: Url,
+    pub(crate) audience: Option<ObjectId<ApubCommunity>>,
 }
 
 #[async_trait::async_trait]
 impl InCommunity for CreateOrUpdatePage {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
-    let community = self.object.community(context).await?;
-    if let Some(audience) = &self.audience {
-      verify_community_matches(audience, community.actor_id.clone())?;
+    async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+        let community = self.object.community(context).await?;
+        if let Some(audience) = &self.audience {
+            verify_community_matches(audience, community.actor_id.clone())?;
+        }
+        Ok(community)
     }
-    Ok(community)
-  }
 }

--- a/crates/apub/src/protocol/activities/deletion/delete.rs
+++ b/crates/apub/src/protocol/activities/deletion/delete.rs
@@ -1,19 +1,17 @@
 use crate::{
-  activities::{deletion::DeletableObjects, verify_community_matches},
-  objects::{community::ApubCommunity, person::ApubPerson},
-  protocol::{objects::tombstone::Tombstone, IdOrNestedObject, InCommunity},
+    activities::{deletion::DeletableObjects, verify_community_matches},
+    objects::{community::ApubCommunity, person::ApubPerson},
+    protocol::{objects::tombstone::Tombstone, IdOrNestedObject, InCommunity},
 };
 use activitypub_federation::{
-  config::Data,
-  fetch::object_id::ObjectId,
-  kinds::activity::DeleteType,
-  protocol::helpers::deserialize_one_or_many,
+    config::Data, fetch::object_id::ObjectId, kinds::activity::DeleteType,
+    protocol::helpers::deserialize_one_or_many,
 };
 use anyhow::anyhow;
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::{
-  source::{community::Community, post::Post},
-  traits::Crud,
+    source::{community::Community, post::Post},
+    traits::Crud,
 };
 use lemmy_utils::error::LemmyError;
 use serde::{Deserialize, Serialize};
@@ -24,42 +22,42 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Delete {
-  pub(crate) actor: ObjectId<ApubPerson>,
-  #[serde(deserialize_with = "deserialize_one_or_many")]
-  pub(crate) to: Vec<Url>,
-  pub(crate) object: IdOrNestedObject<Tombstone>,
-  #[serde(rename = "type")]
-  pub(crate) kind: DeleteType,
-  pub(crate) id: Url,
-  pub(crate) audience: Option<ObjectId<ApubCommunity>>,
+    pub(crate) actor: ObjectId<ApubPerson>,
+    #[serde(deserialize_with = "deserialize_one_or_many")]
+    pub(crate) to: Vec<Url>,
+    pub(crate) object: IdOrNestedObject<Tombstone>,
+    #[serde(rename = "type")]
+    pub(crate) kind: DeleteType,
+    pub(crate) id: Url,
+    pub(crate) audience: Option<ObjectId<ApubCommunity>>,
 
-  #[serde(deserialize_with = "deserialize_one_or_many")]
-  #[serde(default)]
-  #[serde(skip_serializing_if = "Vec::is_empty")]
-  pub(crate) cc: Vec<Url>,
-  /// If summary is present, this is a mod action (Remove in Lemmy terms). Otherwise, its a user
-  /// deleting their own content.
-  pub(crate) summary: Option<String>,
+    #[serde(deserialize_with = "deserialize_one_or_many")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(crate) cc: Vec<Url>,
+    /// If summary is present, this is a mod action (Remove in Lemmy terms). Otherwise, its a user
+    /// deleting their own content.
+    pub(crate) summary: Option<String>,
 }
 
 #[async_trait::async_trait]
 impl InCommunity for Delete {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
-    let community_id = match DeletableObjects::read_from_db(self.object.id(), context).await? {
-      DeletableObjects::Community(c) => c.id,
-      DeletableObjects::Comment(c) => {
-        let post = Post::read(&mut context.pool(), c.post_id).await?;
-        post.community_id
-      }
-      DeletableObjects::Post(p) => p.community_id,
-      DeletableObjects::PrivateMessage(_) => {
-        return Err(anyhow!("Private message is not part of community").into())
-      }
-    };
-    let community = Community::read(&mut context.pool(), community_id).await?;
-    if let Some(audience) = &self.audience {
-      verify_community_matches(audience, community.actor_id.clone())?;
+    async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+        let community_id = match DeletableObjects::read_from_db(self.object.id(), context).await? {
+            DeletableObjects::Community(c) => c.id,
+            DeletableObjects::Comment(c) => {
+                let post = Post::read(&mut context.pool(), c.post_id).await?;
+                post.community_id
+            }
+            DeletableObjects::Post(p) => p.community_id,
+            DeletableObjects::PrivateMessage(_) => {
+                return Err(anyhow!("Private message is not part of community").into())
+            }
+        };
+        let community = Community::read(&mut context.pool(), community_id).await?;
+        if let Some(audience) = &self.audience {
+            verify_community_matches(audience, community.actor_id.clone())?;
+        }
+        Ok(community.into())
     }
-    Ok(community.into())
-  }
 }

--- a/crates/apub/src/protocol/activities/deletion/delete_user.rs
+++ b/crates/apub/src/protocol/activities/deletion/delete_user.rs
@@ -1,8 +1,7 @@
 use crate::objects::person::ApubPerson;
 use activitypub_federation::{
-  fetch::object_id::ObjectId,
-  kinds::activity::DeleteType,
-  protocol::helpers::deserialize_one_or_many,
+    fetch::object_id::ObjectId, kinds::activity::DeleteType,
+    protocol::helpers::deserialize_one_or_many,
 };
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -12,17 +11,17 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DeleteUser {
-  pub(crate) actor: ObjectId<ApubPerson>,
-  #[serde(deserialize_with = "deserialize_one_or_many")]
-  pub(crate) to: Vec<Url>,
-  pub(crate) object: ObjectId<ApubPerson>,
-  #[serde(rename = "type")]
-  pub(crate) kind: DeleteType,
-  pub(crate) id: Url,
+    pub(crate) actor: ObjectId<ApubPerson>,
+    #[serde(deserialize_with = "deserialize_one_or_many")]
+    pub(crate) to: Vec<Url>,
+    pub(crate) object: ObjectId<ApubPerson>,
+    #[serde(rename = "type")]
+    pub(crate) kind: DeleteType,
+    pub(crate) id: Url,
 
-  #[serde(deserialize_with = "deserialize_one_or_many", default)]
-  #[serde(skip_serializing_if = "Vec::is_empty")]
-  pub(crate) cc: Vec<Url>,
-  /// Nonstandard field. If present, all content from the user should be deleted along with the account
-  pub(crate) remove_data: Option<bool>,
+    #[serde(deserialize_with = "deserialize_one_or_many", default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(crate) cc: Vec<Url>,
+    /// Nonstandard field. If present, all content from the user should be deleted along with the account
+    pub(crate) remove_data: Option<bool>,
 }

--- a/crates/apub/src/protocol/activities/deletion/mod.rs
+++ b/crates/apub/src/protocol/activities/deletion/mod.rs
@@ -4,31 +4,39 @@ pub mod undo_delete;
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::protocol::{
-    activities::deletion::{delete::Delete, delete_user::DeleteUser, undo_delete::UndoDelete},
-    tests::test_parse_lemmy_item,
-  };
+    use crate::protocol::{
+        activities::deletion::{delete::Delete, delete_user::DeleteUser, undo_delete::UndoDelete},
+        tests::test_parse_lemmy_item,
+    };
 
-  #[test]
-  fn test_parse_lemmy_deletion() {
-    test_parse_lemmy_item::<Delete>("assets/lemmy/activities/deletion/remove_note.json").unwrap();
-    test_parse_lemmy_item::<Delete>("assets/lemmy/activities/deletion/delete_page.json").unwrap();
+    #[test]
+    fn test_parse_lemmy_deletion() {
+        test_parse_lemmy_item::<Delete>("assets/lemmy/activities/deletion/remove_note.json")
+            .unwrap();
+        test_parse_lemmy_item::<Delete>("assets/lemmy/activities/deletion/delete_page.json")
+            .unwrap();
 
-    test_parse_lemmy_item::<UndoDelete>("assets/lemmy/activities/deletion/undo_remove_note.json")
-      .unwrap();
-    test_parse_lemmy_item::<UndoDelete>("assets/lemmy/activities/deletion/undo_delete_page.json")
-      .unwrap();
-    test_parse_lemmy_item::<Delete>("assets/lemmy/activities/deletion/delete_private_message.json")
-      .unwrap();
-    test_parse_lemmy_item::<UndoDelete>(
-      "assets/lemmy/activities/deletion/undo_delete_private_message.json",
-    )
-    .unwrap();
+        test_parse_lemmy_item::<UndoDelete>(
+            "assets/lemmy/activities/deletion/undo_remove_note.json",
+        )
+        .unwrap();
+        test_parse_lemmy_item::<UndoDelete>(
+            "assets/lemmy/activities/deletion/undo_delete_page.json",
+        )
+        .unwrap();
+        test_parse_lemmy_item::<Delete>(
+            "assets/lemmy/activities/deletion/delete_private_message.json",
+        )
+        .unwrap();
+        test_parse_lemmy_item::<UndoDelete>(
+            "assets/lemmy/activities/deletion/undo_delete_private_message.json",
+        )
+        .unwrap();
 
-    test_parse_lemmy_item::<DeleteUser>("assets/lemmy/activities/deletion/delete_user.json")
-      .unwrap();
-  }
+        test_parse_lemmy_item::<DeleteUser>("assets/lemmy/activities/deletion/delete_user.json")
+            .unwrap();
+    }
 }

--- a/crates/apub/src/protocol/activities/deletion/undo_delete.rs
+++ b/crates/apub/src/protocol/activities/deletion/undo_delete.rs
@@ -1,13 +1,11 @@
 use crate::{
-  activities::verify_community_matches,
-  objects::{community::ApubCommunity, person::ApubPerson},
-  protocol::{activities::deletion::delete::Delete, InCommunity},
+    activities::verify_community_matches,
+    objects::{community::ApubCommunity, person::ApubPerson},
+    protocol::{activities::deletion::delete::Delete, InCommunity},
 };
 use activitypub_federation::{
-  config::Data,
-  fetch::object_id::ObjectId,
-  kinds::activity::UndoType,
-  protocol::helpers::deserialize_one_or_many,
+    config::Data, fetch::object_id::ObjectId, kinds::activity::UndoType,
+    protocol::helpers::deserialize_one_or_many,
 };
 use lemmy_api_common::context::LemmyContext;
 use lemmy_utils::error::LemmyError;
@@ -19,27 +17,27 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UndoDelete {
-  pub(crate) actor: ObjectId<ApubPerson>,
-  #[serde(deserialize_with = "deserialize_one_or_many")]
-  pub(crate) to: Vec<Url>,
-  pub(crate) object: Delete,
-  #[serde(rename = "type")]
-  pub(crate) kind: UndoType,
-  pub(crate) id: Url,
-  pub(crate) audience: Option<ObjectId<ApubCommunity>>,
+    pub(crate) actor: ObjectId<ApubPerson>,
+    #[serde(deserialize_with = "deserialize_one_or_many")]
+    pub(crate) to: Vec<Url>,
+    pub(crate) object: Delete,
+    #[serde(rename = "type")]
+    pub(crate) kind: UndoType,
+    pub(crate) id: Url,
+    pub(crate) audience: Option<ObjectId<ApubCommunity>>,
 
-  #[serde(deserialize_with = "deserialize_one_or_many", default)]
-  #[serde(skip_serializing_if = "Vec::is_empty")]
-  pub(crate) cc: Vec<Url>,
+    #[serde(deserialize_with = "deserialize_one_or_many", default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(crate) cc: Vec<Url>,
 }
 
 #[async_trait::async_trait]
 impl InCommunity for UndoDelete {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
-    let community = self.object.community(context).await?;
-    if let Some(audience) = &self.audience {
-      verify_community_matches(audience, community.actor_id.clone())?;
+    async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+        let community = self.object.community(context).await?;
+        if let Some(audience) = &self.audience {
+            verify_community_matches(audience, community.actor_id.clone())?;
+        }
+        Ok(community)
     }
-    Ok(community)
-  }
 }

--- a/crates/apub/src/protocol/activities/following/accept.rs
+++ b/crates/apub/src/protocol/activities/following/accept.rs
@@ -1,11 +1,10 @@
 use crate::{
-  objects::{community::ApubCommunity, person::ApubPerson},
-  protocol::activities::following::follow::Follow,
+    objects::{community::ApubCommunity, person::ApubPerson},
+    protocol::activities::following::follow::Follow,
 };
 use activitypub_federation::{
-  fetch::object_id::ObjectId,
-  kinds::activity::AcceptType,
-  protocol::helpers::deserialize_skip_error,
+    fetch::object_id::ObjectId, kinds::activity::AcceptType,
+    protocol::helpers::deserialize_skip_error,
 };
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -13,12 +12,12 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AcceptFollow {
-  pub(crate) actor: ObjectId<ApubCommunity>,
-  /// Optional, for compatibility with platforms that always expect recipient field
-  #[serde(deserialize_with = "deserialize_skip_error", default)]
-  pub(crate) to: Option<[ObjectId<ApubPerson>; 1]>,
-  pub(crate) object: Follow,
-  #[serde(rename = "type")]
-  pub(crate) kind: AcceptType,
-  pub(crate) id: Url,
+    pub(crate) actor: ObjectId<ApubCommunity>,
+    /// Optional, for compatibility with platforms that always expect recipient field
+    #[serde(deserialize_with = "deserialize_skip_error", default)]
+    pub(crate) to: Option<[ObjectId<ApubPerson>; 1]>,
+    pub(crate) object: Follow,
+    #[serde(rename = "type")]
+    pub(crate) kind: AcceptType,
+    pub(crate) id: Url,
 }

--- a/crates/apub/src/protocol/activities/following/follow.rs
+++ b/crates/apub/src/protocol/activities/following/follow.rs
@@ -1,8 +1,7 @@
 use crate::{fetcher::user_or_community::UserOrCommunity, objects::person::ApubPerson};
 use activitypub_federation::{
-  fetch::object_id::ObjectId,
-  kinds::activity::FollowType,
-  protocol::helpers::deserialize_skip_error,
+    fetch::object_id::ObjectId, kinds::activity::FollowType,
+    protocol::helpers::deserialize_skip_error,
 };
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -10,12 +9,12 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Follow {
-  pub(crate) actor: ObjectId<ApubPerson>,
-  /// Optional, for compatibility with platforms that always expect recipient field
-  #[serde(deserialize_with = "deserialize_skip_error", default)]
-  pub(crate) to: Option<[ObjectId<UserOrCommunity>; 1]>,
-  pub(crate) object: ObjectId<UserOrCommunity>,
-  #[serde(rename = "type")]
-  pub(crate) kind: FollowType,
-  pub(crate) id: Url,
+    pub(crate) actor: ObjectId<ApubPerson>,
+    /// Optional, for compatibility with platforms that always expect recipient field
+    #[serde(deserialize_with = "deserialize_skip_error", default)]
+    pub(crate) to: Option<[ObjectId<UserOrCommunity>; 1]>,
+    pub(crate) object: ObjectId<UserOrCommunity>,
+    #[serde(rename = "type")]
+    pub(crate) kind: FollowType,
+    pub(crate) id: Url,
 }

--- a/crates/apub/src/protocol/activities/following/mod.rs
+++ b/crates/apub/src/protocol/activities/following/mod.rs
@@ -4,19 +4,20 @@ pub mod undo_follow;
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::protocol::{
-    activities::following::{accept::AcceptFollow, follow::Follow, undo_follow::UndoFollow},
-    tests::test_parse_lemmy_item,
-  };
+    use crate::protocol::{
+        activities::following::{accept::AcceptFollow, follow::Follow, undo_follow::UndoFollow},
+        tests::test_parse_lemmy_item,
+    };
 
-  #[test]
-  fn test_parse_lemmy_accept_follow() {
-    test_parse_lemmy_item::<Follow>("assets/lemmy/activities/following/follow.json").unwrap();
-    test_parse_lemmy_item::<AcceptFollow>("assets/lemmy/activities/following/accept.json").unwrap();
-    test_parse_lemmy_item::<UndoFollow>("assets/lemmy/activities/following/undo_follow.json")
-      .unwrap();
-  }
+    #[test]
+    fn test_parse_lemmy_accept_follow() {
+        test_parse_lemmy_item::<Follow>("assets/lemmy/activities/following/follow.json").unwrap();
+        test_parse_lemmy_item::<AcceptFollow>("assets/lemmy/activities/following/accept.json")
+            .unwrap();
+        test_parse_lemmy_item::<UndoFollow>("assets/lemmy/activities/following/undo_follow.json")
+            .unwrap();
+    }
 }

--- a/crates/apub/src/protocol/activities/following/undo_follow.rs
+++ b/crates/apub/src/protocol/activities/following/undo_follow.rs
@@ -1,8 +1,7 @@
 use crate::{objects::person::ApubPerson, protocol::activities::following::follow::Follow};
 use activitypub_federation::{
-  fetch::object_id::ObjectId,
-  kinds::activity::UndoType,
-  protocol::helpers::deserialize_skip_error,
+    fetch::object_id::ObjectId, kinds::activity::UndoType,
+    protocol::helpers::deserialize_skip_error,
 };
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -10,12 +9,12 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UndoFollow {
-  pub(crate) actor: ObjectId<ApubPerson>,
-  /// Optional, for compatibility with platforms that always expect recipient field
-  #[serde(deserialize_with = "deserialize_skip_error", default)]
-  pub(crate) to: Option<[ObjectId<ApubPerson>; 1]>,
-  pub(crate) object: Follow,
-  #[serde(rename = "type")]
-  pub(crate) kind: UndoType,
-  pub(crate) id: Url,
+    pub(crate) actor: ObjectId<ApubPerson>,
+    /// Optional, for compatibility with platforms that always expect recipient field
+    #[serde(deserialize_with = "deserialize_skip_error", default)]
+    pub(crate) to: Option<[ObjectId<ApubPerson>; 1]>,
+    pub(crate) object: Follow,
+    #[serde(rename = "type")]
+    pub(crate) kind: UndoType,
+    pub(crate) id: Url,
 }

--- a/crates/apub/src/protocol/activities/mod.rs
+++ b/crates/apub/src/protocol/activities/mod.rs
@@ -10,77 +10,77 @@ pub mod voting;
 
 #[derive(Clone, Debug, Display, Deserialize, Serialize, PartialEq, Eq)]
 pub enum CreateOrUpdateType {
-  Create,
-  Update,
+    Create,
+    Update,
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::protocol::{
-    activities::{
-      community::announce::AnnounceActivity,
-      create_or_update::{note::CreateOrUpdateNote, page::CreateOrUpdatePage},
-      deletion::delete::Delete,
-      following::{follow::Follow, undo_follow::UndoFollow},
-      voting::{undo_vote::UndoVote, vote::Vote},
-    },
-    tests::test_json,
-  };
+    use crate::protocol::{
+        activities::{
+            community::announce::AnnounceActivity,
+            create_or_update::{note::CreateOrUpdateNote, page::CreateOrUpdatePage},
+            deletion::delete::Delete,
+            following::{follow::Follow, undo_follow::UndoFollow},
+            voting::{undo_vote::UndoVote, vote::Vote},
+        },
+        tests::test_json,
+    };
 
-  #[test]
-  fn test_parse_smithereen_activities() {
-    test_json::<CreateOrUpdateNote>("assets/smithereen/activities/create_note.json").unwrap();
-  }
+    #[test]
+    fn test_parse_smithereen_activities() {
+        test_json::<CreateOrUpdateNote>("assets/smithereen/activities/create_note.json").unwrap();
+    }
 
-  #[test]
-  fn test_parse_pleroma_activities() {
-    test_json::<CreateOrUpdateNote>("assets/pleroma/activities/create_note.json").unwrap();
-    test_json::<Delete>("assets/pleroma/activities/delete.json").unwrap();
-    test_json::<Follow>("assets/pleroma/activities/follow.json").unwrap();
-  }
+    #[test]
+    fn test_parse_pleroma_activities() {
+        test_json::<CreateOrUpdateNote>("assets/pleroma/activities/create_note.json").unwrap();
+        test_json::<Delete>("assets/pleroma/activities/delete.json").unwrap();
+        test_json::<Follow>("assets/pleroma/activities/follow.json").unwrap();
+    }
 
-  #[test]
-  fn test_parse_mastodon_activities() {
-    test_json::<CreateOrUpdateNote>("assets/mastodon/activities/create_note.json").unwrap();
-    test_json::<Delete>("assets/mastodon/activities/delete.json").unwrap();
-    test_json::<Follow>("assets/mastodon/activities/follow.json").unwrap();
-    test_json::<UndoFollow>("assets/mastodon/activities/undo_follow.json").unwrap();
-    test_json::<Vote>("assets/mastodon/activities/like_page.json").unwrap();
-    test_json::<UndoVote>("assets/mastodon/activities/undo_like_page.json").unwrap();
-  }
+    #[test]
+    fn test_parse_mastodon_activities() {
+        test_json::<CreateOrUpdateNote>("assets/mastodon/activities/create_note.json").unwrap();
+        test_json::<Delete>("assets/mastodon/activities/delete.json").unwrap();
+        test_json::<Follow>("assets/mastodon/activities/follow.json").unwrap();
+        test_json::<UndoFollow>("assets/mastodon/activities/undo_follow.json").unwrap();
+        test_json::<Vote>("assets/mastodon/activities/like_page.json").unwrap();
+        test_json::<UndoVote>("assets/mastodon/activities/undo_like_page.json").unwrap();
+    }
 
-  #[test]
-  fn test_parse_lotide_activities() {
-    test_json::<Follow>("assets/lotide/activities/follow.json").unwrap();
-    test_json::<CreateOrUpdatePage>("assets/lotide/activities/create_page.json").unwrap();
-    test_json::<CreateOrUpdatePage>("assets/lotide/activities/create_page_image.json").unwrap();
-    test_json::<CreateOrUpdateNote>("assets/lotide/activities/create_note_reply.json").unwrap();
-  }
+    #[test]
+    fn test_parse_lotide_activities() {
+        test_json::<Follow>("assets/lotide/activities/follow.json").unwrap();
+        test_json::<CreateOrUpdatePage>("assets/lotide/activities/create_page.json").unwrap();
+        test_json::<CreateOrUpdatePage>("assets/lotide/activities/create_page_image.json").unwrap();
+        test_json::<CreateOrUpdateNote>("assets/lotide/activities/create_note_reply.json").unwrap();
+    }
 
-  #[test]
-  fn test_parse_friendica_activities() {
-    test_json::<CreateOrUpdatePage>("assets/friendica/activities/create_page_1.json").unwrap();
-    test_json::<CreateOrUpdatePage>("assets/friendica/activities/create_page_2.json").unwrap();
-    test_json::<CreateOrUpdateNote>("assets/friendica/activities/create_note.json").unwrap();
-    test_json::<CreateOrUpdateNote>("assets/friendica/activities/update_note.json").unwrap();
-    test_json::<Delete>("assets/friendica/activities/delete.json").unwrap();
-    test_json::<Vote>("assets/friendica/activities/like_page.json").unwrap();
-    test_json::<Vote>("assets/friendica/activities/dislike_page.json").unwrap();
-    test_json::<UndoVote>("assets/friendica/activities/undo_dislike_page.json").unwrap();
-  }
+    #[test]
+    fn test_parse_friendica_activities() {
+        test_json::<CreateOrUpdatePage>("assets/friendica/activities/create_page_1.json").unwrap();
+        test_json::<CreateOrUpdatePage>("assets/friendica/activities/create_page_2.json").unwrap();
+        test_json::<CreateOrUpdateNote>("assets/friendica/activities/create_note.json").unwrap();
+        test_json::<CreateOrUpdateNote>("assets/friendica/activities/update_note.json").unwrap();
+        test_json::<Delete>("assets/friendica/activities/delete.json").unwrap();
+        test_json::<Vote>("assets/friendica/activities/like_page.json").unwrap();
+        test_json::<Vote>("assets/friendica/activities/dislike_page.json").unwrap();
+        test_json::<UndoVote>("assets/friendica/activities/undo_dislike_page.json").unwrap();
+    }
 
-  #[test]
-  fn test_parse_gnusocial_activities() {
-    test_json::<CreateOrUpdatePage>("assets/gnusocial/activities/create_page.json").unwrap();
-    test_json::<CreateOrUpdateNote>("assets/gnusocial/activities/create_note.json").unwrap();
-    test_json::<Vote>("assets/gnusocial/activities/like_note.json").unwrap();
-  }
+    #[test]
+    fn test_parse_gnusocial_activities() {
+        test_json::<CreateOrUpdatePage>("assets/gnusocial/activities/create_page.json").unwrap();
+        test_json::<CreateOrUpdateNote>("assets/gnusocial/activities/create_note.json").unwrap();
+        test_json::<Vote>("assets/gnusocial/activities/like_note.json").unwrap();
+    }
 
-  #[test]
-  fn test_parse_peertube_activities() {
-    test_json::<AnnounceActivity>("assets/peertube/activities/announce_video.json").unwrap();
-  }
+    #[test]
+    fn test_parse_peertube_activities() {
+        test_json::<AnnounceActivity>("assets/peertube/activities/announce_video.json").unwrap();
+    }
 }

--- a/crates/apub/src/protocol/activities/voting/mod.rs
+++ b/crates/apub/src/protocol/activities/voting/mod.rs
@@ -3,22 +3,22 @@ pub mod vote;
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::protocol::{
-    activities::voting::{undo_vote::UndoVote, vote::Vote},
-    tests::test_parse_lemmy_item,
-  };
+    use crate::protocol::{
+        activities::voting::{undo_vote::UndoVote, vote::Vote},
+        tests::test_parse_lemmy_item,
+    };
 
-  #[test]
-  fn test_parse_lemmy_voting() {
-    test_parse_lemmy_item::<Vote>("assets/lemmy/activities/voting/like_note.json").unwrap();
-    test_parse_lemmy_item::<Vote>("assets/lemmy/activities/voting/dislike_page.json").unwrap();
+    #[test]
+    fn test_parse_lemmy_voting() {
+        test_parse_lemmy_item::<Vote>("assets/lemmy/activities/voting/like_note.json").unwrap();
+        test_parse_lemmy_item::<Vote>("assets/lemmy/activities/voting/dislike_page.json").unwrap();
 
-    test_parse_lemmy_item::<UndoVote>("assets/lemmy/activities/voting/undo_like_note.json")
-      .unwrap();
-    test_parse_lemmy_item::<UndoVote>("assets/lemmy/activities/voting/undo_dislike_page.json")
-      .unwrap();
-  }
+        test_parse_lemmy_item::<UndoVote>("assets/lemmy/activities/voting/undo_like_note.json")
+            .unwrap();
+        test_parse_lemmy_item::<UndoVote>("assets/lemmy/activities/voting/undo_dislike_page.json")
+            .unwrap();
+    }
 }

--- a/crates/apub/src/protocol/activities/voting/undo_vote.rs
+++ b/crates/apub/src/protocol/activities/voting/undo_vote.rs
@@ -1,7 +1,7 @@
 use crate::{
-  activities::verify_community_matches,
-  objects::{community::ApubCommunity, person::ApubPerson},
-  protocol::{activities::voting::vote::Vote, InCommunity},
+    activities::verify_community_matches,
+    objects::{community::ApubCommunity, person::ApubPerson},
+    protocol::{activities::voting::vote::Vote, InCommunity},
 };
 use activitypub_federation::{config::Data, fetch::object_id::ObjectId, kinds::activity::UndoType};
 use lemmy_api_common::context::LemmyContext;
@@ -12,21 +12,21 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UndoVote {
-  pub(crate) actor: ObjectId<ApubPerson>,
-  pub(crate) object: Vote,
-  #[serde(rename = "type")]
-  pub(crate) kind: UndoType,
-  pub(crate) id: Url,
-  pub(crate) audience: Option<ObjectId<ApubCommunity>>,
+    pub(crate) actor: ObjectId<ApubPerson>,
+    pub(crate) object: Vote,
+    #[serde(rename = "type")]
+    pub(crate) kind: UndoType,
+    pub(crate) id: Url,
+    pub(crate) audience: Option<ObjectId<ApubCommunity>>,
 }
 
 #[async_trait::async_trait]
 impl InCommunity for UndoVote {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
-    let community = self.object.community(context).await?;
-    if let Some(audience) = &self.audience {
-      verify_community_matches(audience, community.actor_id.clone())?;
+    async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+        let community = self.object.community(context).await?;
+        if let Some(audience) = &self.audience {
+            verify_community_matches(audience, community.actor_id.clone())?;
+        }
+        Ok(community)
     }
-    Ok(community)
-  }
 }

--- a/crates/apub/src/protocol/activities/voting/vote.rs
+++ b/crates/apub/src/protocol/activities/voting/vote.rs
@@ -1,8 +1,8 @@
 use crate::{
-  activities::verify_community_matches,
-  fetcher::post_or_comment::PostOrComment,
-  objects::{community::ApubCommunity, person::ApubPerson},
-  protocol::InCommunity,
+    activities::verify_community_matches,
+    fetcher::post_or_comment::PostOrComment,
+    objects::{community::ApubCommunity, person::ApubPerson},
+    protocol::InCommunity,
 };
 use activitypub_federation::{config::Data, fetch::object_id::ObjectId};
 use lemmy_api_common::context::LemmyContext;
@@ -15,53 +15,53 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Vote {
-  pub(crate) actor: ObjectId<ApubPerson>,
-  pub(crate) object: ObjectId<PostOrComment>,
-  #[serde(rename = "type")]
-  pub(crate) kind: VoteType,
-  pub(crate) id: Url,
-  pub(crate) audience: Option<ObjectId<ApubCommunity>>,
+    pub(crate) actor: ObjectId<ApubPerson>,
+    pub(crate) object: ObjectId<PostOrComment>,
+    #[serde(rename = "type")]
+    pub(crate) kind: VoteType,
+    pub(crate) id: Url,
+    pub(crate) audience: Option<ObjectId<ApubCommunity>>,
 }
 
 #[derive(Clone, Debug, Display, Deserialize, Serialize, PartialEq, Eq)]
 pub enum VoteType {
-  Like,
-  Dislike,
+    Like,
+    Dislike,
 }
 
 impl TryFrom<i16> for VoteType {
-  type Error = LemmyError;
+    type Error = LemmyError;
 
-  fn try_from(value: i16) -> Result<Self, Self::Error> {
-    match value {
-      1 => Ok(VoteType::Like),
-      -1 => Ok(VoteType::Dislike),
-      _ => Err(LemmyErrorType::InvalidVoteValue.into()),
+    fn try_from(value: i16) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(VoteType::Like),
+            -1 => Ok(VoteType::Dislike),
+            _ => Err(LemmyErrorType::InvalidVoteValue.into()),
+        }
     }
-  }
 }
 
 impl From<&VoteType> for i16 {
-  fn from(value: &VoteType) -> i16 {
-    match value {
-      VoteType::Like => 1,
-      VoteType::Dislike => -1,
+    fn from(value: &VoteType) -> i16 {
+        match value {
+            VoteType::Like => 1,
+            VoteType::Dislike => -1,
+        }
     }
-  }
 }
 
 #[async_trait::async_trait]
 impl InCommunity for Vote {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
-    let community = self
-      .object
-      .dereference(context)
-      .await?
-      .community(context)
-      .await?;
-    if let Some(audience) = &self.audience {
-      verify_community_matches(audience, community.actor_id.clone())?;
+    async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+        let community = self
+            .object
+            .dereference(context)
+            .await?
+            .community(context)
+            .await?;
+        if let Some(audience) = &self.audience {
+            verify_community_matches(audience, community.actor_id.clone())?;
+        }
+        Ok(community)
     }
-    Ok(community)
-  }
 }

--- a/crates/apub/src/protocol/collections/empty_outbox.rs
+++ b/crates/apub/src/protocol/collections/empty_outbox.rs
@@ -7,19 +7,19 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct EmptyOutbox {
-  r#type: OrderedCollectionType,
-  id: Url,
-  ordered_items: Vec<()>,
-  total_items: i32,
+    r#type: OrderedCollectionType,
+    id: Url,
+    ordered_items: Vec<()>,
+    total_items: i32,
 }
 
 impl EmptyOutbox {
-  pub(crate) fn new(outbox_id: Url) -> Result<EmptyOutbox, LemmyError> {
-    Ok(EmptyOutbox {
-      r#type: OrderedCollectionType::OrderedCollection,
-      id: outbox_id,
-      ordered_items: vec![],
-      total_items: 0,
-    })
-  }
+    pub(crate) fn new(outbox_id: Url) -> Result<EmptyOutbox, LemmyError> {
+        Ok(EmptyOutbox {
+            r#type: OrderedCollectionType::OrderedCollection,
+            id: outbox_id,
+            ordered_items: vec![],
+            total_items: 0,
+        })
+    }
 }

--- a/crates/apub/src/protocol/collections/group_featured.rs
+++ b/crates/apub/src/protocol/collections/group_featured.rs
@@ -6,8 +6,8 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GroupFeatured {
-  pub(crate) r#type: OrderedCollectionType,
-  pub(crate) id: Url,
-  pub(crate) total_items: i32,
-  pub(crate) ordered_items: Vec<Page>,
+    pub(crate) r#type: OrderedCollectionType,
+    pub(crate) id: Url,
+    pub(crate) total_items: i32,
+    pub(crate) ordered_items: Vec<Page>,
 }

--- a/crates/apub/src/protocol/collections/group_followers.rs
+++ b/crates/apub/src/protocol/collections/group_followers.rs
@@ -9,26 +9,27 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct GroupFollowers {
-  id: Url,
-  r#type: CollectionType,
-  total_items: i32,
-  items: Vec<()>,
+    id: Url,
+    r#type: CollectionType,
+    total_items: i32,
+    items: Vec<()>,
 }
 
 impl GroupFollowers {
-  pub(crate) async fn new(
-    community: Community,
-    context: &LemmyContext,
-  ) -> Result<GroupFollowers, LemmyError> {
-    let community_id = community.id;
-    let community_followers =
-      CommunityFollowerView::count_community_followers(&mut context.pool(), community_id).await?;
+    pub(crate) async fn new(
+        community: Community,
+        context: &LemmyContext,
+    ) -> Result<GroupFollowers, LemmyError> {
+        let community_id = community.id;
+        let community_followers =
+            CommunityFollowerView::count_community_followers(&mut context.pool(), community_id)
+                .await?;
 
-    Ok(GroupFollowers {
-      id: generate_followers_url(&community.actor_id)?.into(),
-      r#type: CollectionType::Collection,
-      total_items: community_followers as i32,
-      items: vec![],
-    })
-  }
+        Ok(GroupFollowers {
+            id: generate_followers_url(&community.actor_id)?.into(),
+            r#type: CollectionType::Collection,
+            total_items: community_followers as i32,
+            items: vec![],
+        })
+    }
 }

--- a/crates/apub/src/protocol/collections/group_moderators.rs
+++ b/crates/apub/src/protocol/collections/group_moderators.rs
@@ -1,7 +1,6 @@
 use crate::objects::person::ApubPerson;
 use activitypub_federation::{
-  fetch::object_id::ObjectId,
-  kinds::collection::OrderedCollectionType,
+    fetch::object_id::ObjectId, kinds::collection::OrderedCollectionType,
 };
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -9,7 +8,7 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GroupModerators {
-  pub(crate) r#type: OrderedCollectionType,
-  pub(crate) id: Url,
-  pub(crate) ordered_items: Vec<ObjectId<ApubPerson>>,
+    pub(crate) r#type: OrderedCollectionType,
+    pub(crate) id: Url,
+    pub(crate) ordered_items: Vec<ObjectId<ApubPerson>>,
 }

--- a/crates/apub/src/protocol/collections/group_outbox.rs
+++ b/crates/apub/src/protocol/collections/group_outbox.rs
@@ -6,8 +6,8 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GroupOutbox {
-  pub(crate) r#type: OrderedCollectionType,
-  pub(crate) id: Url,
-  pub(crate) total_items: i32,
-  pub(crate) ordered_items: Vec<AnnounceActivity>,
+    pub(crate) r#type: OrderedCollectionType,
+    pub(crate) id: Url,
+    pub(crate) total_items: i32,
+    pub(crate) ordered_items: Vec<AnnounceActivity>,
 }

--- a/crates/apub/src/protocol/collections/mod.rs
+++ b/crates/apub/src/protocol/collections/mod.rs
@@ -6,36 +6,38 @@ pub(crate) mod group_outbox;
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::protocol::{
-    collections::{
-      empty_outbox::EmptyOutbox,
-      group_featured::GroupFeatured,
-      group_followers::GroupFollowers,
-      group_moderators::GroupModerators,
-      group_outbox::GroupOutbox,
-    },
-    tests::{test_json, test_parse_lemmy_item},
-  };
+    use crate::protocol::{
+        collections::{
+            empty_outbox::EmptyOutbox, group_featured::GroupFeatured,
+            group_followers::GroupFollowers, group_moderators::GroupModerators,
+            group_outbox::GroupOutbox,
+        },
+        tests::{test_json, test_parse_lemmy_item},
+    };
 
-  #[test]
-  fn test_parse_lemmy_collections() {
-    test_parse_lemmy_item::<GroupFollowers>("assets/lemmy/collections/group_followers.json")
-      .unwrap();
-    let outbox =
-      test_parse_lemmy_item::<GroupOutbox>("assets/lemmy/collections/group_outbox.json").unwrap();
-    assert_eq!(outbox.ordered_items.len() as i32, outbox.total_items);
-    test_parse_lemmy_item::<GroupFeatured>("assets/lemmy/collections/group_featured_posts.json")
-      .unwrap();
-    test_parse_lemmy_item::<GroupModerators>("assets/lemmy/collections/group_moderators.json")
-      .unwrap();
-    test_parse_lemmy_item::<EmptyOutbox>("assets/lemmy/collections/person_outbox.json").unwrap();
-  }
+    #[test]
+    fn test_parse_lemmy_collections() {
+        test_parse_lemmy_item::<GroupFollowers>("assets/lemmy/collections/group_followers.json")
+            .unwrap();
+        let outbox =
+            test_parse_lemmy_item::<GroupOutbox>("assets/lemmy/collections/group_outbox.json")
+                .unwrap();
+        assert_eq!(outbox.ordered_items.len() as i32, outbox.total_items);
+        test_parse_lemmy_item::<GroupFeatured>(
+            "assets/lemmy/collections/group_featured_posts.json",
+        )
+        .unwrap();
+        test_parse_lemmy_item::<GroupModerators>("assets/lemmy/collections/group_moderators.json")
+            .unwrap();
+        test_parse_lemmy_item::<EmptyOutbox>("assets/lemmy/collections/person_outbox.json")
+            .unwrap();
+    }
 
-  #[test]
-  fn test_parse_mastodon_collections() {
-    test_json::<GroupFeatured>("assets/mastodon/collections/featured.json").unwrap();
-  }
+    #[test]
+    fn test_parse_mastodon_collections() {
+        test_json::<GroupFeatured>("assets/mastodon/collections/featured.json").unwrap();
+    }
 }

--- a/crates/apub/src/protocol/mod.rs
+++ b/crates/apub/src/protocol/mod.rs
@@ -1,9 +1,7 @@
 use crate::objects::community::ApubCommunity;
 use activitypub_federation::{
-  config::Data,
-  fetch::fetch_object_http,
-  kinds::object::ImageType,
-  protocol::values::MediaTypeMarkdown,
+    config::Data, fetch::fetch_object_http, kinds::object::ImageType,
+    protocol::values::MediaTypeMarkdown,
 };
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::newtypes::DbUrl;
@@ -19,34 +17,34 @@ pub(crate) mod objects;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Source {
-  pub(crate) content: String,
-  pub(crate) media_type: MediaTypeMarkdown,
+    pub(crate) content: String,
+    pub(crate) media_type: MediaTypeMarkdown,
 }
 
 impl Source {
-  pub(crate) fn new(content: String) -> Self {
-    Source {
-      content,
-      media_type: MediaTypeMarkdown::Markdown,
+    pub(crate) fn new(content: String) -> Self {
+        Source {
+            content,
+            media_type: MediaTypeMarkdown::Markdown,
+        }
     }
-  }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ImageObject {
-  #[serde(rename = "type")]
-  kind: ImageType,
-  pub(crate) url: Url,
+    #[serde(rename = "type")]
+    kind: ImageType,
+    pub(crate) url: Url,
 }
 
 impl ImageObject {
-  pub(crate) fn new(url: DbUrl) -> Self {
-    ImageObject {
-      kind: ImageType::Image,
-      url: url.into(),
+    pub(crate) fn new(url: DbUrl) -> Self {
+        ImageObject {
+            kind: ImageType::Image,
+            url: url.into(),
+        }
     }
-  }
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -54,72 +52,72 @@ impl ImageObject {
 pub struct Unparsed(HashMap<String, serde_json::Value>);
 
 pub(crate) trait Id {
-  fn object_id(&self) -> &Url;
+    fn object_id(&self) -> &Url;
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub(crate) enum IdOrNestedObject<Kind: Id> {
-  Id(Url),
-  NestedObject(Kind),
+    Id(Url),
+    NestedObject(Kind),
 }
 
 impl<Kind: Id + DeserializeOwned + Send> IdOrNestedObject<Kind> {
-  pub(crate) fn id(&self) -> &Url {
-    match self {
-      IdOrNestedObject::Id(i) => i,
-      IdOrNestedObject::NestedObject(n) => n.object_id(),
+    pub(crate) fn id(&self) -> &Url {
+        match self {
+            IdOrNestedObject::Id(i) => i,
+            IdOrNestedObject::NestedObject(n) => n.object_id(),
+        }
     }
-  }
-  pub(crate) async fn object(self, context: &Data<LemmyContext>) -> Result<Kind, LemmyError> {
-    match self {
-      // TODO: move IdOrNestedObject struct to library and make fetch_object_http private
-      IdOrNestedObject::Id(i) => Ok(fetch_object_http(&i, context).await?),
-      IdOrNestedObject::NestedObject(o) => Ok(o),
+    pub(crate) async fn object(self, context: &Data<LemmyContext>) -> Result<Kind, LemmyError> {
+        match self {
+            // TODO: move IdOrNestedObject struct to library and make fetch_object_http private
+            IdOrNestedObject::Id(i) => Ok(fetch_object_http(&i, context).await?),
+            IdOrNestedObject::NestedObject(o) => Ok(o),
+        }
     }
-  }
 }
 
 #[async_trait::async_trait]
 pub trait InCommunity {
-  // TODO: after we use audience field and remove backwards compat, it should be possible to change
-  //       this to simply `fn community(&self)  -> Result<ObjectId<ApubCommunity>, LemmyError>`
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError>;
+    // TODO: after we use audience field and remove backwards compat, it should be possible to change
+    //       this to simply `fn community(&self)  -> Result<ObjectId<ApubCommunity>, LemmyError>`
+    async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError>;
 }
 
 #[cfg(test)]
 pub(crate) mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use activitypub_federation::protocol::context::WithContext;
-  use assert_json_diff::assert_json_include;
-  use lemmy_utils::error::LemmyError;
-  use serde::{de::DeserializeOwned, Serialize};
-  use std::{collections::HashMap, fs::File, io::BufReader};
+    use activitypub_federation::protocol::context::WithContext;
+    use assert_json_diff::assert_json_include;
+    use lemmy_utils::error::LemmyError;
+    use serde::{de::DeserializeOwned, Serialize};
+    use std::{collections::HashMap, fs::File, io::BufReader};
 
-  pub(crate) fn file_to_json_object<T: DeserializeOwned>(path: &str) -> Result<T, LemmyError> {
-    let file = File::open(path)?;
-    let reader = BufReader::new(file);
-    Ok(serde_json::from_reader(reader)?)
-  }
+    pub(crate) fn file_to_json_object<T: DeserializeOwned>(path: &str) -> Result<T, LemmyError> {
+        let file = File::open(path)?;
+        let reader = BufReader::new(file);
+        Ok(serde_json::from_reader(reader)?)
+    }
 
-  pub(crate) fn test_json<T: DeserializeOwned>(path: &str) -> Result<WithContext<T>, LemmyError> {
-    file_to_json_object::<WithContext<T>>(path)
-  }
+    pub(crate) fn test_json<T: DeserializeOwned>(path: &str) -> Result<WithContext<T>, LemmyError> {
+        file_to_json_object::<WithContext<T>>(path)
+    }
 
-  /// Check that json deserialize -> serialize -> deserialize gives identical file as initial one.
-  /// Ensures that there are no breaking changes in sent data.
-  pub(crate) fn test_parse_lemmy_item<T: Serialize + DeserializeOwned + std::fmt::Debug>(
-    path: &str,
-  ) -> Result<T, LemmyError> {
-    // parse file as T
-    let parsed = file_to_json_object::<T>(path)?;
+    /// Check that json deserialize -> serialize -> deserialize gives identical file as initial one.
+    /// Ensures that there are no breaking changes in sent data.
+    pub(crate) fn test_parse_lemmy_item<T: Serialize + DeserializeOwned + std::fmt::Debug>(
+        path: &str,
+    ) -> Result<T, LemmyError> {
+        // parse file as T
+        let parsed = file_to_json_object::<T>(path)?;
 
-    // parse file into hashmap, which ensures that every field is included
-    let raw = file_to_json_object::<HashMap<String, serde_json::Value>>(path)?;
-    // assert that all fields are identical, otherwise print diff
-    assert_json_include!(actual: &parsed, expected: raw);
-    Ok(parsed)
-  }
+        // parse file into hashmap, which ensures that every field is included
+        let raw = file_to_json_object::<HashMap<String, serde_json::Value>>(path)?;
+        // assert that all fields are identical, otherwise print diff
+        assert_json_include!(actual: &parsed, expected: raw);
+        Ok(parsed)
+    }
 }

--- a/crates/apub/src/protocol/objects/chat_message.rs
+++ b/crates/apub/src/protocol/objects/chat_message.rs
@@ -1,13 +1,13 @@
 use crate::{
-  objects::{person::ApubPerson, private_message::ApubPrivateMessage},
-  protocol::Source,
+    objects::{person::ApubPerson, private_message::ApubPrivateMessage},
+    protocol::Source,
 };
 use activitypub_federation::{
-  fetch::object_id::ObjectId,
-  protocol::{
-    helpers::{deserialize_one, deserialize_skip_error},
-    values::MediaTypeHtml,
-  },
+    fetch::object_id::ObjectId,
+    protocol::{
+        helpers::{deserialize_one, deserialize_skip_error},
+        values::MediaTypeHtml,
+    },
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -17,22 +17,22 @@ use serde_with::skip_serializing_none;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ChatMessage {
-  pub(crate) r#type: ChatMessageType,
-  pub(crate) id: ObjectId<ApubPrivateMessage>,
-  pub(crate) attributed_to: ObjectId<ApubPerson>,
-  #[serde(deserialize_with = "deserialize_one")]
-  pub(crate) to: [ObjectId<ApubPerson>; 1],
-  pub(crate) content: String,
+    pub(crate) r#type: ChatMessageType,
+    pub(crate) id: ObjectId<ApubPrivateMessage>,
+    pub(crate) attributed_to: ObjectId<ApubPerson>,
+    #[serde(deserialize_with = "deserialize_one")]
+    pub(crate) to: [ObjectId<ApubPerson>; 1],
+    pub(crate) content: String,
 
-  pub(crate) media_type: Option<MediaTypeHtml>,
-  #[serde(deserialize_with = "deserialize_skip_error", default)]
-  pub(crate) source: Option<Source>,
-  pub(crate) published: Option<DateTime<Utc>>,
-  pub(crate) updated: Option<DateTime<Utc>>,
+    pub(crate) media_type: Option<MediaTypeHtml>,
+    #[serde(deserialize_with = "deserialize_skip_error", default)]
+    pub(crate) source: Option<Source>,
+    pub(crate) published: Option<DateTime<Utc>>,
+    pub(crate) updated: Option<DateTime<Utc>>,
 }
 
 /// https://docs.pleroma.social/backend/development/ap_extensions/#chatmessages
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum ChatMessageType {
-  ChatMessage,
+    ChatMessage,
 }

--- a/crates/apub/src/protocol/objects/group.rs
+++ b/crates/apub/src/protocol/objects/group.rs
@@ -1,40 +1,36 @@
 use crate::{
-  check_apub_id_valid_with_strictness,
-  collections::{
-    community_featured::ApubCommunityFeatured,
-    community_moderators::ApubCommunityModerators,
-    community_outbox::ApubCommunityOutbox,
-  },
-  local_site_data_cached,
-  objects::{community::ApubCommunity, read_from_string_or_source_opt},
-  protocol::{
-    objects::{Endpoints, LanguageTag},
-    ImageObject,
-    Source,
-  },
+    check_apub_id_valid_with_strictness,
+    collections::{
+        community_featured::ApubCommunityFeatured, community_moderators::ApubCommunityModerators,
+        community_outbox::ApubCommunityOutbox,
+    },
+    local_site_data_cached,
+    objects::{community::ApubCommunity, read_from_string_or_source_opt},
+    protocol::{
+        objects::{Endpoints, LanguageTag},
+        ImageObject, Source,
+    },
 };
 use activitypub_federation::{
-  fetch::{collection_id::CollectionId, object_id::ObjectId},
-  kinds::actor::GroupType,
-  protocol::{
-    helpers::deserialize_skip_error,
-    public_key::PublicKey,
-    verification::verify_domains_match,
-  },
+    fetch::{collection_id::CollectionId, object_id::ObjectId},
+    kinds::actor::GroupType,
+    protocol::{
+        helpers::deserialize_skip_error, public_key::PublicKey, verification::verify_domains_match,
+    },
 };
 use chrono::{DateTime, Utc};
 use lemmy_api_common::{
-  context::LemmyContext,
-  utils::{local_site_opt_to_slur_regex, sanitize_html, sanitize_html_opt},
+    context::LemmyContext,
+    utils::{local_site_opt_to_slur_regex, sanitize_html, sanitize_html_opt},
 };
 use lemmy_db_schema::{
-  newtypes::InstanceId,
-  source::community::{CommunityInsertForm, CommunityUpdateForm},
-  utils::naive_now,
+    newtypes::InstanceId,
+    source::community::{CommunityInsertForm, CommunityUpdateForm},
+    utils::naive_now,
 };
 use lemmy_utils::{
-  error::LemmyError,
-  utils::slurs::{check_slurs, check_slurs_opt},
+    error::LemmyError,
+    utils::slurs::{check_slurs, check_slurs_opt},
 };
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -45,117 +41,117 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Group {
-  #[serde(rename = "type")]
-  pub(crate) kind: GroupType,
-  pub(crate) id: ObjectId<ApubCommunity>,
-  /// username, set at account creation and usually fixed after that
-  pub(crate) preferred_username: String,
-  pub(crate) inbox: Url,
-  pub(crate) followers: Url,
-  pub(crate) public_key: PublicKey,
+    #[serde(rename = "type")]
+    pub(crate) kind: GroupType,
+    pub(crate) id: ObjectId<ApubCommunity>,
+    /// username, set at account creation and usually fixed after that
+    pub(crate) preferred_username: String,
+    pub(crate) inbox: Url,
+    pub(crate) followers: Url,
+    pub(crate) public_key: PublicKey,
 
-  /// title
-  pub(crate) name: Option<String>,
-  pub(crate) summary: Option<String>,
-  #[serde(deserialize_with = "deserialize_skip_error", default)]
-  pub(crate) source: Option<Source>,
-  pub(crate) icon: Option<ImageObject>,
-  /// banner
-  pub(crate) image: Option<ImageObject>,
-  // lemmy extension
-  pub(crate) sensitive: Option<bool>,
-  #[serde(deserialize_with = "deserialize_skip_error", default)]
-  pub(crate) attributed_to: Option<CollectionId<ApubCommunityModerators>>,
-  // lemmy extension
-  pub(crate) posting_restricted_to_mods: Option<bool>,
-  pub(crate) outbox: CollectionId<ApubCommunityOutbox>,
-  pub(crate) endpoints: Option<Endpoints>,
-  pub(crate) featured: Option<CollectionId<ApubCommunityFeatured>>,
-  #[serde(default)]
-  pub(crate) language: Vec<LanguageTag>,
-  pub(crate) published: Option<DateTime<Utc>>,
-  pub(crate) updated: Option<DateTime<Utc>>,
+    /// title
+    pub(crate) name: Option<String>,
+    pub(crate) summary: Option<String>,
+    #[serde(deserialize_with = "deserialize_skip_error", default)]
+    pub(crate) source: Option<Source>,
+    pub(crate) icon: Option<ImageObject>,
+    /// banner
+    pub(crate) image: Option<ImageObject>,
+    // lemmy extension
+    pub(crate) sensitive: Option<bool>,
+    #[serde(deserialize_with = "deserialize_skip_error", default)]
+    pub(crate) attributed_to: Option<CollectionId<ApubCommunityModerators>>,
+    // lemmy extension
+    pub(crate) posting_restricted_to_mods: Option<bool>,
+    pub(crate) outbox: CollectionId<ApubCommunityOutbox>,
+    pub(crate) endpoints: Option<Endpoints>,
+    pub(crate) featured: Option<CollectionId<ApubCommunityFeatured>>,
+    #[serde(default)]
+    pub(crate) language: Vec<LanguageTag>,
+    pub(crate) published: Option<DateTime<Utc>>,
+    pub(crate) updated: Option<DateTime<Utc>>,
 }
 
 impl Group {
-  pub(crate) async fn verify(
-    &self,
-    expected_domain: &Url,
-    context: &LemmyContext,
-  ) -> Result<(), LemmyError> {
-    check_apub_id_valid_with_strictness(self.id.inner(), true, context).await?;
-    verify_domains_match(expected_domain, self.id.inner())?;
+    pub(crate) async fn verify(
+        &self,
+        expected_domain: &Url,
+        context: &LemmyContext,
+    ) -> Result<(), LemmyError> {
+        check_apub_id_valid_with_strictness(self.id.inner(), true, context).await?;
+        verify_domains_match(expected_domain, self.id.inner())?;
 
-    let local_site_data = local_site_data_cached(&mut context.pool()).await?;
-    let slur_regex = &local_site_opt_to_slur_regex(&local_site_data.local_site);
+        let local_site_data = local_site_data_cached(&mut context.pool()).await?;
+        let slur_regex = &local_site_opt_to_slur_regex(&local_site_data.local_site);
 
-    check_slurs(&self.preferred_username, slur_regex)?;
-    check_slurs_opt(&self.name, slur_regex)?;
-    let description = read_from_string_or_source_opt(&self.summary, &None, &self.source);
-    check_slurs_opt(&description, slur_regex)?;
-    Ok(())
-  }
-
-  pub(crate) fn into_insert_form(self, instance_id: InstanceId) -> CommunityInsertForm {
-    let name = sanitize_html(&self.preferred_username);
-    let title = sanitize_html(&self.name.unwrap_or(self.preferred_username));
-    let description = read_from_string_or_source_opt(&self.summary, &None, &self.source);
-    let description = sanitize_html_opt(&description);
-
-    CommunityInsertForm {
-      name,
-      title,
-      description,
-      removed: None,
-      published: self.published,
-      updated: self.updated,
-      deleted: Some(false),
-      nsfw: Some(self.sensitive.unwrap_or(false)),
-      actor_id: Some(self.id.into()),
-      local: Some(false),
-      private_key: None,
-      hidden: None,
-      public_key: self.public_key.public_key_pem,
-      last_refreshed_at: Some(naive_now()),
-      icon: self.icon.map(|i| i.url.into()),
-      banner: self.image.map(|i| i.url.into()),
-      followers_url: Some(self.followers.into()),
-      inbox_url: Some(self.inbox.into()),
-      shared_inbox_url: self.endpoints.map(|e| e.shared_inbox.into()),
-      moderators_url: self.attributed_to.map(Into::into),
-      posting_restricted_to_mods: self.posting_restricted_to_mods,
-      instance_id,
-      featured_url: self.featured.map(Into::into),
+        check_slurs(&self.preferred_username, slur_regex)?;
+        check_slurs_opt(&self.name, slur_regex)?;
+        let description = read_from_string_or_source_opt(&self.summary, &None, &self.source);
+        check_slurs_opt(&description, slur_regex)?;
+        Ok(())
     }
-  }
 
-  pub(crate) fn into_update_form(self) -> CommunityUpdateForm {
-    CommunityUpdateForm {
-      title: Some(self.name.unwrap_or(self.preferred_username)),
-      description: Some(read_from_string_or_source_opt(
-        &self.summary,
-        &None,
-        &self.source,
-      )),
-      removed: None,
-      published: self.published.map(Into::into),
-      updated: Some(self.updated.map(Into::into)),
-      deleted: None,
-      nsfw: Some(self.sensitive.unwrap_or(false)),
-      actor_id: Some(self.id.into()),
-      local: None,
-      private_key: None,
-      hidden: None,
-      public_key: Some(self.public_key.public_key_pem),
-      last_refreshed_at: Some(naive_now()),
-      icon: Some(self.icon.map(|i| i.url.into())),
-      banner: Some(self.image.map(|i| i.url.into())),
-      followers_url: Some(self.followers.into()),
-      inbox_url: Some(self.inbox.into()),
-      shared_inbox_url: Some(self.endpoints.map(|e| e.shared_inbox.into())),
-      moderators_url: self.attributed_to.map(Into::into),
-      posting_restricted_to_mods: self.posting_restricted_to_mods,
-      featured_url: self.featured.map(Into::into),
+    pub(crate) fn into_insert_form(self, instance_id: InstanceId) -> CommunityInsertForm {
+        let name = sanitize_html(&self.preferred_username);
+        let title = sanitize_html(&self.name.unwrap_or(self.preferred_username));
+        let description = read_from_string_or_source_opt(&self.summary, &None, &self.source);
+        let description = sanitize_html_opt(&description);
+
+        CommunityInsertForm {
+            name,
+            title,
+            description,
+            removed: None,
+            published: self.published,
+            updated: self.updated,
+            deleted: Some(false),
+            nsfw: Some(self.sensitive.unwrap_or(false)),
+            actor_id: Some(self.id.into()),
+            local: Some(false),
+            private_key: None,
+            hidden: None,
+            public_key: self.public_key.public_key_pem,
+            last_refreshed_at: Some(naive_now()),
+            icon: self.icon.map(|i| i.url.into()),
+            banner: self.image.map(|i| i.url.into()),
+            followers_url: Some(self.followers.into()),
+            inbox_url: Some(self.inbox.into()),
+            shared_inbox_url: self.endpoints.map(|e| e.shared_inbox.into()),
+            moderators_url: self.attributed_to.map(Into::into),
+            posting_restricted_to_mods: self.posting_restricted_to_mods,
+            instance_id,
+            featured_url: self.featured.map(Into::into),
+        }
     }
-  }
+
+    pub(crate) fn into_update_form(self) -> CommunityUpdateForm {
+        CommunityUpdateForm {
+            title: Some(self.name.unwrap_or(self.preferred_username)),
+            description: Some(read_from_string_or_source_opt(
+                &self.summary,
+                &None,
+                &self.source,
+            )),
+            removed: None,
+            published: self.published.map(Into::into),
+            updated: Some(self.updated.map(Into::into)),
+            deleted: None,
+            nsfw: Some(self.sensitive.unwrap_or(false)),
+            actor_id: Some(self.id.into()),
+            local: None,
+            private_key: None,
+            hidden: None,
+            public_key: Some(self.public_key.public_key_pem),
+            last_refreshed_at: Some(naive_now()),
+            icon: Some(self.icon.map(|i| i.url.into())),
+            banner: Some(self.image.map(|i| i.url.into())),
+            followers_url: Some(self.followers.into()),
+            inbox_url: Some(self.inbox.into()),
+            shared_inbox_url: Some(self.endpoints.map(|e| e.shared_inbox.into())),
+            moderators_url: self.attributed_to.map(Into::into),
+            posting_restricted_to_mods: self.posting_restricted_to_mods,
+            featured_url: self.featured.map(Into::into),
+        }
+    }
 }

--- a/crates/apub/src/protocol/objects/instance.rs
+++ b/crates/apub/src/protocol/objects/instance.rs
@@ -1,11 +1,11 @@
 use crate::{
-  objects::instance::ApubSite,
-  protocol::{objects::LanguageTag, ImageObject, Source},
+    objects::instance::ApubSite,
+    protocol::{objects::LanguageTag, ImageObject, Source},
 };
 use activitypub_federation::{
-  fetch::object_id::ObjectId,
-  kinds::actor::ApplicationType,
-  protocol::{helpers::deserialize_skip_error, public_key::PublicKey, values::MediaTypeHtml},
+    fetch::object_id::ObjectId,
+    kinds::actor::ApplicationType,
+    protocol::{helpers::deserialize_skip_error, public_key::PublicKey, values::MediaTypeHtml},
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -16,29 +16,29 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Instance {
-  #[serde(rename = "type")]
-  pub(crate) kind: ApplicationType,
-  pub(crate) id: ObjectId<ApubSite>,
-  // site name
-  pub(crate) name: String,
-  pub(crate) inbox: Url,
-  /// mandatory field in activitypub, lemmy currently serves an empty outbox
-  pub(crate) outbox: Url,
-  pub(crate) public_key: PublicKey,
+    #[serde(rename = "type")]
+    pub(crate) kind: ApplicationType,
+    pub(crate) id: ObjectId<ApubSite>,
+    // site name
+    pub(crate) name: String,
+    pub(crate) inbox: Url,
+    /// mandatory field in activitypub, lemmy currently serves an empty outbox
+    pub(crate) outbox: Url,
+    pub(crate) public_key: PublicKey,
 
-  // sidebar
-  pub(crate) content: Option<String>,
-  #[serde(deserialize_with = "deserialize_skip_error", default)]
-  pub(crate) source: Option<Source>,
-  // short instance description
-  pub(crate) summary: Option<String>,
-  pub(crate) media_type: Option<MediaTypeHtml>,
-  /// instance icon
-  pub(crate) icon: Option<ImageObject>,
-  /// instance banner
-  pub(crate) image: Option<ImageObject>,
-  #[serde(default)]
-  pub(crate) language: Vec<LanguageTag>,
-  pub(crate) published: DateTime<Utc>,
-  pub(crate) updated: Option<DateTime<Utc>>,
+    // sidebar
+    pub(crate) content: Option<String>,
+    #[serde(deserialize_with = "deserialize_skip_error", default)]
+    pub(crate) source: Option<Source>,
+    // short instance description
+    pub(crate) summary: Option<String>,
+    pub(crate) media_type: Option<MediaTypeHtml>,
+    /// instance icon
+    pub(crate) icon: Option<ImageObject>,
+    /// instance banner
+    pub(crate) image: Option<ImageObject>,
+    #[serde(default)]
+    pub(crate) language: Vec<LanguageTag>,
+    pub(crate) published: DateTime<Utc>,
+    pub(crate) updated: Option<DateTime<Utc>>,
 }

--- a/crates/apub/src/protocol/objects/mod.rs
+++ b/crates/apub/src/protocol/objects/mod.rs
@@ -1,8 +1,6 @@
 use lemmy_db_schema::{
-  impls::actor_language::UNDETERMINED_ID,
-  newtypes::LanguageId,
-  source::language::Language,
-  utils::DbPool,
+    impls::actor_language::UNDETERMINED_ID, newtypes::LanguageId, source::language::Language,
+    utils::DbPool,
 };
 use lemmy_utils::error::LemmyError;
 use serde::{Deserialize, Serialize};
@@ -19,168 +17,163 @@ pub(crate) mod tombstone;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Endpoints {
-  pub shared_inbox: Url,
+    pub shared_inbox: Url,
 }
 
 /// As specified in https://schema.org/Language
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct LanguageTag {
-  pub(crate) identifier: String,
-  pub(crate) name: String,
+    pub(crate) identifier: String,
+    pub(crate) name: String,
 }
 
 impl LanguageTag {
-  pub(crate) async fn new_single(
-    lang: LanguageId,
-    pool: &mut DbPool<'_>,
-  ) -> Result<Option<LanguageTag>, LemmyError> {
-    let lang = Language::read_from_id(pool, lang).await?;
+    pub(crate) async fn new_single(
+        lang: LanguageId,
+        pool: &mut DbPool<'_>,
+    ) -> Result<Option<LanguageTag>, LemmyError> {
+        let lang = Language::read_from_id(pool, lang).await?;
 
-    // undetermined
-    if lang.id == UNDETERMINED_ID {
-      Ok(None)
-    } else {
-      Ok(Some(LanguageTag {
-        identifier: lang.code,
-        name: lang.name,
-      }))
-    }
-  }
-
-  pub(crate) async fn new_multiple(
-    lang_ids: Vec<LanguageId>,
-    pool: &mut DbPool<'_>,
-  ) -> Result<Vec<LanguageTag>, LemmyError> {
-    let mut langs = Vec::<Language>::new();
-
-    for l in lang_ids {
-      langs.push(Language::read_from_id(pool, l).await?);
+        // undetermined
+        if lang.id == UNDETERMINED_ID {
+            Ok(None)
+        } else {
+            Ok(Some(LanguageTag {
+                identifier: lang.code,
+                name: lang.name,
+            }))
+        }
     }
 
-    let langs = langs
-      .into_iter()
-      .map(|l| LanguageTag {
-        identifier: l.code,
-        name: l.name,
-      })
-      .collect();
-    Ok(langs)
-  }
+    pub(crate) async fn new_multiple(
+        lang_ids: Vec<LanguageId>,
+        pool: &mut DbPool<'_>,
+    ) -> Result<Vec<LanguageTag>, LemmyError> {
+        let mut langs = Vec::<Language>::new();
 
-  pub(crate) async fn to_language_id_single(
-    lang: Option<Self>,
-    pool: &mut DbPool<'_>,
-  ) -> Result<Option<LanguageId>, LemmyError> {
-    let identifier = lang.map(|l| l.identifier);
-    let language = Language::read_id_from_code(pool, identifier.as_deref()).await?;
+        for l in lang_ids {
+            langs.push(Language::read_from_id(pool, l).await?);
+        }
 
-    Ok(language)
-  }
-
-  pub(crate) async fn to_language_id_multiple(
-    langs: Vec<Self>,
-    pool: &mut DbPool<'_>,
-  ) -> Result<Vec<LanguageId>, LemmyError> {
-    let mut language_ids = Vec::new();
-
-    for l in langs {
-      let id = l.identifier;
-      language_ids.push(Language::read_id_from_code(pool, Some(&id)).await?);
+        let langs = langs
+            .into_iter()
+            .map(|l| LanguageTag {
+                identifier: l.code,
+                name: l.name,
+            })
+            .collect();
+        Ok(langs)
     }
 
-    Ok(language_ids.into_iter().flatten().collect())
-  }
+    pub(crate) async fn to_language_id_single(
+        lang: Option<Self>,
+        pool: &mut DbPool<'_>,
+    ) -> Result<Option<LanguageId>, LemmyError> {
+        let identifier = lang.map(|l| l.identifier);
+        let language = Language::read_id_from_code(pool, identifier.as_deref()).await?;
+
+        Ok(language)
+    }
+
+    pub(crate) async fn to_language_id_multiple(
+        langs: Vec<Self>,
+        pool: &mut DbPool<'_>,
+    ) -> Result<Vec<LanguageId>, LemmyError> {
+        let mut language_ids = Vec::new();
+
+        for l in langs {
+            let id = l.identifier;
+            language_ids.push(Language::read_id_from_code(pool, Some(&id)).await?);
+        }
+
+        Ok(language_ids.into_iter().flatten().collect())
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::protocol::{
-    objects::{
-      chat_message::ChatMessage,
-      group::Group,
-      instance::Instance,
-      note::Note,
-      page::Page,
-      person::Person,
-      tombstone::Tombstone,
-    },
-    tests::{test_json, test_parse_lemmy_item},
-  };
+    use crate::protocol::{
+        objects::{
+            chat_message::ChatMessage, group::Group, instance::Instance, note::Note, page::Page,
+            person::Person, tombstone::Tombstone,
+        },
+        tests::{test_json, test_parse_lemmy_item},
+    };
 
-  #[test]
-  fn test_parse_objects_lemmy() {
-    test_parse_lemmy_item::<Instance>("assets/lemmy/objects/instance.json").unwrap();
-    test_parse_lemmy_item::<Group>("assets/lemmy/objects/group.json").unwrap();
-    test_parse_lemmy_item::<Person>("assets/lemmy/objects/person.json").unwrap();
-    test_parse_lemmy_item::<Page>("assets/lemmy/objects/page.json").unwrap();
-    test_parse_lemmy_item::<Note>("assets/lemmy/objects/note.json").unwrap();
-    test_parse_lemmy_item::<ChatMessage>("assets/lemmy/objects/chat_message.json").unwrap();
-    test_parse_lemmy_item::<Tombstone>("assets/lemmy/objects/tombstone.json").unwrap();
-  }
+    #[test]
+    fn test_parse_objects_lemmy() {
+        test_parse_lemmy_item::<Instance>("assets/lemmy/objects/instance.json").unwrap();
+        test_parse_lemmy_item::<Group>("assets/lemmy/objects/group.json").unwrap();
+        test_parse_lemmy_item::<Person>("assets/lemmy/objects/person.json").unwrap();
+        test_parse_lemmy_item::<Page>("assets/lemmy/objects/page.json").unwrap();
+        test_parse_lemmy_item::<Note>("assets/lemmy/objects/note.json").unwrap();
+        test_parse_lemmy_item::<ChatMessage>("assets/lemmy/objects/chat_message.json").unwrap();
+        test_parse_lemmy_item::<Tombstone>("assets/lemmy/objects/tombstone.json").unwrap();
+    }
 
-  #[test]
-  fn test_parse_objects_pleroma() {
-    test_json::<Person>("assets/pleroma/objects/person.json").unwrap();
-    test_json::<Note>("assets/pleroma/objects/note.json").unwrap();
-    test_json::<ChatMessage>("assets/pleroma/objects/chat_message.json").unwrap();
-  }
+    #[test]
+    fn test_parse_objects_pleroma() {
+        test_json::<Person>("assets/pleroma/objects/person.json").unwrap();
+        test_json::<Note>("assets/pleroma/objects/note.json").unwrap();
+        test_json::<ChatMessage>("assets/pleroma/objects/chat_message.json").unwrap();
+    }
 
-  #[test]
-  fn test_parse_objects_smithereen() {
-    test_json::<Person>("assets/smithereen/objects/person.json").unwrap();
-    test_json::<Note>("assets/smithereen/objects/note.json").unwrap();
-  }
+    #[test]
+    fn test_parse_objects_smithereen() {
+        test_json::<Person>("assets/smithereen/objects/person.json").unwrap();
+        test_json::<Note>("assets/smithereen/objects/note.json").unwrap();
+    }
 
-  #[test]
-  fn test_parse_objects_mastodon() {
-    test_json::<Person>("assets/mastodon/objects/person.json").unwrap();
-    test_json::<Note>("assets/mastodon/objects/note.json").unwrap();
-    test_json::<Page>("assets/mastodon/objects/page.json").unwrap();
-  }
+    #[test]
+    fn test_parse_objects_mastodon() {
+        test_json::<Person>("assets/mastodon/objects/person.json").unwrap();
+        test_json::<Note>("assets/mastodon/objects/note.json").unwrap();
+        test_json::<Page>("assets/mastodon/objects/page.json").unwrap();
+    }
 
-  #[test]
-  fn test_parse_objects_lotide() {
-    test_json::<Group>("assets/lotide/objects/group.json").unwrap();
-    test_json::<Person>("assets/lotide/objects/person.json").unwrap();
-    test_json::<Note>("assets/lotide/objects/note.json").unwrap();
-    test_json::<Page>("assets/lotide/objects/page.json").unwrap();
-    test_json::<Tombstone>("assets/lotide/objects/tombstone.json").unwrap();
-  }
+    #[test]
+    fn test_parse_objects_lotide() {
+        test_json::<Group>("assets/lotide/objects/group.json").unwrap();
+        test_json::<Person>("assets/lotide/objects/person.json").unwrap();
+        test_json::<Note>("assets/lotide/objects/note.json").unwrap();
+        test_json::<Page>("assets/lotide/objects/page.json").unwrap();
+        test_json::<Tombstone>("assets/lotide/objects/tombstone.json").unwrap();
+    }
 
-  #[test]
-  fn test_parse_object_friendica() {
-    test_json::<Person>("assets/friendica/objects/person_1.json").unwrap();
-    test_json::<Person>("assets/friendica/objects/person_2.json").unwrap();
-    test_json::<Page>("assets/friendica/objects/page_1.json").unwrap();
-    test_json::<Page>("assets/friendica/objects/page_2.json").unwrap();
-    test_json::<Note>("assets/friendica/objects/note_1.json").unwrap();
-    test_json::<Note>("assets/friendica/objects/note_2.json").unwrap();
-  }
+    #[test]
+    fn test_parse_object_friendica() {
+        test_json::<Person>("assets/friendica/objects/person_1.json").unwrap();
+        test_json::<Person>("assets/friendica/objects/person_2.json").unwrap();
+        test_json::<Page>("assets/friendica/objects/page_1.json").unwrap();
+        test_json::<Page>("assets/friendica/objects/page_2.json").unwrap();
+        test_json::<Note>("assets/friendica/objects/note_1.json").unwrap();
+        test_json::<Note>("assets/friendica/objects/note_2.json").unwrap();
+    }
 
-  #[test]
-  fn test_parse_object_gnusocial() {
-    test_json::<Person>("assets/gnusocial/objects/person.json").unwrap();
-    test_json::<Group>("assets/gnusocial/objects/group.json").unwrap();
-    test_json::<Page>("assets/gnusocial/objects/page.json").unwrap();
-    test_json::<Note>("assets/gnusocial/objects/note.json").unwrap();
-  }
+    #[test]
+    fn test_parse_object_gnusocial() {
+        test_json::<Person>("assets/gnusocial/objects/person.json").unwrap();
+        test_json::<Group>("assets/gnusocial/objects/group.json").unwrap();
+        test_json::<Page>("assets/gnusocial/objects/page.json").unwrap();
+        test_json::<Note>("assets/gnusocial/objects/note.json").unwrap();
+    }
 
-  #[test]
-  fn test_parse_object_peertube() {
-    test_json::<Person>("assets/peertube/objects/person.json").unwrap();
-    test_json::<Group>("assets/peertube/objects/group.json").unwrap();
-    test_json::<Page>("assets/peertube/objects/video.json").unwrap();
-    test_json::<Note>("assets/peertube/objects/note.json").unwrap();
-  }
+    #[test]
+    fn test_parse_object_peertube() {
+        test_json::<Person>("assets/peertube/objects/person.json").unwrap();
+        test_json::<Group>("assets/peertube/objects/group.json").unwrap();
+        test_json::<Page>("assets/peertube/objects/video.json").unwrap();
+        test_json::<Note>("assets/peertube/objects/note.json").unwrap();
+    }
 
-  #[test]
-  fn test_parse_object_mobilizon() {
-    test_json::<Group>("assets/mobilizon/objects/group.json").unwrap();
-    test_json::<Page>("assets/mobilizon/objects/event.json").unwrap();
-    test_json::<Person>("assets/mobilizon/objects/person.json").unwrap();
-  }
+    #[test]
+    fn test_parse_object_mobilizon() {
+        test_json::<Group>("assets/mobilizon/objects/group.json").unwrap();
+        test_json::<Page>("assets/mobilizon/objects/event.json").unwrap();
+        test_json::<Person>("assets/mobilizon/objects/person.json").unwrap();
+    }
 }

--- a/crates/apub/src/protocol/objects/note.rs
+++ b/crates/apub/src/protocol/objects/note.rs
@@ -1,24 +1,24 @@
 use crate::{
-  activities::verify_community_matches,
-  fetcher::post_or_comment::PostOrComment,
-  mentions::MentionOrValue,
-  objects::{comment::ApubComment, community::ApubCommunity, person::ApubPerson, post::ApubPost},
-  protocol::{objects::LanguageTag, InCommunity, Source},
+    activities::verify_community_matches,
+    fetcher::post_or_comment::PostOrComment,
+    mentions::MentionOrValue,
+    objects::{comment::ApubComment, community::ApubCommunity, person::ApubPerson, post::ApubPost},
+    protocol::{objects::LanguageTag, InCommunity, Source},
 };
 use activitypub_federation::{
-  config::Data,
-  fetch::object_id::ObjectId,
-  kinds::object::NoteType,
-  protocol::{
-    helpers::{deserialize_one_or_many, deserialize_skip_error},
-    values::MediaTypeMarkdownOrHtml,
-  },
+    config::Data,
+    fetch::object_id::ObjectId,
+    kinds::object::NoteType,
+    protocol::{
+        helpers::{deserialize_one_or_many, deserialize_skip_error},
+        values::MediaTypeMarkdownOrHtml,
+    },
 };
 use chrono::{DateTime, Utc};
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::{
-  source::{community::Community, post::Post},
-  traits::Crud,
+    source::{community::Community, post::Post},
+    traits::Crud,
 };
 use lemmy_utils::error::LemmyError;
 use serde::{Deserialize, Serialize};
@@ -30,55 +30,55 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Note {
-  pub(crate) r#type: NoteType,
-  pub(crate) id: ObjectId<ApubComment>,
-  pub(crate) attributed_to: ObjectId<ApubPerson>,
-  #[serde(deserialize_with = "deserialize_one_or_many")]
-  pub(crate) to: Vec<Url>,
-  #[serde(deserialize_with = "deserialize_one_or_many", default)]
-  pub(crate) cc: Vec<Url>,
-  pub(crate) content: String,
-  pub(crate) in_reply_to: ObjectId<PostOrComment>,
+    pub(crate) r#type: NoteType,
+    pub(crate) id: ObjectId<ApubComment>,
+    pub(crate) attributed_to: ObjectId<ApubPerson>,
+    #[serde(deserialize_with = "deserialize_one_or_many")]
+    pub(crate) to: Vec<Url>,
+    #[serde(deserialize_with = "deserialize_one_or_many", default)]
+    pub(crate) cc: Vec<Url>,
+    pub(crate) content: String,
+    pub(crate) in_reply_to: ObjectId<PostOrComment>,
 
-  pub(crate) media_type: Option<MediaTypeMarkdownOrHtml>,
-  #[serde(deserialize_with = "deserialize_skip_error", default)]
-  pub(crate) source: Option<Source>,
-  pub(crate) published: Option<DateTime<Utc>>,
-  pub(crate) updated: Option<DateTime<Utc>>,
-  #[serde(default)]
-  pub(crate) tag: Vec<MentionOrValue>,
-  // lemmy extension
-  pub(crate) distinguished: Option<bool>,
-  pub(crate) language: Option<LanguageTag>,
-  pub(crate) audience: Option<ObjectId<ApubCommunity>>,
+    pub(crate) media_type: Option<MediaTypeMarkdownOrHtml>,
+    #[serde(deserialize_with = "deserialize_skip_error", default)]
+    pub(crate) source: Option<Source>,
+    pub(crate) published: Option<DateTime<Utc>>,
+    pub(crate) updated: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub(crate) tag: Vec<MentionOrValue>,
+    // lemmy extension
+    pub(crate) distinguished: Option<bool>,
+    pub(crate) language: Option<LanguageTag>,
+    pub(crate) audience: Option<ObjectId<ApubCommunity>>,
 }
 
 impl Note {
-  pub(crate) async fn get_parents(
-    &self,
-    context: &Data<LemmyContext>,
-  ) -> Result<(ApubPost, Option<ApubComment>), LemmyError> {
-    // Fetch parent comment chain in a box, otherwise it can cause a stack overflow.
-    let parent = Box::pin(self.in_reply_to.dereference(context).await?);
-    match parent.deref() {
-      PostOrComment::Post(p) => Ok((p.clone(), None)),
-      PostOrComment::Comment(c) => {
-        let post_id = c.post_id;
-        let post = Post::read(&mut context.pool(), post_id).await?;
-        Ok((post.into(), Some(c.clone())))
-      }
+    pub(crate) async fn get_parents(
+        &self,
+        context: &Data<LemmyContext>,
+    ) -> Result<(ApubPost, Option<ApubComment>), LemmyError> {
+        // Fetch parent comment chain in a box, otherwise it can cause a stack overflow.
+        let parent = Box::pin(self.in_reply_to.dereference(context).await?);
+        match parent.deref() {
+            PostOrComment::Post(p) => Ok((p.clone(), None)),
+            PostOrComment::Comment(c) => {
+                let post_id = c.post_id;
+                let post = Post::read(&mut context.pool(), post_id).await?;
+                Ok((post.into(), Some(c.clone())))
+            }
+        }
     }
-  }
 }
 
 #[async_trait::async_trait]
 impl InCommunity for Note {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
-    let (post, _) = self.get_parents(context).await?;
-    let community = Community::read(&mut context.pool(), post.community_id).await?;
-    if let Some(audience) = &self.audience {
-      verify_community_matches(audience, community.actor_id.clone())?;
+    async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+        let (post, _) = self.get_parents(context).await?;
+        let community = Community::read(&mut context.pool(), post.community_id).await?;
+        if let Some(audience) = &self.audience {
+            verify_community_matches(audience, community.actor_id.clone())?;
+        }
+        Ok(community.into())
     }
-    Ok(community.into())
-  }
 }

--- a/crates/apub/src/protocol/objects/page.rs
+++ b/crates/apub/src/protocol/objects/page.rs
@@ -1,21 +1,21 @@
 use crate::{
-  activities::verify_community_matches,
-  fetcher::user_or_community::{PersonOrGroupType, UserOrCommunity},
-  objects::{community::ApubCommunity, person::ApubPerson, post::ApubPost},
-  protocol::{objects::LanguageTag, ImageObject, InCommunity, Source},
+    activities::verify_community_matches,
+    fetcher::user_or_community::{PersonOrGroupType, UserOrCommunity},
+    objects::{community::ApubCommunity, person::ApubPerson, post::ApubPost},
+    protocol::{objects::LanguageTag, ImageObject, InCommunity, Source},
 };
 use activitypub_federation::{
-  config::Data,
-  fetch::object_id::ObjectId,
-  kinds::{
-    link::LinkType,
-    object::{DocumentType, ImageType},
-  },
-  protocol::{
-    helpers::{deserialize_one_or_many, deserialize_skip_error},
-    values::MediaTypeMarkdownOrHtml,
-  },
-  traits::{ActivityHandler, Object},
+    config::Data,
+    fetch::object_id::ObjectId,
+    kinds::{
+        link::LinkType,
+        object::{DocumentType, ImageType},
+    },
+    protocol::{
+        helpers::{deserialize_one_or_many, deserialize_skip_error},
+        values::MediaTypeMarkdownOrHtml,
+    },
+    traits::{ActivityHandler, Object},
 };
 use chrono::{DateTime, Utc};
 use itertools::Itertools;
@@ -28,227 +28,227 @@ use url::Url;
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub enum PageType {
-  Page,
-  Article,
-  Note,
-  Video,
-  Event,
+    Page,
+    Article,
+    Note,
+    Video,
+    Event,
 }
 
 #[skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Page {
-  #[serde(rename = "type")]
-  pub(crate) kind: PageType,
-  pub(crate) id: ObjectId<ApubPost>,
-  pub(crate) attributed_to: AttributedTo,
-  #[serde(deserialize_with = "deserialize_one_or_many")]
-  pub(crate) to: Vec<Url>,
-  // If there is inReplyTo field this is actually a comment and must not be parsed
-  #[serde(deserialize_with = "deserialize_not_present", default)]
-  pub(crate) in_reply_to: Option<String>,
+    #[serde(rename = "type")]
+    pub(crate) kind: PageType,
+    pub(crate) id: ObjectId<ApubPost>,
+    pub(crate) attributed_to: AttributedTo,
+    #[serde(deserialize_with = "deserialize_one_or_many")]
+    pub(crate) to: Vec<Url>,
+    // If there is inReplyTo field this is actually a comment and must not be parsed
+    #[serde(deserialize_with = "deserialize_not_present", default)]
+    pub(crate) in_reply_to: Option<String>,
 
-  pub(crate) name: Option<String>,
-  #[serde(deserialize_with = "deserialize_one_or_many", default)]
-  pub(crate) cc: Vec<Url>,
-  pub(crate) content: Option<String>,
-  pub(crate) media_type: Option<MediaTypeMarkdownOrHtml>,
-  #[serde(deserialize_with = "deserialize_skip_error", default)]
-  pub(crate) source: Option<Source>,
-  /// most software uses array type for attachment field, so we do the same. nevertheless, we only
-  /// use the first item
-  #[serde(default)]
-  pub(crate) attachment: Vec<Attachment>,
-  pub(crate) image: Option<ImageObject>,
-  pub(crate) comments_enabled: Option<bool>,
-  pub(crate) sensitive: Option<bool>,
-  pub(crate) published: Option<DateTime<Utc>>,
-  pub(crate) updated: Option<DateTime<Utc>>,
-  pub(crate) language: Option<LanguageTag>,
-  pub(crate) audience: Option<ObjectId<ApubCommunity>>,
+    pub(crate) name: Option<String>,
+    #[serde(deserialize_with = "deserialize_one_or_many", default)]
+    pub(crate) cc: Vec<Url>,
+    pub(crate) content: Option<String>,
+    pub(crate) media_type: Option<MediaTypeMarkdownOrHtml>,
+    #[serde(deserialize_with = "deserialize_skip_error", default)]
+    pub(crate) source: Option<Source>,
+    /// most software uses array type for attachment field, so we do the same. nevertheless, we only
+    /// use the first item
+    #[serde(default)]
+    pub(crate) attachment: Vec<Attachment>,
+    pub(crate) image: Option<ImageObject>,
+    pub(crate) comments_enabled: Option<bool>,
+    pub(crate) sensitive: Option<bool>,
+    pub(crate) published: Option<DateTime<Utc>>,
+    pub(crate) updated: Option<DateTime<Utc>>,
+    pub(crate) language: Option<LanguageTag>,
+    pub(crate) audience: Option<ObjectId<ApubCommunity>>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Link {
-  pub(crate) href: Url,
-  pub(crate) r#type: LinkType,
+    pub(crate) href: Url,
+    pub(crate) r#type: LinkType,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Image {
-  #[serde(rename = "type")]
-  pub(crate) kind: ImageType,
-  pub(crate) url: Url,
+    #[serde(rename = "type")]
+    pub(crate) kind: ImageType,
+    pub(crate) url: Url,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Document {
-  #[serde(rename = "type")]
-  pub(crate) kind: DocumentType,
-  pub(crate) url: Url,
+    #[serde(rename = "type")]
+    pub(crate) kind: DocumentType,
+    pub(crate) url: Url,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub(crate) enum Attachment {
-  Link(Link),
-  Image(Image),
-  Document(Document),
+    Link(Link),
+    Image(Image),
+    Document(Document),
 }
 
 impl Attachment {
-  pub(crate) fn url(self) -> Url {
-    match self {
-      // url as sent by Lemmy (new)
-      Attachment::Link(l) => l.href,
-      // image sent by lotide
-      Attachment::Image(i) => i.url,
-      // sent by mobilizon
-      Attachment::Document(d) => d.url,
+    pub(crate) fn url(self) -> Url {
+        match self {
+            // url as sent by Lemmy (new)
+            Attachment::Link(l) => l.href,
+            // image sent by lotide
+            Attachment::Image(i) => i.url,
+            // sent by mobilizon
+            Attachment::Document(d) => d.url,
+        }
     }
-  }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub(crate) enum AttributedTo {
-  Lemmy(ObjectId<ApubPerson>),
-  Peertube([AttributedToPeertube; 2]),
+    Lemmy(ObjectId<ApubPerson>),
+    Peertube([AttributedToPeertube; 2]),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct AttributedToPeertube {
-  #[serde(rename = "type")]
-  pub kind: PersonOrGroupType,
-  pub id: ObjectId<UserOrCommunity>,
+    #[serde(rename = "type")]
+    pub kind: PersonOrGroupType,
+    pub id: ObjectId<UserOrCommunity>,
 }
 
 impl Page {
-  /// Only mods can change the post's locked status. So if it is changed from the default value,
-  /// it is a mod action and needs to be verified as such.
-  ///
-  /// Locked needs to be false on a newly created post (verified in [[CreatePost]].
-  pub(crate) async fn is_mod_action(
-    &self,
-    context: &Data<LemmyContext>,
-  ) -> Result<bool, LemmyError> {
-    let old_post = self.id.clone().dereference_local(context).await;
-    Ok(Page::is_locked_changed(&old_post, &self.comments_enabled))
-  }
-
-  pub(crate) fn is_locked_changed<E>(
-    old_post: &Result<ApubPost, E>,
-    new_comments_enabled: &Option<bool>,
-  ) -> bool {
-    if let Some(new_comments_enabled) = new_comments_enabled {
-      if let Ok(old_post) = old_post {
-        return new_comments_enabled != &!old_post.locked;
-      }
+    /// Only mods can change the post's locked status. So if it is changed from the default value,
+    /// it is a mod action and needs to be verified as such.
+    ///
+    /// Locked needs to be false on a newly created post (verified in [[CreatePost]].
+    pub(crate) async fn is_mod_action(
+        &self,
+        context: &Data<LemmyContext>,
+    ) -> Result<bool, LemmyError> {
+        let old_post = self.id.clone().dereference_local(context).await;
+        Ok(Page::is_locked_changed(&old_post, &self.comments_enabled))
     }
 
-    false
-  }
+    pub(crate) fn is_locked_changed<E>(
+        old_post: &Result<ApubPost, E>,
+        new_comments_enabled: &Option<bool>,
+    ) -> bool {
+        if let Some(new_comments_enabled) = new_comments_enabled {
+            if let Ok(old_post) = old_post {
+                return new_comments_enabled != &!old_post.locked;
+            }
+        }
 
-  pub(crate) fn creator(&self) -> Result<ObjectId<ApubPerson>, LemmyError> {
-    match &self.attributed_to {
-      AttributedTo::Lemmy(l) => Ok(l.clone()),
-      AttributedTo::Peertube(p) => p
-        .iter()
-        .find(|a| a.kind == PersonOrGroupType::Person)
-        .map(|a| ObjectId::<ApubPerson>::from(a.id.clone().into_inner()))
-        .ok_or_else(|| LemmyErrorType::PageDoesNotSpecifyCreator.into()),
+        false
     }
-  }
+
+    pub(crate) fn creator(&self) -> Result<ObjectId<ApubPerson>, LemmyError> {
+        match &self.attributed_to {
+            AttributedTo::Lemmy(l) => Ok(l.clone()),
+            AttributedTo::Peertube(p) => p
+                .iter()
+                .find(|a| a.kind == PersonOrGroupType::Person)
+                .map(|a| ObjectId::<ApubPerson>::from(a.id.clone().into_inner()))
+                .ok_or_else(|| LemmyErrorType::PageDoesNotSpecifyCreator.into()),
+        }
+    }
 }
 
 impl Attachment {
-  pub(crate) fn new(url: DbUrl) -> Attachment {
-    Attachment::Link(Link {
-      href: url.into(),
-      r#type: Default::default(),
-    })
-  }
+    pub(crate) fn new(url: DbUrl) -> Attachment {
+        Attachment::Link(Link {
+            href: url.into(),
+            r#type: Default::default(),
+        })
+    }
 }
 
 // Used for community outbox, so that it can be compatible with Pleroma/Mastodon.
 #[async_trait::async_trait]
 impl ActivityHandler for Page {
-  type DataType = LemmyContext;
-  type Error = LemmyError;
-  fn id(&self) -> &Url {
-    unimplemented!()
-  }
-  fn actor(&self) -> &Url {
-    unimplemented!()
-  }
-  async fn verify(&self, data: &Data<Self::DataType>) -> Result<(), LemmyError> {
-    ApubPost::verify(self, self.id.inner(), data).await
-  }
-  async fn receive(self, data: &Data<Self::DataType>) -> Result<(), LemmyError> {
-    ApubPost::from_json(self, data).await?;
-    Ok(())
-  }
+    type DataType = LemmyContext;
+    type Error = LemmyError;
+    fn id(&self) -> &Url {
+        unimplemented!()
+    }
+    fn actor(&self) -> &Url {
+        unimplemented!()
+    }
+    async fn verify(&self, data: &Data<Self::DataType>) -> Result<(), LemmyError> {
+        ApubPost::verify(self, self.id.inner(), data).await
+    }
+    async fn receive(self, data: &Data<Self::DataType>) -> Result<(), LemmyError> {
+        ApubPost::from_json(self, data).await?;
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait]
 impl InCommunity for Page {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
-    let community = match &self.attributed_to {
-      AttributedTo::Lemmy(_) => {
-        let mut iter = self.to.iter().merge(self.cc.iter());
-        loop {
-          if let Some(cid) = iter.next() {
-            let cid = ObjectId::from(cid.clone());
-            if let Ok(c) = cid.dereference(context).await {
-              break c;
+    async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+        let community = match &self.attributed_to {
+            AttributedTo::Lemmy(_) => {
+                let mut iter = self.to.iter().merge(self.cc.iter());
+                loop {
+                    if let Some(cid) = iter.next() {
+                        let cid = ObjectId::from(cid.clone());
+                        if let Ok(c) = cid.dereference(context).await {
+                            break c;
+                        }
+                    } else {
+                        Err(LemmyErrorType::NoCommunityFoundInCc)?
+                    }
+                }
             }
-          } else {
-            Err(LemmyErrorType::NoCommunityFoundInCc)?
-          }
+            AttributedTo::Peertube(p) => {
+                p.iter()
+                    .find(|a| a.kind == PersonOrGroupType::Group)
+                    .map(|a| ObjectId::<ApubCommunity>::from(a.id.clone().into_inner()))
+                    .ok_or(LemmyErrorType::PageDoesNotSpecifyGroup)?
+                    .dereference(context)
+                    .await?
+            }
+        };
+        if let Some(audience) = &self.audience {
+            verify_community_matches(audience, community.actor_id.clone())?;
         }
-      }
-      AttributedTo::Peertube(p) => {
-        p.iter()
-          .find(|a| a.kind == PersonOrGroupType::Group)
-          .map(|a| ObjectId::<ApubCommunity>::from(a.id.clone().into_inner()))
-          .ok_or(LemmyErrorType::PageDoesNotSpecifyGroup)?
-          .dereference(context)
-          .await?
-      }
-    };
-    if let Some(audience) = &self.audience {
-      verify_community_matches(audience, community.actor_id.clone())?;
+        Ok(community)
     }
-    Ok(community)
-  }
 }
 
 /// Only allows deserialization if the field is missing or null. If it is present, throws an error.
 pub fn deserialize_not_present<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
 where
-  D: Deserializer<'de>,
+    D: Deserializer<'de>,
 {
-  let result: Option<String> = Deserialize::deserialize(deserializer)?;
-  match result {
-    None => Ok(None),
-    Some(_) => Err(D::Error::custom("Post must not have inReplyTo property")),
-  }
+    let result: Option<String> = Deserialize::deserialize(deserializer)?;
+    match result {
+        None => Ok(None),
+        Some(_) => Err(D::Error::custom("Post must not have inReplyTo property")),
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::protocol::{objects::page::Page, tests::test_parse_lemmy_item};
+    use crate::protocol::{objects::page::Page, tests::test_parse_lemmy_item};
 
-  #[test]
-  fn test_not_parsing_note_as_page() {
-    assert!(test_parse_lemmy_item::<Page>("assets/lemmy/objects/note.json").is_err());
-  }
+    #[test]
+    fn test_not_parsing_note_as_page() {
+        assert!(test_parse_lemmy_item::<Page>("assets/lemmy/objects/note.json").is_err());
+    }
 }

--- a/crates/apub/src/protocol/objects/person.rs
+++ b/crates/apub/src/protocol/objects/person.rs
@@ -1,10 +1,10 @@
 use crate::{
-  objects::person::ApubPerson,
-  protocol::{objects::Endpoints, ImageObject, Source},
+    objects::person::ApubPerson,
+    protocol::{objects::Endpoints, ImageObject, Source},
 };
 use activitypub_federation::{
-  fetch::object_id::ObjectId,
-  protocol::{helpers::deserialize_skip_error, public_key::PublicKey},
+    fetch::object_id::ObjectId,
+    protocol::{helpers::deserialize_skip_error, public_key::PublicKey},
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -13,36 +13,36 @@ use url::Url;
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub enum UserTypes {
-  Person,
-  Service,
-  Organization,
+    Person,
+    Service,
+    Organization,
 }
 
 #[skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Person {
-  #[serde(rename = "type")]
-  pub(crate) kind: UserTypes,
-  pub(crate) id: ObjectId<ApubPerson>,
-  /// username, set at account creation and usually fixed after that
-  pub(crate) preferred_username: String,
-  pub(crate) inbox: Url,
-  /// mandatory field in activitypub, lemmy currently serves an empty outbox
-  pub(crate) outbox: Url,
-  pub(crate) public_key: PublicKey,
+    #[serde(rename = "type")]
+    pub(crate) kind: UserTypes,
+    pub(crate) id: ObjectId<ApubPerson>,
+    /// username, set at account creation and usually fixed after that
+    pub(crate) preferred_username: String,
+    pub(crate) inbox: Url,
+    /// mandatory field in activitypub, lemmy currently serves an empty outbox
+    pub(crate) outbox: Url,
+    pub(crate) public_key: PublicKey,
 
-  /// displayname
-  pub(crate) name: Option<String>,
-  pub(crate) summary: Option<String>,
-  #[serde(deserialize_with = "deserialize_skip_error", default)]
-  pub(crate) source: Option<Source>,
-  /// user avatar
-  pub(crate) icon: Option<ImageObject>,
-  /// user banner
-  pub(crate) image: Option<ImageObject>,
-  pub(crate) matrix_user_id: Option<String>,
-  pub(crate) endpoints: Option<Endpoints>,
-  pub(crate) published: Option<DateTime<Utc>>,
-  pub(crate) updated: Option<DateTime<Utc>>,
+    /// displayname
+    pub(crate) name: Option<String>,
+    pub(crate) summary: Option<String>,
+    #[serde(deserialize_with = "deserialize_skip_error", default)]
+    pub(crate) source: Option<Source>,
+    /// user avatar
+    pub(crate) icon: Option<ImageObject>,
+    /// user banner
+    pub(crate) image: Option<ImageObject>,
+    pub(crate) matrix_user_id: Option<String>,
+    pub(crate) endpoints: Option<Endpoints>,
+    pub(crate) published: Option<DateTime<Utc>>,
+    pub(crate) updated: Option<DateTime<Utc>>,
 }

--- a/crates/apub/src/protocol/objects/tombstone.rs
+++ b/crates/apub/src/protocol/objects/tombstone.rs
@@ -8,22 +8,22 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Tombstone {
-  pub(crate) id: Url,
-  #[serde(rename = "type")]
-  pub(crate) kind: TombstoneType,
+    pub(crate) id: Url,
+    #[serde(rename = "type")]
+    pub(crate) kind: TombstoneType,
 }
 
 impl Tombstone {
-  pub fn new(id: Url) -> Tombstone {
-    Tombstone {
-      id,
-      kind: TombstoneType::Tombstone,
+    pub fn new(id: Url) -> Tombstone {
+        Tombstone {
+            id,
+            kind: TombstoneType::Tombstone,
+        }
     }
-  }
 }
 
 impl Id for Tombstone {
-  fn object_id(&self) -> &Url {
-    &self.id
-  }
+    fn object_id(&self) -> &Url {
+        &self.id
+    }
 }

--- a/crates/db_schema/src/aggregates/comment_aggregates.rs
+++ b/crates/db_schema/src/aggregates/comment_aggregates.rs
@@ -1,185 +1,185 @@
 use crate::{
-  aggregates::structs::CommentAggregates,
-  newtypes::CommentId,
-  schema::comment_aggregates,
-  utils::{functions::hot_rank, get_conn, DbPool},
+    aggregates::structs::CommentAggregates,
+    newtypes::CommentId,
+    schema::comment_aggregates,
+    utils::{functions::hot_rank, get_conn, DbPool},
 };
 use diesel::{result::Error, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 
 impl CommentAggregates {
-  pub async fn read(pool: &mut DbPool<'_>, comment_id: CommentId) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    comment_aggregates::table
-      .filter(comment_aggregates::comment_id.eq(comment_id))
-      .first::<Self>(conn)
-      .await
-  }
+    pub async fn read(pool: &mut DbPool<'_>, comment_id: CommentId) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        comment_aggregates::table
+            .filter(comment_aggregates::comment_id.eq(comment_id))
+            .first::<Self>(conn)
+            .await
+    }
 
-  pub async fn update_hot_rank(
-    pool: &mut DbPool<'_>,
-    comment_id: CommentId,
-  ) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
+    pub async fn update_hot_rank(
+        pool: &mut DbPool<'_>,
+        comment_id: CommentId,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
 
-    diesel::update(comment_aggregates::table)
-      .filter(comment_aggregates::comment_id.eq(comment_id))
-      .set(comment_aggregates::hot_rank.eq(hot_rank(
-        comment_aggregates::score,
-        comment_aggregates::published,
-      )))
-      .get_result::<Self>(conn)
-      .await
-  }
+        diesel::update(comment_aggregates::table)
+            .filter(comment_aggregates::comment_id.eq(comment_id))
+            .set(comment_aggregates::hot_rank.eq(hot_rank(
+                comment_aggregates::score,
+                comment_aggregates::published,
+            )))
+            .get_result::<Self>(conn)
+            .await
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::{
-    aggregates::comment_aggregates::CommentAggregates,
-    source::{
-      comment::{Comment, CommentInsertForm, CommentLike, CommentLikeForm},
-      community::{Community, CommunityInsertForm},
-      instance::Instance,
-      person::{Person, PersonInsertForm},
-      post::{Post, PostInsertForm},
-    },
-    traits::{Crud, Likeable},
-    utils::build_db_pool_for_tests,
-  };
-  use serial_test::serial;
-
-  #[tokio::test]
-  #[serial]
-  async fn test_crud() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-
-    let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
-      .await
-      .unwrap();
-
-    let new_person = PersonInsertForm::builder()
-      .name("thommy_comment_agg".into())
-      .public_key("pubkey".into())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_person = Person::create(pool, &new_person).await.unwrap();
-
-    let another_person = PersonInsertForm::builder()
-      .name("jerry_comment_agg".into())
-      .public_key("pubkey".into())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let another_inserted_person = Person::create(pool, &another_person).await.unwrap();
-
-    let new_community = CommunityInsertForm::builder()
-      .name("TIL_comment_agg".into())
-      .title("nada".to_owned())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_community = Community::create(pool, &new_community).await.unwrap();
-
-    let new_post = PostInsertForm::builder()
-      .name("A test post".into())
-      .creator_id(inserted_person.id)
-      .community_id(inserted_community.id)
-      .build();
-
-    let inserted_post = Post::create(pool, &new_post).await.unwrap();
-
-    let comment_form = CommentInsertForm::builder()
-      .content("A test comment".into())
-      .creator_id(inserted_person.id)
-      .post_id(inserted_post.id)
-      .build();
-
-    let inserted_comment = Comment::create(pool, &comment_form, None).await.unwrap();
-
-    let child_comment_form = CommentInsertForm::builder()
-      .content("A test comment".into())
-      .creator_id(inserted_person.id)
-      .post_id(inserted_post.id)
-      .build();
-
-    let _inserted_child_comment =
-      Comment::create(pool, &child_comment_form, Some(&inserted_comment.path))
-        .await
-        .unwrap();
-
-    let comment_like = CommentLikeForm {
-      comment_id: inserted_comment.id,
-      post_id: inserted_post.id,
-      person_id: inserted_person.id,
-      score: 1,
+    use crate::{
+        aggregates::comment_aggregates::CommentAggregates,
+        source::{
+            comment::{Comment, CommentInsertForm, CommentLike, CommentLikeForm},
+            community::{Community, CommunityInsertForm},
+            instance::Instance,
+            person::{Person, PersonInsertForm},
+            post::{Post, PostInsertForm},
+        },
+        traits::{Crud, Likeable},
+        utils::build_db_pool_for_tests,
     };
+    use serial_test::serial;
 
-    CommentLike::like(pool, &comment_like).await.unwrap();
+    #[tokio::test]
+    #[serial]
+    async fn test_crud() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
 
-    let comment_aggs_before_delete = CommentAggregates::read(pool, inserted_comment.id)
-      .await
-      .unwrap();
+        let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
+            .await
+            .unwrap();
 
-    assert_eq!(1, comment_aggs_before_delete.score);
-    assert_eq!(1, comment_aggs_before_delete.upvotes);
-    assert_eq!(0, comment_aggs_before_delete.downvotes);
+        let new_person = PersonInsertForm::builder()
+            .name("thommy_comment_agg".into())
+            .public_key("pubkey".into())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    // Add a post dislike from the other person
-    let comment_dislike = CommentLikeForm {
-      comment_id: inserted_comment.id,
-      post_id: inserted_post.id,
-      person_id: another_inserted_person.id,
-      score: -1,
-    };
+        let inserted_person = Person::create(pool, &new_person).await.unwrap();
 
-    CommentLike::like(pool, &comment_dislike).await.unwrap();
+        let another_person = PersonInsertForm::builder()
+            .name("jerry_comment_agg".into())
+            .public_key("pubkey".into())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let comment_aggs_after_dislike = CommentAggregates::read(pool, inserted_comment.id)
-      .await
-      .unwrap();
+        let another_inserted_person = Person::create(pool, &another_person).await.unwrap();
 
-    assert_eq!(0, comment_aggs_after_dislike.score);
-    assert_eq!(1, comment_aggs_after_dislike.upvotes);
-    assert_eq!(1, comment_aggs_after_dislike.downvotes);
+        let new_community = CommunityInsertForm::builder()
+            .name("TIL_comment_agg".into())
+            .title("nada".to_owned())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    // Remove the first comment like
-    CommentLike::remove(pool, inserted_person.id, inserted_comment.id)
-      .await
-      .unwrap();
-    let after_like_remove = CommentAggregates::read(pool, inserted_comment.id)
-      .await
-      .unwrap();
-    assert_eq!(-1, after_like_remove.score);
-    assert_eq!(0, after_like_remove.upvotes);
-    assert_eq!(1, after_like_remove.downvotes);
+        let inserted_community = Community::create(pool, &new_community).await.unwrap();
 
-    // Remove the parent post
-    Post::delete(pool, inserted_post.id).await.unwrap();
+        let new_post = PostInsertForm::builder()
+            .name("A test post".into())
+            .creator_id(inserted_person.id)
+            .community_id(inserted_community.id)
+            .build();
 
-    // Should be none found, since the post was deleted
-    let after_delete = CommentAggregates::read(pool, inserted_comment.id).await;
-    assert!(after_delete.is_err());
+        let inserted_post = Post::create(pool, &new_post).await.unwrap();
 
-    // This should delete all the associated rows, and fire triggers
-    Person::delete(pool, another_inserted_person.id)
-      .await
-      .unwrap();
-    let person_num_deleted = Person::delete(pool, inserted_person.id).await.unwrap();
-    assert_eq!(1, person_num_deleted);
+        let comment_form = CommentInsertForm::builder()
+            .content("A test comment".into())
+            .creator_id(inserted_person.id)
+            .post_id(inserted_post.id)
+            .build();
 
-    // Delete the community
-    let community_num_deleted = Community::delete(pool, inserted_community.id)
-      .await
-      .unwrap();
-    assert_eq!(1, community_num_deleted);
+        let inserted_comment = Comment::create(pool, &comment_form, None).await.unwrap();
 
-    Instance::delete(pool, inserted_instance.id).await.unwrap();
-  }
+        let child_comment_form = CommentInsertForm::builder()
+            .content("A test comment".into())
+            .creator_id(inserted_person.id)
+            .post_id(inserted_post.id)
+            .build();
+
+        let _inserted_child_comment =
+            Comment::create(pool, &child_comment_form, Some(&inserted_comment.path))
+                .await
+                .unwrap();
+
+        let comment_like = CommentLikeForm {
+            comment_id: inserted_comment.id,
+            post_id: inserted_post.id,
+            person_id: inserted_person.id,
+            score: 1,
+        };
+
+        CommentLike::like(pool, &comment_like).await.unwrap();
+
+        let comment_aggs_before_delete = CommentAggregates::read(pool, inserted_comment.id)
+            .await
+            .unwrap();
+
+        assert_eq!(1, comment_aggs_before_delete.score);
+        assert_eq!(1, comment_aggs_before_delete.upvotes);
+        assert_eq!(0, comment_aggs_before_delete.downvotes);
+
+        // Add a post dislike from the other person
+        let comment_dislike = CommentLikeForm {
+            comment_id: inserted_comment.id,
+            post_id: inserted_post.id,
+            person_id: another_inserted_person.id,
+            score: -1,
+        };
+
+        CommentLike::like(pool, &comment_dislike).await.unwrap();
+
+        let comment_aggs_after_dislike = CommentAggregates::read(pool, inserted_comment.id)
+            .await
+            .unwrap();
+
+        assert_eq!(0, comment_aggs_after_dislike.score);
+        assert_eq!(1, comment_aggs_after_dislike.upvotes);
+        assert_eq!(1, comment_aggs_after_dislike.downvotes);
+
+        // Remove the first comment like
+        CommentLike::remove(pool, inserted_person.id, inserted_comment.id)
+            .await
+            .unwrap();
+        let after_like_remove = CommentAggregates::read(pool, inserted_comment.id)
+            .await
+            .unwrap();
+        assert_eq!(-1, after_like_remove.score);
+        assert_eq!(0, after_like_remove.upvotes);
+        assert_eq!(1, after_like_remove.downvotes);
+
+        // Remove the parent post
+        Post::delete(pool, inserted_post.id).await.unwrap();
+
+        // Should be none found, since the post was deleted
+        let after_delete = CommentAggregates::read(pool, inserted_comment.id).await;
+        assert!(after_delete.is_err());
+
+        // This should delete all the associated rows, and fire triggers
+        Person::delete(pool, another_inserted_person.id)
+            .await
+            .unwrap();
+        let person_num_deleted = Person::delete(pool, inserted_person.id).await.unwrap();
+        assert_eq!(1, person_num_deleted);
+
+        // Delete the community
+        let community_num_deleted = Community::delete(pool, inserted_community.id)
+            .await
+            .unwrap();
+        assert_eq!(1, community_num_deleted);
+
+        Instance::delete(pool, inserted_instance.id).await.unwrap();
+    }
 }

--- a/crates/db_schema/src/aggregates/community_aggregates.rs
+++ b/crates/db_schema/src/aggregates/community_aggregates.rs
@@ -1,210 +1,211 @@
 use crate::{
-  aggregates::structs::CommunityAggregates,
-  newtypes::CommunityId,
-  schema::community_aggregates,
-  utils::{get_conn, DbPool},
+    aggregates::structs::CommunityAggregates,
+    newtypes::CommunityId,
+    schema::community_aggregates,
+    utils::{get_conn, DbPool},
 };
 use diesel::{result::Error, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 
 impl CommunityAggregates {
-  pub async fn read(pool: &mut DbPool<'_>, community_id: CommunityId) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    community_aggregates::table
-      .filter(community_aggregates::community_id.eq(community_id))
-      .first::<Self>(conn)
-      .await
-  }
+    pub async fn read(pool: &mut DbPool<'_>, community_id: CommunityId) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        community_aggregates::table
+            .filter(community_aggregates::community_id.eq(community_id))
+            .first::<Self>(conn)
+            .await
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::{
-    aggregates::community_aggregates::CommunityAggregates,
-    source::{
-      comment::{Comment, CommentInsertForm},
-      community::{Community, CommunityFollower, CommunityFollowerForm, CommunityInsertForm},
-      instance::Instance,
-      person::{Person, PersonInsertForm},
-      post::{Post, PostInsertForm},
-    },
-    traits::{Crud, Followable},
-    utils::build_db_pool_for_tests,
-  };
-  use serial_test::serial;
-
-  #[tokio::test]
-  #[serial]
-  async fn test_crud() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-
-    let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
-      .await
-      .unwrap();
-
-    let new_person = PersonInsertForm::builder()
-      .name("thommy_community_agg".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_person = Person::create(pool, &new_person).await.unwrap();
-
-    let another_person = PersonInsertForm::builder()
-      .name("jerry_community_agg".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let another_inserted_person = Person::create(pool, &another_person).await.unwrap();
-
-    let new_community = CommunityInsertForm::builder()
-      .name("TIL_community_agg".into())
-      .title("nada".to_owned())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_community = Community::create(pool, &new_community).await.unwrap();
-
-    let another_community = CommunityInsertForm::builder()
-      .name("TIL_community_agg_2".into())
-      .title("nada".to_owned())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let another_inserted_community = Community::create(pool, &another_community).await.unwrap();
-
-    let first_person_follow = CommunityFollowerForm {
-      community_id: inserted_community.id,
-      person_id: inserted_person.id,
-      pending: false,
+    use crate::{
+        aggregates::community_aggregates::CommunityAggregates,
+        source::{
+            comment::{Comment, CommentInsertForm},
+            community::{Community, CommunityFollower, CommunityFollowerForm, CommunityInsertForm},
+            instance::Instance,
+            person::{Person, PersonInsertForm},
+            post::{Post, PostInsertForm},
+        },
+        traits::{Crud, Followable},
+        utils::build_db_pool_for_tests,
     };
+    use serial_test::serial;
 
-    CommunityFollower::follow(pool, &first_person_follow)
-      .await
-      .unwrap();
+    #[tokio::test]
+    #[serial]
+    async fn test_crud() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
 
-    let second_person_follow = CommunityFollowerForm {
-      community_id: inserted_community.id,
-      person_id: another_inserted_person.id,
-      pending: false,
-    };
+        let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
+            .await
+            .unwrap();
 
-    CommunityFollower::follow(pool, &second_person_follow)
-      .await
-      .unwrap();
+        let new_person = PersonInsertForm::builder()
+            .name("thommy_community_agg".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let another_community_follow = CommunityFollowerForm {
-      community_id: another_inserted_community.id,
-      person_id: inserted_person.id,
-      pending: false,
-    };
+        let inserted_person = Person::create(pool, &new_person).await.unwrap();
 
-    CommunityFollower::follow(pool, &another_community_follow)
-      .await
-      .unwrap();
+        let another_person = PersonInsertForm::builder()
+            .name("jerry_community_agg".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let new_post = PostInsertForm::builder()
-      .name("A test post".into())
-      .creator_id(inserted_person.id)
-      .community_id(inserted_community.id)
-      .build();
+        let another_inserted_person = Person::create(pool, &another_person).await.unwrap();
 
-    let inserted_post = Post::create(pool, &new_post).await.unwrap();
+        let new_community = CommunityInsertForm::builder()
+            .name("TIL_community_agg".into())
+            .title("nada".to_owned())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let comment_form = CommentInsertForm::builder()
-      .content("A test comment".into())
-      .creator_id(inserted_person.id)
-      .post_id(inserted_post.id)
-      .build();
+        let inserted_community = Community::create(pool, &new_community).await.unwrap();
 
-    let inserted_comment = Comment::create(pool, &comment_form, None).await.unwrap();
+        let another_community = CommunityInsertForm::builder()
+            .name("TIL_community_agg_2".into())
+            .title("nada".to_owned())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let child_comment_form = CommentInsertForm::builder()
-      .content("A test comment".into())
-      .creator_id(inserted_person.id)
-      .post_id(inserted_post.id)
-      .build();
+        let another_inserted_community = Community::create(pool, &another_community).await.unwrap();
 
-    let _inserted_child_comment =
-      Comment::create(pool, &child_comment_form, Some(&inserted_comment.path))
-        .await
-        .unwrap();
+        let first_person_follow = CommunityFollowerForm {
+            community_id: inserted_community.id,
+            person_id: inserted_person.id,
+            pending: false,
+        };
 
-    let community_aggregates_before_delete = CommunityAggregates::read(pool, inserted_community.id)
-      .await
-      .unwrap();
+        CommunityFollower::follow(pool, &first_person_follow)
+            .await
+            .unwrap();
 
-    assert_eq!(2, community_aggregates_before_delete.subscribers);
-    assert_eq!(1, community_aggregates_before_delete.posts);
-    assert_eq!(2, community_aggregates_before_delete.comments);
+        let second_person_follow = CommunityFollowerForm {
+            community_id: inserted_community.id,
+            person_id: another_inserted_person.id,
+            pending: false,
+        };
 
-    // Test the other community
-    let another_community_aggs = CommunityAggregates::read(pool, another_inserted_community.id)
-      .await
-      .unwrap();
-    assert_eq!(1, another_community_aggs.subscribers);
-    assert_eq!(0, another_community_aggs.posts);
-    assert_eq!(0, another_community_aggs.comments);
+        CommunityFollower::follow(pool, &second_person_follow)
+            .await
+            .unwrap();
 
-    // Unfollow test
-    CommunityFollower::unfollow(pool, &second_person_follow)
-      .await
-      .unwrap();
-    let after_unfollow = CommunityAggregates::read(pool, inserted_community.id)
-      .await
-      .unwrap();
-    assert_eq!(1, after_unfollow.subscribers);
+        let another_community_follow = CommunityFollowerForm {
+            community_id: another_inserted_community.id,
+            person_id: inserted_person.id,
+            pending: false,
+        };
 
-    // Follow again just for the later tests
-    CommunityFollower::follow(pool, &second_person_follow)
-      .await
-      .unwrap();
-    let after_follow_again = CommunityAggregates::read(pool, inserted_community.id)
-      .await
-      .unwrap();
-    assert_eq!(2, after_follow_again.subscribers);
+        CommunityFollower::follow(pool, &another_community_follow)
+            .await
+            .unwrap();
 
-    // Remove a parent post (the comment count should also be 0)
-    Post::delete(pool, inserted_post.id).await.unwrap();
-    let after_parent_post_delete = CommunityAggregates::read(pool, inserted_community.id)
-      .await
-      .unwrap();
-    assert_eq!(0, after_parent_post_delete.comments);
-    assert_eq!(0, after_parent_post_delete.posts);
+        let new_post = PostInsertForm::builder()
+            .name("A test post".into())
+            .creator_id(inserted_person.id)
+            .community_id(inserted_community.id)
+            .build();
 
-    // Remove the 2nd person
-    Person::delete(pool, another_inserted_person.id)
-      .await
-      .unwrap();
-    let after_person_delete = CommunityAggregates::read(pool, inserted_community.id)
-      .await
-      .unwrap();
-    assert_eq!(1, after_person_delete.subscribers);
+        let inserted_post = Post::create(pool, &new_post).await.unwrap();
 
-    // This should delete all the associated rows, and fire triggers
-    let person_num_deleted = Person::delete(pool, inserted_person.id).await.unwrap();
-    assert_eq!(1, person_num_deleted);
+        let comment_form = CommentInsertForm::builder()
+            .content("A test comment".into())
+            .creator_id(inserted_person.id)
+            .post_id(inserted_post.id)
+            .build();
 
-    // Delete the community
-    let community_num_deleted = Community::delete(pool, inserted_community.id)
-      .await
-      .unwrap();
-    assert_eq!(1, community_num_deleted);
+        let inserted_comment = Comment::create(pool, &comment_form, None).await.unwrap();
 
-    let another_community_num_deleted = Community::delete(pool, another_inserted_community.id)
-      .await
-      .unwrap();
-    assert_eq!(1, another_community_num_deleted);
+        let child_comment_form = CommentInsertForm::builder()
+            .content("A test comment".into())
+            .creator_id(inserted_person.id)
+            .post_id(inserted_post.id)
+            .build();
 
-    // Should be none found, since the creator was deleted
-    let after_delete = CommunityAggregates::read(pool, inserted_community.id).await;
-    assert!(after_delete.is_err());
-  }
+        let _inserted_child_comment =
+            Comment::create(pool, &child_comment_form, Some(&inserted_comment.path))
+                .await
+                .unwrap();
+
+        let community_aggregates_before_delete =
+            CommunityAggregates::read(pool, inserted_community.id)
+                .await
+                .unwrap();
+
+        assert_eq!(2, community_aggregates_before_delete.subscribers);
+        assert_eq!(1, community_aggregates_before_delete.posts);
+        assert_eq!(2, community_aggregates_before_delete.comments);
+
+        // Test the other community
+        let another_community_aggs = CommunityAggregates::read(pool, another_inserted_community.id)
+            .await
+            .unwrap();
+        assert_eq!(1, another_community_aggs.subscribers);
+        assert_eq!(0, another_community_aggs.posts);
+        assert_eq!(0, another_community_aggs.comments);
+
+        // Unfollow test
+        CommunityFollower::unfollow(pool, &second_person_follow)
+            .await
+            .unwrap();
+        let after_unfollow = CommunityAggregates::read(pool, inserted_community.id)
+            .await
+            .unwrap();
+        assert_eq!(1, after_unfollow.subscribers);
+
+        // Follow again just for the later tests
+        CommunityFollower::follow(pool, &second_person_follow)
+            .await
+            .unwrap();
+        let after_follow_again = CommunityAggregates::read(pool, inserted_community.id)
+            .await
+            .unwrap();
+        assert_eq!(2, after_follow_again.subscribers);
+
+        // Remove a parent post (the comment count should also be 0)
+        Post::delete(pool, inserted_post.id).await.unwrap();
+        let after_parent_post_delete = CommunityAggregates::read(pool, inserted_community.id)
+            .await
+            .unwrap();
+        assert_eq!(0, after_parent_post_delete.comments);
+        assert_eq!(0, after_parent_post_delete.posts);
+
+        // Remove the 2nd person
+        Person::delete(pool, another_inserted_person.id)
+            .await
+            .unwrap();
+        let after_person_delete = CommunityAggregates::read(pool, inserted_community.id)
+            .await
+            .unwrap();
+        assert_eq!(1, after_person_delete.subscribers);
+
+        // This should delete all the associated rows, and fire triggers
+        let person_num_deleted = Person::delete(pool, inserted_person.id).await.unwrap();
+        assert_eq!(1, person_num_deleted);
+
+        // Delete the community
+        let community_num_deleted = Community::delete(pool, inserted_community.id)
+            .await
+            .unwrap();
+        assert_eq!(1, community_num_deleted);
+
+        let another_community_num_deleted = Community::delete(pool, another_inserted_community.id)
+            .await
+            .unwrap();
+        assert_eq!(1, another_community_num_deleted);
+
+        // Should be none found, since the creator was deleted
+        let after_delete = CommunityAggregates::read(pool, inserted_community.id).await;
+        assert!(after_delete.is_err());
+    }
 }

--- a/crates/db_schema/src/aggregates/person_aggregates.rs
+++ b/crates/db_schema/src/aggregates/person_aggregates.rs
@@ -1,229 +1,232 @@
 use crate::{
-  aggregates::structs::PersonAggregates,
-  newtypes::PersonId,
-  schema::person_aggregates,
-  utils::{get_conn, DbPool},
+    aggregates::structs::PersonAggregates,
+    newtypes::PersonId,
+    schema::person_aggregates,
+    utils::{get_conn, DbPool},
 };
 use diesel::{result::Error, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 
 impl PersonAggregates {
-  pub async fn read(pool: &mut DbPool<'_>, person_id: PersonId) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    person_aggregates::table
-      .filter(person_aggregates::person_id.eq(person_id))
-      .first::<Self>(conn)
-      .await
-  }
+    pub async fn read(pool: &mut DbPool<'_>, person_id: PersonId) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        person_aggregates::table
+            .filter(person_aggregates::person_id.eq(person_id))
+            .first::<Self>(conn)
+            .await
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::{
-    aggregates::person_aggregates::PersonAggregates,
-    source::{
-      comment::{Comment, CommentInsertForm, CommentLike, CommentLikeForm, CommentUpdateForm},
-      community::{Community, CommunityInsertForm},
-      instance::Instance,
-      person::{Person, PersonInsertForm},
-      post::{Post, PostInsertForm, PostLike, PostLikeForm},
-    },
-    traits::{Crud, Likeable},
-    utils::build_db_pool_for_tests,
-  };
-  use serial_test::serial;
-
-  #[tokio::test]
-  #[serial]
-  async fn test_crud() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-
-    let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
-      .await
-      .unwrap();
-
-    let new_person = PersonInsertForm::builder()
-      .name("thommy_user_agg".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_person = Person::create(pool, &new_person).await.unwrap();
-
-    let another_person = PersonInsertForm::builder()
-      .name("jerry_user_agg".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let another_inserted_person = Person::create(pool, &another_person).await.unwrap();
-
-    let new_community = CommunityInsertForm::builder()
-      .name("TIL_site_agg".into())
-      .title("nada".to_owned())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_community = Community::create(pool, &new_community).await.unwrap();
-
-    let new_post = PostInsertForm::builder()
-      .name("A test post".into())
-      .creator_id(inserted_person.id)
-      .community_id(inserted_community.id)
-      .build();
-
-    let inserted_post = Post::create(pool, &new_post).await.unwrap();
-
-    let post_like = PostLikeForm {
-      post_id: inserted_post.id,
-      person_id: inserted_person.id,
-      score: 1,
+    use crate::{
+        aggregates::person_aggregates::PersonAggregates,
+        source::{
+            comment::{
+                Comment, CommentInsertForm, CommentLike, CommentLikeForm, CommentUpdateForm,
+            },
+            community::{Community, CommunityInsertForm},
+            instance::Instance,
+            person::{Person, PersonInsertForm},
+            post::{Post, PostInsertForm, PostLike, PostLikeForm},
+        },
+        traits::{Crud, Likeable},
+        utils::build_db_pool_for_tests,
     };
+    use serial_test::serial;
 
-    let _inserted_post_like = PostLike::like(pool, &post_like).await.unwrap();
+    #[tokio::test]
+    #[serial]
+    async fn test_crud() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
 
-    let comment_form = CommentInsertForm::builder()
-      .content("A test comment".into())
-      .creator_id(inserted_person.id)
-      .post_id(inserted_post.id)
-      .build();
+        let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
+            .await
+            .unwrap();
 
-    let inserted_comment = Comment::create(pool, &comment_form, None).await.unwrap();
+        let new_person = PersonInsertForm::builder()
+            .name("thommy_user_agg".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let mut comment_like = CommentLikeForm {
-      comment_id: inserted_comment.id,
-      person_id: inserted_person.id,
-      post_id: inserted_post.id,
-      score: 1,
-    };
+        let inserted_person = Person::create(pool, &new_person).await.unwrap();
 
-    let _inserted_comment_like = CommentLike::like(pool, &comment_like).await.unwrap();
+        let another_person = PersonInsertForm::builder()
+            .name("jerry_user_agg".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let child_comment_form = CommentInsertForm::builder()
-      .content("A test comment".into())
-      .creator_id(inserted_person.id)
-      .post_id(inserted_post.id)
-      .build();
+        let another_inserted_person = Person::create(pool, &another_person).await.unwrap();
 
-    let inserted_child_comment =
-      Comment::create(pool, &child_comment_form, Some(&inserted_comment.path))
+        let new_community = CommunityInsertForm::builder()
+            .name("TIL_site_agg".into())
+            .title("nada".to_owned())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
+
+        let inserted_community = Community::create(pool, &new_community).await.unwrap();
+
+        let new_post = PostInsertForm::builder()
+            .name("A test post".into())
+            .creator_id(inserted_person.id)
+            .community_id(inserted_community.id)
+            .build();
+
+        let inserted_post = Post::create(pool, &new_post).await.unwrap();
+
+        let post_like = PostLikeForm {
+            post_id: inserted_post.id,
+            person_id: inserted_person.id,
+            score: 1,
+        };
+
+        let _inserted_post_like = PostLike::like(pool, &post_like).await.unwrap();
+
+        let comment_form = CommentInsertForm::builder()
+            .content("A test comment".into())
+            .creator_id(inserted_person.id)
+            .post_id(inserted_post.id)
+            .build();
+
+        let inserted_comment = Comment::create(pool, &comment_form, None).await.unwrap();
+
+        let mut comment_like = CommentLikeForm {
+            comment_id: inserted_comment.id,
+            person_id: inserted_person.id,
+            post_id: inserted_post.id,
+            score: 1,
+        };
+
+        let _inserted_comment_like = CommentLike::like(pool, &comment_like).await.unwrap();
+
+        let child_comment_form = CommentInsertForm::builder()
+            .content("A test comment".into())
+            .creator_id(inserted_person.id)
+            .post_id(inserted_post.id)
+            .build();
+
+        let inserted_child_comment =
+            Comment::create(pool, &child_comment_form, Some(&inserted_comment.path))
+                .await
+                .unwrap();
+
+        let child_comment_like = CommentLikeForm {
+            comment_id: inserted_child_comment.id,
+            person_id: another_inserted_person.id,
+            post_id: inserted_post.id,
+            score: 1,
+        };
+
+        let _inserted_child_comment_like =
+            CommentLike::like(pool, &child_comment_like).await.unwrap();
+
+        let person_aggregates_before_delete = PersonAggregates::read(pool, inserted_person.id)
+            .await
+            .unwrap();
+
+        assert_eq!(1, person_aggregates_before_delete.post_count);
+        assert_eq!(1, person_aggregates_before_delete.post_score);
+        assert_eq!(2, person_aggregates_before_delete.comment_count);
+        assert_eq!(2, person_aggregates_before_delete.comment_score);
+
+        // Remove a post like
+        PostLike::remove(pool, inserted_person.id, inserted_post.id)
+            .await
+            .unwrap();
+        let after_post_like_remove = PersonAggregates::read(pool, inserted_person.id)
+            .await
+            .unwrap();
+        assert_eq!(0, after_post_like_remove.post_score);
+
+        Comment::update(
+            pool,
+            inserted_comment.id,
+            &CommentUpdateForm {
+                removed: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        Comment::update(
+            pool,
+            inserted_child_comment.id,
+            &CommentUpdateForm {
+                removed: Some(true),
+                ..Default::default()
+            },
+        )
         .await
         .unwrap();
 
-    let child_comment_like = CommentLikeForm {
-      comment_id: inserted_child_comment.id,
-      person_id: another_inserted_person.id,
-      post_id: inserted_post.id,
-      score: 1,
-    };
+        let after_parent_comment_removed = PersonAggregates::read(pool, inserted_person.id)
+            .await
+            .unwrap();
+        assert_eq!(0, after_parent_comment_removed.comment_count);
+        // TODO: fix person aggregate comment score calculation
+        // assert_eq!(0, after_parent_comment_removed.comment_score);
 
-    let _inserted_child_comment_like = CommentLike::like(pool, &child_comment_like).await.unwrap();
+        // Remove a parent comment (the scores should also be removed)
+        Comment::delete(pool, inserted_comment.id).await.unwrap();
+        Comment::delete(pool, inserted_child_comment.id)
+            .await
+            .unwrap();
+        let after_parent_comment_delete = PersonAggregates::read(pool, inserted_person.id)
+            .await
+            .unwrap();
+        assert_eq!(0, after_parent_comment_delete.comment_count);
+        // TODO: fix person aggregate comment score calculation
+        // assert_eq!(0, after_parent_comment_delete.comment_score);
 
-    let person_aggregates_before_delete = PersonAggregates::read(pool, inserted_person.id)
-      .await
-      .unwrap();
+        // Add in the two comments again, then delete the post.
+        let new_parent_comment = Comment::create(pool, &comment_form, None).await.unwrap();
+        let _new_child_comment =
+            Comment::create(pool, &child_comment_form, Some(&new_parent_comment.path))
+                .await
+                .unwrap();
+        comment_like.comment_id = new_parent_comment.id;
+        CommentLike::like(pool, &comment_like).await.unwrap();
+        let after_comment_add = PersonAggregates::read(pool, inserted_person.id)
+            .await
+            .unwrap();
+        assert_eq!(2, after_comment_add.comment_count);
+        // TODO: fix person aggregate comment score calculation
+        // assert_eq!(1, after_comment_add.comment_score);
 
-    assert_eq!(1, person_aggregates_before_delete.post_count);
-    assert_eq!(1, person_aggregates_before_delete.post_score);
-    assert_eq!(2, person_aggregates_before_delete.comment_count);
-    assert_eq!(2, person_aggregates_before_delete.comment_score);
+        Post::delete(pool, inserted_post.id).await.unwrap();
+        let after_post_delete = PersonAggregates::read(pool, inserted_person.id)
+            .await
+            .unwrap();
+        // TODO: fix person aggregate comment score calculation
+        // assert_eq!(0, after_post_delete.comment_score);
+        assert_eq!(0, after_post_delete.comment_count);
+        assert_eq!(0, after_post_delete.post_score);
+        assert_eq!(0, after_post_delete.post_count);
 
-    // Remove a post like
-    PostLike::remove(pool, inserted_person.id, inserted_post.id)
-      .await
-      .unwrap();
-    let after_post_like_remove = PersonAggregates::read(pool, inserted_person.id)
-      .await
-      .unwrap();
-    assert_eq!(0, after_post_like_remove.post_score);
+        // This should delete all the associated rows, and fire triggers
+        let person_num_deleted = Person::delete(pool, inserted_person.id).await.unwrap();
+        assert_eq!(1, person_num_deleted);
+        Person::delete(pool, another_inserted_person.id)
+            .await
+            .unwrap();
 
-    Comment::update(
-      pool,
-      inserted_comment.id,
-      &CommentUpdateForm {
-        removed: Some(true),
-        ..Default::default()
-      },
-    )
-    .await
-    .unwrap();
-    Comment::update(
-      pool,
-      inserted_child_comment.id,
-      &CommentUpdateForm {
-        removed: Some(true),
-        ..Default::default()
-      },
-    )
-    .await
-    .unwrap();
+        // Delete the community
+        let community_num_deleted = Community::delete(pool, inserted_community.id)
+            .await
+            .unwrap();
+        assert_eq!(1, community_num_deleted);
 
-    let after_parent_comment_removed = PersonAggregates::read(pool, inserted_person.id)
-      .await
-      .unwrap();
-    assert_eq!(0, after_parent_comment_removed.comment_count);
-    // TODO: fix person aggregate comment score calculation
-    // assert_eq!(0, after_parent_comment_removed.comment_score);
+        // Should be none found
+        let after_delete = PersonAggregates::read(pool, inserted_person.id).await;
+        assert!(after_delete.is_err());
 
-    // Remove a parent comment (the scores should also be removed)
-    Comment::delete(pool, inserted_comment.id).await.unwrap();
-    Comment::delete(pool, inserted_child_comment.id)
-      .await
-      .unwrap();
-    let after_parent_comment_delete = PersonAggregates::read(pool, inserted_person.id)
-      .await
-      .unwrap();
-    assert_eq!(0, after_parent_comment_delete.comment_count);
-    // TODO: fix person aggregate comment score calculation
-    // assert_eq!(0, after_parent_comment_delete.comment_score);
-
-    // Add in the two comments again, then delete the post.
-    let new_parent_comment = Comment::create(pool, &comment_form, None).await.unwrap();
-    let _new_child_comment =
-      Comment::create(pool, &child_comment_form, Some(&new_parent_comment.path))
-        .await
-        .unwrap();
-    comment_like.comment_id = new_parent_comment.id;
-    CommentLike::like(pool, &comment_like).await.unwrap();
-    let after_comment_add = PersonAggregates::read(pool, inserted_person.id)
-      .await
-      .unwrap();
-    assert_eq!(2, after_comment_add.comment_count);
-    // TODO: fix person aggregate comment score calculation
-    // assert_eq!(1, after_comment_add.comment_score);
-
-    Post::delete(pool, inserted_post.id).await.unwrap();
-    let after_post_delete = PersonAggregates::read(pool, inserted_person.id)
-      .await
-      .unwrap();
-    // TODO: fix person aggregate comment score calculation
-    // assert_eq!(0, after_post_delete.comment_score);
-    assert_eq!(0, after_post_delete.comment_count);
-    assert_eq!(0, after_post_delete.post_score);
-    assert_eq!(0, after_post_delete.post_count);
-
-    // This should delete all the associated rows, and fire triggers
-    let person_num_deleted = Person::delete(pool, inserted_person.id).await.unwrap();
-    assert_eq!(1, person_num_deleted);
-    Person::delete(pool, another_inserted_person.id)
-      .await
-      .unwrap();
-
-    // Delete the community
-    let community_num_deleted = Community::delete(pool, inserted_community.id)
-      .await
-      .unwrap();
-    assert_eq!(1, community_num_deleted);
-
-    // Should be none found
-    let after_delete = PersonAggregates::read(pool, inserted_person.id).await;
-    assert!(after_delete.is_err());
-
-    Instance::delete(pool, inserted_instance.id).await.unwrap();
-  }
+        Instance::delete(pool, inserted_instance.id).await.unwrap();
+    }
 }

--- a/crates/db_schema/src/aggregates/person_post_aggregates.rs
+++ b/crates/db_schema/src/aggregates/person_post_aggregates.rs
@@ -1,36 +1,36 @@
 use crate::{
-  aggregates::structs::{PersonPostAggregates, PersonPostAggregatesForm},
-  diesel::BoolExpressionMethods,
-  newtypes::{PersonId, PostId},
-  schema::person_post_aggregates::dsl::{person_id, person_post_aggregates, post_id},
-  utils::{get_conn, DbPool},
+    aggregates::structs::{PersonPostAggregates, PersonPostAggregatesForm},
+    diesel::BoolExpressionMethods,
+    newtypes::{PersonId, PostId},
+    schema::person_post_aggregates::dsl::{person_id, person_post_aggregates, post_id},
+    utils::{get_conn, DbPool},
 };
 use diesel::{insert_into, result::Error, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 
 impl PersonPostAggregates {
-  pub async fn upsert(
-    pool: &mut DbPool<'_>,
-    form: &PersonPostAggregatesForm,
-  ) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    insert_into(person_post_aggregates)
-      .values(form)
-      .on_conflict((person_id, post_id))
-      .do_update()
-      .set(form)
-      .get_result::<Self>(conn)
-      .await
-  }
-  pub async fn read(
-    pool: &mut DbPool<'_>,
-    person_id_: PersonId,
-    post_id_: PostId,
-  ) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    person_post_aggregates
-      .filter(post_id.eq(post_id_).and(person_id.eq(person_id_)))
-      .first::<Self>(conn)
-      .await
-  }
+    pub async fn upsert(
+        pool: &mut DbPool<'_>,
+        form: &PersonPostAggregatesForm,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        insert_into(person_post_aggregates)
+            .values(form)
+            .on_conflict((person_id, post_id))
+            .do_update()
+            .set(form)
+            .get_result::<Self>(conn)
+            .await
+    }
+    pub async fn read(
+        pool: &mut DbPool<'_>,
+        person_id_: PersonId,
+        post_id_: PostId,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        person_post_aggregates
+            .filter(post_id.eq(post_id_).and(person_id.eq(person_id_)))
+            .first::<Self>(conn)
+            .await
+    }
 }

--- a/crates/db_schema/src/aggregates/post_aggregates.rs
+++ b/crates/db_schema/src/aggregates/post_aggregates.rs
@@ -1,297 +1,300 @@
 use crate::{
-  aggregates::structs::PostAggregates,
-  newtypes::PostId,
-  schema::post_aggregates,
-  utils::{functions::hot_rank, get_conn, DbPool},
+    aggregates::structs::PostAggregates,
+    newtypes::PostId,
+    schema::post_aggregates,
+    utils::{functions::hot_rank, get_conn, DbPool},
 };
 use diesel::{result::Error, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 
 impl PostAggregates {
-  pub async fn read(pool: &mut DbPool<'_>, post_id: PostId) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    post_aggregates::table
-      .filter(post_aggregates::post_id.eq(post_id))
-      .first::<Self>(conn)
-      .await
-  }
+    pub async fn read(pool: &mut DbPool<'_>, post_id: PostId) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        post_aggregates::table
+            .filter(post_aggregates::post_id.eq(post_id))
+            .first::<Self>(conn)
+            .await
+    }
 
-  pub async fn update_hot_rank(pool: &mut DbPool<'_>, post_id: PostId) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
+    pub async fn update_hot_rank(pool: &mut DbPool<'_>, post_id: PostId) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
 
-    diesel::update(post_aggregates::table)
-      .filter(post_aggregates::post_id.eq(post_id))
-      .set((
-        post_aggregates::hot_rank.eq(hot_rank(post_aggregates::score, post_aggregates::published)),
-        post_aggregates::hot_rank_active.eq(hot_rank(
-          post_aggregates::score,
-          post_aggregates::newest_comment_time_necro,
-        )),
-      ))
-      .get_result::<Self>(conn)
-      .await
-  }
+        diesel::update(post_aggregates::table)
+            .filter(post_aggregates::post_id.eq(post_id))
+            .set((
+                post_aggregates::hot_rank
+                    .eq(hot_rank(post_aggregates::score, post_aggregates::published)),
+                post_aggregates::hot_rank_active.eq(hot_rank(
+                    post_aggregates::score,
+                    post_aggregates::newest_comment_time_necro,
+                )),
+            ))
+            .get_result::<Self>(conn)
+            .await
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::{
-    aggregates::post_aggregates::PostAggregates,
-    source::{
-      comment::{Comment, CommentInsertForm, CommentUpdateForm},
-      community::{Community, CommunityInsertForm},
-      instance::Instance,
-      person::{Person, PersonInsertForm},
-      post::{Post, PostInsertForm, PostLike, PostLikeForm},
-    },
-    traits::{Crud, Likeable},
-    utils::build_db_pool_for_tests,
-  };
-  use serial_test::serial;
+    use crate::{
+        aggregates::post_aggregates::PostAggregates,
+        source::{
+            comment::{Comment, CommentInsertForm, CommentUpdateForm},
+            community::{Community, CommunityInsertForm},
+            instance::Instance,
+            person::{Person, PersonInsertForm},
+            post::{Post, PostInsertForm, PostLike, PostLikeForm},
+        },
+        traits::{Crud, Likeable},
+        utils::build_db_pool_for_tests,
+    };
+    use serial_test::serial;
 
-  #[tokio::test]
-  #[serial]
-  async fn test_crud() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
+    #[tokio::test]
+    #[serial]
+    async fn test_crud() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
 
-    let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
-      .await
-      .unwrap();
+        let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
+            .await
+            .unwrap();
 
-    let new_person = PersonInsertForm::builder()
-      .name("thommy_community_agg".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
+        let new_person = PersonInsertForm::builder()
+            .name("thommy_community_agg".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let inserted_person = Person::create(pool, &new_person).await.unwrap();
+        let inserted_person = Person::create(pool, &new_person).await.unwrap();
 
-    let another_person = PersonInsertForm::builder()
-      .name("jerry_community_agg".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
+        let another_person = PersonInsertForm::builder()
+            .name("jerry_community_agg".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let another_inserted_person = Person::create(pool, &another_person).await.unwrap();
+        let another_inserted_person = Person::create(pool, &another_person).await.unwrap();
 
-    let new_community = CommunityInsertForm::builder()
-      .name("TIL_community_agg".into())
-      .title("nada".to_owned())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
+        let new_community = CommunityInsertForm::builder()
+            .name("TIL_community_agg".into())
+            .title("nada".to_owned())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let inserted_community = Community::create(pool, &new_community).await.unwrap();
+        let inserted_community = Community::create(pool, &new_community).await.unwrap();
 
-    let new_post = PostInsertForm::builder()
-      .name("A test post".into())
-      .creator_id(inserted_person.id)
-      .community_id(inserted_community.id)
-      .build();
+        let new_post = PostInsertForm::builder()
+            .name("A test post".into())
+            .creator_id(inserted_person.id)
+            .community_id(inserted_community.id)
+            .build();
 
-    let inserted_post = Post::create(pool, &new_post).await.unwrap();
+        let inserted_post = Post::create(pool, &new_post).await.unwrap();
 
-    let comment_form = CommentInsertForm::builder()
-      .content("A test comment".into())
-      .creator_id(inserted_person.id)
-      .post_id(inserted_post.id)
-      .build();
+        let comment_form = CommentInsertForm::builder()
+            .content("A test comment".into())
+            .creator_id(inserted_person.id)
+            .post_id(inserted_post.id)
+            .build();
 
-    let inserted_comment = Comment::create(pool, &comment_form, None).await.unwrap();
+        let inserted_comment = Comment::create(pool, &comment_form, None).await.unwrap();
 
-    let child_comment_form = CommentInsertForm::builder()
-      .content("A test comment".into())
-      .creator_id(inserted_person.id)
-      .post_id(inserted_post.id)
-      .build();
+        let child_comment_form = CommentInsertForm::builder()
+            .content("A test comment".into())
+            .creator_id(inserted_person.id)
+            .post_id(inserted_post.id)
+            .build();
 
-    let inserted_child_comment =
-      Comment::create(pool, &child_comment_form, Some(&inserted_comment.path))
+        let inserted_child_comment =
+            Comment::create(pool, &child_comment_form, Some(&inserted_comment.path))
+                .await
+                .unwrap();
+
+        let post_like = PostLikeForm {
+            post_id: inserted_post.id,
+            person_id: inserted_person.id,
+            score: 1,
+        };
+
+        PostLike::like(pool, &post_like).await.unwrap();
+
+        let post_aggs_before_delete = PostAggregates::read(pool, inserted_post.id).await.unwrap();
+
+        assert_eq!(2, post_aggs_before_delete.comments);
+        assert_eq!(1, post_aggs_before_delete.score);
+        assert_eq!(1, post_aggs_before_delete.upvotes);
+        assert_eq!(0, post_aggs_before_delete.downvotes);
+
+        // Add a post dislike from the other person
+        let post_dislike = PostLikeForm {
+            post_id: inserted_post.id,
+            person_id: another_inserted_person.id,
+            score: -1,
+        };
+
+        PostLike::like(pool, &post_dislike).await.unwrap();
+
+        let post_aggs_after_dislike = PostAggregates::read(pool, inserted_post.id).await.unwrap();
+
+        assert_eq!(2, post_aggs_after_dislike.comments);
+        assert_eq!(0, post_aggs_after_dislike.score);
+        assert_eq!(1, post_aggs_after_dislike.upvotes);
+        assert_eq!(1, post_aggs_after_dislike.downvotes);
+
+        // Remove the comments
+        Comment::delete(pool, inserted_comment.id).await.unwrap();
+        Comment::delete(pool, inserted_child_comment.id)
+            .await
+            .unwrap();
+        let after_comment_delete = PostAggregates::read(pool, inserted_post.id).await.unwrap();
+        assert_eq!(0, after_comment_delete.comments);
+        assert_eq!(0, after_comment_delete.score);
+        assert_eq!(1, after_comment_delete.upvotes);
+        assert_eq!(1, after_comment_delete.downvotes);
+
+        // Remove the first post like
+        PostLike::remove(pool, inserted_person.id, inserted_post.id)
+            .await
+            .unwrap();
+        let after_like_remove = PostAggregates::read(pool, inserted_post.id).await.unwrap();
+        assert_eq!(0, after_like_remove.comments);
+        assert_eq!(-1, after_like_remove.score);
+        assert_eq!(0, after_like_remove.upvotes);
+        assert_eq!(1, after_like_remove.downvotes);
+
+        // This should delete all the associated rows, and fire triggers
+        Person::delete(pool, another_inserted_person.id)
+            .await
+            .unwrap();
+        let person_num_deleted = Person::delete(pool, inserted_person.id).await.unwrap();
+        assert_eq!(1, person_num_deleted);
+
+        // Delete the community
+        let community_num_deleted = Community::delete(pool, inserted_community.id)
+            .await
+            .unwrap();
+        assert_eq!(1, community_num_deleted);
+
+        // Should be none found, since the creator was deleted
+        let after_delete = PostAggregates::read(pool, inserted_post.id).await;
+        assert!(after_delete.is_err());
+
+        Instance::delete(pool, inserted_instance.id).await.unwrap();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_soft_delete() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
+
+        let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
+            .await
+            .unwrap();
+
+        let new_person = PersonInsertForm::builder()
+            .name("thommy_community_agg".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
+
+        let inserted_person = Person::create(pool, &new_person).await.unwrap();
+
+        let new_community = CommunityInsertForm::builder()
+            .name("TIL_community_agg".into())
+            .title("nada".to_owned())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
+
+        let inserted_community = Community::create(pool, &new_community).await.unwrap();
+
+        let new_post = PostInsertForm::builder()
+            .name("A test post".into())
+            .creator_id(inserted_person.id)
+            .community_id(inserted_community.id)
+            .build();
+
+        let inserted_post = Post::create(pool, &new_post).await.unwrap();
+
+        let comment_form = CommentInsertForm::builder()
+            .content("A test comment".into())
+            .creator_id(inserted_person.id)
+            .post_id(inserted_post.id)
+            .build();
+
+        let inserted_comment = Comment::create(pool, &comment_form, None).await.unwrap();
+
+        let post_aggregates_before = PostAggregates::read(pool, inserted_post.id).await.unwrap();
+        assert_eq!(1, post_aggregates_before.comments);
+
+        Comment::update(
+            pool,
+            inserted_comment.id,
+            &CommentUpdateForm {
+                removed: Some(true),
+                ..Default::default()
+            },
+        )
         .await
         .unwrap();
 
-    let post_like = PostLikeForm {
-      post_id: inserted_post.id,
-      person_id: inserted_person.id,
-      score: 1,
-    };
+        let post_aggregates_after_remove =
+            PostAggregates::read(pool, inserted_post.id).await.unwrap();
+        assert_eq!(0, post_aggregates_after_remove.comments);
 
-    PostLike::like(pool, &post_like).await.unwrap();
+        Comment::update(
+            pool,
+            inserted_comment.id,
+            &CommentUpdateForm {
+                removed: Some(false),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
 
-    let post_aggs_before_delete = PostAggregates::read(pool, inserted_post.id).await.unwrap();
+        Comment::update(
+            pool,
+            inserted_comment.id,
+            &CommentUpdateForm {
+                deleted: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
 
-    assert_eq!(2, post_aggs_before_delete.comments);
-    assert_eq!(1, post_aggs_before_delete.score);
-    assert_eq!(1, post_aggs_before_delete.upvotes);
-    assert_eq!(0, post_aggs_before_delete.downvotes);
+        let post_aggregates_after_delete =
+            PostAggregates::read(pool, inserted_post.id).await.unwrap();
+        assert_eq!(0, post_aggregates_after_delete.comments);
 
-    // Add a post dislike from the other person
-    let post_dislike = PostLikeForm {
-      post_id: inserted_post.id,
-      person_id: another_inserted_person.id,
-      score: -1,
-    };
+        Comment::update(
+            pool,
+            inserted_comment.id,
+            &CommentUpdateForm {
+                removed: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
 
-    PostLike::like(pool, &post_dislike).await.unwrap();
+        let post_aggregates_after_delete_remove =
+            PostAggregates::read(pool, inserted_post.id).await.unwrap();
+        assert_eq!(0, post_aggregates_after_delete_remove.comments);
 
-    let post_aggs_after_dislike = PostAggregates::read(pool, inserted_post.id).await.unwrap();
-
-    assert_eq!(2, post_aggs_after_dislike.comments);
-    assert_eq!(0, post_aggs_after_dislike.score);
-    assert_eq!(1, post_aggs_after_dislike.upvotes);
-    assert_eq!(1, post_aggs_after_dislike.downvotes);
-
-    // Remove the comments
-    Comment::delete(pool, inserted_comment.id).await.unwrap();
-    Comment::delete(pool, inserted_child_comment.id)
-      .await
-      .unwrap();
-    let after_comment_delete = PostAggregates::read(pool, inserted_post.id).await.unwrap();
-    assert_eq!(0, after_comment_delete.comments);
-    assert_eq!(0, after_comment_delete.score);
-    assert_eq!(1, after_comment_delete.upvotes);
-    assert_eq!(1, after_comment_delete.downvotes);
-
-    // Remove the first post like
-    PostLike::remove(pool, inserted_person.id, inserted_post.id)
-      .await
-      .unwrap();
-    let after_like_remove = PostAggregates::read(pool, inserted_post.id).await.unwrap();
-    assert_eq!(0, after_like_remove.comments);
-    assert_eq!(-1, after_like_remove.score);
-    assert_eq!(0, after_like_remove.upvotes);
-    assert_eq!(1, after_like_remove.downvotes);
-
-    // This should delete all the associated rows, and fire triggers
-    Person::delete(pool, another_inserted_person.id)
-      .await
-      .unwrap();
-    let person_num_deleted = Person::delete(pool, inserted_person.id).await.unwrap();
-    assert_eq!(1, person_num_deleted);
-
-    // Delete the community
-    let community_num_deleted = Community::delete(pool, inserted_community.id)
-      .await
-      .unwrap();
-    assert_eq!(1, community_num_deleted);
-
-    // Should be none found, since the creator was deleted
-    let after_delete = PostAggregates::read(pool, inserted_post.id).await;
-    assert!(after_delete.is_err());
-
-    Instance::delete(pool, inserted_instance.id).await.unwrap();
-  }
-
-  #[tokio::test]
-  #[serial]
-  async fn test_soft_delete() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-
-    let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
-      .await
-      .unwrap();
-
-    let new_person = PersonInsertForm::builder()
-      .name("thommy_community_agg".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_person = Person::create(pool, &new_person).await.unwrap();
-
-    let new_community = CommunityInsertForm::builder()
-      .name("TIL_community_agg".into())
-      .title("nada".to_owned())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_community = Community::create(pool, &new_community).await.unwrap();
-
-    let new_post = PostInsertForm::builder()
-      .name("A test post".into())
-      .creator_id(inserted_person.id)
-      .community_id(inserted_community.id)
-      .build();
-
-    let inserted_post = Post::create(pool, &new_post).await.unwrap();
-
-    let comment_form = CommentInsertForm::builder()
-      .content("A test comment".into())
-      .creator_id(inserted_person.id)
-      .post_id(inserted_post.id)
-      .build();
-
-    let inserted_comment = Comment::create(pool, &comment_form, None).await.unwrap();
-
-    let post_aggregates_before = PostAggregates::read(pool, inserted_post.id).await.unwrap();
-    assert_eq!(1, post_aggregates_before.comments);
-
-    Comment::update(
-      pool,
-      inserted_comment.id,
-      &CommentUpdateForm {
-        removed: Some(true),
-        ..Default::default()
-      },
-    )
-    .await
-    .unwrap();
-
-    let post_aggregates_after_remove = PostAggregates::read(pool, inserted_post.id).await.unwrap();
-    assert_eq!(0, post_aggregates_after_remove.comments);
-
-    Comment::update(
-      pool,
-      inserted_comment.id,
-      &CommentUpdateForm {
-        removed: Some(false),
-        ..Default::default()
-      },
-    )
-    .await
-    .unwrap();
-
-    Comment::update(
-      pool,
-      inserted_comment.id,
-      &CommentUpdateForm {
-        deleted: Some(true),
-        ..Default::default()
-      },
-    )
-    .await
-    .unwrap();
-
-    let post_aggregates_after_delete = PostAggregates::read(pool, inserted_post.id).await.unwrap();
-    assert_eq!(0, post_aggregates_after_delete.comments);
-
-    Comment::update(
-      pool,
-      inserted_comment.id,
-      &CommentUpdateForm {
-        removed: Some(true),
-        ..Default::default()
-      },
-    )
-    .await
-    .unwrap();
-
-    let post_aggregates_after_delete_remove =
-      PostAggregates::read(pool, inserted_post.id).await.unwrap();
-    assert_eq!(0, post_aggregates_after_delete_remove.comments);
-
-    Comment::delete(pool, inserted_comment.id).await.unwrap();
-    Post::delete(pool, inserted_post.id).await.unwrap();
-    Person::delete(pool, inserted_person.id).await.unwrap();
-    Community::delete(pool, inserted_community.id)
-      .await
-      .unwrap();
-    Instance::delete(pool, inserted_instance.id).await.unwrap();
-  }
+        Comment::delete(pool, inserted_comment.id).await.unwrap();
+        Post::delete(pool, inserted_post.id).await.unwrap();
+        Person::delete(pool, inserted_person.id).await.unwrap();
+        Community::delete(pool, inserted_community.id)
+            .await
+            .unwrap();
+        Instance::delete(pool, inserted_instance.id).await.unwrap();
+    }
 }

--- a/crates/db_schema/src/aggregates/site_aggregates.rs
+++ b/crates/db_schema/src/aggregates/site_aggregates.rs
@@ -1,220 +1,220 @@
 use crate::{
-  aggregates::structs::SiteAggregates,
-  schema::site_aggregates,
-  utils::{get_conn, DbPool},
+    aggregates::structs::SiteAggregates,
+    schema::site_aggregates,
+    utils::{get_conn, DbPool},
 };
 use diesel::result::Error;
 use diesel_async::RunQueryDsl;
 
 impl SiteAggregates {
-  pub async fn read(pool: &mut DbPool<'_>) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    site_aggregates::table.first::<Self>(conn).await
-  }
+    pub async fn read(pool: &mut DbPool<'_>) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        site_aggregates::table.first::<Self>(conn).await
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::{
-    aggregates::site_aggregates::SiteAggregates,
-    source::{
-      comment::{Comment, CommentInsertForm},
-      community::{Community, CommunityInsertForm, CommunityUpdateForm},
-      instance::Instance,
-      person::{Person, PersonInsertForm},
-      post::{Post, PostInsertForm},
-      site::{Site, SiteInsertForm},
-    },
-    traits::Crud,
-    utils::{build_db_pool_for_tests, DbPool},
-  };
-  use serial_test::serial;
+    use crate::{
+        aggregates::site_aggregates::SiteAggregates,
+        source::{
+            comment::{Comment, CommentInsertForm},
+            community::{Community, CommunityInsertForm, CommunityUpdateForm},
+            instance::Instance,
+            person::{Person, PersonInsertForm},
+            post::{Post, PostInsertForm},
+            site::{Site, SiteInsertForm},
+        },
+        traits::Crud,
+        utils::{build_db_pool_for_tests, DbPool},
+    };
+    use serial_test::serial;
 
-  async fn prepare_site_with_community(
-    pool: &mut DbPool<'_>,
-  ) -> (Instance, Person, Site, Community) {
-    let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
-      .await
-      .unwrap();
+    async fn prepare_site_with_community(
+        pool: &mut DbPool<'_>,
+    ) -> (Instance, Person, Site, Community) {
+        let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
+            .await
+            .unwrap();
 
-    let new_person = PersonInsertForm::builder()
-      .name("thommy_site_agg".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
+        let new_person = PersonInsertForm::builder()
+            .name("thommy_site_agg".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let inserted_person = Person::create(pool, &new_person).await.unwrap();
+        let inserted_person = Person::create(pool, &new_person).await.unwrap();
 
-    let site_form = SiteInsertForm::builder()
-      .name("test_site".into())
-      .instance_id(inserted_instance.id)
-      .build();
+        let site_form = SiteInsertForm::builder()
+            .name("test_site".into())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let inserted_site = Site::create(pool, &site_form).await.unwrap();
+        let inserted_site = Site::create(pool, &site_form).await.unwrap();
 
-    let new_community = CommunityInsertForm::builder()
-      .name("TIL_site_agg".into())
-      .title("nada".to_owned())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
+        let new_community = CommunityInsertForm::builder()
+            .name("TIL_site_agg".into())
+            .title("nada".to_owned())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let inserted_community = Community::create(pool, &new_community).await.unwrap();
-    (
-      inserted_instance,
-      inserted_person,
-      inserted_site,
-      inserted_community,
-    )
-  }
+        let inserted_community = Community::create(pool, &new_community).await.unwrap();
+        (
+            inserted_instance,
+            inserted_person,
+            inserted_site,
+            inserted_community,
+        )
+    }
 
-  #[tokio::test]
-  #[serial]
-  async fn test_crud() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
+    #[tokio::test]
+    #[serial]
+    async fn test_crud() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
 
-    let (inserted_instance, inserted_person, inserted_site, inserted_community) =
-      prepare_site_with_community(pool).await;
+        let (inserted_instance, inserted_person, inserted_site, inserted_community) =
+            prepare_site_with_community(pool).await;
 
-    let new_post = PostInsertForm::builder()
-      .name("A test post".into())
-      .creator_id(inserted_person.id)
-      .community_id(inserted_community.id)
-      .build();
+        let new_post = PostInsertForm::builder()
+            .name("A test post".into())
+            .creator_id(inserted_person.id)
+            .community_id(inserted_community.id)
+            .build();
 
-    // Insert two of those posts
-    let inserted_post = Post::create(pool, &new_post).await.unwrap();
-    let _inserted_post_again = Post::create(pool, &new_post).await.unwrap();
+        // Insert two of those posts
+        let inserted_post = Post::create(pool, &new_post).await.unwrap();
+        let _inserted_post_again = Post::create(pool, &new_post).await.unwrap();
 
-    let comment_form = CommentInsertForm::builder()
-      .content("A test comment".into())
-      .creator_id(inserted_person.id)
-      .post_id(inserted_post.id)
-      .build();
+        let comment_form = CommentInsertForm::builder()
+            .content("A test comment".into())
+            .creator_id(inserted_person.id)
+            .post_id(inserted_post.id)
+            .build();
 
-    // Insert two of those comments
-    let inserted_comment = Comment::create(pool, &comment_form, None).await.unwrap();
+        // Insert two of those comments
+        let inserted_comment = Comment::create(pool, &comment_form, None).await.unwrap();
 
-    let child_comment_form = CommentInsertForm::builder()
-      .content("A test comment".into())
-      .creator_id(inserted_person.id)
-      .post_id(inserted_post.id)
-      .build();
+        let child_comment_form = CommentInsertForm::builder()
+            .content("A test comment".into())
+            .creator_id(inserted_person.id)
+            .post_id(inserted_post.id)
+            .build();
 
-    let _inserted_child_comment =
-      Comment::create(pool, &child_comment_form, Some(&inserted_comment.path))
+        let _inserted_child_comment =
+            Comment::create(pool, &child_comment_form, Some(&inserted_comment.path))
+                .await
+                .unwrap();
+
+        let site_aggregates_before_delete = SiteAggregates::read(pool).await.unwrap();
+
+        // TODO: this is unstable, sometimes it returns 0 users, sometimes 1
+        //assert_eq!(0, site_aggregates_before_delete.users);
+        assert_eq!(1, site_aggregates_before_delete.communities);
+        assert_eq!(2, site_aggregates_before_delete.posts);
+        assert_eq!(2, site_aggregates_before_delete.comments);
+
+        // Try a post delete
+        Post::delete(pool, inserted_post.id).await.unwrap();
+        let site_aggregates_after_post_delete = SiteAggregates::read(pool).await.unwrap();
+        assert_eq!(1, site_aggregates_after_post_delete.posts);
+        assert_eq!(0, site_aggregates_after_post_delete.comments);
+
+        // This shouuld delete all the associated rows, and fire triggers
+        let person_num_deleted = Person::delete(pool, inserted_person.id).await.unwrap();
+        assert_eq!(1, person_num_deleted);
+
+        // Delete the community
+        let community_num_deleted = Community::delete(pool, inserted_community.id)
+            .await
+            .unwrap();
+        assert_eq!(1, community_num_deleted);
+
+        // Site should still exist, it can without a site creator.
+        let after_delete_creator = SiteAggregates::read(pool).await;
+        assert!(after_delete_creator.is_ok());
+
+        Site::delete(pool, inserted_site.id).await.unwrap();
+        let after_delete_site = SiteAggregates::read(pool).await;
+        assert!(after_delete_site.is_err());
+
+        Instance::delete(pool, inserted_instance.id).await.unwrap();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_soft_delete() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
+
+        let (inserted_instance, inserted_person, inserted_site, inserted_community) =
+            prepare_site_with_community(pool).await;
+
+        let site_aggregates_before = SiteAggregates::read(pool).await.unwrap();
+        assert_eq!(1, site_aggregates_before.communities);
+
+        Community::update(
+            pool,
+            inserted_community.id,
+            &CommunityUpdateForm {
+                deleted: Some(true),
+                ..Default::default()
+            },
+        )
         .await
         .unwrap();
 
-    let site_aggregates_before_delete = SiteAggregates::read(pool).await.unwrap();
+        let site_aggregates_after_delete = SiteAggregates::read(pool).await.unwrap();
+        assert_eq!(0, site_aggregates_after_delete.communities);
 
-    // TODO: this is unstable, sometimes it returns 0 users, sometimes 1
-    //assert_eq!(0, site_aggregates_before_delete.users);
-    assert_eq!(1, site_aggregates_before_delete.communities);
-    assert_eq!(2, site_aggregates_before_delete.posts);
-    assert_eq!(2, site_aggregates_before_delete.comments);
+        Community::update(
+            pool,
+            inserted_community.id,
+            &CommunityUpdateForm {
+                deleted: Some(false),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
 
-    // Try a post delete
-    Post::delete(pool, inserted_post.id).await.unwrap();
-    let site_aggregates_after_post_delete = SiteAggregates::read(pool).await.unwrap();
-    assert_eq!(1, site_aggregates_after_post_delete.posts);
-    assert_eq!(0, site_aggregates_after_post_delete.comments);
+        Community::update(
+            pool,
+            inserted_community.id,
+            &CommunityUpdateForm {
+                removed: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
 
-    // This shouuld delete all the associated rows, and fire triggers
-    let person_num_deleted = Person::delete(pool, inserted_person.id).await.unwrap();
-    assert_eq!(1, person_num_deleted);
+        let site_aggregates_after_remove = SiteAggregates::read(pool).await.unwrap();
+        assert_eq!(0, site_aggregates_after_remove.communities);
 
-    // Delete the community
-    let community_num_deleted = Community::delete(pool, inserted_community.id)
-      .await
-      .unwrap();
-    assert_eq!(1, community_num_deleted);
+        Community::update(
+            pool,
+            inserted_community.id,
+            &CommunityUpdateForm {
+                deleted: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
 
-    // Site should still exist, it can without a site creator.
-    let after_delete_creator = SiteAggregates::read(pool).await;
-    assert!(after_delete_creator.is_ok());
+        let site_aggregates_after_remove_delete = SiteAggregates::read(pool).await.unwrap();
+        assert_eq!(0, site_aggregates_after_remove_delete.communities);
 
-    Site::delete(pool, inserted_site.id).await.unwrap();
-    let after_delete_site = SiteAggregates::read(pool).await;
-    assert!(after_delete_site.is_err());
-
-    Instance::delete(pool, inserted_instance.id).await.unwrap();
-  }
-
-  #[tokio::test]
-  #[serial]
-  async fn test_soft_delete() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-
-    let (inserted_instance, inserted_person, inserted_site, inserted_community) =
-      prepare_site_with_community(pool).await;
-
-    let site_aggregates_before = SiteAggregates::read(pool).await.unwrap();
-    assert_eq!(1, site_aggregates_before.communities);
-
-    Community::update(
-      pool,
-      inserted_community.id,
-      &CommunityUpdateForm {
-        deleted: Some(true),
-        ..Default::default()
-      },
-    )
-    .await
-    .unwrap();
-
-    let site_aggregates_after_delete = SiteAggregates::read(pool).await.unwrap();
-    assert_eq!(0, site_aggregates_after_delete.communities);
-
-    Community::update(
-      pool,
-      inserted_community.id,
-      &CommunityUpdateForm {
-        deleted: Some(false),
-        ..Default::default()
-      },
-    )
-    .await
-    .unwrap();
-
-    Community::update(
-      pool,
-      inserted_community.id,
-      &CommunityUpdateForm {
-        removed: Some(true),
-        ..Default::default()
-      },
-    )
-    .await
-    .unwrap();
-
-    let site_aggregates_after_remove = SiteAggregates::read(pool).await.unwrap();
-    assert_eq!(0, site_aggregates_after_remove.communities);
-
-    Community::update(
-      pool,
-      inserted_community.id,
-      &CommunityUpdateForm {
-        deleted: Some(true),
-        ..Default::default()
-      },
-    )
-    .await
-    .unwrap();
-
-    let site_aggregates_after_remove_delete = SiteAggregates::read(pool).await.unwrap();
-    assert_eq!(0, site_aggregates_after_remove_delete.communities);
-
-    Community::delete(pool, inserted_community.id)
-      .await
-      .unwrap();
-    Site::delete(pool, inserted_site.id).await.unwrap();
-    Person::delete(pool, inserted_person.id).await.unwrap();
-    Instance::delete(pool, inserted_instance.id).await.unwrap();
-  }
+        Community::delete(pool, inserted_community.id)
+            .await
+            .unwrap();
+        Site::delete(pool, inserted_site.id).await.unwrap();
+        Person::delete(pool, inserted_person.id).await.unwrap();
+        Instance::delete(pool, inserted_instance.id).await.unwrap();
+    }
 }

--- a/crates/db_schema/src/aggregates/structs.rs
+++ b/crates/db_schema/src/aggregates/structs.rs
@@ -1,12 +1,8 @@
 use crate::newtypes::{CommentId, CommunityId, PersonId, PostId, SiteId};
 #[cfg(feature = "full")]
 use crate::schema::{
-  comment_aggregates,
-  community_aggregates,
-  person_aggregates,
-  person_post_aggregates,
-  post_aggregates,
-  site_aggregates,
+    comment_aggregates, community_aggregates, person_aggregates, person_post_aggregates,
+    post_aggregates, site_aggregates,
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -19,43 +15,43 @@ use ts_rs::TS;
 #[cfg_attr(feature = "full", ts(export))]
 /// Aggregate data for a comment.
 pub struct CommentAggregates {
-  pub id: i32,
-  pub comment_id: CommentId,
-  pub score: i64,
-  pub upvotes: i64,
-  pub downvotes: i64,
-  pub published: DateTime<Utc>,
-  /// The total number of children in this comment branch.
-  pub child_count: i32,
-  pub hot_rank: i32,
-  pub controversy_rank: f64,
+    pub id: i32,
+    pub comment_id: CommentId,
+    pub score: i64,
+    pub upvotes: i64,
+    pub downvotes: i64,
+    pub published: DateTime<Utc>,
+    /// The total number of children in this comment branch.
+    pub child_count: i32,
+    pub hot_rank: i32,
+    pub controversy_rank: f64,
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "full", derive(Queryable, Associations, Identifiable, TS))]
 #[cfg_attr(feature = "full", diesel(table_name = community_aggregates))]
 #[cfg_attr(
-  feature = "full",
-  diesel(belongs_to(crate::source::community::Community))
+    feature = "full",
+    diesel(belongs_to(crate::source::community::Community))
 )]
 #[cfg_attr(feature = "full", ts(export))]
 /// Aggregate data for a community.
 pub struct CommunityAggregates {
-  pub id: i32,
-  pub community_id: CommunityId,
-  pub subscribers: i64,
-  pub posts: i64,
-  pub comments: i64,
-  pub published: DateTime<Utc>,
-  /// The number of users with any activity in the last day.
-  pub users_active_day: i64,
-  /// The number of users with any activity in the last week.
-  pub users_active_week: i64,
-  /// The number of users with any activity in the last month.
-  pub users_active_month: i64,
-  /// The number of users with any activity in the last year.
-  pub users_active_half_year: i64,
-  pub hot_rank: i32,
+    pub id: i32,
+    pub community_id: CommunityId,
+    pub subscribers: i64,
+    pub posts: i64,
+    pub comments: i64,
+    pub published: DateTime<Utc>,
+    /// The number of users with any activity in the last day.
+    pub users_active_day: i64,
+    /// The number of users with any activity in the last week.
+    pub users_active_week: i64,
+    /// The number of users with any activity in the last month.
+    pub users_active_month: i64,
+    /// The number of users with any activity in the last year.
+    pub users_active_half_year: i64,
+    pub hot_rank: i32,
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone, Default)]
@@ -65,12 +61,12 @@ pub struct CommunityAggregates {
 #[cfg_attr(feature = "full", ts(export))]
 /// Aggregate data for a person.
 pub struct PersonAggregates {
-  pub id: i32,
-  pub person_id: PersonId,
-  pub post_count: i64,
-  pub post_score: i64,
-  pub comment_count: i64,
-  pub comment_score: i64,
+    pub id: i32,
+    pub person_id: PersonId,
+    pub post_count: i64,
+    pub post_score: i64,
+    pub comment_count: i64,
+    pub comment_score: i64,
 }
 
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
@@ -80,26 +76,26 @@ pub struct PersonAggregates {
 #[cfg_attr(feature = "full", ts(export))]
 /// Aggregate data for a post.
 pub struct PostAggregates {
-  pub id: i32,
-  pub post_id: PostId,
-  pub comments: i64,
-  pub score: i64,
-  pub upvotes: i64,
-  pub downvotes: i64,
-  pub published: DateTime<Utc>,
-  /// A newest comment time, limited to 2 days, to prevent necrobumping  
-  pub newest_comment_time_necro: DateTime<Utc>,
-  /// The time of the newest comment in the post.
-  pub newest_comment_time: DateTime<Utc>,
-  /// If the post is featured on the community.
-  pub featured_community: bool,
-  /// If the post is featured on the site / to local.
-  pub featured_local: bool,
-  pub hot_rank: i32,
-  pub hot_rank_active: i32,
-  pub community_id: CommunityId,
-  pub creator_id: PersonId,
-  pub controversy_rank: f64,
+    pub id: i32,
+    pub post_id: PostId,
+    pub comments: i64,
+    pub score: i64,
+    pub upvotes: i64,
+    pub downvotes: i64,
+    pub published: DateTime<Utc>,
+    /// A newest comment time, limited to 2 days, to prevent necrobumping  
+    pub newest_comment_time_necro: DateTime<Utc>,
+    /// The time of the newest comment in the post.
+    pub newest_comment_time: DateTime<Utc>,
+    /// If the post is featured on the community.
+    pub featured_community: bool,
+    /// If the post is featured on the site / to local.
+    pub featured_local: bool,
+    pub hot_rank: i32,
+    pub hot_rank_active: i32,
+    pub community_id: CommunityId,
+    pub creator_id: PersonId,
+    pub controversy_rank: f64,
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
@@ -108,24 +104,24 @@ pub struct PostAggregates {
 #[cfg_attr(feature = "full", diesel(belongs_to(crate::source::person::Person)))]
 /// Aggregate data for a person's post.
 pub struct PersonPostAggregates {
-  pub id: i32,
-  pub person_id: PersonId,
-  pub post_id: PostId,
-  /// The number of comments they've read on that post.
-  ///
-  /// This is updated to the current post comment count every time they view a post.
-  pub read_comments: i64,
-  pub published: DateTime<Utc>,
+    pub id: i32,
+    pub person_id: PersonId,
+    pub post_id: PostId,
+    /// The number of comments they've read on that post.
+    ///
+    /// This is updated to the current post comment count every time they view a post.
+    pub read_comments: i64,
+    pub published: DateTime<Utc>,
 }
 
 #[derive(Clone, Default)]
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = person_post_aggregates))]
 pub struct PersonPostAggregatesForm {
-  pub person_id: PersonId,
-  pub post_id: PostId,
-  pub read_comments: i64,
-  pub published: Option<DateTime<Utc>>,
+    pub person_id: PersonId,
+    pub post_id: PostId,
+    pub read_comments: i64,
+    pub published: Option<DateTime<Utc>>,
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
@@ -135,18 +131,18 @@ pub struct PersonPostAggregatesForm {
 #[cfg_attr(feature = "full", ts(export))]
 /// Aggregate data for a site.
 pub struct SiteAggregates {
-  pub id: i32,
-  pub site_id: SiteId,
-  pub users: i64,
-  pub posts: i64,
-  pub comments: i64,
-  pub communities: i64,
-  /// The number of users with any activity in the last day.
-  pub users_active_day: i64,
-  /// The number of users with any activity in the last week.
-  pub users_active_week: i64,
-  /// The number of users with any activity in the last month.
-  pub users_active_month: i64,
-  /// The number of users with any activity in the last half year.
-  pub users_active_half_year: i64,
+    pub id: i32,
+    pub site_id: SiteId,
+    pub users: i64,
+    pub posts: i64,
+    pub comments: i64,
+    pub communities: i64,
+    /// The number of users with any activity in the last day.
+    pub users_active_day: i64,
+    /// The number of users with any activity in the last week.
+    pub users_active_week: i64,
+    /// The number of users with any activity in the last month.
+    pub users_active_month: i64,
+    /// The number of users with any activity in the last half year.
+    pub users_active_half_year: i64,
 }

--- a/crates/db_schema/src/impls/activity.rs
+++ b/crates/db_schema/src/impls/activity.rs
@@ -1,114 +1,116 @@
 use crate::{
-  diesel::OptionalExtension,
-  newtypes::DbUrl,
-  source::activity::{ReceivedActivity, SentActivity, SentActivityForm},
-  utils::{get_conn, DbPool},
+    diesel::OptionalExtension,
+    newtypes::DbUrl,
+    source::activity::{ReceivedActivity, SentActivity, SentActivityForm},
+    utils::{get_conn, DbPool},
 };
 use diesel::{
-  dsl::insert_into,
-  result::{DatabaseErrorKind, Error, Error::DatabaseError},
-  ExpressionMethods,
-  QueryDsl,
+    dsl::insert_into,
+    result::{DatabaseErrorKind, Error, Error::DatabaseError},
+    ExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 
 impl SentActivity {
-  pub async fn create(pool: &mut DbPool<'_>, form: SentActivityForm) -> Result<Self, Error> {
-    use crate::schema::sent_activity::dsl::sent_activity;
-    let conn = &mut get_conn(pool).await?;
-    insert_into(sent_activity)
-      .values(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    pub async fn create(pool: &mut DbPool<'_>, form: SentActivityForm) -> Result<Self, Error> {
+        use crate::schema::sent_activity::dsl::sent_activity;
+        let conn = &mut get_conn(pool).await?;
+        insert_into(sent_activity)
+            .values(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 
-  pub async fn read_from_apub_id(pool: &mut DbPool<'_>, object_id: &DbUrl) -> Result<Self, Error> {
-    use crate::schema::sent_activity::dsl::{ap_id, sent_activity};
-    let conn = &mut get_conn(pool).await?;
-    sent_activity
-      .filter(ap_id.eq(object_id))
-      .first::<Self>(conn)
-      .await
-  }
+    pub async fn read_from_apub_id(
+        pool: &mut DbPool<'_>,
+        object_id: &DbUrl,
+    ) -> Result<Self, Error> {
+        use crate::schema::sent_activity::dsl::{ap_id, sent_activity};
+        let conn = &mut get_conn(pool).await?;
+        sent_activity
+            .filter(ap_id.eq(object_id))
+            .first::<Self>(conn)
+            .await
+    }
 }
 
 impl ReceivedActivity {
-  pub async fn create(pool: &mut DbPool<'_>, ap_id_: &DbUrl) -> Result<(), Error> {
-    use crate::schema::received_activity::dsl::{ap_id, id, received_activity};
-    let conn = &mut get_conn(pool).await?;
-    let res = insert_into(received_activity)
-      .values(ap_id.eq(ap_id_))
-      .on_conflict_do_nothing()
-      .returning(id)
-      .get_result::<i64>(conn)
-      .await
-      .optional()?;
-    if res.is_some() {
-      // new activity inserted successfully
-      Ok(())
-    } else {
-      // duplicate activity
-      Err(DatabaseError(
-        DatabaseErrorKind::UniqueViolation,
-        Box::<String>::default(),
-      ))
+    pub async fn create(pool: &mut DbPool<'_>, ap_id_: &DbUrl) -> Result<(), Error> {
+        use crate::schema::received_activity::dsl::{ap_id, id, received_activity};
+        let conn = &mut get_conn(pool).await?;
+        let res = insert_into(received_activity)
+            .values(ap_id.eq(ap_id_))
+            .on_conflict_do_nothing()
+            .returning(id)
+            .get_result::<i64>(conn)
+            .await
+            .optional()?;
+        if res.is_some() {
+            // new activity inserted successfully
+            Ok(())
+        } else {
+            // duplicate activity
+            Err(DatabaseError(
+                DatabaseErrorKind::UniqueViolation,
+                Box::<String>::default(),
+            ))
+        }
     }
-  }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use super::*;
-  use crate::utils::build_db_pool_for_tests;
-  use serde_json::json;
-  use serial_test::serial;
-  use url::Url;
+    use super::*;
+    use crate::utils::build_db_pool_for_tests;
+    use serde_json::json;
+    use serial_test::serial;
+    use url::Url;
 
-  #[tokio::test]
-  #[serial]
-  async fn receive_activity_duplicate() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-    let ap_id: DbUrl = Url::parse("http://example.com/activity/531")
-      .unwrap()
-      .into();
+    #[tokio::test]
+    #[serial]
+    async fn receive_activity_duplicate() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
+        let ap_id: DbUrl = Url::parse("http://example.com/activity/531")
+            .unwrap()
+            .into();
 
-    // inserting activity for first time
-    let res = ReceivedActivity::create(pool, &ap_id).await;
-    assert!(res.is_ok());
+        // inserting activity for first time
+        let res = ReceivedActivity::create(pool, &ap_id).await;
+        assert!(res.is_ok());
 
-    let res = ReceivedActivity::create(pool, &ap_id).await;
-    assert!(res.is_err());
-  }
+        let res = ReceivedActivity::create(pool, &ap_id).await;
+        assert!(res.is_err());
+    }
 
-  #[tokio::test]
-  #[serial]
-  async fn sent_activity_write_read() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-    let ap_id: DbUrl = Url::parse("http://example.com/activity/412")
-      .unwrap()
-      .into();
-    let data = json!({
-        "key1": "0xF9BA143B95FF6D82",
-        "key2": "42",
-    });
-    let sensitive = false;
+    #[tokio::test]
+    #[serial]
+    async fn sent_activity_write_read() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
+        let ap_id: DbUrl = Url::parse("http://example.com/activity/412")
+            .unwrap()
+            .into();
+        let data = json!({
+            "key1": "0xF9BA143B95FF6D82",
+            "key2": "42",
+        });
+        let sensitive = false;
 
-    let form = SentActivityForm {
-      ap_id: ap_id.clone(),
-      data: data.clone(),
-      sensitive,
-    };
+        let form = SentActivityForm {
+            ap_id: ap_id.clone(),
+            data: data.clone(),
+            sensitive,
+        };
 
-    SentActivity::create(pool, form).await.unwrap();
+        SentActivity::create(pool, form).await.unwrap();
 
-    let res = SentActivity::read_from_apub_id(pool, &ap_id).await.unwrap();
-    assert_eq!(res.ap_id, ap_id);
-    assert_eq!(res.data, data);
-    assert_eq!(res.sensitive, sensitive);
-  }
+        let res = SentActivity::read_from_apub_id(pool, &ap_id).await.unwrap();
+        assert_eq!(res.ap_id, ap_id);
+        assert_eq!(res.data, data);
+        assert_eq!(res.sensitive, sensitive);
+    }
 }

--- a/crates/db_schema/src/impls/actor_language.rs
+++ b/crates/db_schema/src/impls/actor_language.rs
@@ -1,29 +1,23 @@
 use crate::{
-  diesel::JoinOnDsl,
-  newtypes::{CommunityId, InstanceId, LanguageId, LocalUserId, SiteId},
-  schema::{local_site, site, site_language},
-  source::{
-    actor_language::{
-      CommunityLanguage,
-      CommunityLanguageForm,
-      LocalUserLanguage,
-      LocalUserLanguageForm,
-      SiteLanguage,
-      SiteLanguageForm,
+    diesel::JoinOnDsl,
+    newtypes::{CommunityId, InstanceId, LanguageId, LocalUserId, SiteId},
+    schema::{local_site, site, site_language},
+    source::{
+        actor_language::{
+            CommunityLanguage, CommunityLanguageForm, LocalUserLanguage, LocalUserLanguageForm,
+            SiteLanguage, SiteLanguageForm,
+        },
+        language::Language,
+        site::Site,
     },
-    language::Language,
-    site::Site,
-  },
-  utils::{get_conn, DbPool},
+    utils::{get_conn, DbPool},
 };
 use diesel::{
-  delete,
-  dsl::{count, exists},
-  insert_into,
-  result::Error,
-  select,
-  ExpressionMethods,
-  QueryDsl,
+    delete,
+    dsl::{count, exists},
+    insert_into,
+    result::Error,
+    select, ExpressionMethods, QueryDsl,
 };
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use lemmy_utils::error::{LemmyError, LemmyErrorType};
@@ -32,682 +26,680 @@ use tokio::sync::OnceCell;
 pub const UNDETERMINED_ID: LanguageId = LanguageId(0);
 
 impl LocalUserLanguage {
-  pub async fn read(
-    pool: &mut DbPool<'_>,
-    for_local_user_id: LocalUserId,
-  ) -> Result<Vec<LanguageId>, Error> {
-    use crate::schema::local_user_language::dsl::{
-      language_id,
-      local_user_id,
-      local_user_language,
-    };
-    let conn = &mut get_conn(pool).await?;
+    pub async fn read(
+        pool: &mut DbPool<'_>,
+        for_local_user_id: LocalUserId,
+    ) -> Result<Vec<LanguageId>, Error> {
+        use crate::schema::local_user_language::dsl::{
+            language_id, local_user_id, local_user_language,
+        };
+        let conn = &mut get_conn(pool).await?;
 
-    conn
-      .build_transaction()
-      .run(|conn| {
-        Box::pin(async move {
-          let langs = local_user_language
-            .filter(local_user_id.eq(for_local_user_id))
+        conn.build_transaction()
+            .run(|conn| {
+                Box::pin(async move {
+                    let langs = local_user_language
+                        .filter(local_user_id.eq(for_local_user_id))
+                        .order(language_id)
+                        .select(language_id)
+                        .get_results(conn)
+                        .await?;
+                    convert_read_languages(conn, langs).await
+                }) as _
+            })
+            .await
+    }
+
+    /// Update the user's languages.
+    ///
+    /// If no language_id vector is given, it will show all languages
+    pub async fn update(
+        pool: &mut DbPool<'_>,
+        language_ids: Vec<LanguageId>,
+        for_local_user_id: LocalUserId,
+    ) -> Result<(), Error> {
+        let conn = &mut get_conn(pool).await?;
+        let mut lang_ids = convert_update_languages(conn, language_ids).await?;
+
+        // No need to update if languages are unchanged
+        let current = LocalUserLanguage::read(&mut conn.into(), for_local_user_id).await?;
+        if current == lang_ids {
+            return Ok(());
+        }
+
+        // TODO: Force enable undetermined language for all users. This is necessary because many posts
+        //       don't have a language tag (e.g. those from other federated platforms), so Lemmy users
+        //       won't see them if undetermined language is disabled.
+        //       This hack can be removed once a majority of posts have language tags, or when it is
+        //       clearer for new users that they need to enable undetermined language.
+        //       See https://github.com/LemmyNet/lemmy-ui/issues/999
+        if !lang_ids.contains(&UNDETERMINED_ID) {
+            lang_ids.push(UNDETERMINED_ID);
+        }
+
+        conn.build_transaction()
+            .run(|conn| {
+                Box::pin(async move {
+                    use crate::schema::local_user_language::dsl::{
+                        local_user_id, local_user_language,
+                    };
+                    // Clear the current user languages
+                    delete(local_user_language.filter(local_user_id.eq(for_local_user_id)))
+                        .execute(conn)
+                        .await?;
+
+                    for l in lang_ids {
+                        let form = LocalUserLanguageForm {
+                            local_user_id: for_local_user_id,
+                            language_id: l,
+                        };
+                        insert_into(local_user_language)
+                            .values(form)
+                            .get_result::<Self>(conn)
+                            .await?;
+                    }
+                    Ok(())
+                }) as _
+            })
+            .await
+    }
+}
+
+impl SiteLanguage {
+    pub async fn read_local_raw(pool: &mut DbPool<'_>) -> Result<Vec<LanguageId>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        site::table
+            .inner_join(local_site::table)
+            .inner_join(site_language::table)
+            .order(site_language::id)
+            .select(site_language::language_id)
+            .load(conn)
+            .await
+    }
+
+    pub async fn read(
+        pool: &mut DbPool<'_>,
+        for_site_id: SiteId,
+    ) -> Result<Vec<LanguageId>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let langs = site_language::table
+            .filter(site_language::site_id.eq(for_site_id))
+            .order(site_language::language_id)
+            .select(site_language::language_id)
+            .load(conn)
+            .await?;
+
+        convert_read_languages(conn, langs).await
+    }
+
+    pub async fn update(
+        pool: &mut DbPool<'_>,
+        language_ids: Vec<LanguageId>,
+        site: &Site,
+    ) -> Result<(), Error> {
+        let conn = &mut get_conn(pool).await?;
+        let for_site_id = site.id;
+        let instance_id = site.instance_id;
+        let lang_ids = convert_update_languages(conn, language_ids).await?;
+
+        // No need to update if languages are unchanged
+        let current = SiteLanguage::read(&mut conn.into(), site.id).await?;
+        if current == lang_ids {
+            return Ok(());
+        }
+
+        conn.build_transaction()
+            .run(|conn| {
+                Box::pin(async move {
+                    use crate::schema::site_language::dsl::{site_id, site_language};
+
+                    // Clear the current languages
+                    delete(site_language.filter(site_id.eq(for_site_id)))
+                        .execute(conn)
+                        .await?;
+
+                    for l in lang_ids {
+                        let form = SiteLanguageForm {
+                            site_id: for_site_id,
+                            language_id: l,
+                        };
+                        insert_into(site_language)
+                            .values(form)
+                            .get_result::<Self>(conn)
+                            .await?;
+                    }
+
+                    CommunityLanguage::limit_languages(conn, instance_id).await?;
+
+                    Ok(())
+                }) as _
+            })
+            .await
+    }
+}
+
+impl CommunityLanguage {
+    /// Returns true if the given language is one of configured languages for given community
+    pub async fn is_allowed_community_language(
+        pool: &mut DbPool<'_>,
+        for_language_id: Option<LanguageId>,
+        for_community_id: CommunityId,
+    ) -> Result<(), LemmyError> {
+        use crate::schema::community_language::dsl::{
+            community_id, community_language, language_id,
+        };
+        let conn = &mut get_conn(pool).await?;
+
+        if let Some(for_language_id) = for_language_id {
+            let is_allowed = select(exists(
+                community_language
+                    .filter(language_id.eq(for_language_id))
+                    .filter(community_id.eq(for_community_id)),
+            ))
+            .get_result(conn)
+            .await?;
+
+            if is_allowed {
+                Ok(())
+            } else {
+                Err(LemmyErrorType::LanguageNotAllowed)?
+            }
+        } else {
+            Ok(())
+        }
+    }
+
+    /// When site languages are updated, delete all languages of local communities which are not
+    /// also part of site languages. This is because post/comment language is only checked against
+    /// community language, and it shouldnt be possible to post content in languages which are not
+    /// allowed by local site.
+    async fn limit_languages(
+        conn: &mut AsyncPgConnection,
+        for_instance_id: InstanceId,
+    ) -> Result<(), Error> {
+        use crate::schema::{
+            community::dsl as c, community_language::dsl as cl, site_language::dsl as sl,
+        };
+        let community_languages: Vec<LanguageId> = cl::community_language
+            .left_outer_join(sl::site_language.on(cl::language_id.eq(sl::language_id)))
+            .inner_join(c::community)
+            .filter(c::instance_id.eq(for_instance_id))
+            .filter(sl::language_id.is_null())
+            .select(cl::language_id)
+            .get_results(conn)
+            .await?;
+
+        for c in community_languages {
+            delete(cl::community_language.filter(cl::language_id.eq(c)))
+                .execute(conn)
+                .await?;
+        }
+        Ok(())
+    }
+
+    pub async fn read(
+        pool: &mut DbPool<'_>,
+        for_community_id: CommunityId,
+    ) -> Result<Vec<LanguageId>, Error> {
+        use crate::schema::community_language::dsl::{
+            community_id, community_language, language_id,
+        };
+        let conn = &mut get_conn(pool).await?;
+        let langs = community_language
+            .filter(community_id.eq(for_community_id))
             .order(language_id)
             .select(language_id)
             .get_results(conn)
             .await?;
-          convert_read_languages(conn, langs).await
-        }) as _
-      })
-      .await
-  }
-
-  /// Update the user's languages.
-  ///
-  /// If no language_id vector is given, it will show all languages
-  pub async fn update(
-    pool: &mut DbPool<'_>,
-    language_ids: Vec<LanguageId>,
-    for_local_user_id: LocalUserId,
-  ) -> Result<(), Error> {
-    let conn = &mut get_conn(pool).await?;
-    let mut lang_ids = convert_update_languages(conn, language_ids).await?;
-
-    // No need to update if languages are unchanged
-    let current = LocalUserLanguage::read(&mut conn.into(), for_local_user_id).await?;
-    if current == lang_ids {
-      return Ok(());
+        convert_read_languages(conn, langs).await
     }
 
-    // TODO: Force enable undetermined language for all users. This is necessary because many posts
-    //       don't have a language tag (e.g. those from other federated platforms), so Lemmy users
-    //       won't see them if undetermined language is disabled.
-    //       This hack can be removed once a majority of posts have language tags, or when it is
-    //       clearer for new users that they need to enable undetermined language.
-    //       See https://github.com/LemmyNet/lemmy-ui/issues/999
-    if !lang_ids.contains(&UNDETERMINED_ID) {
-      lang_ids.push(UNDETERMINED_ID);
-    }
+    pub async fn update(
+        pool: &mut DbPool<'_>,
+        mut language_ids: Vec<LanguageId>,
+        for_community_id: CommunityId,
+    ) -> Result<(), Error> {
+        if language_ids.is_empty() {
+            language_ids = SiteLanguage::read_local_raw(pool).await?;
+        }
+        let conn = &mut get_conn(pool).await?;
+        let lang_ids = convert_update_languages(conn, language_ids).await?;
 
-    conn
-      .build_transaction()
-      .run(|conn| {
-        Box::pin(async move {
-          use crate::schema::local_user_language::dsl::{local_user_id, local_user_language};
-          // Clear the current user languages
-          delete(local_user_language.filter(local_user_id.eq(for_local_user_id)))
-            .execute(conn)
-            .await?;
-
-          for l in lang_ids {
-            let form = LocalUserLanguageForm {
-              local_user_id: for_local_user_id,
-              language_id: l,
-            };
-            insert_into(local_user_language)
-              .values(form)
-              .get_result::<Self>(conn)
-              .await?;
-          }
-          Ok(())
-        }) as _
-      })
-      .await
-  }
-}
-
-impl SiteLanguage {
-  pub async fn read_local_raw(pool: &mut DbPool<'_>) -> Result<Vec<LanguageId>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    site::table
-      .inner_join(local_site::table)
-      .inner_join(site_language::table)
-      .order(site_language::id)
-      .select(site_language::language_id)
-      .load(conn)
-      .await
-  }
-
-  pub async fn read(pool: &mut DbPool<'_>, for_site_id: SiteId) -> Result<Vec<LanguageId>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let langs = site_language::table
-      .filter(site_language::site_id.eq(for_site_id))
-      .order(site_language::language_id)
-      .select(site_language::language_id)
-      .load(conn)
-      .await?;
-
-    convert_read_languages(conn, langs).await
-  }
-
-  pub async fn update(
-    pool: &mut DbPool<'_>,
-    language_ids: Vec<LanguageId>,
-    site: &Site,
-  ) -> Result<(), Error> {
-    let conn = &mut get_conn(pool).await?;
-    let for_site_id = site.id;
-    let instance_id = site.instance_id;
-    let lang_ids = convert_update_languages(conn, language_ids).await?;
-
-    // No need to update if languages are unchanged
-    let current = SiteLanguage::read(&mut conn.into(), site.id).await?;
-    if current == lang_ids {
-      return Ok(());
-    }
-
-    conn
-      .build_transaction()
-      .run(|conn| {
-        Box::pin(async move {
-          use crate::schema::site_language::dsl::{site_id, site_language};
-
-          // Clear the current languages
-          delete(site_language.filter(site_id.eq(for_site_id)))
-            .execute(conn)
-            .await?;
-
-          for l in lang_ids {
-            let form = SiteLanguageForm {
-              site_id: for_site_id,
-              language_id: l,
-            };
-            insert_into(site_language)
-              .values(form)
-              .get_result::<Self>(conn)
-              .await?;
-          }
-
-          CommunityLanguage::limit_languages(conn, instance_id).await?;
-
-          Ok(())
-        }) as _
-      })
-      .await
-  }
-}
-
-impl CommunityLanguage {
-  /// Returns true if the given language is one of configured languages for given community
-  pub async fn is_allowed_community_language(
-    pool: &mut DbPool<'_>,
-    for_language_id: Option<LanguageId>,
-    for_community_id: CommunityId,
-  ) -> Result<(), LemmyError> {
-    use crate::schema::community_language::dsl::{community_id, community_language, language_id};
-    let conn = &mut get_conn(pool).await?;
-
-    if let Some(for_language_id) = for_language_id {
-      let is_allowed = select(exists(
-        community_language
-          .filter(language_id.eq(for_language_id))
-          .filter(community_id.eq(for_community_id)),
-      ))
-      .get_result(conn)
-      .await?;
-
-      if is_allowed {
-        Ok(())
-      } else {
-        Err(LemmyErrorType::LanguageNotAllowed)?
-      }
-    } else {
-      Ok(())
-    }
-  }
-
-  /// When site languages are updated, delete all languages of local communities which are not
-  /// also part of site languages. This is because post/comment language is only checked against
-  /// community language, and it shouldnt be possible to post content in languages which are not
-  /// allowed by local site.
-  async fn limit_languages(
-    conn: &mut AsyncPgConnection,
-    for_instance_id: InstanceId,
-  ) -> Result<(), Error> {
-    use crate::schema::{
-      community::dsl as c,
-      community_language::dsl as cl,
-      site_language::dsl as sl,
-    };
-    let community_languages: Vec<LanguageId> = cl::community_language
-      .left_outer_join(sl::site_language.on(cl::language_id.eq(sl::language_id)))
-      .inner_join(c::community)
-      .filter(c::instance_id.eq(for_instance_id))
-      .filter(sl::language_id.is_null())
-      .select(cl::language_id)
-      .get_results(conn)
-      .await?;
-
-    for c in community_languages {
-      delete(cl::community_language.filter(cl::language_id.eq(c)))
-        .execute(conn)
-        .await?;
-    }
-    Ok(())
-  }
-
-  pub async fn read(
-    pool: &mut DbPool<'_>,
-    for_community_id: CommunityId,
-  ) -> Result<Vec<LanguageId>, Error> {
-    use crate::schema::community_language::dsl::{community_id, community_language, language_id};
-    let conn = &mut get_conn(pool).await?;
-    let langs = community_language
-      .filter(community_id.eq(for_community_id))
-      .order(language_id)
-      .select(language_id)
-      .get_results(conn)
-      .await?;
-    convert_read_languages(conn, langs).await
-  }
-
-  pub async fn update(
-    pool: &mut DbPool<'_>,
-    mut language_ids: Vec<LanguageId>,
-    for_community_id: CommunityId,
-  ) -> Result<(), Error> {
-    if language_ids.is_empty() {
-      language_ids = SiteLanguage::read_local_raw(pool).await?;
-    }
-    let conn = &mut get_conn(pool).await?;
-    let lang_ids = convert_update_languages(conn, language_ids).await?;
-
-    // No need to update if languages are unchanged
-    let current = CommunityLanguage::read(&mut conn.into(), for_community_id).await?;
-    if current == lang_ids {
-      return Ok(());
-    }
-
-    let form = lang_ids
-      .into_iter()
-      .map(|language_id| CommunityLanguageForm {
-        community_id: for_community_id,
-        language_id,
-      })
-      .collect::<Vec<_>>();
-
-    conn
-      .build_transaction()
-      .run(|conn| {
-        Box::pin(async move {
-          use crate::schema::community_language::dsl::{community_id, community_language};
-          use diesel::result::DatabaseErrorKind::UniqueViolation;
-          // Clear the current languages
-          delete(community_language.filter(community_id.eq(for_community_id)))
-            .execute(conn)
-            .await?;
-
-          let insert_res = insert_into(community_language)
-            .values(form)
-            .get_result::<Self>(conn)
-            .await;
-
-          if let Err(Error::DatabaseError(UniqueViolation, _info)) = insert_res {
-            // race condition: this function was probably called simultaneously from another caller. ignore error
-            // tracing::warn!("unique error: {_info:#?}");
-            // _info.constraint_name() should be = "community_language_community_id_language_id_key"
+        // No need to update if languages are unchanged
+        let current = CommunityLanguage::read(&mut conn.into(), for_community_id).await?;
+        if current == lang_ids {
             return Ok(());
-          } else {
-            insert_res?;
-          }
-          Ok(())
-        }) as _
-      })
-      .await
-  }
+        }
+
+        let form = lang_ids
+            .into_iter()
+            .map(|language_id| CommunityLanguageForm {
+                community_id: for_community_id,
+                language_id,
+            })
+            .collect::<Vec<_>>();
+
+        conn.build_transaction()
+            .run(|conn| {
+                Box::pin(async move {
+                    use crate::schema::community_language::dsl::{
+                        community_id, community_language,
+                    };
+                    use diesel::result::DatabaseErrorKind::UniqueViolation;
+                    // Clear the current languages
+                    delete(community_language.filter(community_id.eq(for_community_id)))
+                        .execute(conn)
+                        .await?;
+
+                    let insert_res = insert_into(community_language)
+                        .values(form)
+                        .get_result::<Self>(conn)
+                        .await;
+
+                    if let Err(Error::DatabaseError(UniqueViolation, _info)) = insert_res {
+                        // race condition: this function was probably called simultaneously from another caller. ignore error
+                        // tracing::warn!("unique error: {_info:#?}");
+                        // _info.constraint_name() should be = "community_language_community_id_language_id_key"
+                        return Ok(());
+                    } else {
+                        insert_res?;
+                    }
+                    Ok(())
+                }) as _
+            })
+            .await
+    }
 }
 
 pub async fn default_post_language(
-  pool: &mut DbPool<'_>,
-  community_id: CommunityId,
-  local_user_id: LocalUserId,
+    pool: &mut DbPool<'_>,
+    community_id: CommunityId,
+    local_user_id: LocalUserId,
 ) -> Result<Option<LanguageId>, Error> {
-  use crate::schema::{community_language::dsl as cl, local_user_language::dsl as ul};
-  let conn = &mut get_conn(pool).await?;
-  let mut intersection = ul::local_user_language
-    .inner_join(cl::community_language.on(ul::language_id.eq(cl::language_id)))
-    .filter(ul::local_user_id.eq(local_user_id))
-    .filter(cl::community_id.eq(community_id))
-    .select(cl::language_id)
-    .get_results::<LanguageId>(conn)
-    .await?;
+    use crate::schema::{community_language::dsl as cl, local_user_language::dsl as ul};
+    let conn = &mut get_conn(pool).await?;
+    let mut intersection = ul::local_user_language
+        .inner_join(cl::community_language.on(ul::language_id.eq(cl::language_id)))
+        .filter(ul::local_user_id.eq(local_user_id))
+        .filter(cl::community_id.eq(community_id))
+        .select(cl::language_id)
+        .get_results::<LanguageId>(conn)
+        .await?;
 
-  if intersection.len() == 1 {
-    Ok(intersection.pop())
-  } else if intersection.len() == 2 && intersection.contains(&UNDETERMINED_ID) {
-    intersection.retain(|i| i != &UNDETERMINED_ID);
-    Ok(intersection.pop())
-  } else {
-    Ok(None)
-  }
+    if intersection.len() == 1 {
+        Ok(intersection.pop())
+    } else if intersection.len() == 2 && intersection.contains(&UNDETERMINED_ID) {
+        intersection.retain(|i| i != &UNDETERMINED_ID);
+        Ok(intersection.pop())
+    } else {
+        Ok(None)
+    }
 }
 
 /// If no language is given, set all languages
 async fn convert_update_languages(
-  conn: &mut AsyncPgConnection,
-  language_ids: Vec<LanguageId>,
+    conn: &mut AsyncPgConnection,
+    language_ids: Vec<LanguageId>,
 ) -> Result<Vec<LanguageId>, Error> {
-  if language_ids.is_empty() {
-    Ok(
-      Language::read_all(&mut conn.into())
-        .await?
-        .into_iter()
-        .map(|l| l.id)
-        .collect(),
-    )
-  } else {
-    Ok(language_ids)
-  }
+    if language_ids.is_empty() {
+        Ok(Language::read_all(&mut conn.into())
+            .await?
+            .into_iter()
+            .map(|l| l.id)
+            .collect())
+    } else {
+        Ok(language_ids)
+    }
 }
 
 /// If all languages are returned, return empty vec instead
 async fn convert_read_languages(
-  conn: &mut AsyncPgConnection,
-  language_ids: Vec<LanguageId>,
+    conn: &mut AsyncPgConnection,
+    language_ids: Vec<LanguageId>,
 ) -> Result<Vec<LanguageId>, Error> {
-  static ALL_LANGUAGES_COUNT: OnceCell<usize> = OnceCell::const_new();
-  let count = ALL_LANGUAGES_COUNT
-    .get_or_init(|| async {
-      use crate::schema::language::dsl::{id, language};
-      let count: i64 = language
-        .select(count(id))
-        .first(conn)
-        .await
-        .expect("read number of languages");
-      count as usize
-    })
-    .await;
+    static ALL_LANGUAGES_COUNT: OnceCell<usize> = OnceCell::const_new();
+    let count = ALL_LANGUAGES_COUNT
+        .get_or_init(|| async {
+            use crate::schema::language::dsl::{id, language};
+            let count: i64 = language
+                .select(count(id))
+                .first(conn)
+                .await
+                .expect("read number of languages");
+            count as usize
+        })
+        .await;
 
-  if &language_ids.len() == count {
-    Ok(vec![])
-  } else {
-    Ok(language_ids)
-  }
+    if &language_ids.len() == count {
+        Ok(vec![])
+    } else {
+        Ok(language_ids)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use super::*;
-  use crate::{
-    impls::actor_language::{
-      convert_read_languages,
-      convert_update_languages,
-      default_post_language,
-      get_conn,
-      CommunityLanguage,
-      DbPool,
-      Language,
-      LanguageId,
-      LocalUserLanguage,
-      QueryDsl,
-      RunQueryDsl,
-      SiteLanguage,
-    },
-    source::{
-      community::{Community, CommunityInsertForm},
-      instance::Instance,
-      local_site::{LocalSite, LocalSiteInsertForm},
-      local_user::{LocalUser, LocalUserInsertForm},
-      person::{Person, PersonInsertForm},
-      site::{Site, SiteInsertForm},
-    },
-    traits::Crud,
-    utils::build_db_pool_for_tests,
-  };
-  use serial_test::serial;
+    use super::*;
+    use crate::{
+        impls::actor_language::{
+            convert_read_languages, convert_update_languages, default_post_language, get_conn,
+            CommunityLanguage, DbPool, Language, LanguageId, LocalUserLanguage, QueryDsl,
+            RunQueryDsl, SiteLanguage,
+        },
+        source::{
+            community::{Community, CommunityInsertForm},
+            instance::Instance,
+            local_site::{LocalSite, LocalSiteInsertForm},
+            local_user::{LocalUser, LocalUserInsertForm},
+            person::{Person, PersonInsertForm},
+            site::{Site, SiteInsertForm},
+        },
+        traits::Crud,
+        utils::build_db_pool_for_tests,
+    };
+    use serial_test::serial;
 
-  async fn test_langs1(pool: &mut DbPool<'_>) -> Vec<LanguageId> {
-    vec![
-      Language::read_id_from_code(pool, Some("en"))
-        .await
-        .unwrap()
-        .unwrap(),
-      Language::read_id_from_code(pool, Some("fr"))
-        .await
-        .unwrap()
-        .unwrap(),
-      Language::read_id_from_code(pool, Some("ru"))
-        .await
-        .unwrap()
-        .unwrap(),
-    ]
-  }
-  async fn test_langs2(pool: &mut DbPool<'_>) -> Vec<LanguageId> {
-    vec![
-      Language::read_id_from_code(pool, Some("fi"))
-        .await
-        .unwrap()
-        .unwrap(),
-      Language::read_id_from_code(pool, Some("se"))
-        .await
-        .unwrap()
-        .unwrap(),
-    ]
-  }
+    async fn test_langs1(pool: &mut DbPool<'_>) -> Vec<LanguageId> {
+        vec![
+            Language::read_id_from_code(pool, Some("en"))
+                .await
+                .unwrap()
+                .unwrap(),
+            Language::read_id_from_code(pool, Some("fr"))
+                .await
+                .unwrap()
+                .unwrap(),
+            Language::read_id_from_code(pool, Some("ru"))
+                .await
+                .unwrap()
+                .unwrap(),
+        ]
+    }
+    async fn test_langs2(pool: &mut DbPool<'_>) -> Vec<LanguageId> {
+        vec![
+            Language::read_id_from_code(pool, Some("fi"))
+                .await
+                .unwrap()
+                .unwrap(),
+            Language::read_id_from_code(pool, Some("se"))
+                .await
+                .unwrap()
+                .unwrap(),
+        ]
+    }
 
-  async fn create_test_site(pool: &mut DbPool<'_>) -> (Site, Instance) {
-    let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
-      .await
-      .unwrap();
+    async fn create_test_site(pool: &mut DbPool<'_>) -> (Site, Instance) {
+        let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
+            .await
+            .unwrap();
 
-    let site_form = SiteInsertForm::builder()
-      .name("test site".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-    let site = Site::create(pool, &site_form).await.unwrap();
+        let site_form = SiteInsertForm::builder()
+            .name("test site".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
+        let site = Site::create(pool, &site_form).await.unwrap();
 
-    // Create a local site, since this is necessary for local languages
-    let local_site_form = LocalSiteInsertForm::builder().site_id(site.id).build();
-    LocalSite::create(pool, &local_site_form).await.unwrap();
+        // Create a local site, since this is necessary for local languages
+        let local_site_form = LocalSiteInsertForm::builder().site_id(site.id).build();
+        LocalSite::create(pool, &local_site_form).await.unwrap();
 
-    (site, inserted_instance)
-  }
+        (site, inserted_instance)
+    }
 
-  #[tokio::test]
-  #[serial]
-  async fn test_convert_update_languages() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
+    #[tokio::test]
+    #[serial]
+    async fn test_convert_update_languages() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
 
-    // call with empty vec, returns all languages
-    let conn = &mut get_conn(pool).await.unwrap();
-    let converted1 = convert_update_languages(conn, vec![]).await.unwrap();
-    assert_eq!(184, converted1.len());
+        // call with empty vec, returns all languages
+        let conn = &mut get_conn(pool).await.unwrap();
+        let converted1 = convert_update_languages(conn, vec![]).await.unwrap();
+        assert_eq!(184, converted1.len());
 
-    // call with nonempty vec, returns same vec
-    let test_langs = test_langs1(&mut conn.into()).await;
-    let converted2 = convert_update_languages(conn, test_langs.clone())
-      .await
-      .unwrap();
-    assert_eq!(test_langs, converted2);
-  }
-  #[tokio::test]
-  #[serial]
-  async fn test_convert_read_languages() {
-    use crate::schema::language::dsl::{id, language};
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
+        // call with nonempty vec, returns same vec
+        let test_langs = test_langs1(&mut conn.into()).await;
+        let converted2 = convert_update_languages(conn, test_langs.clone())
+            .await
+            .unwrap();
+        assert_eq!(test_langs, converted2);
+    }
+    #[tokio::test]
+    #[serial]
+    async fn test_convert_read_languages() {
+        use crate::schema::language::dsl::{id, language};
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
 
-    // call with all languages, returns empty vec
-    let conn = &mut get_conn(pool).await.unwrap();
-    let all_langs = language.select(id).get_results(conn).await.unwrap();
-    let converted1: Vec<LanguageId> = convert_read_languages(conn, all_langs).await.unwrap();
-    assert_eq!(0, converted1.len());
+        // call with all languages, returns empty vec
+        let conn = &mut get_conn(pool).await.unwrap();
+        let all_langs = language.select(id).get_results(conn).await.unwrap();
+        let converted1: Vec<LanguageId> = convert_read_languages(conn, all_langs).await.unwrap();
+        assert_eq!(0, converted1.len());
 
-    // call with nonempty vec, returns same vec
-    let test_langs = test_langs1(&mut conn.into()).await;
-    let converted2 = convert_read_languages(conn, test_langs.clone())
-      .await
-      .unwrap();
-    assert_eq!(test_langs, converted2);
-  }
+        // call with nonempty vec, returns same vec
+        let test_langs = test_langs1(&mut conn.into()).await;
+        let converted2 = convert_read_languages(conn, test_langs.clone())
+            .await
+            .unwrap();
+        assert_eq!(test_langs, converted2);
+    }
 
-  #[tokio::test]
-  #[serial]
-  async fn test_site_languages() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
+    #[tokio::test]
+    #[serial]
+    async fn test_site_languages() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
 
-    let (site, instance) = create_test_site(pool).await;
-    let site_languages1 = SiteLanguage::read_local_raw(pool).await.unwrap();
-    // site is created with all languages
-    assert_eq!(184, site_languages1.len());
+        let (site, instance) = create_test_site(pool).await;
+        let site_languages1 = SiteLanguage::read_local_raw(pool).await.unwrap();
+        // site is created with all languages
+        assert_eq!(184, site_languages1.len());
 
-    let test_langs = test_langs1(pool).await;
-    SiteLanguage::update(pool, test_langs.clone(), &site)
-      .await
-      .unwrap();
+        let test_langs = test_langs1(pool).await;
+        SiteLanguage::update(pool, test_langs.clone(), &site)
+            .await
+            .unwrap();
 
-    let site_languages2 = SiteLanguage::read_local_raw(pool).await.unwrap();
-    // after update, site only has new languages
-    assert_eq!(test_langs, site_languages2);
+        let site_languages2 = SiteLanguage::read_local_raw(pool).await.unwrap();
+        // after update, site only has new languages
+        assert_eq!(test_langs, site_languages2);
 
-    Site::delete(pool, site.id).await.unwrap();
-    Instance::delete(pool, instance.id).await.unwrap();
-    LocalSite::delete(pool).await.unwrap();
-  }
+        Site::delete(pool, site.id).await.unwrap();
+        Instance::delete(pool, instance.id).await.unwrap();
+        LocalSite::delete(pool).await.unwrap();
+    }
 
-  #[tokio::test]
-  #[serial]
-  async fn test_user_languages() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
+    #[tokio::test]
+    #[serial]
+    async fn test_user_languages() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
 
-    let (site, instance) = create_test_site(pool).await;
-    let mut test_langs = test_langs1(pool).await;
-    SiteLanguage::update(pool, test_langs.clone(), &site)
-      .await
-      .unwrap();
+        let (site, instance) = create_test_site(pool).await;
+        let mut test_langs = test_langs1(pool).await;
+        SiteLanguage::update(pool, test_langs.clone(), &site)
+            .await
+            .unwrap();
 
-    let person_form = PersonInsertForm::builder()
-      .name("my test person".to_string())
-      .public_key("pubkey".to_string())
-      .instance_id(instance.id)
-      .build();
-    let person = Person::create(pool, &person_form).await.unwrap();
-    let local_user_form = LocalUserInsertForm::builder()
-      .person_id(person.id)
-      .password_encrypted("my_pw".to_string())
-      .build();
+        let person_form = PersonInsertForm::builder()
+            .name("my test person".to_string())
+            .public_key("pubkey".to_string())
+            .instance_id(instance.id)
+            .build();
+        let person = Person::create(pool, &person_form).await.unwrap();
+        let local_user_form = LocalUserInsertForm::builder()
+            .person_id(person.id)
+            .password_encrypted("my_pw".to_string())
+            .build();
 
-    let local_user = LocalUser::create(pool, &local_user_form).await.unwrap();
-    let local_user_langs1 = LocalUserLanguage::read(pool, local_user.id).await.unwrap();
+        let local_user = LocalUser::create(pool, &local_user_form).await.unwrap();
+        let local_user_langs1 = LocalUserLanguage::read(pool, local_user.id).await.unwrap();
 
-    // new user should be initialized with site languages and undetermined
-    //test_langs.push(UNDETERMINED_ID);
-    //test_langs.sort();
-    test_langs.insert(0, UNDETERMINED_ID);
-    assert_eq!(test_langs, local_user_langs1);
+        // new user should be initialized with site languages and undetermined
+        //test_langs.push(UNDETERMINED_ID);
+        //test_langs.sort();
+        test_langs.insert(0, UNDETERMINED_ID);
+        assert_eq!(test_langs, local_user_langs1);
 
-    // update user languages
-    let test_langs2 = test_langs2(pool).await;
-    LocalUserLanguage::update(pool, test_langs2, local_user.id)
-      .await
-      .unwrap();
-    let local_user_langs2 = LocalUserLanguage::read(pool, local_user.id).await.unwrap();
-    assert_eq!(3, local_user_langs2.len());
+        // update user languages
+        let test_langs2 = test_langs2(pool).await;
+        LocalUserLanguage::update(pool, test_langs2, local_user.id)
+            .await
+            .unwrap();
+        let local_user_langs2 = LocalUserLanguage::read(pool, local_user.id).await.unwrap();
+        assert_eq!(3, local_user_langs2.len());
 
-    Person::delete(pool, person.id).await.unwrap();
-    LocalUser::delete(pool, local_user.id).await.unwrap();
-    Site::delete(pool, site.id).await.unwrap();
-    LocalSite::delete(pool).await.unwrap();
-    Instance::delete(pool, instance.id).await.unwrap();
-  }
+        Person::delete(pool, person.id).await.unwrap();
+        LocalUser::delete(pool, local_user.id).await.unwrap();
+        Site::delete(pool, site.id).await.unwrap();
+        LocalSite::delete(pool).await.unwrap();
+        Instance::delete(pool, instance.id).await.unwrap();
+    }
 
-  #[tokio::test]
-  #[serial]
-  async fn test_community_languages() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-    let (site, instance) = create_test_site(pool).await;
-    let test_langs = test_langs1(pool).await;
-    SiteLanguage::update(pool, test_langs.clone(), &site)
-      .await
-      .unwrap();
+    #[tokio::test]
+    #[serial]
+    async fn test_community_languages() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
+        let (site, instance) = create_test_site(pool).await;
+        let test_langs = test_langs1(pool).await;
+        SiteLanguage::update(pool, test_langs.clone(), &site)
+            .await
+            .unwrap();
 
-    let read_site_langs = SiteLanguage::read(pool, site.id).await.unwrap();
-    assert_eq!(test_langs, read_site_langs);
+        let read_site_langs = SiteLanguage::read(pool, site.id).await.unwrap();
+        assert_eq!(test_langs, read_site_langs);
 
-    // Test the local ones are the same
-    let read_local_site_langs = SiteLanguage::read_local_raw(pool).await.unwrap();
-    assert_eq!(test_langs, read_local_site_langs);
+        // Test the local ones are the same
+        let read_local_site_langs = SiteLanguage::read_local_raw(pool).await.unwrap();
+        assert_eq!(test_langs, read_local_site_langs);
 
-    let community_form = CommunityInsertForm::builder()
-      .name("test community".to_string())
-      .title("test community".to_string())
-      .public_key("pubkey".to_string())
-      .instance_id(instance.id)
-      .build();
-    let community = Community::create(pool, &community_form).await.unwrap();
-    let community_langs1 = CommunityLanguage::read(pool, community.id).await.unwrap();
+        let community_form = CommunityInsertForm::builder()
+            .name("test community".to_string())
+            .title("test community".to_string())
+            .public_key("pubkey".to_string())
+            .instance_id(instance.id)
+            .build();
+        let community = Community::create(pool, &community_form).await.unwrap();
+        let community_langs1 = CommunityLanguage::read(pool, community.id).await.unwrap();
 
-    // community is initialized with site languages
-    assert_eq!(test_langs, community_langs1);
+        // community is initialized with site languages
+        assert_eq!(test_langs, community_langs1);
 
-    let allowed_lang1 =
-      CommunityLanguage::is_allowed_community_language(pool, Some(test_langs[0]), community.id)
+        let allowed_lang1 = CommunityLanguage::is_allowed_community_language(
+            pool,
+            Some(test_langs[0]),
+            community.id,
+        )
         .await;
-    assert!(allowed_lang1.is_ok());
+        assert!(allowed_lang1.is_ok());
 
-    let test_langs2 = test_langs2(pool).await;
-    let allowed_lang2 =
-      CommunityLanguage::is_allowed_community_language(pool, Some(test_langs2[0]), community.id)
+        let test_langs2 = test_langs2(pool).await;
+        let allowed_lang2 = CommunityLanguage::is_allowed_community_language(
+            pool,
+            Some(test_langs2[0]),
+            community.id,
+        )
         .await;
-    assert!(allowed_lang2.is_err());
+        assert!(allowed_lang2.is_err());
 
-    // limit site languages to en, fi. after this, community languages should be updated to
-    // intersection of old languages (en, fr, ru) and (en, fi), which is only fi.
-    SiteLanguage::update(pool, vec![test_langs[0], test_langs2[0]], &site)
-      .await
-      .unwrap();
-    let community_langs2 = CommunityLanguage::read(pool, community.id).await.unwrap();
-    assert_eq!(vec![test_langs[0]], community_langs2);
+        // limit site languages to en, fi. after this, community languages should be updated to
+        // intersection of old languages (en, fr, ru) and (en, fi), which is only fi.
+        SiteLanguage::update(pool, vec![test_langs[0], test_langs2[0]], &site)
+            .await
+            .unwrap();
+        let community_langs2 = CommunityLanguage::read(pool, community.id).await.unwrap();
+        assert_eq!(vec![test_langs[0]], community_langs2);
 
-    // update community languages to different ones
-    CommunityLanguage::update(pool, test_langs2.clone(), community.id)
-      .await
-      .unwrap();
-    let community_langs3 = CommunityLanguage::read(pool, community.id).await.unwrap();
-    assert_eq!(test_langs2, community_langs3);
+        // update community languages to different ones
+        CommunityLanguage::update(pool, test_langs2.clone(), community.id)
+            .await
+            .unwrap();
+        let community_langs3 = CommunityLanguage::read(pool, community.id).await.unwrap();
+        assert_eq!(test_langs2, community_langs3);
 
-    Community::delete(pool, community.id).await.unwrap();
-    Site::delete(pool, site.id).await.unwrap();
-    LocalSite::delete(pool).await.unwrap();
-    Instance::delete(pool, instance.id).await.unwrap();
-  }
+        Community::delete(pool, community.id).await.unwrap();
+        Site::delete(pool, site.id).await.unwrap();
+        LocalSite::delete(pool).await.unwrap();
+        Instance::delete(pool, instance.id).await.unwrap();
+    }
 
-  #[tokio::test]
-  #[serial]
-  async fn test_default_post_language() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-    let (site, instance) = create_test_site(pool).await;
-    let test_langs = test_langs1(pool).await;
-    let test_langs2 = test_langs2(pool).await;
+    #[tokio::test]
+    #[serial]
+    async fn test_default_post_language() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
+        let (site, instance) = create_test_site(pool).await;
+        let test_langs = test_langs1(pool).await;
+        let test_langs2 = test_langs2(pool).await;
 
-    let community_form = CommunityInsertForm::builder()
-      .name("test community".to_string())
-      .title("test community".to_string())
-      .public_key("pubkey".to_string())
-      .instance_id(instance.id)
-      .build();
-    let community = Community::create(pool, &community_form).await.unwrap();
-    CommunityLanguage::update(pool, test_langs, community.id)
-      .await
-      .unwrap();
+        let community_form = CommunityInsertForm::builder()
+            .name("test community".to_string())
+            .title("test community".to_string())
+            .public_key("pubkey".to_string())
+            .instance_id(instance.id)
+            .build();
+        let community = Community::create(pool, &community_form).await.unwrap();
+        CommunityLanguage::update(pool, test_langs, community.id)
+            .await
+            .unwrap();
 
-    let person_form = PersonInsertForm::builder()
-      .name("my test person".to_string())
-      .public_key("pubkey".to_string())
-      .instance_id(instance.id)
-      .build();
-    let person = Person::create(pool, &person_form).await.unwrap();
-    let local_user_form = LocalUserInsertForm::builder()
-      .person_id(person.id)
-      .password_encrypted("my_pw".to_string())
-      .build();
-    let local_user = LocalUser::create(pool, &local_user_form).await.unwrap();
-    LocalUserLanguage::update(pool, test_langs2, local_user.id)
-      .await
-      .unwrap();
+        let person_form = PersonInsertForm::builder()
+            .name("my test person".to_string())
+            .public_key("pubkey".to_string())
+            .instance_id(instance.id)
+            .build();
+        let person = Person::create(pool, &person_form).await.unwrap();
+        let local_user_form = LocalUserInsertForm::builder()
+            .person_id(person.id)
+            .password_encrypted("my_pw".to_string())
+            .build();
+        let local_user = LocalUser::create(pool, &local_user_form).await.unwrap();
+        LocalUserLanguage::update(pool, test_langs2, local_user.id)
+            .await
+            .unwrap();
 
-    // no overlap in user/community languages, so defaults to undetermined
-    let def1 = default_post_language(pool, community.id, local_user.id)
-      .await
-      .unwrap();
-    assert_eq!(None, def1);
+        // no overlap in user/community languages, so defaults to undetermined
+        let def1 = default_post_language(pool, community.id, local_user.id)
+            .await
+            .unwrap();
+        assert_eq!(None, def1);
 
-    let ru = Language::read_id_from_code(pool, Some("ru"))
-      .await
-      .unwrap()
-      .unwrap();
-    let test_langs3 = vec![
-      ru,
-      Language::read_id_from_code(pool, Some("fi"))
-        .await
-        .unwrap()
-        .unwrap(),
-      Language::read_id_from_code(pool, Some("se"))
-        .await
-        .unwrap()
-        .unwrap(),
-      UNDETERMINED_ID,
-    ];
-    LocalUserLanguage::update(pool, test_langs3, local_user.id)
-      .await
-      .unwrap();
+        let ru = Language::read_id_from_code(pool, Some("ru"))
+            .await
+            .unwrap()
+            .unwrap();
+        let test_langs3 = vec![
+            ru,
+            Language::read_id_from_code(pool, Some("fi"))
+                .await
+                .unwrap()
+                .unwrap(),
+            Language::read_id_from_code(pool, Some("se"))
+                .await
+                .unwrap()
+                .unwrap(),
+            UNDETERMINED_ID,
+        ];
+        LocalUserLanguage::update(pool, test_langs3, local_user.id)
+            .await
+            .unwrap();
 
-    // this time, both have ru as common lang
-    let def2 = default_post_language(pool, community.id, local_user.id)
-      .await
-      .unwrap();
-    assert_eq!(Some(ru), def2);
+        // this time, both have ru as common lang
+        let def2 = default_post_language(pool, community.id, local_user.id)
+            .await
+            .unwrap();
+        assert_eq!(Some(ru), def2);
 
-    Person::delete(pool, person.id).await.unwrap();
-    Community::delete(pool, community.id).await.unwrap();
-    LocalUser::delete(pool, local_user.id).await.unwrap();
-    Site::delete(pool, site.id).await.unwrap();
-    LocalSite::delete(pool).await.unwrap();
-    Instance::delete(pool, instance.id).await.unwrap();
-  }
+        Person::delete(pool, person.id).await.unwrap();
+        Community::delete(pool, community.id).await.unwrap();
+        LocalUser::delete(pool, local_user.id).await.unwrap();
+        Site::delete(pool, site.id).await.unwrap();
+        LocalSite::delete(pool).await.unwrap();
+        Instance::delete(pool, instance.id).await.unwrap();
+    }
 }

--- a/crates/db_schema/src/impls/captcha_answer.rs
+++ b/crates/db_schema/src/impls/captcha_answer.rs
@@ -1,126 +1,120 @@
 use crate::{
-  schema::captcha_answer::dsl::{answer, captcha_answer, uuid},
-  source::captcha_answer::{CaptchaAnswer, CaptchaAnswerForm, CheckCaptchaAnswer},
-  utils::{functions::lower, get_conn, DbPool},
+    schema::captcha_answer::dsl::{answer, captcha_answer, uuid},
+    source::captcha_answer::{CaptchaAnswer, CaptchaAnswerForm, CheckCaptchaAnswer},
+    utils::{functions::lower, get_conn, DbPool},
 };
 use diesel::{
-  delete,
-  dsl::exists,
-  insert_into,
-  result::Error,
-  select,
-  ExpressionMethods,
-  QueryDsl,
+    delete, dsl::exists, insert_into, result::Error, select, ExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 
 impl CaptchaAnswer {
-  pub async fn insert(pool: &mut DbPool<'_>, captcha: &CaptchaAnswerForm) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
+    pub async fn insert(pool: &mut DbPool<'_>, captcha: &CaptchaAnswerForm) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
 
-    insert_into(captcha_answer)
-      .values(captcha)
-      .get_result::<Self>(conn)
-      .await
-  }
+        insert_into(captcha_answer)
+            .values(captcha)
+            .get_result::<Self>(conn)
+            .await
+    }
 
-  pub async fn check_captcha(
-    pool: &mut DbPool<'_>,
-    to_check: CheckCaptchaAnswer,
-  ) -> Result<bool, Error> {
-    let conn = &mut get_conn(pool).await?;
+    pub async fn check_captcha(
+        pool: &mut DbPool<'_>,
+        to_check: CheckCaptchaAnswer,
+    ) -> Result<bool, Error> {
+        let conn = &mut get_conn(pool).await?;
 
-    // fetch requested captcha
-    let captcha_exists = select(exists(
-      captcha_answer
-        .filter((uuid).eq(to_check.uuid))
-        .filter(lower(answer).eq(to_check.answer.to_lowercase().clone())),
-    ))
-    .get_result::<bool>(conn)
-    .await?;
+        // fetch requested captcha
+        let captcha_exists = select(exists(
+            captcha_answer
+                .filter((uuid).eq(to_check.uuid))
+                .filter(lower(answer).eq(to_check.answer.to_lowercase().clone())),
+        ))
+        .get_result::<bool>(conn)
+        .await?;
 
-    // delete checked captcha
-    delete(captcha_answer.filter(uuid.eq(to_check.uuid)))
-      .execute(conn)
-      .await?;
+        // delete checked captcha
+        delete(captcha_answer.filter(uuid.eq(to_check.uuid)))
+            .execute(conn)
+            .await?;
 
-    Ok(captcha_exists)
-  }
+        Ok(captcha_exists)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::{
-    source::captcha_answer::{CaptchaAnswer, CaptchaAnswerForm, CheckCaptchaAnswer},
-    utils::build_db_pool_for_tests,
-  };
-  use serial_test::serial;
+    use crate::{
+        source::captcha_answer::{CaptchaAnswer, CaptchaAnswerForm, CheckCaptchaAnswer},
+        utils::build_db_pool_for_tests,
+    };
+    use serial_test::serial;
 
-  #[tokio::test]
-  #[serial]
-  async fn test_captcha_happy_path() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
+    #[tokio::test]
+    #[serial]
+    async fn test_captcha_happy_path() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
 
-    let inserted = CaptchaAnswer::insert(
-      pool,
-      &CaptchaAnswerForm {
-        answer: "XYZ".to_string(),
-      },
-    )
-    .await
-    .expect("should not fail to insert captcha");
+        let inserted = CaptchaAnswer::insert(
+            pool,
+            &CaptchaAnswerForm {
+                answer: "XYZ".to_string(),
+            },
+        )
+        .await
+        .expect("should not fail to insert captcha");
 
-    let result = CaptchaAnswer::check_captcha(
-      pool,
-      CheckCaptchaAnswer {
-        uuid: inserted.uuid,
-        answer: "xyz".to_string(),
-      },
-    )
-    .await;
+        let result = CaptchaAnswer::check_captcha(
+            pool,
+            CheckCaptchaAnswer {
+                uuid: inserted.uuid,
+                answer: "xyz".to_string(),
+            },
+        )
+        .await;
 
-    assert!(result.is_ok());
-    assert!(result.unwrap());
-  }
+        assert!(result.is_ok());
+        assert!(result.unwrap());
+    }
 
-  #[tokio::test]
-  #[serial]
-  async fn test_captcha_repeat_answer_fails() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
+    #[tokio::test]
+    #[serial]
+    async fn test_captcha_repeat_answer_fails() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
 
-    let inserted = CaptchaAnswer::insert(
-      pool,
-      &CaptchaAnswerForm {
-        answer: "XYZ".to_string(),
-      },
-    )
-    .await
-    .expect("should not fail to insert captcha");
+        let inserted = CaptchaAnswer::insert(
+            pool,
+            &CaptchaAnswerForm {
+                answer: "XYZ".to_string(),
+            },
+        )
+        .await
+        .expect("should not fail to insert captcha");
 
-    let _result = CaptchaAnswer::check_captcha(
-      pool,
-      CheckCaptchaAnswer {
-        uuid: inserted.uuid,
-        answer: "xyz".to_string(),
-      },
-    )
-    .await;
+        let _result = CaptchaAnswer::check_captcha(
+            pool,
+            CheckCaptchaAnswer {
+                uuid: inserted.uuid,
+                answer: "xyz".to_string(),
+            },
+        )
+        .await;
 
-    let result_repeat = CaptchaAnswer::check_captcha(
-      pool,
-      CheckCaptchaAnswer {
-        uuid: inserted.uuid,
-        answer: "xyz".to_string(),
-      },
-    )
-    .await;
+        let result_repeat = CaptchaAnswer::check_captcha(
+            pool,
+            CheckCaptchaAnswer {
+                uuid: inserted.uuid,
+                answer: "xyz".to_string(),
+            },
+        )
+        .await;
 
-    assert!(result_repeat.is_ok());
-    assert!(!result_repeat.unwrap());
-  }
+        assert!(result_repeat.is_ok());
+        assert!(!result_repeat.unwrap());
+    }
 }

--- a/crates/db_schema/src/impls/comment.rs
+++ b/crates/db_schema/src/impls/comment.rs
@@ -1,110 +1,104 @@
 use crate::{
-  newtypes::{CommentId, DbUrl, PersonId},
-  schema::comment::dsl::{ap_id, comment, content, creator_id, deleted, path, removed, updated},
-  source::comment::{
-    Comment,
-    CommentInsertForm,
-    CommentLike,
-    CommentLikeForm,
-    CommentSaved,
-    CommentSavedForm,
-    CommentUpdateForm,
-  },
-  traits::{Crud, Likeable, Saveable},
-  utils::{get_conn, naive_now, DbPool, DELETED_REPLACEMENT_TEXT},
+    newtypes::{CommentId, DbUrl, PersonId},
+    schema::comment::dsl::{ap_id, comment, content, creator_id, deleted, path, removed, updated},
+    source::comment::{
+        Comment, CommentInsertForm, CommentLike, CommentLikeForm, CommentSaved, CommentSavedForm,
+        CommentUpdateForm,
+    },
+    traits::{Crud, Likeable, Saveable},
+    utils::{get_conn, naive_now, DbPool, DELETED_REPLACEMENT_TEXT},
 };
 use diesel::{
-  dsl::{insert_into, sql_query},
-  result::Error,
-  ExpressionMethods,
-  QueryDsl,
+    dsl::{insert_into, sql_query},
+    result::Error,
+    ExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use diesel_ltree::Ltree;
 use url::Url;
 
 impl Comment {
-  pub async fn permadelete_for_creator(
-    pool: &mut DbPool<'_>,
-    for_creator_id: PersonId,
-  ) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
+    pub async fn permadelete_for_creator(
+        pool: &mut DbPool<'_>,
+        for_creator_id: PersonId,
+    ) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
 
-    diesel::update(comment.filter(creator_id.eq(for_creator_id)))
-      .set((
-        content.eq(DELETED_REPLACEMENT_TEXT),
-        deleted.eq(true),
-        updated.eq(naive_now()),
-      ))
-      .get_results::<Self>(conn)
-      .await
-  }
+        diesel::update(comment.filter(creator_id.eq(for_creator_id)))
+            .set((
+                content.eq(DELETED_REPLACEMENT_TEXT),
+                deleted.eq(true),
+                updated.eq(naive_now()),
+            ))
+            .get_results::<Self>(conn)
+            .await
+    }
 
-  pub async fn update_removed_for_creator(
-    pool: &mut DbPool<'_>,
-    for_creator_id: PersonId,
-    new_removed: bool,
-  ) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(comment.filter(creator_id.eq(for_creator_id)))
-      .set((removed.eq(new_removed), updated.eq(naive_now())))
-      .get_results::<Self>(conn)
-      .await
-  }
+    pub async fn update_removed_for_creator(
+        pool: &mut DbPool<'_>,
+        for_creator_id: PersonId,
+        new_removed: bool,
+    ) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(comment.filter(creator_id.eq(for_creator_id)))
+            .set((removed.eq(new_removed), updated.eq(naive_now())))
+            .get_results::<Self>(conn)
+            .await
+    }
 
-  pub async fn create(
-    pool: &mut DbPool<'_>,
-    comment_form: &CommentInsertForm,
-    parent_path: Option<&Ltree>,
-  ) -> Result<Comment, Error> {
-    let conn = &mut get_conn(pool).await?;
+    pub async fn create(
+        pool: &mut DbPool<'_>,
+        comment_form: &CommentInsertForm,
+        parent_path: Option<&Ltree>,
+    ) -> Result<Comment, Error> {
+        let conn = &mut get_conn(pool).await?;
 
-    // Insert, to get the id
-    let inserted_comment = insert_into(comment)
-      .values(comment_form)
-      .on_conflict(ap_id)
-      .do_update()
-      .set(comment_form)
-      .get_result::<Self>(conn)
-      .await;
+        // Insert, to get the id
+        let inserted_comment = insert_into(comment)
+            .values(comment_form)
+            .on_conflict(ap_id)
+            .do_update()
+            .set(comment_form)
+            .get_result::<Self>(conn)
+            .await;
 
-    if let Ok(comment_insert) = inserted_comment {
-      let comment_id = comment_insert.id;
+        if let Ok(comment_insert) = inserted_comment {
+            let comment_id = comment_insert.id;
 
-      // You need to update the ltree column
-      let ltree = Ltree(if let Some(parent_path) = parent_path {
-        // The previous parent will already have 0 in it
-        // Append this comment id
-        format!("{}.{}", parent_path.0, comment_id)
-      } else {
-        // '0' is always the first path, append to that
-        format!("{}.{}", 0, comment_id)
-      });
+            // You need to update the ltree column
+            let ltree = Ltree(if let Some(parent_path) = parent_path {
+                // The previous parent will already have 0 in it
+                // Append this comment id
+                format!("{}.{}", parent_path.0, comment_id)
+            } else {
+                // '0' is always the first path, append to that
+                format!("{}.{}", 0, comment_id)
+            });
 
-      let updated_comment = diesel::update(comment.find(comment_id))
-        .set(path.eq(ltree))
-        .get_result::<Self>(conn)
-        .await;
+            let updated_comment = diesel::update(comment.find(comment_id))
+                .set(path.eq(ltree))
+                .get_result::<Self>(conn)
+                .await;
 
-      // Update the child count for the parent comment_aggregates
-      // You could do this with a trigger, but since you have to do this manually anyway,
-      // you can just have it here
-      if let Some(parent_path) = parent_path {
-        // You have to update counts for all parents, not just the immediate one
-        // TODO if the performance of this is terrible, it might be better to do this as part of a
-        // scheduled query... although the counts would often be wrong.
-        //
-        // The child_count query for reference:
-        // select c.id, c.path, count(c2.id) as child_count from comment c
-        // left join comment c2 on c2.path <@ c.path and c2.path != c.path
-        // group by c.id
+            // Update the child count for the parent comment_aggregates
+            // You could do this with a trigger, but since you have to do this manually anyway,
+            // you can just have it here
+            if let Some(parent_path) = parent_path {
+                // You have to update counts for all parents, not just the immediate one
+                // TODO if the performance of this is terrible, it might be better to do this as part of a
+                // scheduled query... although the counts would often be wrong.
+                //
+                // The child_count query for reference:
+                // select c.id, c.path, count(c2.id) as child_count from comment c
+                // left join comment c2 on c2.path <@ c.path and c2.path != c.path
+                // group by c.id
 
-        let parent_id = parent_path.0.split('.').nth(1);
+                let parent_id = parent_path.0.split('.').nth(1);
 
-        if let Some(parent_id) = parent_id {
-          let top_parent = format!("0.{}", parent_id);
-          let update_child_count_stmt = format!(
-            "
+                if let Some(parent_id) = parent_id {
+                    let top_parent = format!("0.{}", parent_id);
+                    let update_child_count_stmt = format!(
+                        "
 update comment_aggregates ca set child_count = c.child_count
 from (
   select c.id, c.path, count(c2.id) as child_count from comment c
@@ -113,303 +107,302 @@ from (
   group by c.id
 ) as c
 where ca.comment_id = c.id"
-          );
+                    );
 
-          sql_query(update_child_count_stmt).execute(conn).await?;
+                    sql_query(update_child_count_stmt).execute(conn).await?;
+                }
+            }
+            updated_comment
+        } else {
+            inserted_comment
         }
-      }
-      updated_comment
-    } else {
-      inserted_comment
     }
-  }
-  pub async fn read_from_apub_id(
-    pool: &mut DbPool<'_>,
-    object_id: Url,
-  ) -> Result<Option<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let object_id: DbUrl = object_id.into();
-    Ok(
-      comment
-        .filter(ap_id.eq(object_id))
-        .first::<Comment>(conn)
-        .await
-        .ok()
-        .map(Into::into),
-    )
-  }
+    pub async fn read_from_apub_id(
+        pool: &mut DbPool<'_>,
+        object_id: Url,
+    ) -> Result<Option<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let object_id: DbUrl = object_id.into();
+        Ok(comment
+            .filter(ap_id.eq(object_id))
+            .first::<Comment>(conn)
+            .await
+            .ok()
+            .map(Into::into))
+    }
 
-  pub fn parent_comment_id(&self) -> Option<CommentId> {
-    let mut ltree_split: Vec<&str> = self.path.0.split('.').collect();
-    ltree_split.remove(0); // The first is always 0
-    if ltree_split.len() > 1 {
-      let parent_comment_id = ltree_split.get(ltree_split.len() - 2);
-      parent_comment_id.and_then(|p| p.parse::<i32>().map(CommentId).ok())
-    } else {
-      None
+    pub fn parent_comment_id(&self) -> Option<CommentId> {
+        let mut ltree_split: Vec<&str> = self.path.0.split('.').collect();
+        ltree_split.remove(0); // The first is always 0
+        if ltree_split.len() > 1 {
+            let parent_comment_id = ltree_split.get(ltree_split.len() - 2);
+            parent_comment_id.and_then(|p| p.parse::<i32>().map(CommentId).ok())
+        } else {
+            None
+        }
     }
-  }
 }
 
 #[async_trait]
 impl Crud for Comment {
-  type InsertForm = CommentInsertForm;
-  type UpdateForm = CommentUpdateForm;
-  type IdType = CommentId;
+    type InsertForm = CommentInsertForm;
+    type UpdateForm = CommentUpdateForm;
+    type IdType = CommentId;
 
-  /// This is unimplemented, use [[Comment::create]]
-  async fn create(_pool: &mut DbPool<'_>, _comment_form: &Self::InsertForm) -> Result<Self, Error> {
-    unimplemented!();
-  }
+    /// This is unimplemented, use [[Comment::create]]
+    async fn create(
+        _pool: &mut DbPool<'_>,
+        _comment_form: &Self::InsertForm,
+    ) -> Result<Self, Error> {
+        unimplemented!();
+    }
 
-  async fn update(
-    pool: &mut DbPool<'_>,
-    comment_id: CommentId,
-    comment_form: &Self::UpdateForm,
-  ) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(comment.find(comment_id))
-      .set(comment_form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn update(
+        pool: &mut DbPool<'_>,
+        comment_id: CommentId,
+        comment_form: &Self::UpdateForm,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(comment.find(comment_id))
+            .set(comment_form)
+            .get_result::<Self>(conn)
+            .await
+    }
 }
 
 #[async_trait]
 impl Likeable for CommentLike {
-  type Form = CommentLikeForm;
-  type IdType = CommentId;
-  async fn like(pool: &mut DbPool<'_>, comment_like_form: &CommentLikeForm) -> Result<Self, Error> {
-    use crate::schema::comment_like::dsl::{comment_id, comment_like, person_id};
-    let conn = &mut get_conn(pool).await?;
-    insert_into(comment_like)
-      .values(comment_like_form)
-      .on_conflict((comment_id, person_id))
-      .do_update()
-      .set(comment_like_form)
-      .get_result::<Self>(conn)
-      .await
-  }
-  async fn remove(
-    pool: &mut DbPool<'_>,
-    person_id_: PersonId,
-    comment_id_: CommentId,
-  ) -> Result<usize, Error> {
-    use crate::schema::comment_like::dsl::{comment_id, comment_like, person_id};
-    let conn = &mut get_conn(pool).await?;
-    diesel::delete(
-      comment_like
-        .filter(comment_id.eq(comment_id_))
-        .filter(person_id.eq(person_id_)),
-    )
-    .execute(conn)
-    .await
-  }
+    type Form = CommentLikeForm;
+    type IdType = CommentId;
+    async fn like(
+        pool: &mut DbPool<'_>,
+        comment_like_form: &CommentLikeForm,
+    ) -> Result<Self, Error> {
+        use crate::schema::comment_like::dsl::{comment_id, comment_like, person_id};
+        let conn = &mut get_conn(pool).await?;
+        insert_into(comment_like)
+            .values(comment_like_form)
+            .on_conflict((comment_id, person_id))
+            .do_update()
+            .set(comment_like_form)
+            .get_result::<Self>(conn)
+            .await
+    }
+    async fn remove(
+        pool: &mut DbPool<'_>,
+        person_id_: PersonId,
+        comment_id_: CommentId,
+    ) -> Result<usize, Error> {
+        use crate::schema::comment_like::dsl::{comment_id, comment_like, person_id};
+        let conn = &mut get_conn(pool).await?;
+        diesel::delete(
+            comment_like
+                .filter(comment_id.eq(comment_id_))
+                .filter(person_id.eq(person_id_)),
+        )
+        .execute(conn)
+        .await
+    }
 }
 
 #[async_trait]
 impl Saveable for CommentSaved {
-  type Form = CommentSavedForm;
-  async fn save(
-    pool: &mut DbPool<'_>,
-    comment_saved_form: &CommentSavedForm,
-  ) -> Result<Self, Error> {
-    use crate::schema::comment_saved::dsl::{comment_id, comment_saved, person_id};
-    let conn = &mut get_conn(pool).await?;
-    insert_into(comment_saved)
-      .values(comment_saved_form)
-      .on_conflict((comment_id, person_id))
-      .do_update()
-      .set(comment_saved_form)
-      .get_result::<Self>(conn)
-      .await
-  }
-  async fn unsave(
-    pool: &mut DbPool<'_>,
-    comment_saved_form: &CommentSavedForm,
-  ) -> Result<usize, Error> {
-    use crate::schema::comment_saved::dsl::{comment_id, comment_saved, person_id};
-    let conn = &mut get_conn(pool).await?;
-    diesel::delete(
-      comment_saved
-        .filter(comment_id.eq(comment_saved_form.comment_id))
-        .filter(person_id.eq(comment_saved_form.person_id)),
-    )
-    .execute(conn)
-    .await
-  }
+    type Form = CommentSavedForm;
+    async fn save(
+        pool: &mut DbPool<'_>,
+        comment_saved_form: &CommentSavedForm,
+    ) -> Result<Self, Error> {
+        use crate::schema::comment_saved::dsl::{comment_id, comment_saved, person_id};
+        let conn = &mut get_conn(pool).await?;
+        insert_into(comment_saved)
+            .values(comment_saved_form)
+            .on_conflict((comment_id, person_id))
+            .do_update()
+            .set(comment_saved_form)
+            .get_result::<Self>(conn)
+            .await
+    }
+    async fn unsave(
+        pool: &mut DbPool<'_>,
+        comment_saved_form: &CommentSavedForm,
+    ) -> Result<usize, Error> {
+        use crate::schema::comment_saved::dsl::{comment_id, comment_saved, person_id};
+        let conn = &mut get_conn(pool).await?;
+        diesel::delete(
+            comment_saved
+                .filter(comment_id.eq(comment_saved_form.comment_id))
+                .filter(person_id.eq(comment_saved_form.person_id)),
+        )
+        .execute(conn)
+        .await
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::{
-    newtypes::LanguageId,
-    source::{
-      comment::{
-        Comment,
-        CommentInsertForm,
-        CommentLike,
-        CommentLikeForm,
-        CommentSaved,
-        CommentSavedForm,
-        CommentUpdateForm,
-      },
-      community::{Community, CommunityInsertForm},
-      instance::Instance,
-      person::{Person, PersonInsertForm},
-      post::{Post, PostInsertForm},
-    },
-    traits::{Crud, Likeable, Saveable},
-    utils::build_db_pool_for_tests,
-  };
-  use diesel_ltree::Ltree;
-  use serial_test::serial;
-
-  #[tokio::test]
-  #[serial]
-  async fn test_crud() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-
-    let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
-      .await
-      .unwrap();
-
-    let new_person = PersonInsertForm::builder()
-      .name("terry".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_person = Person::create(pool, &new_person).await.unwrap();
-
-    let new_community = CommunityInsertForm::builder()
-      .name("test community".to_string())
-      .title("nada".to_owned())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_community = Community::create(pool, &new_community).await.unwrap();
-
-    let new_post = PostInsertForm::builder()
-      .name("A test post".into())
-      .creator_id(inserted_person.id)
-      .community_id(inserted_community.id)
-      .build();
-
-    let inserted_post = Post::create(pool, &new_post).await.unwrap();
-
-    let comment_form = CommentInsertForm::builder()
-      .content("A test comment".into())
-      .creator_id(inserted_person.id)
-      .post_id(inserted_post.id)
-      .build();
-
-    let inserted_comment = Comment::create(pool, &comment_form, None).await.unwrap();
-
-    let expected_comment = Comment {
-      id: inserted_comment.id,
-      content: "A test comment".into(),
-      creator_id: inserted_person.id,
-      post_id: inserted_post.id,
-      removed: false,
-      deleted: false,
-      path: Ltree(format!("0.{}", inserted_comment.id)),
-      published: inserted_comment.published,
-      updated: None,
-      ap_id: inserted_comment.ap_id.clone(),
-      distinguished: false,
-      local: true,
-      language_id: LanguageId::default(),
+    use crate::{
+        newtypes::LanguageId,
+        source::{
+            comment::{
+                Comment, CommentInsertForm, CommentLike, CommentLikeForm, CommentSaved,
+                CommentSavedForm, CommentUpdateForm,
+            },
+            community::{Community, CommunityInsertForm},
+            instance::Instance,
+            person::{Person, PersonInsertForm},
+            post::{Post, PostInsertForm},
+        },
+        traits::{Crud, Likeable, Saveable},
+        utils::build_db_pool_for_tests,
     };
+    use diesel_ltree::Ltree;
+    use serial_test::serial;
 
-    let child_comment_form = CommentInsertForm::builder()
-      .content("A child comment".into())
-      .creator_id(inserted_person.id)
-      .post_id(inserted_post.id)
-      .build();
+    #[tokio::test]
+    #[serial]
+    async fn test_crud() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
 
-    let inserted_child_comment =
-      Comment::create(pool, &child_comment_form, Some(&inserted_comment.path))
-        .await
-        .unwrap();
+        let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
+            .await
+            .unwrap();
 
-    // Comment Like
-    let comment_like_form = CommentLikeForm {
-      comment_id: inserted_comment.id,
-      post_id: inserted_post.id,
-      person_id: inserted_person.id,
-      score: 1,
-    };
+        let new_person = PersonInsertForm::builder()
+            .name("terry".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let inserted_comment_like = CommentLike::like(pool, &comment_like_form).await.unwrap();
+        let inserted_person = Person::create(pool, &new_person).await.unwrap();
 
-    let expected_comment_like = CommentLike {
-      id: inserted_comment_like.id,
-      comment_id: inserted_comment.id,
-      post_id: inserted_post.id,
-      person_id: inserted_person.id,
-      published: inserted_comment_like.published,
-      score: 1,
-    };
+        let new_community = CommunityInsertForm::builder()
+            .name("test community".to_string())
+            .title("nada".to_owned())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    // Comment Saved
-    let comment_saved_form = CommentSavedForm {
-      comment_id: inserted_comment.id,
-      person_id: inserted_person.id,
-    };
+        let inserted_community = Community::create(pool, &new_community).await.unwrap();
 
-    let inserted_comment_saved = CommentSaved::save(pool, &comment_saved_form).await.unwrap();
+        let new_post = PostInsertForm::builder()
+            .name("A test post".into())
+            .creator_id(inserted_person.id)
+            .community_id(inserted_community.id)
+            .build();
 
-    let expected_comment_saved = CommentSaved {
-      id: inserted_comment_saved.id,
-      comment_id: inserted_comment.id,
-      person_id: inserted_person.id,
-      published: inserted_comment_saved.published,
-    };
+        let inserted_post = Post::create(pool, &new_post).await.unwrap();
 
-    let comment_update_form = CommentUpdateForm {
-      content: Some("A test comment".into()),
-      ..Default::default()
-    };
+        let comment_form = CommentInsertForm::builder()
+            .content("A test comment".into())
+            .creator_id(inserted_person.id)
+            .post_id(inserted_post.id)
+            .build();
 
-    let updated_comment = Comment::update(pool, inserted_comment.id, &comment_update_form)
-      .await
-      .unwrap();
+        let inserted_comment = Comment::create(pool, &comment_form, None).await.unwrap();
 
-    let read_comment = Comment::read(pool, inserted_comment.id).await.unwrap();
-    let like_removed = CommentLike::remove(pool, inserted_person.id, inserted_comment.id)
-      .await
-      .unwrap();
-    let saved_removed = CommentSaved::unsave(pool, &comment_saved_form)
-      .await
-      .unwrap();
-    let num_deleted = Comment::delete(pool, inserted_comment.id).await.unwrap();
-    Comment::delete(pool, inserted_child_comment.id)
-      .await
-      .unwrap();
-    Post::delete(pool, inserted_post.id).await.unwrap();
-    Community::delete(pool, inserted_community.id)
-      .await
-      .unwrap();
-    Person::delete(pool, inserted_person.id).await.unwrap();
-    Instance::delete(pool, inserted_instance.id).await.unwrap();
+        let expected_comment = Comment {
+            id: inserted_comment.id,
+            content: "A test comment".into(),
+            creator_id: inserted_person.id,
+            post_id: inserted_post.id,
+            removed: false,
+            deleted: false,
+            path: Ltree(format!("0.{}", inserted_comment.id)),
+            published: inserted_comment.published,
+            updated: None,
+            ap_id: inserted_comment.ap_id.clone(),
+            distinguished: false,
+            local: true,
+            language_id: LanguageId::default(),
+        };
 
-    assert_eq!(expected_comment, read_comment);
-    assert_eq!(expected_comment, inserted_comment);
-    assert_eq!(expected_comment, updated_comment);
-    assert_eq!(expected_comment_like, inserted_comment_like);
-    assert_eq!(expected_comment_saved, inserted_comment_saved);
-    assert_eq!(
-      format!("0.{}.{}", expected_comment.id, inserted_child_comment.id),
-      inserted_child_comment.path.0,
-    );
-    assert_eq!(1, like_removed);
-    assert_eq!(1, saved_removed);
-    assert_eq!(1, num_deleted);
-  }
+        let child_comment_form = CommentInsertForm::builder()
+            .content("A child comment".into())
+            .creator_id(inserted_person.id)
+            .post_id(inserted_post.id)
+            .build();
+
+        let inserted_child_comment =
+            Comment::create(pool, &child_comment_form, Some(&inserted_comment.path))
+                .await
+                .unwrap();
+
+        // Comment Like
+        let comment_like_form = CommentLikeForm {
+            comment_id: inserted_comment.id,
+            post_id: inserted_post.id,
+            person_id: inserted_person.id,
+            score: 1,
+        };
+
+        let inserted_comment_like = CommentLike::like(pool, &comment_like_form).await.unwrap();
+
+        let expected_comment_like = CommentLike {
+            id: inserted_comment_like.id,
+            comment_id: inserted_comment.id,
+            post_id: inserted_post.id,
+            person_id: inserted_person.id,
+            published: inserted_comment_like.published,
+            score: 1,
+        };
+
+        // Comment Saved
+        let comment_saved_form = CommentSavedForm {
+            comment_id: inserted_comment.id,
+            person_id: inserted_person.id,
+        };
+
+        let inserted_comment_saved = CommentSaved::save(pool, &comment_saved_form).await.unwrap();
+
+        let expected_comment_saved = CommentSaved {
+            id: inserted_comment_saved.id,
+            comment_id: inserted_comment.id,
+            person_id: inserted_person.id,
+            published: inserted_comment_saved.published,
+        };
+
+        let comment_update_form = CommentUpdateForm {
+            content: Some("A test comment".into()),
+            ..Default::default()
+        };
+
+        let updated_comment = Comment::update(pool, inserted_comment.id, &comment_update_form)
+            .await
+            .unwrap();
+
+        let read_comment = Comment::read(pool, inserted_comment.id).await.unwrap();
+        let like_removed = CommentLike::remove(pool, inserted_person.id, inserted_comment.id)
+            .await
+            .unwrap();
+        let saved_removed = CommentSaved::unsave(pool, &comment_saved_form)
+            .await
+            .unwrap();
+        let num_deleted = Comment::delete(pool, inserted_comment.id).await.unwrap();
+        Comment::delete(pool, inserted_child_comment.id)
+            .await
+            .unwrap();
+        Post::delete(pool, inserted_post.id).await.unwrap();
+        Community::delete(pool, inserted_community.id)
+            .await
+            .unwrap();
+        Person::delete(pool, inserted_person.id).await.unwrap();
+        Instance::delete(pool, inserted_instance.id).await.unwrap();
+
+        assert_eq!(expected_comment, read_comment);
+        assert_eq!(expected_comment, inserted_comment);
+        assert_eq!(expected_comment, updated_comment);
+        assert_eq!(expected_comment_like, inserted_comment_like);
+        assert_eq!(expected_comment_saved, inserted_comment_saved);
+        assert_eq!(
+            format!("0.{}.{}", expected_comment.id, inserted_child_comment.id),
+            inserted_child_comment.path.0,
+        );
+        assert_eq!(1, like_removed);
+        assert_eq!(1, saved_removed);
+        assert_eq!(1, num_deleted);
+    }
 }

--- a/crates/db_schema/src/impls/comment_reply.rs
+++ b/crates/db_schema/src/impls/comment_reply.rs
@@ -1,183 +1,184 @@
 use crate::{
-  newtypes::{CommentId, CommentReplyId, PersonId},
-  schema::comment_reply::dsl::{comment_id, comment_reply, read, recipient_id},
-  source::comment_reply::{CommentReply, CommentReplyInsertForm, CommentReplyUpdateForm},
-  traits::Crud,
-  utils::{get_conn, DbPool},
+    newtypes::{CommentId, CommentReplyId, PersonId},
+    schema::comment_reply::dsl::{comment_id, comment_reply, read, recipient_id},
+    source::comment_reply::{CommentReply, CommentReplyInsertForm, CommentReplyUpdateForm},
+    traits::Crud,
+    utils::{get_conn, DbPool},
 };
 use diesel::{dsl::insert_into, result::Error, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 
 #[async_trait]
 impl Crud for CommentReply {
-  type InsertForm = CommentReplyInsertForm;
-  type UpdateForm = CommentReplyUpdateForm;
-  type IdType = CommentReplyId;
+    type InsertForm = CommentReplyInsertForm;
+    type UpdateForm = CommentReplyUpdateForm;
+    type IdType = CommentReplyId;
 
-  async fn create(
-    pool: &mut DbPool<'_>,
-    comment_reply_form: &Self::InsertForm,
-  ) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
+    async fn create(
+        pool: &mut DbPool<'_>,
+        comment_reply_form: &Self::InsertForm,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
 
-    // since the return here isnt utilized, we dont need to do an update
-    // but get_result doesnt return the existing row here
-    insert_into(comment_reply)
-      .values(comment_reply_form)
-      .on_conflict((recipient_id, comment_id))
-      .do_update()
-      .set(comment_reply_form)
-      .get_result::<Self>(conn)
-      .await
-  }
+        // since the return here isnt utilized, we dont need to do an update
+        // but get_result doesnt return the existing row here
+        insert_into(comment_reply)
+            .values(comment_reply_form)
+            .on_conflict((recipient_id, comment_id))
+            .do_update()
+            .set(comment_reply_form)
+            .get_result::<Self>(conn)
+            .await
+    }
 
-  async fn update(
-    pool: &mut DbPool<'_>,
-    comment_reply_id: CommentReplyId,
-    comment_reply_form: &Self::UpdateForm,
-  ) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(comment_reply.find(comment_reply_id))
-      .set(comment_reply_form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn update(
+        pool: &mut DbPool<'_>,
+        comment_reply_id: CommentReplyId,
+        comment_reply_form: &Self::UpdateForm,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(comment_reply.find(comment_reply_id))
+            .set(comment_reply_form)
+            .get_result::<Self>(conn)
+            .await
+    }
 }
 
 impl CommentReply {
-  pub async fn mark_all_as_read(
-    pool: &mut DbPool<'_>,
-    for_recipient_id: PersonId,
-  ) -> Result<Vec<CommentReply>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(
-      comment_reply
-        .filter(recipient_id.eq(for_recipient_id))
-        .filter(read.eq(false)),
-    )
-    .set(read.eq(true))
-    .get_results::<Self>(conn)
-    .await
-  }
+    pub async fn mark_all_as_read(
+        pool: &mut DbPool<'_>,
+        for_recipient_id: PersonId,
+    ) -> Result<Vec<CommentReply>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(
+            comment_reply
+                .filter(recipient_id.eq(for_recipient_id))
+                .filter(read.eq(false)),
+        )
+        .set(read.eq(true))
+        .get_results::<Self>(conn)
+        .await
+    }
 
-  pub async fn read_by_comment(
-    pool: &mut DbPool<'_>,
-    for_comment_id: CommentId,
-  ) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    comment_reply
-      .filter(comment_id.eq(for_comment_id))
-      .first::<Self>(conn)
-      .await
-  }
+    pub async fn read_by_comment(
+        pool: &mut DbPool<'_>,
+        for_comment_id: CommentId,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        comment_reply
+            .filter(comment_id.eq(for_comment_id))
+            .first::<Self>(conn)
+            .await
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::{
-    source::{
-      comment::{Comment, CommentInsertForm},
-      comment_reply::{CommentReply, CommentReplyInsertForm, CommentReplyUpdateForm},
-      community::{Community, CommunityInsertForm},
-      instance::Instance,
-      person::{Person, PersonInsertForm},
-      post::{Post, PostInsertForm},
-    },
-    traits::Crud,
-    utils::build_db_pool_for_tests,
-  };
-  use serial_test::serial;
-
-  #[tokio::test]
-  #[serial]
-  async fn test_crud() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-
-    let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
-      .await
-      .unwrap();
-
-    let new_person = PersonInsertForm::builder()
-      .name("terrylake".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_person = Person::create(pool, &new_person).await.unwrap();
-
-    let recipient_form = PersonInsertForm::builder()
-      .name("terrylakes recipient".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_recipient = Person::create(pool, &recipient_form).await.unwrap();
-
-    let new_community = CommunityInsertForm::builder()
-      .name("test community lake".to_string())
-      .title("nada".to_owned())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_community = Community::create(pool, &new_community).await.unwrap();
-
-    let new_post = PostInsertForm::builder()
-      .name("A test post".into())
-      .creator_id(inserted_person.id)
-      .community_id(inserted_community.id)
-      .build();
-
-    let inserted_post = Post::create(pool, &new_post).await.unwrap();
-
-    let comment_form = CommentInsertForm::builder()
-      .content("A test comment".into())
-      .creator_id(inserted_person.id)
-      .post_id(inserted_post.id)
-      .build();
-
-    let inserted_comment = Comment::create(pool, &comment_form, None).await.unwrap();
-
-    let comment_reply_form = CommentReplyInsertForm {
-      recipient_id: inserted_recipient.id,
-      comment_id: inserted_comment.id,
-      read: None,
+    use crate::{
+        source::{
+            comment::{Comment, CommentInsertForm},
+            comment_reply::{CommentReply, CommentReplyInsertForm, CommentReplyUpdateForm},
+            community::{Community, CommunityInsertForm},
+            instance::Instance,
+            person::{Person, PersonInsertForm},
+            post::{Post, PostInsertForm},
+        },
+        traits::Crud,
+        utils::build_db_pool_for_tests,
     };
+    use serial_test::serial;
 
-    let inserted_reply = CommentReply::create(pool, &comment_reply_form)
-      .await
-      .unwrap();
+    #[tokio::test]
+    #[serial]
+    async fn test_crud() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
 
-    let expected_reply = CommentReply {
-      id: inserted_reply.id,
-      recipient_id: inserted_reply.recipient_id,
-      comment_id: inserted_reply.comment_id,
-      read: false,
-      published: inserted_reply.published,
-    };
+        let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
+            .await
+            .unwrap();
 
-    let read_reply = CommentReply::read(pool, inserted_reply.id).await.unwrap();
+        let new_person = PersonInsertForm::builder()
+            .name("terrylake".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let comment_reply_update_form = CommentReplyUpdateForm { read: Some(false) };
-    let updated_reply = CommentReply::update(pool, inserted_reply.id, &comment_reply_update_form)
-      .await
-      .unwrap();
+        let inserted_person = Person::create(pool, &new_person).await.unwrap();
 
-    Comment::delete(pool, inserted_comment.id).await.unwrap();
-    Post::delete(pool, inserted_post.id).await.unwrap();
-    Community::delete(pool, inserted_community.id)
-      .await
-      .unwrap();
-    Person::delete(pool, inserted_person.id).await.unwrap();
-    Person::delete(pool, inserted_recipient.id).await.unwrap();
-    Instance::delete(pool, inserted_instance.id).await.unwrap();
+        let recipient_form = PersonInsertForm::builder()
+            .name("terrylakes recipient".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    assert_eq!(expected_reply, read_reply);
-    assert_eq!(expected_reply, inserted_reply);
-    assert_eq!(expected_reply, updated_reply);
-  }
+        let inserted_recipient = Person::create(pool, &recipient_form).await.unwrap();
+
+        let new_community = CommunityInsertForm::builder()
+            .name("test community lake".to_string())
+            .title("nada".to_owned())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
+
+        let inserted_community = Community::create(pool, &new_community).await.unwrap();
+
+        let new_post = PostInsertForm::builder()
+            .name("A test post".into())
+            .creator_id(inserted_person.id)
+            .community_id(inserted_community.id)
+            .build();
+
+        let inserted_post = Post::create(pool, &new_post).await.unwrap();
+
+        let comment_form = CommentInsertForm::builder()
+            .content("A test comment".into())
+            .creator_id(inserted_person.id)
+            .post_id(inserted_post.id)
+            .build();
+
+        let inserted_comment = Comment::create(pool, &comment_form, None).await.unwrap();
+
+        let comment_reply_form = CommentReplyInsertForm {
+            recipient_id: inserted_recipient.id,
+            comment_id: inserted_comment.id,
+            read: None,
+        };
+
+        let inserted_reply = CommentReply::create(pool, &comment_reply_form)
+            .await
+            .unwrap();
+
+        let expected_reply = CommentReply {
+            id: inserted_reply.id,
+            recipient_id: inserted_reply.recipient_id,
+            comment_id: inserted_reply.comment_id,
+            read: false,
+            published: inserted_reply.published,
+        };
+
+        let read_reply = CommentReply::read(pool, inserted_reply.id).await.unwrap();
+
+        let comment_reply_update_form = CommentReplyUpdateForm { read: Some(false) };
+        let updated_reply =
+            CommentReply::update(pool, inserted_reply.id, &comment_reply_update_form)
+                .await
+                .unwrap();
+
+        Comment::delete(pool, inserted_comment.id).await.unwrap();
+        Post::delete(pool, inserted_post.id).await.unwrap();
+        Community::delete(pool, inserted_community.id)
+            .await
+            .unwrap();
+        Person::delete(pool, inserted_person.id).await.unwrap();
+        Person::delete(pool, inserted_recipient.id).await.unwrap();
+        Instance::delete(pool, inserted_instance.id).await.unwrap();
+
+        assert_eq!(expected_reply, read_reply);
+        assert_eq!(expected_reply, inserted_reply);
+        assert_eq!(expected_reply, updated_reply);
+    }
 }

--- a/crates/db_schema/src/impls/comment_report.rs
+++ b/crates/db_schema/src/impls/comment_report.rs
@@ -1,76 +1,75 @@
 use crate::{
-  newtypes::{CommentReportId, PersonId},
-  schema::comment_report::dsl::{comment_report, resolved, resolver_id, updated},
-  source::comment_report::{CommentReport, CommentReportForm},
-  traits::Reportable,
-  utils::{get_conn, naive_now, DbPool},
+    newtypes::{CommentReportId, PersonId},
+    schema::comment_report::dsl::{comment_report, resolved, resolver_id, updated},
+    source::comment_report::{CommentReport, CommentReportForm},
+    traits::Reportable,
+    utils::{get_conn, naive_now, DbPool},
 };
 use diesel::{
-  dsl::{insert_into, update},
-  result::Error,
-  ExpressionMethods,
-  QueryDsl,
+    dsl::{insert_into, update},
+    result::Error,
+    ExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 
 #[async_trait]
 impl Reportable for CommentReport {
-  type Form = CommentReportForm;
-  type IdType = CommentReportId;
-  /// creates a comment report and returns it
-  ///
-  /// * `conn` - the postgres connection
-  /// * `comment_report_form` - the filled CommentReportForm to insert
-  async fn report(
-    pool: &mut DbPool<'_>,
-    comment_report_form: &CommentReportForm,
-  ) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    insert_into(comment_report)
-      .values(comment_report_form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    type Form = CommentReportForm;
+    type IdType = CommentReportId;
+    /// creates a comment report and returns it
+    ///
+    /// * `conn` - the postgres connection
+    /// * `comment_report_form` - the filled CommentReportForm to insert
+    async fn report(
+        pool: &mut DbPool<'_>,
+        comment_report_form: &CommentReportForm,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        insert_into(comment_report)
+            .values(comment_report_form)
+            .get_result::<Self>(conn)
+            .await
+    }
 
-  /// resolve a comment report
-  ///
-  /// * `conn` - the postgres connection
-  /// * `report_id` - the id of the report to resolve
-  /// * `by_resolver_id` - the id of the user resolving the report
-  async fn resolve(
-    pool: &mut DbPool<'_>,
-    report_id_: Self::IdType,
-    by_resolver_id: PersonId,
-  ) -> Result<usize, Error> {
-    let conn = &mut get_conn(pool).await?;
-    update(comment_report.find(report_id_))
-      .set((
-        resolved.eq(true),
-        resolver_id.eq(by_resolver_id),
-        updated.eq(naive_now()),
-      ))
-      .execute(conn)
-      .await
-  }
+    /// resolve a comment report
+    ///
+    /// * `conn` - the postgres connection
+    /// * `report_id` - the id of the report to resolve
+    /// * `by_resolver_id` - the id of the user resolving the report
+    async fn resolve(
+        pool: &mut DbPool<'_>,
+        report_id_: Self::IdType,
+        by_resolver_id: PersonId,
+    ) -> Result<usize, Error> {
+        let conn = &mut get_conn(pool).await?;
+        update(comment_report.find(report_id_))
+            .set((
+                resolved.eq(true),
+                resolver_id.eq(by_resolver_id),
+                updated.eq(naive_now()),
+            ))
+            .execute(conn)
+            .await
+    }
 
-  /// unresolve a comment report
-  ///
-  /// * `conn` - the postgres connection
-  /// * `report_id` - the id of the report to unresolve
-  /// * `by_resolver_id` - the id of the user unresolving the report
-  async fn unresolve(
-    pool: &mut DbPool<'_>,
-    report_id_: Self::IdType,
-    by_resolver_id: PersonId,
-  ) -> Result<usize, Error> {
-    let conn = &mut get_conn(pool).await?;
-    update(comment_report.find(report_id_))
-      .set((
-        resolved.eq(false),
-        resolver_id.eq(by_resolver_id),
-        updated.eq(naive_now()),
-      ))
-      .execute(conn)
-      .await
-  }
+    /// unresolve a comment report
+    ///
+    /// * `conn` - the postgres connection
+    /// * `report_id` - the id of the report to unresolve
+    /// * `by_resolver_id` - the id of the user unresolving the report
+    async fn unresolve(
+        pool: &mut DbPool<'_>,
+        report_id_: Self::IdType,
+        by_resolver_id: PersonId,
+    ) -> Result<usize, Error> {
+        let conn = &mut get_conn(pool).await?;
+        update(comment_report.find(report_id_))
+            .set((
+                resolved.eq(false),
+                resolver_id.eq(by_resolver_id),
+                updated.eq(naive_now()),
+            ))
+            .execute(conn)
+            .await
+    }
 }

--- a/crates/db_schema/src/impls/community_block.rs
+++ b/crates/db_schema/src/impls/community_block.rs
@@ -1,36 +1,39 @@
 use crate::{
-  schema::community_block::dsl::{community_block, community_id, person_id},
-  source::community_block::{CommunityBlock, CommunityBlockForm},
-  traits::Blockable,
-  utils::{get_conn, DbPool},
+    schema::community_block::dsl::{community_block, community_id, person_id},
+    source::community_block::{CommunityBlock, CommunityBlockForm},
+    traits::Blockable,
+    utils::{get_conn, DbPool},
 };
 use diesel::{dsl::insert_into, result::Error, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 
 #[async_trait]
 impl Blockable for CommunityBlock {
-  type Form = CommunityBlockForm;
-  async fn block(pool: &mut DbPool<'_>, community_block_form: &Self::Form) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    insert_into(community_block)
-      .values(community_block_form)
-      .on_conflict((person_id, community_id))
-      .do_update()
-      .set(community_block_form)
-      .get_result::<Self>(conn)
-      .await
-  }
-  async fn unblock(
-    pool: &mut DbPool<'_>,
-    community_block_form: &Self::Form,
-  ) -> Result<usize, Error> {
-    let conn = &mut get_conn(pool).await?;
-    diesel::delete(
-      community_block
-        .filter(person_id.eq(community_block_form.person_id))
-        .filter(community_id.eq(community_block_form.community_id)),
-    )
-    .execute(conn)
-    .await
-  }
+    type Form = CommunityBlockForm;
+    async fn block(
+        pool: &mut DbPool<'_>,
+        community_block_form: &Self::Form,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        insert_into(community_block)
+            .values(community_block_form)
+            .on_conflict((person_id, community_id))
+            .do_update()
+            .set(community_block_form)
+            .get_result::<Self>(conn)
+            .await
+    }
+    async fn unblock(
+        pool: &mut DbPool<'_>,
+        community_block_form: &Self::Form,
+    ) -> Result<usize, Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::delete(
+            community_block
+                .filter(person_id.eq(community_block_form.person_id))
+                .filter(community_id.eq(community_block_form.community_id)),
+        )
+        .execute(conn)
+        .await
+    }
 }

--- a/crates/db_schema/src/impls/custom_emoji.rs
+++ b/crates/db_schema/src/impls/custom_emoji.rs
@@ -1,60 +1,63 @@
 use crate::{
-  newtypes::CustomEmojiId,
-  schema::{
-    custom_emoji::dsl::custom_emoji,
-    custom_emoji_keyword::dsl::{custom_emoji_id, custom_emoji_keyword},
-  },
-  source::{
-    custom_emoji::{CustomEmoji, CustomEmojiInsertForm, CustomEmojiUpdateForm},
-    custom_emoji_keyword::{CustomEmojiKeyword, CustomEmojiKeywordInsertForm},
-  },
-  utils::{get_conn, DbPool},
+    newtypes::CustomEmojiId,
+    schema::{
+        custom_emoji::dsl::custom_emoji,
+        custom_emoji_keyword::dsl::{custom_emoji_id, custom_emoji_keyword},
+    },
+    source::{
+        custom_emoji::{CustomEmoji, CustomEmojiInsertForm, CustomEmojiUpdateForm},
+        custom_emoji_keyword::{CustomEmojiKeyword, CustomEmojiKeywordInsertForm},
+    },
+    utils::{get_conn, DbPool},
 };
 use diesel::{dsl::insert_into, result::Error, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 
 impl CustomEmoji {
-  pub async fn create(pool: &mut DbPool<'_>, form: &CustomEmojiInsertForm) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    insert_into(custom_emoji)
-      .values(form)
-      .get_result::<Self>(conn)
-      .await
-  }
-  pub async fn update(
-    pool: &mut DbPool<'_>,
-    emoji_id: CustomEmojiId,
-    form: &CustomEmojiUpdateForm,
-  ) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(custom_emoji.find(emoji_id))
-      .set(form)
-      .get_result::<Self>(conn)
-      .await
-  }
-  pub async fn delete(pool: &mut DbPool<'_>, emoji_id: CustomEmojiId) -> Result<usize, Error> {
-    let conn = &mut get_conn(pool).await?;
-    diesel::delete(custom_emoji.find(emoji_id))
-      .execute(conn)
-      .await
-  }
+    pub async fn create(
+        pool: &mut DbPool<'_>,
+        form: &CustomEmojiInsertForm,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        insert_into(custom_emoji)
+            .values(form)
+            .get_result::<Self>(conn)
+            .await
+    }
+    pub async fn update(
+        pool: &mut DbPool<'_>,
+        emoji_id: CustomEmojiId,
+        form: &CustomEmojiUpdateForm,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(custom_emoji.find(emoji_id))
+            .set(form)
+            .get_result::<Self>(conn)
+            .await
+    }
+    pub async fn delete(pool: &mut DbPool<'_>, emoji_id: CustomEmojiId) -> Result<usize, Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::delete(custom_emoji.find(emoji_id))
+            .execute(conn)
+            .await
+    }
 }
 
 impl CustomEmojiKeyword {
-  pub async fn create(
-    pool: &mut DbPool<'_>,
-    form: Vec<CustomEmojiKeywordInsertForm>,
-  ) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    insert_into(custom_emoji_keyword)
-      .values(form)
-      .get_results::<Self>(conn)
-      .await
-  }
-  pub async fn delete(pool: &mut DbPool<'_>, emoji_id: CustomEmojiId) -> Result<usize, Error> {
-    let conn = &mut get_conn(pool).await?;
-    diesel::delete(custom_emoji_keyword.filter(custom_emoji_id.eq(emoji_id)))
-      .execute(conn)
-      .await
-  }
+    pub async fn create(
+        pool: &mut DbPool<'_>,
+        form: Vec<CustomEmojiKeywordInsertForm>,
+    ) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        insert_into(custom_emoji_keyword)
+            .values(form)
+            .get_results::<Self>(conn)
+            .await
+    }
+    pub async fn delete(pool: &mut DbPool<'_>, emoji_id: CustomEmojiId) -> Result<usize, Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::delete(custom_emoji_keyword.filter(custom_emoji_id.eq(emoji_id)))
+            .execute(conn)
+            .await
+    }
 }

--- a/crates/db_schema/src/impls/email_verification.rs
+++ b/crates/db_schema/src/impls/email_verification.rs
@@ -1,49 +1,47 @@
 use crate::{
-  newtypes::LocalUserId,
-  schema::email_verification::dsl::{
-    email_verification,
-    local_user_id,
-    published,
-    verification_token,
-  },
-  source::email_verification::{EmailVerification, EmailVerificationForm},
-  utils::{get_conn, DbPool},
+    newtypes::LocalUserId,
+    schema::email_verification::dsl::{
+        email_verification, local_user_id, published, verification_token,
+    },
+    source::email_verification::{EmailVerification, EmailVerificationForm},
+    utils::{get_conn, DbPool},
 };
 use diesel::{
-  dsl::{now, IntervalDsl},
-  insert_into,
-  result::Error,
-  sql_types::Timestamptz,
-  ExpressionMethods,
-  IntoSql,
-  QueryDsl,
+    dsl::{now, IntervalDsl},
+    insert_into,
+    result::Error,
+    sql_types::Timestamptz,
+    ExpressionMethods, IntoSql, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 
 impl EmailVerification {
-  pub async fn create(pool: &mut DbPool<'_>, form: &EmailVerificationForm) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    insert_into(email_verification)
-      .values(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    pub async fn create(
+        pool: &mut DbPool<'_>,
+        form: &EmailVerificationForm,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        insert_into(email_verification)
+            .values(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 
-  pub async fn read_for_token(pool: &mut DbPool<'_>, token: &str) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    email_verification
-      .filter(verification_token.eq(token))
-      .filter(published.gt(now.into_sql::<Timestamptz>() - 7.days()))
-      .first::<Self>(conn)
-      .await
-  }
-  pub async fn delete_old_tokens_for_local_user(
-    pool: &mut DbPool<'_>,
-    local_user_id_: LocalUserId,
-  ) -> Result<usize, Error> {
-    let conn = &mut get_conn(pool).await?;
-    diesel::delete(email_verification.filter(local_user_id.eq(local_user_id_)))
-      .execute(conn)
-      .await
-  }
+    pub async fn read_for_token(pool: &mut DbPool<'_>, token: &str) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        email_verification
+            .filter(verification_token.eq(token))
+            .filter(published.gt(now.into_sql::<Timestamptz>() - 7.days()))
+            .first::<Self>(conn)
+            .await
+    }
+    pub async fn delete_old_tokens_for_local_user(
+        pool: &mut DbPool<'_>,
+        local_user_id_: LocalUserId,
+    ) -> Result<usize, Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::delete(email_verification.filter(local_user_id.eq(local_user_id_)))
+            .execute(conn)
+            .await
+    }
 }

--- a/crates/db_schema/src/impls/federation_allowlist.rs
+++ b/crates/db_schema/src/impls/federation_allowlist.rs
@@ -1,97 +1,100 @@
 use crate::{
-  schema::federation_allowlist,
-  source::{
-    federation_allowlist::{FederationAllowList, FederationAllowListForm},
-    instance::Instance,
-  },
-  utils::{get_conn, DbPool},
+    schema::federation_allowlist,
+    source::{
+        federation_allowlist::{FederationAllowList, FederationAllowListForm},
+        instance::Instance,
+    },
+    utils::{get_conn, DbPool},
 };
 use diesel::{dsl::insert_into, result::Error};
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 
 impl FederationAllowList {
-  pub async fn replace(pool: &mut DbPool<'_>, list_opt: Option<Vec<String>>) -> Result<(), Error> {
-    let conn = &mut get_conn(pool).await?;
-    conn
-      .build_transaction()
-      .run(|conn| {
-        Box::pin(async move {
-          if let Some(list) = list_opt {
-            Self::clear(conn).await?;
+    pub async fn replace(
+        pool: &mut DbPool<'_>,
+        list_opt: Option<Vec<String>>,
+    ) -> Result<(), Error> {
+        let conn = &mut get_conn(pool).await?;
+        conn.build_transaction()
+            .run(|conn| {
+                Box::pin(async move {
+                    if let Some(list) = list_opt {
+                        Self::clear(conn).await?;
 
-            for domain in list {
-              // Upsert all of these as instances
-              let instance = Instance::read_or_create(&mut conn.into(), domain).await?;
+                        for domain in list {
+                            // Upsert all of these as instances
+                            let instance =
+                                Instance::read_or_create(&mut conn.into(), domain).await?;
 
-              let form = FederationAllowListForm {
-                instance_id: instance.id,
-                updated: None,
-              };
-              insert_into(federation_allowlist::table)
-                .values(form)
-                .get_result::<Self>(conn)
-                .await?;
-            }
-            Ok(())
-          } else {
-            Ok(())
-          }
-        }) as _
-      })
-      .await
-  }
+                            let form = FederationAllowListForm {
+                                instance_id: instance.id,
+                                updated: None,
+                            };
+                            insert_into(federation_allowlist::table)
+                                .values(form)
+                                .get_result::<Self>(conn)
+                                .await?;
+                        }
+                        Ok(())
+                    } else {
+                        Ok(())
+                    }
+                }) as _
+            })
+            .await
+    }
 
-  async fn clear(conn: &mut AsyncPgConnection) -> Result<usize, Error> {
-    diesel::delete(federation_allowlist::table)
-      .execute(conn)
-      .await
-  }
+    async fn clear(conn: &mut AsyncPgConnection) -> Result<usize, Error> {
+        diesel::delete(federation_allowlist::table)
+            .execute(conn)
+            .await
+    }
 }
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::{
-    source::{federation_allowlist::FederationAllowList, instance::Instance},
-    utils::build_db_pool_for_tests,
-  };
-  use serial_test::serial;
+    use crate::{
+        source::{federation_allowlist::FederationAllowList, instance::Instance},
+        utils::build_db_pool_for_tests,
+    };
+    use serial_test::serial;
 
-  #[tokio::test]
-  #[serial]
-  async fn test_allowlist_insert_and_clear() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-    let domains = vec![
-      "tld1.xyz".to_string(),
-      "tld2.xyz".to_string(),
-      "tld3.xyz".to_string(),
-    ];
+    #[tokio::test]
+    #[serial]
+    async fn test_allowlist_insert_and_clear() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
+        let domains = vec![
+            "tld1.xyz".to_string(),
+            "tld2.xyz".to_string(),
+            "tld3.xyz".to_string(),
+        ];
 
-    let allowed = Some(domains.clone());
+        let allowed = Some(domains.clone());
 
-    FederationAllowList::replace(pool, allowed).await.unwrap();
+        FederationAllowList::replace(pool, allowed).await.unwrap();
 
-    let allows = Instance::allowlist(pool).await.unwrap();
-    let allows_domains = allows
-      .iter()
-      .map(|i| i.domain.clone())
-      .collect::<Vec<String>>();
+        let allows = Instance::allowlist(pool).await.unwrap();
+        let allows_domains = allows
+            .iter()
+            .map(|i| i.domain.clone())
+            .collect::<Vec<String>>();
 
-    assert_eq!(3, allows.len());
-    assert_eq!(domains, allows_domains);
+        assert_eq!(3, allows.len());
+        assert_eq!(domains, allows_domains);
 
-    // Now test clearing them via Some(empty vec)
-    let clear_allows = Some(Vec::new());
+        // Now test clearing them via Some(empty vec)
+        let clear_allows = Some(Vec::new());
 
-    FederationAllowList::replace(pool, clear_allows)
-      .await
-      .unwrap();
-    let allows = Instance::allowlist(pool).await.unwrap();
+        FederationAllowList::replace(pool, clear_allows)
+            .await
+            .unwrap();
+        let allows = Instance::allowlist(pool).await.unwrap();
 
-    assert_eq!(0, allows.len());
+        assert_eq!(0, allows.len());
 
-    Instance::delete_all(pool).await.unwrap();
-  }
+        Instance::delete_all(pool).await.unwrap();
+    }
 }

--- a/crates/db_schema/src/impls/federation_blocklist.rs
+++ b/crates/db_schema/src/impls/federation_blocklist.rs
@@ -1,49 +1,52 @@
 use crate::{
-  schema::federation_blocklist,
-  source::{
-    federation_blocklist::{FederationBlockList, FederationBlockListForm},
-    instance::Instance,
-  },
-  utils::{get_conn, DbPool},
+    schema::federation_blocklist,
+    source::{
+        federation_blocklist::{FederationBlockList, FederationBlockListForm},
+        instance::Instance,
+    },
+    utils::{get_conn, DbPool},
 };
 use diesel::{dsl::insert_into, result::Error};
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 
 impl FederationBlockList {
-  pub async fn replace(pool: &mut DbPool<'_>, list_opt: Option<Vec<String>>) -> Result<(), Error> {
-    let conn = &mut get_conn(pool).await?;
-    conn
-      .build_transaction()
-      .run(|conn| {
-        Box::pin(async move {
-          if let Some(list) = list_opt {
-            Self::clear(conn).await?;
+    pub async fn replace(
+        pool: &mut DbPool<'_>,
+        list_opt: Option<Vec<String>>,
+    ) -> Result<(), Error> {
+        let conn = &mut get_conn(pool).await?;
+        conn.build_transaction()
+            .run(|conn| {
+                Box::pin(async move {
+                    if let Some(list) = list_opt {
+                        Self::clear(conn).await?;
 
-            for domain in list {
-              // Upsert all of these as instances
-              let instance = Instance::read_or_create(&mut conn.into(), domain).await?;
+                        for domain in list {
+                            // Upsert all of these as instances
+                            let instance =
+                                Instance::read_or_create(&mut conn.into(), domain).await?;
 
-              let form = FederationBlockListForm {
-                instance_id: instance.id,
-                updated: None,
-              };
-              insert_into(federation_blocklist::table)
-                .values(form)
-                .get_result::<Self>(conn)
-                .await?;
-            }
-            Ok(())
-          } else {
-            Ok(())
-          }
-        }) as _
-      })
-      .await
-  }
+                            let form = FederationBlockListForm {
+                                instance_id: instance.id,
+                                updated: None,
+                            };
+                            insert_into(federation_blocklist::table)
+                                .values(form)
+                                .get_result::<Self>(conn)
+                                .await?;
+                        }
+                        Ok(())
+                    } else {
+                        Ok(())
+                    }
+                }) as _
+            })
+            .await
+    }
 
-  async fn clear(conn: &mut AsyncPgConnection) -> Result<usize, Error> {
-    diesel::delete(federation_blocklist::table)
-      .execute(conn)
-      .await
-  }
+    async fn clear(conn: &mut AsyncPgConnection) -> Result<usize, Error> {
+        diesel::delete(federation_blocklist::table)
+            .execute(conn)
+            .await
+    }
 }

--- a/crates/db_schema/src/impls/instance.rs
+++ b/crates/db_schema/src/impls/instance.rs
@@ -1,112 +1,111 @@
 use crate::{
-  diesel::dsl::IntervalDsl,
-  newtypes::InstanceId,
-  schema::{federation_allowlist, federation_blocklist, instance, local_site, site},
-  source::instance::{Instance, InstanceForm},
-  utils::{functions::lower, get_conn, naive_now, now, DbPool},
+    diesel::dsl::IntervalDsl,
+    newtypes::InstanceId,
+    schema::{federation_allowlist, federation_blocklist, instance, local_site, site},
+    source::instance::{Instance, InstanceForm},
+    utils::{functions::lower, get_conn, naive_now, now, DbPool},
 };
 use diesel::{
-  dsl::insert_into,
-  result::Error,
-  sql_types::{Nullable, Timestamptz},
-  ExpressionMethods,
-  QueryDsl,
+    dsl::insert_into,
+    result::Error,
+    sql_types::{Nullable, Timestamptz},
+    ExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 
 impl Instance {
-  /// Attempt to read Instance column for the given domain. If it doesnt exist, insert a new one.
-  /// There is no need for update as the domain of an existing instance cant change.
-  pub async fn read_or_create(pool: &mut DbPool<'_>, domain_: String) -> Result<Self, Error> {
-    use crate::schema::instance::domain;
-    let conn = &mut get_conn(pool).await?;
+    /// Attempt to read Instance column for the given domain. If it doesnt exist, insert a new one.
+    /// There is no need for update as the domain of an existing instance cant change.
+    pub async fn read_or_create(pool: &mut DbPool<'_>, domain_: String) -> Result<Self, Error> {
+        use crate::schema::instance::domain;
+        let conn = &mut get_conn(pool).await?;
 
-    // First try to read the instance row and return directly if found
-    let instance = instance::table
-      .filter(lower(domain).eq(&domain_.to_lowercase()))
-      .first::<Self>(conn)
-      .await;
-    match instance {
-      Ok(i) => Ok(i),
-      Err(diesel::NotFound) => {
-        // Instance not in database yet, insert it
-        let form = InstanceForm::builder()
-          .domain(domain_)
-          .updated(Some(naive_now()))
-          .build();
-        insert_into(instance::table)
-          .values(&form)
-          // Necessary because this method may be called concurrently for the same domain. This
-          // could be handled with a transaction, but nested transactions arent allowed
-          .on_conflict(instance::domain)
-          .do_update()
-          .set(&form)
-          .get_result::<Self>(conn)
-          .await
-      }
-      e => e,
+        // First try to read the instance row and return directly if found
+        let instance = instance::table
+            .filter(lower(domain).eq(&domain_.to_lowercase()))
+            .first::<Self>(conn)
+            .await;
+        match instance {
+            Ok(i) => Ok(i),
+            Err(diesel::NotFound) => {
+                // Instance not in database yet, insert it
+                let form = InstanceForm::builder()
+                    .domain(domain_)
+                    .updated(Some(naive_now()))
+                    .build();
+                insert_into(instance::table)
+                    .values(&form)
+                    // Necessary because this method may be called concurrently for the same domain. This
+                    // could be handled with a transaction, but nested transactions arent allowed
+                    .on_conflict(instance::domain)
+                    .do_update()
+                    .set(&form)
+                    .get_result::<Self>(conn)
+                    .await
+            }
+            e => e,
+        }
     }
-  }
-  pub async fn delete(pool: &mut DbPool<'_>, instance_id: InstanceId) -> Result<usize, Error> {
-    let conn = &mut get_conn(pool).await?;
-    diesel::delete(instance::table.find(instance_id))
-      .execute(conn)
-      .await
-  }
+    pub async fn delete(pool: &mut DbPool<'_>, instance_id: InstanceId) -> Result<usize, Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::delete(instance::table.find(instance_id))
+            .execute(conn)
+            .await
+    }
 
-  pub async fn read_all(pool: &mut DbPool<'_>) -> Result<Vec<Instance>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    instance::table
-      .select(instance::all_columns)
-      .get_results(conn)
-      .await
-  }
+    pub async fn read_all(pool: &mut DbPool<'_>) -> Result<Vec<Instance>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        instance::table
+            .select(instance::all_columns)
+            .get_results(conn)
+            .await
+    }
 
-  pub async fn dead_instances(pool: &mut DbPool<'_>) -> Result<Vec<String>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    instance::table
-      .select(instance::domain)
-      .filter(coalesce(instance::updated, instance::published).lt(now() - 3.days()))
-      .get_results(conn)
-      .await
-  }
+    pub async fn dead_instances(pool: &mut DbPool<'_>) -> Result<Vec<String>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        instance::table
+            .select(instance::domain)
+            .filter(coalesce(instance::updated, instance::published).lt(now() - 3.days()))
+            .get_results(conn)
+            .await
+    }
 
-  #[cfg(test)]
-  pub async fn delete_all(pool: &mut DbPool<'_>) -> Result<usize, Error> {
-    let conn = &mut get_conn(pool).await?;
-    diesel::delete(instance::table).execute(conn).await
-  }
-  pub async fn allowlist(pool: &mut DbPool<'_>) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    instance::table
-      .inner_join(federation_allowlist::table)
-      .select(instance::all_columns)
-      .get_results(conn)
-      .await
-  }
+    #[cfg(test)]
+    pub async fn delete_all(pool: &mut DbPool<'_>) -> Result<usize, Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::delete(instance::table).execute(conn).await
+    }
+    pub async fn allowlist(pool: &mut DbPool<'_>) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        instance::table
+            .inner_join(federation_allowlist::table)
+            .select(instance::all_columns)
+            .get_results(conn)
+            .await
+    }
 
-  pub async fn blocklist(pool: &mut DbPool<'_>) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    instance::table
-      .inner_join(federation_blocklist::table)
-      .select(instance::all_columns)
-      .get_results(conn)
-      .await
-  }
+    pub async fn blocklist(pool: &mut DbPool<'_>) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        instance::table
+            .inner_join(federation_blocklist::table)
+            .select(instance::all_columns)
+            .get_results(conn)
+            .await
+    }
 
-  pub async fn linked(pool: &mut DbPool<'_>) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    instance::table
-      // omit instance representing the local site
-      .left_join(site::table.inner_join(local_site::table))
-      .filter(local_site::id.is_null())
-      // omit instances in the blocklist
-      .left_join(federation_blocklist::table)
-      .filter(federation_blocklist::id.is_null())
-      .select(instance::all_columns)
-      .get_results(conn)
-      .await
-  }
+    pub async fn linked(pool: &mut DbPool<'_>) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        instance::table
+            // omit instance representing the local site
+            .left_join(site::table.inner_join(local_site::table))
+            .filter(local_site::id.is_null())
+            // omit instances in the blocklist
+            .left_join(federation_blocklist::table)
+            .filter(federation_blocklist::id.is_null())
+            .select(instance::all_columns)
+            .get_results(conn)
+            .await
+    }
 }
 
 sql_function! { fn coalesce(x: Nullable<Timestamptz>, y: Timestamptz) -> Timestamptz; }

--- a/crates/db_schema/src/impls/language.rs
+++ b/crates/db_schema/src/impls/language.rs
@@ -1,64 +1,62 @@
 use crate::{
-  diesel::ExpressionMethods,
-  newtypes::LanguageId,
-  schema::language::dsl::{code, id, language},
-  source::language::Language,
-  utils::{get_conn, DbPool},
+    diesel::ExpressionMethods,
+    newtypes::LanguageId,
+    schema::language::dsl::{code, id, language},
+    source::language::Language,
+    utils::{get_conn, DbPool},
 };
 use diesel::{result::Error, QueryDsl};
 use diesel_async::RunQueryDsl;
 
 impl Language {
-  pub async fn read_all(pool: &mut DbPool<'_>) -> Result<Vec<Language>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    language.load::<Self>(conn).await
-  }
-
-  pub async fn read_from_id(pool: &mut DbPool<'_>, id_: LanguageId) -> Result<Language, Error> {
-    let conn = &mut get_conn(pool).await?;
-    language.filter(id.eq(id_)).first::<Self>(conn).await
-  }
-
-  /// Attempts to find the given language code and return its ID. If not found, returns none.
-  pub async fn read_id_from_code(
-    pool: &mut DbPool<'_>,
-    code_: Option<&str>,
-  ) -> Result<Option<LanguageId>, Error> {
-    if let Some(code_) = code_ {
-      let conn = &mut get_conn(pool).await?;
-      Ok(
-        language
-          .filter(code.eq(code_))
-          .first::<Self>(conn)
-          .await
-          .map(|l| l.id)
-          .ok(),
-      )
-    } else {
-      Ok(None)
+    pub async fn read_all(pool: &mut DbPool<'_>) -> Result<Vec<Language>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        language.load::<Self>(conn).await
     }
-  }
+
+    pub async fn read_from_id(pool: &mut DbPool<'_>, id_: LanguageId) -> Result<Language, Error> {
+        let conn = &mut get_conn(pool).await?;
+        language.filter(id.eq(id_)).first::<Self>(conn).await
+    }
+
+    /// Attempts to find the given language code and return its ID. If not found, returns none.
+    pub async fn read_id_from_code(
+        pool: &mut DbPool<'_>,
+        code_: Option<&str>,
+    ) -> Result<Option<LanguageId>, Error> {
+        if let Some(code_) = code_ {
+            let conn = &mut get_conn(pool).await?;
+            Ok(language
+                .filter(code.eq(code_))
+                .first::<Self>(conn)
+                .await
+                .map(|l| l.id)
+                .ok())
+        } else {
+            Ok(None)
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::{source::language::Language, utils::build_db_pool_for_tests};
-  use serial_test::serial;
+    use crate::{source::language::Language, utils::build_db_pool_for_tests};
+    use serial_test::serial;
 
-  #[tokio::test]
-  #[serial]
-  async fn test_languages() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
+    #[tokio::test]
+    #[serial]
+    async fn test_languages() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
 
-    let all = Language::read_all(pool).await.unwrap();
+        let all = Language::read_all(pool).await.unwrap();
 
-    assert_eq!(184, all.len());
-    assert_eq!("ak", all[5].code);
-    assert_eq!("lv", all[99].code);
-    assert_eq!("yi", all[179].code);
-  }
+        assert_eq!(184, all.len());
+        assert_eq!("ak", all[5].code);
+        assert_eq!("lv", all[99].code);
+        assert_eq!("yi", all[179].code);
+    }
 }

--- a/crates/db_schema/src/impls/local_site.rs
+++ b/crates/db_schema/src/impls/local_site.rs
@@ -1,32 +1,32 @@
 use crate::{
-  schema::local_site::dsl::local_site,
-  source::local_site::{LocalSite, LocalSiteInsertForm, LocalSiteUpdateForm},
-  utils::{get_conn, DbPool},
+    schema::local_site::dsl::local_site,
+    source::local_site::{LocalSite, LocalSiteInsertForm, LocalSiteUpdateForm},
+    utils::{get_conn, DbPool},
 };
 use diesel::{dsl::insert_into, result::Error};
 use diesel_async::RunQueryDsl;
 
 impl LocalSite {
-  pub async fn create(pool: &mut DbPool<'_>, form: &LocalSiteInsertForm) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    insert_into(local_site)
-      .values(form)
-      .get_result::<Self>(conn)
-      .await
-  }
-  pub async fn read(pool: &mut DbPool<'_>) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    local_site.first::<Self>(conn).await
-  }
-  pub async fn update(pool: &mut DbPool<'_>, form: &LocalSiteUpdateForm) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(local_site)
-      .set(form)
-      .get_result::<Self>(conn)
-      .await
-  }
-  pub async fn delete(pool: &mut DbPool<'_>) -> Result<usize, Error> {
-    let conn = &mut get_conn(pool).await?;
-    diesel::delete(local_site).execute(conn).await
-  }
+    pub async fn create(pool: &mut DbPool<'_>, form: &LocalSiteInsertForm) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        insert_into(local_site)
+            .values(form)
+            .get_result::<Self>(conn)
+            .await
+    }
+    pub async fn read(pool: &mut DbPool<'_>) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        local_site.first::<Self>(conn).await
+    }
+    pub async fn update(pool: &mut DbPool<'_>, form: &LocalSiteUpdateForm) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(local_site)
+            .set(form)
+            .get_result::<Self>(conn)
+            .await
+    }
+    pub async fn delete(pool: &mut DbPool<'_>) -> Result<usize, Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::delete(local_site).execute(conn).await
+    }
 }

--- a/crates/db_schema/src/impls/local_site_rate_limit.rs
+++ b/crates/db_schema/src/impls/local_site_rate_limit.rs
@@ -1,62 +1,60 @@
 use crate::{
-  schema::local_site_rate_limit,
-  source::local_site_rate_limit::{
-    LocalSiteRateLimit,
-    LocalSiteRateLimitInsertForm,
-    LocalSiteRateLimitUpdateForm,
-  },
-  utils::{get_conn, DbPool},
+    schema::local_site_rate_limit,
+    source::local_site_rate_limit::{
+        LocalSiteRateLimit, LocalSiteRateLimitInsertForm, LocalSiteRateLimitUpdateForm,
+    },
+    utils::{get_conn, DbPool},
 };
 use diesel::{dsl::insert_into, result::Error};
 use diesel_async::RunQueryDsl;
 
 impl LocalSiteRateLimit {
-  pub async fn read(pool: &mut DbPool<'_>) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    local_site_rate_limit::table.first::<Self>(conn).await
-  }
-
-  pub async fn create(
-    pool: &mut DbPool<'_>,
-    form: &LocalSiteRateLimitInsertForm,
-  ) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    insert_into(local_site_rate_limit::table)
-      .values(form)
-      .get_result::<Self>(conn)
-      .await
-  }
-  pub async fn update(
-    pool: &mut DbPool<'_>,
-    form: &LocalSiteRateLimitUpdateForm,
-  ) -> Result<(), Error> {
-    // avoid error "There are no changes to save. This query cannot be built"
-    if form.is_empty() {
-      return Ok(());
+    pub async fn read(pool: &mut DbPool<'_>) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        local_site_rate_limit::table.first::<Self>(conn).await
     }
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(local_site_rate_limit::table)
-      .set(form)
-      .get_result::<Self>(conn)
-      .await?;
-    Ok(())
-  }
+
+    pub async fn create(
+        pool: &mut DbPool<'_>,
+        form: &LocalSiteRateLimitInsertForm,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        insert_into(local_site_rate_limit::table)
+            .values(form)
+            .get_result::<Self>(conn)
+            .await
+    }
+    pub async fn update(
+        pool: &mut DbPool<'_>,
+        form: &LocalSiteRateLimitUpdateForm,
+    ) -> Result<(), Error> {
+        // avoid error "There are no changes to save. This query cannot be built"
+        if form.is_empty() {
+            return Ok(());
+        }
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(local_site_rate_limit::table)
+            .set(form)
+            .get_result::<Self>(conn)
+            .await?;
+        Ok(())
+    }
 }
 
 impl LocalSiteRateLimitUpdateForm {
-  fn is_empty(&self) -> bool {
-    self.message.is_none()
-      && self.message_per_second.is_none()
-      && self.post.is_none()
-      && self.post_per_second.is_none()
-      && self.register.is_none()
-      && self.register_per_second.is_none()
-      && self.image.is_none()
-      && self.image_per_second.is_none()
-      && self.comment.is_none()
-      && self.comment_per_second.is_none()
-      && self.search.is_none()
-      && self.search_per_second.is_none()
-      && self.updated.is_none()
-  }
+    fn is_empty(&self) -> bool {
+        self.message.is_none()
+            && self.message_per_second.is_none()
+            && self.post.is_none()
+            && self.post_per_second.is_none()
+            && self.register.is_none()
+            && self.register_per_second.is_none()
+            && self.image.is_none()
+            && self.image_per_second.is_none()
+            && self.comment.is_none()
+            && self.comment_per_second.is_none()
+            && self.search.is_none()
+            && self.search_per_second.is_none()
+            && self.updated.is_none()
+    }
 }

--- a/crates/db_schema/src/impls/local_user.rs
+++ b/crates/db_schema/src/impls/local_user.rs
@@ -1,108 +1,103 @@
 use crate::{
-  newtypes::LocalUserId,
-  schema::local_user::dsl::{
-    accepted_application,
-    email,
-    email_verified,
-    local_user,
-    password_encrypted,
-    validator_time,
-  },
-  source::{
-    actor_language::{LocalUserLanguage, SiteLanguage},
-    local_user::{LocalUser, LocalUserInsertForm, LocalUserUpdateForm},
-  },
-  traits::Crud,
-  utils::{get_conn, naive_now, DbPool},
+    newtypes::LocalUserId,
+    schema::local_user::dsl::{
+        accepted_application, email, email_verified, local_user, password_encrypted, validator_time,
+    },
+    source::{
+        actor_language::{LocalUserLanguage, SiteLanguage},
+        local_user::{LocalUser, LocalUserInsertForm, LocalUserUpdateForm},
+    },
+    traits::Crud,
+    utils::{get_conn, naive_now, DbPool},
 };
 use bcrypt::{hash, DEFAULT_COST};
 use diesel::{dsl::insert_into, result::Error, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 
 impl LocalUser {
-  pub async fn update_password(
-    pool: &mut DbPool<'_>,
-    local_user_id: LocalUserId,
-    new_password: &str,
-  ) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let password_hash = hash(new_password, DEFAULT_COST).expect("Couldn't hash password");
+    pub async fn update_password(
+        pool: &mut DbPool<'_>,
+        local_user_id: LocalUserId,
+        new_password: &str,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let password_hash = hash(new_password, DEFAULT_COST).expect("Couldn't hash password");
 
-    diesel::update(local_user.find(local_user_id))
-      .set((
-        password_encrypted.eq(password_hash),
-        validator_time.eq(naive_now()),
-      ))
-      .get_result::<Self>(conn)
-      .await
-  }
+        diesel::update(local_user.find(local_user_id))
+            .set((
+                password_encrypted.eq(password_hash),
+                validator_time.eq(naive_now()),
+            ))
+            .get_result::<Self>(conn)
+            .await
+    }
 
-  pub async fn set_all_users_email_verified(pool: &mut DbPool<'_>) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(local_user)
-      .set(email_verified.eq(true))
-      .get_results::<Self>(conn)
-      .await
-  }
+    pub async fn set_all_users_email_verified(pool: &mut DbPool<'_>) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(local_user)
+            .set(email_verified.eq(true))
+            .get_results::<Self>(conn)
+            .await
+    }
 
-  pub async fn set_all_users_registration_applications_accepted(
-    pool: &mut DbPool<'_>,
-  ) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(local_user)
-      .set(accepted_application.eq(true))
-      .get_results::<Self>(conn)
-      .await
-  }
+    pub async fn set_all_users_registration_applications_accepted(
+        pool: &mut DbPool<'_>,
+    ) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(local_user)
+            .set(accepted_application.eq(true))
+            .get_results::<Self>(conn)
+            .await
+    }
 
-  pub async fn is_email_taken(pool: &mut DbPool<'_>, email_: &str) -> Result<bool, Error> {
-    use diesel::dsl::{exists, select};
-    let conn = &mut get_conn(pool).await?;
-    select(exists(local_user.filter(email.eq(email_))))
-      .get_result(conn)
-      .await
-  }
+    pub async fn is_email_taken(pool: &mut DbPool<'_>, email_: &str) -> Result<bool, Error> {
+        use diesel::dsl::{exists, select};
+        let conn = &mut get_conn(pool).await?;
+        select(exists(local_user.filter(email.eq(email_))))
+            .get_result(conn)
+            .await
+    }
 }
 
 #[async_trait]
 impl Crud for LocalUser {
-  type InsertForm = LocalUserInsertForm;
-  type UpdateForm = LocalUserUpdateForm;
-  type IdType = LocalUserId;
+    type InsertForm = LocalUserInsertForm;
+    type UpdateForm = LocalUserUpdateForm;
+    type IdType = LocalUserId;
 
-  async fn create(pool: &mut DbPool<'_>, form: &Self::InsertForm) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let mut form_with_encrypted_password = form.clone();
-    let password_hash =
-      hash(&form.password_encrypted, DEFAULT_COST).expect("Couldn't hash password");
-    form_with_encrypted_password.password_encrypted = password_hash;
+    async fn create(pool: &mut DbPool<'_>, form: &Self::InsertForm) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let mut form_with_encrypted_password = form.clone();
+        let password_hash =
+            hash(&form.password_encrypted, DEFAULT_COST).expect("Couldn't hash password");
+        form_with_encrypted_password.password_encrypted = password_hash;
 
-    let local_user_ = insert_into(local_user)
-      .values(form_with_encrypted_password)
-      .get_result::<Self>(conn)
-      .await?;
+        let local_user_ = insert_into(local_user)
+            .values(form_with_encrypted_password)
+            .get_result::<Self>(conn)
+            .await?;
 
-    let site_languages = SiteLanguage::read_local_raw(pool).await;
-    if let Ok(langs) = site_languages {
-      // if site exists, init user with site languages
-      LocalUserLanguage::update(pool, langs, local_user_.id).await?;
-    } else {
-      // otherwise, init with all languages (this only happens during tests and
-      // for first admin user, which is created before site)
-      LocalUserLanguage::update(pool, vec![], local_user_.id).await?;
+        let site_languages = SiteLanguage::read_local_raw(pool).await;
+        if let Ok(langs) = site_languages {
+            // if site exists, init user with site languages
+            LocalUserLanguage::update(pool, langs, local_user_.id).await?;
+        } else {
+            // otherwise, init with all languages (this only happens during tests and
+            // for first admin user, which is created before site)
+            LocalUserLanguage::update(pool, vec![], local_user_.id).await?;
+        }
+
+        Ok(local_user_)
     }
-
-    Ok(local_user_)
-  }
-  async fn update(
-    pool: &mut DbPool<'_>,
-    local_user_id: LocalUserId,
-    form: &Self::UpdateForm,
-  ) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(local_user.find(local_user_id))
-      .set(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn update(
+        pool: &mut DbPool<'_>,
+        local_user_id: LocalUserId,
+        form: &Self::UpdateForm,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(local_user.find(local_user_id))
+            .set(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 }

--- a/crates/db_schema/src/impls/moderator.rs
+++ b/crates/db_schema/src/impls/moderator.rs
@@ -1,783 +1,746 @@
 use crate::{
-  source::moderator::{
-    AdminPurgeComment,
-    AdminPurgeCommentForm,
-    AdminPurgeCommunity,
-    AdminPurgeCommunityForm,
-    AdminPurgePerson,
-    AdminPurgePersonForm,
-    AdminPurgePost,
-    AdminPurgePostForm,
-    ModAdd,
-    ModAddCommunity,
-    ModAddCommunityForm,
-    ModAddForm,
-    ModBan,
-    ModBanForm,
-    ModBanFromCommunity,
-    ModBanFromCommunityForm,
-    ModFeaturePost,
-    ModFeaturePostForm,
-    ModHideCommunity,
-    ModHideCommunityForm,
-    ModLockPost,
-    ModLockPostForm,
-    ModRemoveComment,
-    ModRemoveCommentForm,
-    ModRemoveCommunity,
-    ModRemoveCommunityForm,
-    ModRemovePost,
-    ModRemovePostForm,
-    ModTransferCommunity,
-    ModTransferCommunityForm,
-  },
-  traits::Crud,
-  utils::{get_conn, DbPool},
+    source::moderator::{
+        AdminPurgeComment, AdminPurgeCommentForm, AdminPurgeCommunity, AdminPurgeCommunityForm,
+        AdminPurgePerson, AdminPurgePersonForm, AdminPurgePost, AdminPurgePostForm, ModAdd,
+        ModAddCommunity, ModAddCommunityForm, ModAddForm, ModBan, ModBanForm, ModBanFromCommunity,
+        ModBanFromCommunityForm, ModFeaturePost, ModFeaturePostForm, ModHideCommunity,
+        ModHideCommunityForm, ModLockPost, ModLockPostForm, ModRemoveComment, ModRemoveCommentForm,
+        ModRemoveCommunity, ModRemoveCommunityForm, ModRemovePost, ModRemovePostForm,
+        ModTransferCommunity, ModTransferCommunityForm,
+    },
+    traits::Crud,
+    utils::{get_conn, DbPool},
 };
 use diesel::{dsl::insert_into, result::Error, QueryDsl};
 use diesel_async::RunQueryDsl;
 
 #[async_trait]
 impl Crud for ModRemovePost {
-  type InsertForm = ModRemovePostForm;
-  type UpdateForm = ModRemovePostForm;
-  type IdType = i32;
+    type InsertForm = ModRemovePostForm;
+    type UpdateForm = ModRemovePostForm;
+    type IdType = i32;
 
-  async fn create(pool: &mut DbPool<'_>, form: &ModRemovePostForm) -> Result<Self, Error> {
-    use crate::schema::mod_remove_post::dsl::mod_remove_post;
-    let conn = &mut get_conn(pool).await?;
-    insert_into(mod_remove_post)
-      .values(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn create(pool: &mut DbPool<'_>, form: &ModRemovePostForm) -> Result<Self, Error> {
+        use crate::schema::mod_remove_post::dsl::mod_remove_post;
+        let conn = &mut get_conn(pool).await?;
+        insert_into(mod_remove_post)
+            .values(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 
-  async fn update(
-    pool: &mut DbPool<'_>,
-    from_id: i32,
-    form: &ModRemovePostForm,
-  ) -> Result<Self, Error> {
-    use crate::schema::mod_remove_post::dsl::mod_remove_post;
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(mod_remove_post.find(from_id))
-      .set(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn update(
+        pool: &mut DbPool<'_>,
+        from_id: i32,
+        form: &ModRemovePostForm,
+    ) -> Result<Self, Error> {
+        use crate::schema::mod_remove_post::dsl::mod_remove_post;
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(mod_remove_post.find(from_id))
+            .set(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 }
 
 #[async_trait]
 impl Crud for ModLockPost {
-  type InsertForm = ModLockPostForm;
-  type UpdateForm = ModLockPostForm;
-  type IdType = i32;
+    type InsertForm = ModLockPostForm;
+    type UpdateForm = ModLockPostForm;
+    type IdType = i32;
 
-  async fn create(pool: &mut DbPool<'_>, form: &ModLockPostForm) -> Result<Self, Error> {
-    use crate::schema::mod_lock_post::dsl::mod_lock_post;
-    let conn = &mut get_conn(pool).await?;
-    insert_into(mod_lock_post)
-      .values(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn create(pool: &mut DbPool<'_>, form: &ModLockPostForm) -> Result<Self, Error> {
+        use crate::schema::mod_lock_post::dsl::mod_lock_post;
+        let conn = &mut get_conn(pool).await?;
+        insert_into(mod_lock_post)
+            .values(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 
-  async fn update(
-    pool: &mut DbPool<'_>,
-    from_id: i32,
-    form: &ModLockPostForm,
-  ) -> Result<Self, Error> {
-    use crate::schema::mod_lock_post::dsl::mod_lock_post;
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(mod_lock_post.find(from_id))
-      .set(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn update(
+        pool: &mut DbPool<'_>,
+        from_id: i32,
+        form: &ModLockPostForm,
+    ) -> Result<Self, Error> {
+        use crate::schema::mod_lock_post::dsl::mod_lock_post;
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(mod_lock_post.find(from_id))
+            .set(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 }
 
 #[async_trait]
 impl Crud for ModFeaturePost {
-  type InsertForm = ModFeaturePostForm;
-  type UpdateForm = ModFeaturePostForm;
-  type IdType = i32;
+    type InsertForm = ModFeaturePostForm;
+    type UpdateForm = ModFeaturePostForm;
+    type IdType = i32;
 
-  async fn create(pool: &mut DbPool<'_>, form: &ModFeaturePostForm) -> Result<Self, Error> {
-    use crate::schema::mod_feature_post::dsl::mod_feature_post;
-    let conn = &mut get_conn(pool).await?;
-    insert_into(mod_feature_post)
-      .values(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn create(pool: &mut DbPool<'_>, form: &ModFeaturePostForm) -> Result<Self, Error> {
+        use crate::schema::mod_feature_post::dsl::mod_feature_post;
+        let conn = &mut get_conn(pool).await?;
+        insert_into(mod_feature_post)
+            .values(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 
-  async fn update(
-    pool: &mut DbPool<'_>,
-    from_id: i32,
-    form: &ModFeaturePostForm,
-  ) -> Result<Self, Error> {
-    use crate::schema::mod_feature_post::dsl::mod_feature_post;
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(mod_feature_post.find(from_id))
-      .set(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn update(
+        pool: &mut DbPool<'_>,
+        from_id: i32,
+        form: &ModFeaturePostForm,
+    ) -> Result<Self, Error> {
+        use crate::schema::mod_feature_post::dsl::mod_feature_post;
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(mod_feature_post.find(from_id))
+            .set(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 }
 
 #[async_trait]
 impl Crud for ModRemoveComment {
-  type InsertForm = ModRemoveCommentForm;
-  type UpdateForm = ModRemoveCommentForm;
-  type IdType = i32;
+    type InsertForm = ModRemoveCommentForm;
+    type UpdateForm = ModRemoveCommentForm;
+    type IdType = i32;
 
-  async fn create(pool: &mut DbPool<'_>, form: &ModRemoveCommentForm) -> Result<Self, Error> {
-    use crate::schema::mod_remove_comment::dsl::mod_remove_comment;
-    let conn = &mut get_conn(pool).await?;
-    insert_into(mod_remove_comment)
-      .values(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn create(pool: &mut DbPool<'_>, form: &ModRemoveCommentForm) -> Result<Self, Error> {
+        use crate::schema::mod_remove_comment::dsl::mod_remove_comment;
+        let conn = &mut get_conn(pool).await?;
+        insert_into(mod_remove_comment)
+            .values(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 
-  async fn update(
-    pool: &mut DbPool<'_>,
-    from_id: i32,
-    form: &ModRemoveCommentForm,
-  ) -> Result<Self, Error> {
-    use crate::schema::mod_remove_comment::dsl::mod_remove_comment;
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(mod_remove_comment.find(from_id))
-      .set(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn update(
+        pool: &mut DbPool<'_>,
+        from_id: i32,
+        form: &ModRemoveCommentForm,
+    ) -> Result<Self, Error> {
+        use crate::schema::mod_remove_comment::dsl::mod_remove_comment;
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(mod_remove_comment.find(from_id))
+            .set(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 }
 
 #[async_trait]
 impl Crud for ModRemoveCommunity {
-  type InsertForm = ModRemoveCommunityForm;
-  type UpdateForm = ModRemoveCommunityForm;
-  type IdType = i32;
+    type InsertForm = ModRemoveCommunityForm;
+    type UpdateForm = ModRemoveCommunityForm;
+    type IdType = i32;
 
-  async fn create(pool: &mut DbPool<'_>, form: &ModRemoveCommunityForm) -> Result<Self, Error> {
-    use crate::schema::mod_remove_community::dsl::mod_remove_community;
-    let conn = &mut get_conn(pool).await?;
-    insert_into(mod_remove_community)
-      .values(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn create(pool: &mut DbPool<'_>, form: &ModRemoveCommunityForm) -> Result<Self, Error> {
+        use crate::schema::mod_remove_community::dsl::mod_remove_community;
+        let conn = &mut get_conn(pool).await?;
+        insert_into(mod_remove_community)
+            .values(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 
-  async fn update(
-    pool: &mut DbPool<'_>,
-    from_id: i32,
-    form: &ModRemoveCommunityForm,
-  ) -> Result<Self, Error> {
-    use crate::schema::mod_remove_community::dsl::mod_remove_community;
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(mod_remove_community.find(from_id))
-      .set(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn update(
+        pool: &mut DbPool<'_>,
+        from_id: i32,
+        form: &ModRemoveCommunityForm,
+    ) -> Result<Self, Error> {
+        use crate::schema::mod_remove_community::dsl::mod_remove_community;
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(mod_remove_community.find(from_id))
+            .set(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 }
 
 #[async_trait]
 impl Crud for ModBanFromCommunity {
-  type InsertForm = ModBanFromCommunityForm;
-  type UpdateForm = ModBanFromCommunityForm;
-  type IdType = i32;
+    type InsertForm = ModBanFromCommunityForm;
+    type UpdateForm = ModBanFromCommunityForm;
+    type IdType = i32;
 
-  async fn create(pool: &mut DbPool<'_>, form: &ModBanFromCommunityForm) -> Result<Self, Error> {
-    use crate::schema::mod_ban_from_community::dsl::mod_ban_from_community;
-    let conn = &mut get_conn(pool).await?;
-    insert_into(mod_ban_from_community)
-      .values(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn create(pool: &mut DbPool<'_>, form: &ModBanFromCommunityForm) -> Result<Self, Error> {
+        use crate::schema::mod_ban_from_community::dsl::mod_ban_from_community;
+        let conn = &mut get_conn(pool).await?;
+        insert_into(mod_ban_from_community)
+            .values(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 
-  async fn update(
-    pool: &mut DbPool<'_>,
-    from_id: i32,
-    form: &ModBanFromCommunityForm,
-  ) -> Result<Self, Error> {
-    use crate::schema::mod_ban_from_community::dsl::mod_ban_from_community;
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(mod_ban_from_community.find(from_id))
-      .set(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn update(
+        pool: &mut DbPool<'_>,
+        from_id: i32,
+        form: &ModBanFromCommunityForm,
+    ) -> Result<Self, Error> {
+        use crate::schema::mod_ban_from_community::dsl::mod_ban_from_community;
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(mod_ban_from_community.find(from_id))
+            .set(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 }
 
 #[async_trait]
 impl Crud for ModBan {
-  type InsertForm = ModBanForm;
-  type UpdateForm = ModBanForm;
-  type IdType = i32;
+    type InsertForm = ModBanForm;
+    type UpdateForm = ModBanForm;
+    type IdType = i32;
 
-  async fn create(pool: &mut DbPool<'_>, form: &ModBanForm) -> Result<Self, Error> {
-    use crate::schema::mod_ban::dsl::mod_ban;
-    let conn = &mut get_conn(pool).await?;
-    insert_into(mod_ban)
-      .values(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn create(pool: &mut DbPool<'_>, form: &ModBanForm) -> Result<Self, Error> {
+        use crate::schema::mod_ban::dsl::mod_ban;
+        let conn = &mut get_conn(pool).await?;
+        insert_into(mod_ban)
+            .values(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 
-  async fn update(pool: &mut DbPool<'_>, from_id: i32, form: &ModBanForm) -> Result<Self, Error> {
-    use crate::schema::mod_ban::dsl::mod_ban;
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(mod_ban.find(from_id))
-      .set(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn update(pool: &mut DbPool<'_>, from_id: i32, form: &ModBanForm) -> Result<Self, Error> {
+        use crate::schema::mod_ban::dsl::mod_ban;
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(mod_ban.find(from_id))
+            .set(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 }
 
 #[async_trait]
 impl Crud for ModHideCommunity {
-  type InsertForm = ModHideCommunityForm;
-  type UpdateForm = ModHideCommunityForm;
-  type IdType = i32;
+    type InsertForm = ModHideCommunityForm;
+    type UpdateForm = ModHideCommunityForm;
+    type IdType = i32;
 
-  async fn create(pool: &mut DbPool<'_>, form: &ModHideCommunityForm) -> Result<Self, Error> {
-    use crate::schema::mod_hide_community::dsl::mod_hide_community;
-    let conn = &mut get_conn(pool).await?;
-    insert_into(mod_hide_community)
-      .values(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn create(pool: &mut DbPool<'_>, form: &ModHideCommunityForm) -> Result<Self, Error> {
+        use crate::schema::mod_hide_community::dsl::mod_hide_community;
+        let conn = &mut get_conn(pool).await?;
+        insert_into(mod_hide_community)
+            .values(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 
-  async fn update(
-    pool: &mut DbPool<'_>,
-    from_id: i32,
-    form: &ModHideCommunityForm,
-  ) -> Result<Self, Error> {
-    use crate::schema::mod_hide_community::dsl::mod_hide_community;
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(mod_hide_community.find(from_id))
-      .set(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn update(
+        pool: &mut DbPool<'_>,
+        from_id: i32,
+        form: &ModHideCommunityForm,
+    ) -> Result<Self, Error> {
+        use crate::schema::mod_hide_community::dsl::mod_hide_community;
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(mod_hide_community.find(from_id))
+            .set(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 }
 
 #[async_trait]
 impl Crud for ModAddCommunity {
-  type InsertForm = ModAddCommunityForm;
-  type UpdateForm = ModAddCommunityForm;
-  type IdType = i32;
+    type InsertForm = ModAddCommunityForm;
+    type UpdateForm = ModAddCommunityForm;
+    type IdType = i32;
 
-  async fn create(pool: &mut DbPool<'_>, form: &ModAddCommunityForm) -> Result<Self, Error> {
-    use crate::schema::mod_add_community::dsl::mod_add_community;
-    let conn = &mut get_conn(pool).await?;
-    insert_into(mod_add_community)
-      .values(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn create(pool: &mut DbPool<'_>, form: &ModAddCommunityForm) -> Result<Self, Error> {
+        use crate::schema::mod_add_community::dsl::mod_add_community;
+        let conn = &mut get_conn(pool).await?;
+        insert_into(mod_add_community)
+            .values(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 
-  async fn update(
-    pool: &mut DbPool<'_>,
-    from_id: i32,
-    form: &ModAddCommunityForm,
-  ) -> Result<Self, Error> {
-    use crate::schema::mod_add_community::dsl::mod_add_community;
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(mod_add_community.find(from_id))
-      .set(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn update(
+        pool: &mut DbPool<'_>,
+        from_id: i32,
+        form: &ModAddCommunityForm,
+    ) -> Result<Self, Error> {
+        use crate::schema::mod_add_community::dsl::mod_add_community;
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(mod_add_community.find(from_id))
+            .set(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 }
 
 #[async_trait]
 impl Crud for ModTransferCommunity {
-  type InsertForm = ModTransferCommunityForm;
-  type UpdateForm = ModTransferCommunityForm;
-  type IdType = i32;
+    type InsertForm = ModTransferCommunityForm;
+    type UpdateForm = ModTransferCommunityForm;
+    type IdType = i32;
 
-  async fn create(pool: &mut DbPool<'_>, form: &ModTransferCommunityForm) -> Result<Self, Error> {
-    use crate::schema::mod_transfer_community::dsl::mod_transfer_community;
-    let conn = &mut get_conn(pool).await?;
-    insert_into(mod_transfer_community)
-      .values(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn create(pool: &mut DbPool<'_>, form: &ModTransferCommunityForm) -> Result<Self, Error> {
+        use crate::schema::mod_transfer_community::dsl::mod_transfer_community;
+        let conn = &mut get_conn(pool).await?;
+        insert_into(mod_transfer_community)
+            .values(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 
-  async fn update(
-    pool: &mut DbPool<'_>,
-    from_id: i32,
-    form: &ModTransferCommunityForm,
-  ) -> Result<Self, Error> {
-    use crate::schema::mod_transfer_community::dsl::mod_transfer_community;
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(mod_transfer_community.find(from_id))
-      .set(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn update(
+        pool: &mut DbPool<'_>,
+        from_id: i32,
+        form: &ModTransferCommunityForm,
+    ) -> Result<Self, Error> {
+        use crate::schema::mod_transfer_community::dsl::mod_transfer_community;
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(mod_transfer_community.find(from_id))
+            .set(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 }
 
 #[async_trait]
 impl Crud for ModAdd {
-  type InsertForm = ModAddForm;
-  type UpdateForm = ModAddForm;
-  type IdType = i32;
+    type InsertForm = ModAddForm;
+    type UpdateForm = ModAddForm;
+    type IdType = i32;
 
-  async fn create(pool: &mut DbPool<'_>, form: &ModAddForm) -> Result<Self, Error> {
-    use crate::schema::mod_add::dsl::mod_add;
-    let conn = &mut get_conn(pool).await?;
-    insert_into(mod_add)
-      .values(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn create(pool: &mut DbPool<'_>, form: &ModAddForm) -> Result<Self, Error> {
+        use crate::schema::mod_add::dsl::mod_add;
+        let conn = &mut get_conn(pool).await?;
+        insert_into(mod_add)
+            .values(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 
-  async fn update(pool: &mut DbPool<'_>, from_id: i32, form: &ModAddForm) -> Result<Self, Error> {
-    use crate::schema::mod_add::dsl::mod_add;
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(mod_add.find(from_id))
-      .set(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn update(pool: &mut DbPool<'_>, from_id: i32, form: &ModAddForm) -> Result<Self, Error> {
+        use crate::schema::mod_add::dsl::mod_add;
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(mod_add.find(from_id))
+            .set(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 }
 
 #[async_trait]
 impl Crud for AdminPurgePerson {
-  type InsertForm = AdminPurgePersonForm;
-  type UpdateForm = AdminPurgePersonForm;
-  type IdType = i32;
+    type InsertForm = AdminPurgePersonForm;
+    type UpdateForm = AdminPurgePersonForm;
+    type IdType = i32;
 
-  async fn create(pool: &mut DbPool<'_>, form: &Self::InsertForm) -> Result<Self, Error> {
-    use crate::schema::admin_purge_person::dsl::admin_purge_person;
-    let conn = &mut get_conn(pool).await?;
-    insert_into(admin_purge_person)
-      .values(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn create(pool: &mut DbPool<'_>, form: &Self::InsertForm) -> Result<Self, Error> {
+        use crate::schema::admin_purge_person::dsl::admin_purge_person;
+        let conn = &mut get_conn(pool).await?;
+        insert_into(admin_purge_person)
+            .values(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 
-  async fn update(
-    pool: &mut DbPool<'_>,
-    from_id: i32,
-    form: &Self::InsertForm,
-  ) -> Result<Self, Error> {
-    use crate::schema::admin_purge_person::dsl::admin_purge_person;
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(admin_purge_person.find(from_id))
-      .set(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn update(
+        pool: &mut DbPool<'_>,
+        from_id: i32,
+        form: &Self::InsertForm,
+    ) -> Result<Self, Error> {
+        use crate::schema::admin_purge_person::dsl::admin_purge_person;
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(admin_purge_person.find(from_id))
+            .set(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 }
 
 #[async_trait]
 impl Crud for AdminPurgeCommunity {
-  type InsertForm = AdminPurgeCommunityForm;
-  type UpdateForm = AdminPurgeCommunityForm;
-  type IdType = i32;
+    type InsertForm = AdminPurgeCommunityForm;
+    type UpdateForm = AdminPurgeCommunityForm;
+    type IdType = i32;
 
-  async fn create(pool: &mut DbPool<'_>, form: &Self::InsertForm) -> Result<Self, Error> {
-    use crate::schema::admin_purge_community::dsl::admin_purge_community;
-    let conn = &mut get_conn(pool).await?;
-    insert_into(admin_purge_community)
-      .values(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn create(pool: &mut DbPool<'_>, form: &Self::InsertForm) -> Result<Self, Error> {
+        use crate::schema::admin_purge_community::dsl::admin_purge_community;
+        let conn = &mut get_conn(pool).await?;
+        insert_into(admin_purge_community)
+            .values(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 
-  async fn update(
-    pool: &mut DbPool<'_>,
-    from_id: i32,
-    form: &Self::InsertForm,
-  ) -> Result<Self, Error> {
-    use crate::schema::admin_purge_community::dsl::admin_purge_community;
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(admin_purge_community.find(from_id))
-      .set(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn update(
+        pool: &mut DbPool<'_>,
+        from_id: i32,
+        form: &Self::InsertForm,
+    ) -> Result<Self, Error> {
+        use crate::schema::admin_purge_community::dsl::admin_purge_community;
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(admin_purge_community.find(from_id))
+            .set(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 }
 
 #[async_trait]
 impl Crud for AdminPurgePost {
-  type InsertForm = AdminPurgePostForm;
-  type UpdateForm = AdminPurgePostForm;
-  type IdType = i32;
+    type InsertForm = AdminPurgePostForm;
+    type UpdateForm = AdminPurgePostForm;
+    type IdType = i32;
 
-  async fn create(pool: &mut DbPool<'_>, form: &Self::InsertForm) -> Result<Self, Error> {
-    use crate::schema::admin_purge_post::dsl::admin_purge_post;
-    let conn = &mut get_conn(pool).await?;
-    insert_into(admin_purge_post)
-      .values(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn create(pool: &mut DbPool<'_>, form: &Self::InsertForm) -> Result<Self, Error> {
+        use crate::schema::admin_purge_post::dsl::admin_purge_post;
+        let conn = &mut get_conn(pool).await?;
+        insert_into(admin_purge_post)
+            .values(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 
-  async fn update(
-    pool: &mut DbPool<'_>,
-    from_id: i32,
-    form: &Self::InsertForm,
-  ) -> Result<Self, Error> {
-    use crate::schema::admin_purge_post::dsl::admin_purge_post;
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(admin_purge_post.find(from_id))
-      .set(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn update(
+        pool: &mut DbPool<'_>,
+        from_id: i32,
+        form: &Self::InsertForm,
+    ) -> Result<Self, Error> {
+        use crate::schema::admin_purge_post::dsl::admin_purge_post;
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(admin_purge_post.find(from_id))
+            .set(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 }
 
 #[async_trait]
 impl Crud for AdminPurgeComment {
-  type InsertForm = AdminPurgeCommentForm;
-  type UpdateForm = AdminPurgeCommentForm;
-  type IdType = i32;
+    type InsertForm = AdminPurgeCommentForm;
+    type UpdateForm = AdminPurgeCommentForm;
+    type IdType = i32;
 
-  async fn create(pool: &mut DbPool<'_>, form: &Self::InsertForm) -> Result<Self, Error> {
-    use crate::schema::admin_purge_comment::dsl::admin_purge_comment;
-    let conn = &mut get_conn(pool).await?;
-    insert_into(admin_purge_comment)
-      .values(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn create(pool: &mut DbPool<'_>, form: &Self::InsertForm) -> Result<Self, Error> {
+        use crate::schema::admin_purge_comment::dsl::admin_purge_comment;
+        let conn = &mut get_conn(pool).await?;
+        insert_into(admin_purge_comment)
+            .values(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 
-  async fn update(
-    pool: &mut DbPool<'_>,
-    from_id: i32,
-    form: &Self::InsertForm,
-  ) -> Result<Self, Error> {
-    use crate::schema::admin_purge_comment::dsl::admin_purge_comment;
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(admin_purge_comment.find(from_id))
-      .set(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn update(
+        pool: &mut DbPool<'_>,
+        from_id: i32,
+        form: &Self::InsertForm,
+    ) -> Result<Self, Error> {
+        use crate::schema::admin_purge_comment::dsl::admin_purge_comment;
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(admin_purge_comment.find(from_id))
+            .set(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::{
-    source::{
-      comment::{Comment, CommentInsertForm},
-      community::{Community, CommunityInsertForm},
-      instance::Instance,
-      moderator::{
-        ModAdd,
-        ModAddCommunity,
-        ModAddCommunityForm,
-        ModAddForm,
-        ModBan,
-        ModBanForm,
-        ModBanFromCommunity,
-        ModBanFromCommunityForm,
-        ModFeaturePost,
-        ModFeaturePostForm,
-        ModLockPost,
-        ModLockPostForm,
-        ModRemoveComment,
-        ModRemoveCommentForm,
-        ModRemoveCommunity,
-        ModRemoveCommunityForm,
-        ModRemovePost,
-        ModRemovePostForm,
-      },
-      person::{Person, PersonInsertForm},
-      post::{Post, PostInsertForm},
-    },
-    traits::Crud,
-    utils::build_db_pool_for_tests,
-  };
-  use serial_test::serial;
-
-  #[tokio::test]
-  #[serial]
-  async fn test_crud() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-
-    let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
-      .await
-      .unwrap();
-
-    let new_mod = PersonInsertForm::builder()
-      .name("the mod".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_mod = Person::create(pool, &new_mod).await.unwrap();
-
-    let new_person = PersonInsertForm::builder()
-      .name("jim2".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_person = Person::create(pool, &new_person).await.unwrap();
-
-    let new_community = CommunityInsertForm::builder()
-      .name("mod_community".to_string())
-      .title("nada".to_owned())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_community = Community::create(pool, &new_community).await.unwrap();
-
-    let new_post = PostInsertForm::builder()
-      .name("A test post thweep".into())
-      .creator_id(inserted_person.id)
-      .community_id(inserted_community.id)
-      .build();
-
-    let inserted_post = Post::create(pool, &new_post).await.unwrap();
-
-    let comment_form = CommentInsertForm::builder()
-      .content("A test comment".into())
-      .creator_id(inserted_person.id)
-      .post_id(inserted_post.id)
-      .build();
-
-    let inserted_comment = Comment::create(pool, &comment_form, None).await.unwrap();
-
-    // Now the actual tests
-
-    // remove post
-    let mod_remove_post_form = ModRemovePostForm {
-      mod_person_id: inserted_mod.id,
-      post_id: inserted_post.id,
-      reason: None,
-      removed: None,
+    use crate::{
+        source::{
+            comment::{Comment, CommentInsertForm},
+            community::{Community, CommunityInsertForm},
+            instance::Instance,
+            moderator::{
+                ModAdd, ModAddCommunity, ModAddCommunityForm, ModAddForm, ModBan, ModBanForm,
+                ModBanFromCommunity, ModBanFromCommunityForm, ModFeaturePost, ModFeaturePostForm,
+                ModLockPost, ModLockPostForm, ModRemoveComment, ModRemoveCommentForm,
+                ModRemoveCommunity, ModRemoveCommunityForm, ModRemovePost, ModRemovePostForm,
+            },
+            person::{Person, PersonInsertForm},
+            post::{Post, PostInsertForm},
+        },
+        traits::Crud,
+        utils::build_db_pool_for_tests,
     };
-    let inserted_mod_remove_post = ModRemovePost::create(pool, &mod_remove_post_form)
-      .await
-      .unwrap();
-    let read_mod_remove_post = ModRemovePost::read(pool, inserted_mod_remove_post.id)
-      .await
-      .unwrap();
-    let expected_mod_remove_post = ModRemovePost {
-      id: inserted_mod_remove_post.id,
-      post_id: inserted_post.id,
-      mod_person_id: inserted_mod.id,
-      reason: None,
-      removed: true,
-      when_: inserted_mod_remove_post.when_,
-    };
+    use serial_test::serial;
 
-    // lock post
+    #[tokio::test]
+    #[serial]
+    async fn test_crud() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
 
-    let mod_lock_post_form = ModLockPostForm {
-      mod_person_id: inserted_mod.id,
-      post_id: inserted_post.id,
-      locked: None,
-    };
-    let inserted_mod_lock_post = ModLockPost::create(pool, &mod_lock_post_form)
-      .await
-      .unwrap();
-    let read_mod_lock_post = ModLockPost::read(pool, inserted_mod_lock_post.id)
-      .await
-      .unwrap();
-    let expected_mod_lock_post = ModLockPost {
-      id: inserted_mod_lock_post.id,
-      post_id: inserted_post.id,
-      mod_person_id: inserted_mod.id,
-      locked: true,
-      when_: inserted_mod_lock_post.when_,
-    };
+        let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
+            .await
+            .unwrap();
 
-    // feature post
+        let new_mod = PersonInsertForm::builder()
+            .name("the mod".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let mod_feature_post_form = ModFeaturePostForm {
-      mod_person_id: inserted_mod.id,
-      post_id: inserted_post.id,
-      featured: false,
-      is_featured_community: true,
-    };
-    let inserted_mod_feature_post = ModFeaturePost::create(pool, &mod_feature_post_form)
-      .await
-      .unwrap();
-    let read_mod_feature_post = ModFeaturePost::read(pool, inserted_mod_feature_post.id)
-      .await
-      .unwrap();
-    let expected_mod_feature_post = ModFeaturePost {
-      id: inserted_mod_feature_post.id,
-      post_id: inserted_post.id,
-      mod_person_id: inserted_mod.id,
-      featured: false,
-      is_featured_community: true,
-      when_: inserted_mod_feature_post.when_,
-    };
+        let inserted_mod = Person::create(pool, &new_mod).await.unwrap();
 
-    // comment
+        let new_person = PersonInsertForm::builder()
+            .name("jim2".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let mod_remove_comment_form = ModRemoveCommentForm {
-      mod_person_id: inserted_mod.id,
-      comment_id: inserted_comment.id,
-      reason: None,
-      removed: None,
-    };
-    let inserted_mod_remove_comment = ModRemoveComment::create(pool, &mod_remove_comment_form)
-      .await
-      .unwrap();
-    let read_mod_remove_comment = ModRemoveComment::read(pool, inserted_mod_remove_comment.id)
-      .await
-      .unwrap();
-    let expected_mod_remove_comment = ModRemoveComment {
-      id: inserted_mod_remove_comment.id,
-      comment_id: inserted_comment.id,
-      mod_person_id: inserted_mod.id,
-      reason: None,
-      removed: true,
-      when_: inserted_mod_remove_comment.when_,
-    };
+        let inserted_person = Person::create(pool, &new_person).await.unwrap();
 
-    // community
+        let new_community = CommunityInsertForm::builder()
+            .name("mod_community".to_string())
+            .title("nada".to_owned())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let mod_remove_community_form = ModRemoveCommunityForm {
-      mod_person_id: inserted_mod.id,
-      community_id: inserted_community.id,
-      reason: None,
-      removed: None,
-      expires: None,
-    };
-    let inserted_mod_remove_community =
-      ModRemoveCommunity::create(pool, &mod_remove_community_form)
-        .await
-        .unwrap();
-    let read_mod_remove_community =
-      ModRemoveCommunity::read(pool, inserted_mod_remove_community.id)
-        .await
-        .unwrap();
-    let expected_mod_remove_community = ModRemoveCommunity {
-      id: inserted_mod_remove_community.id,
-      community_id: inserted_community.id,
-      mod_person_id: inserted_mod.id,
-      reason: None,
-      removed: true,
-      expires: None,
-      when_: inserted_mod_remove_community.when_,
-    };
+        let inserted_community = Community::create(pool, &new_community).await.unwrap();
 
-    // ban from community
+        let new_post = PostInsertForm::builder()
+            .name("A test post thweep".into())
+            .creator_id(inserted_person.id)
+            .community_id(inserted_community.id)
+            .build();
 
-    let mod_ban_from_community_form = ModBanFromCommunityForm {
-      mod_person_id: inserted_mod.id,
-      other_person_id: inserted_person.id,
-      community_id: inserted_community.id,
-      reason: None,
-      banned: None,
-      expires: None,
-    };
-    let inserted_mod_ban_from_community =
-      ModBanFromCommunity::create(pool, &mod_ban_from_community_form)
-        .await
-        .unwrap();
-    let read_mod_ban_from_community =
-      ModBanFromCommunity::read(pool, inserted_mod_ban_from_community.id)
-        .await
-        .unwrap();
-    let expected_mod_ban_from_community = ModBanFromCommunity {
-      id: inserted_mod_ban_from_community.id,
-      community_id: inserted_community.id,
-      mod_person_id: inserted_mod.id,
-      other_person_id: inserted_person.id,
-      reason: None,
-      banned: true,
-      expires: None,
-      when_: inserted_mod_ban_from_community.when_,
-    };
+        let inserted_post = Post::create(pool, &new_post).await.unwrap();
 
-    // ban
+        let comment_form = CommentInsertForm::builder()
+            .content("A test comment".into())
+            .creator_id(inserted_person.id)
+            .post_id(inserted_post.id)
+            .build();
 
-    let mod_ban_form = ModBanForm {
-      mod_person_id: inserted_mod.id,
-      other_person_id: inserted_person.id,
-      reason: None,
-      banned: None,
-      expires: None,
-    };
-    let inserted_mod_ban = ModBan::create(pool, &mod_ban_form).await.unwrap();
-    let read_mod_ban = ModBan::read(pool, inserted_mod_ban.id).await.unwrap();
-    let expected_mod_ban = ModBan {
-      id: inserted_mod_ban.id,
-      mod_person_id: inserted_mod.id,
-      other_person_id: inserted_person.id,
-      reason: None,
-      banned: true,
-      expires: None,
-      when_: inserted_mod_ban.when_,
-    };
+        let inserted_comment = Comment::create(pool, &comment_form, None).await.unwrap();
 
-    // mod add community
+        // Now the actual tests
 
-    let mod_add_community_form = ModAddCommunityForm {
-      mod_person_id: inserted_mod.id,
-      other_person_id: inserted_person.id,
-      community_id: inserted_community.id,
-      removed: None,
-    };
-    let inserted_mod_add_community = ModAddCommunity::create(pool, &mod_add_community_form)
-      .await
-      .unwrap();
-    let read_mod_add_community = ModAddCommunity::read(pool, inserted_mod_add_community.id)
-      .await
-      .unwrap();
-    let expected_mod_add_community = ModAddCommunity {
-      id: inserted_mod_add_community.id,
-      community_id: inserted_community.id,
-      mod_person_id: inserted_mod.id,
-      other_person_id: inserted_person.id,
-      removed: false,
-      when_: inserted_mod_add_community.when_,
-    };
+        // remove post
+        let mod_remove_post_form = ModRemovePostForm {
+            mod_person_id: inserted_mod.id,
+            post_id: inserted_post.id,
+            reason: None,
+            removed: None,
+        };
+        let inserted_mod_remove_post = ModRemovePost::create(pool, &mod_remove_post_form)
+            .await
+            .unwrap();
+        let read_mod_remove_post = ModRemovePost::read(pool, inserted_mod_remove_post.id)
+            .await
+            .unwrap();
+        let expected_mod_remove_post = ModRemovePost {
+            id: inserted_mod_remove_post.id,
+            post_id: inserted_post.id,
+            mod_person_id: inserted_mod.id,
+            reason: None,
+            removed: true,
+            when_: inserted_mod_remove_post.when_,
+        };
 
-    // mod add
+        // lock post
 
-    let mod_add_form = ModAddForm {
-      mod_person_id: inserted_mod.id,
-      other_person_id: inserted_person.id,
-      removed: None,
-    };
-    let inserted_mod_add = ModAdd::create(pool, &mod_add_form).await.unwrap();
-    let read_mod_add = ModAdd::read(pool, inserted_mod_add.id).await.unwrap();
-    let expected_mod_add = ModAdd {
-      id: inserted_mod_add.id,
-      mod_person_id: inserted_mod.id,
-      other_person_id: inserted_person.id,
-      removed: false,
-      when_: inserted_mod_add.when_,
-    };
+        let mod_lock_post_form = ModLockPostForm {
+            mod_person_id: inserted_mod.id,
+            post_id: inserted_post.id,
+            locked: None,
+        };
+        let inserted_mod_lock_post = ModLockPost::create(pool, &mod_lock_post_form)
+            .await
+            .unwrap();
+        let read_mod_lock_post = ModLockPost::read(pool, inserted_mod_lock_post.id)
+            .await
+            .unwrap();
+        let expected_mod_lock_post = ModLockPost {
+            id: inserted_mod_lock_post.id,
+            post_id: inserted_post.id,
+            mod_person_id: inserted_mod.id,
+            locked: true,
+            when_: inserted_mod_lock_post.when_,
+        };
 
-    Comment::delete(pool, inserted_comment.id).await.unwrap();
-    Post::delete(pool, inserted_post.id).await.unwrap();
-    Community::delete(pool, inserted_community.id)
-      .await
-      .unwrap();
-    Person::delete(pool, inserted_person.id).await.unwrap();
-    Person::delete(pool, inserted_mod.id).await.unwrap();
-    Instance::delete(pool, inserted_instance.id).await.unwrap();
+        // feature post
 
-    assert_eq!(expected_mod_remove_post, read_mod_remove_post);
-    assert_eq!(expected_mod_lock_post, read_mod_lock_post);
-    assert_eq!(expected_mod_feature_post, read_mod_feature_post);
-    assert_eq!(expected_mod_remove_comment, read_mod_remove_comment);
-    assert_eq!(expected_mod_remove_community, read_mod_remove_community);
-    assert_eq!(expected_mod_ban_from_community, read_mod_ban_from_community);
-    assert_eq!(expected_mod_ban, read_mod_ban);
-    assert_eq!(expected_mod_add_community, read_mod_add_community);
-    assert_eq!(expected_mod_add, read_mod_add);
-  }
+        let mod_feature_post_form = ModFeaturePostForm {
+            mod_person_id: inserted_mod.id,
+            post_id: inserted_post.id,
+            featured: false,
+            is_featured_community: true,
+        };
+        let inserted_mod_feature_post = ModFeaturePost::create(pool, &mod_feature_post_form)
+            .await
+            .unwrap();
+        let read_mod_feature_post = ModFeaturePost::read(pool, inserted_mod_feature_post.id)
+            .await
+            .unwrap();
+        let expected_mod_feature_post = ModFeaturePost {
+            id: inserted_mod_feature_post.id,
+            post_id: inserted_post.id,
+            mod_person_id: inserted_mod.id,
+            featured: false,
+            is_featured_community: true,
+            when_: inserted_mod_feature_post.when_,
+        };
+
+        // comment
+
+        let mod_remove_comment_form = ModRemoveCommentForm {
+            mod_person_id: inserted_mod.id,
+            comment_id: inserted_comment.id,
+            reason: None,
+            removed: None,
+        };
+        let inserted_mod_remove_comment = ModRemoveComment::create(pool, &mod_remove_comment_form)
+            .await
+            .unwrap();
+        let read_mod_remove_comment = ModRemoveComment::read(pool, inserted_mod_remove_comment.id)
+            .await
+            .unwrap();
+        let expected_mod_remove_comment = ModRemoveComment {
+            id: inserted_mod_remove_comment.id,
+            comment_id: inserted_comment.id,
+            mod_person_id: inserted_mod.id,
+            reason: None,
+            removed: true,
+            when_: inserted_mod_remove_comment.when_,
+        };
+
+        // community
+
+        let mod_remove_community_form = ModRemoveCommunityForm {
+            mod_person_id: inserted_mod.id,
+            community_id: inserted_community.id,
+            reason: None,
+            removed: None,
+            expires: None,
+        };
+        let inserted_mod_remove_community =
+            ModRemoveCommunity::create(pool, &mod_remove_community_form)
+                .await
+                .unwrap();
+        let read_mod_remove_community =
+            ModRemoveCommunity::read(pool, inserted_mod_remove_community.id)
+                .await
+                .unwrap();
+        let expected_mod_remove_community = ModRemoveCommunity {
+            id: inserted_mod_remove_community.id,
+            community_id: inserted_community.id,
+            mod_person_id: inserted_mod.id,
+            reason: None,
+            removed: true,
+            expires: None,
+            when_: inserted_mod_remove_community.when_,
+        };
+
+        // ban from community
+
+        let mod_ban_from_community_form = ModBanFromCommunityForm {
+            mod_person_id: inserted_mod.id,
+            other_person_id: inserted_person.id,
+            community_id: inserted_community.id,
+            reason: None,
+            banned: None,
+            expires: None,
+        };
+        let inserted_mod_ban_from_community =
+            ModBanFromCommunity::create(pool, &mod_ban_from_community_form)
+                .await
+                .unwrap();
+        let read_mod_ban_from_community =
+            ModBanFromCommunity::read(pool, inserted_mod_ban_from_community.id)
+                .await
+                .unwrap();
+        let expected_mod_ban_from_community = ModBanFromCommunity {
+            id: inserted_mod_ban_from_community.id,
+            community_id: inserted_community.id,
+            mod_person_id: inserted_mod.id,
+            other_person_id: inserted_person.id,
+            reason: None,
+            banned: true,
+            expires: None,
+            when_: inserted_mod_ban_from_community.when_,
+        };
+
+        // ban
+
+        let mod_ban_form = ModBanForm {
+            mod_person_id: inserted_mod.id,
+            other_person_id: inserted_person.id,
+            reason: None,
+            banned: None,
+            expires: None,
+        };
+        let inserted_mod_ban = ModBan::create(pool, &mod_ban_form).await.unwrap();
+        let read_mod_ban = ModBan::read(pool, inserted_mod_ban.id).await.unwrap();
+        let expected_mod_ban = ModBan {
+            id: inserted_mod_ban.id,
+            mod_person_id: inserted_mod.id,
+            other_person_id: inserted_person.id,
+            reason: None,
+            banned: true,
+            expires: None,
+            when_: inserted_mod_ban.when_,
+        };
+
+        // mod add community
+
+        let mod_add_community_form = ModAddCommunityForm {
+            mod_person_id: inserted_mod.id,
+            other_person_id: inserted_person.id,
+            community_id: inserted_community.id,
+            removed: None,
+        };
+        let inserted_mod_add_community = ModAddCommunity::create(pool, &mod_add_community_form)
+            .await
+            .unwrap();
+        let read_mod_add_community = ModAddCommunity::read(pool, inserted_mod_add_community.id)
+            .await
+            .unwrap();
+        let expected_mod_add_community = ModAddCommunity {
+            id: inserted_mod_add_community.id,
+            community_id: inserted_community.id,
+            mod_person_id: inserted_mod.id,
+            other_person_id: inserted_person.id,
+            removed: false,
+            when_: inserted_mod_add_community.when_,
+        };
+
+        // mod add
+
+        let mod_add_form = ModAddForm {
+            mod_person_id: inserted_mod.id,
+            other_person_id: inserted_person.id,
+            removed: None,
+        };
+        let inserted_mod_add = ModAdd::create(pool, &mod_add_form).await.unwrap();
+        let read_mod_add = ModAdd::read(pool, inserted_mod_add.id).await.unwrap();
+        let expected_mod_add = ModAdd {
+            id: inserted_mod_add.id,
+            mod_person_id: inserted_mod.id,
+            other_person_id: inserted_person.id,
+            removed: false,
+            when_: inserted_mod_add.when_,
+        };
+
+        Comment::delete(pool, inserted_comment.id).await.unwrap();
+        Post::delete(pool, inserted_post.id).await.unwrap();
+        Community::delete(pool, inserted_community.id)
+            .await
+            .unwrap();
+        Person::delete(pool, inserted_person.id).await.unwrap();
+        Person::delete(pool, inserted_mod.id).await.unwrap();
+        Instance::delete(pool, inserted_instance.id).await.unwrap();
+
+        assert_eq!(expected_mod_remove_post, read_mod_remove_post);
+        assert_eq!(expected_mod_lock_post, read_mod_lock_post);
+        assert_eq!(expected_mod_feature_post, read_mod_feature_post);
+        assert_eq!(expected_mod_remove_comment, read_mod_remove_comment);
+        assert_eq!(expected_mod_remove_community, read_mod_remove_community);
+        assert_eq!(expected_mod_ban_from_community, read_mod_ban_from_community);
+        assert_eq!(expected_mod_ban, read_mod_ban);
+        assert_eq!(expected_mod_add_community, read_mod_add_community);
+        assert_eq!(expected_mod_add, read_mod_add);
+    }
 }

--- a/crates/db_schema/src/impls/password_reset_request.rs
+++ b/crates/db_schema/src/impls/password_reset_request.rs
@@ -1,152 +1,152 @@
 use crate::{
-  newtypes::LocalUserId,
-  schema::password_reset_request::dsl::{local_user_id, password_reset_request, published, token},
-  source::password_reset_request::{PasswordResetRequest, PasswordResetRequestForm},
-  traits::Crud,
-  utils::{get_conn, DbPool},
+    newtypes::LocalUserId,
+    schema::password_reset_request::dsl::{
+        local_user_id, password_reset_request, published, token,
+    },
+    source::password_reset_request::{PasswordResetRequest, PasswordResetRequestForm},
+    traits::Crud,
+    utils::{get_conn, DbPool},
 };
 use diesel::{
-  dsl::{insert_into, now, IntervalDsl},
-  result::Error,
-  sql_types::Timestamptz,
-  ExpressionMethods,
-  IntoSql,
-  QueryDsl,
+    dsl::{insert_into, now, IntervalDsl},
+    result::Error,
+    sql_types::Timestamptz,
+    ExpressionMethods, IntoSql, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 
 #[async_trait]
 impl Crud for PasswordResetRequest {
-  type InsertForm = PasswordResetRequestForm;
-  type UpdateForm = PasswordResetRequestForm;
-  type IdType = i32;
+    type InsertForm = PasswordResetRequestForm;
+    type UpdateForm = PasswordResetRequestForm;
+    type IdType = i32;
 
-  async fn create(pool: &mut DbPool<'_>, form: &PasswordResetRequestForm) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    insert_into(password_reset_request)
-      .values(form)
-      .get_result::<Self>(conn)
-      .await
-  }
-  async fn update(
-    pool: &mut DbPool<'_>,
-    password_reset_request_id: i32,
-    form: &PasswordResetRequestForm,
-  ) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(password_reset_request.find(password_reset_request_id))
-      .set(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn create(pool: &mut DbPool<'_>, form: &PasswordResetRequestForm) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        insert_into(password_reset_request)
+            .values(form)
+            .get_result::<Self>(conn)
+            .await
+    }
+    async fn update(
+        pool: &mut DbPool<'_>,
+        password_reset_request_id: i32,
+        form: &PasswordResetRequestForm,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(password_reset_request.find(password_reset_request_id))
+            .set(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 }
 
 impl PasswordResetRequest {
-  pub async fn create_token(
-    pool: &mut DbPool<'_>,
-    from_local_user_id: LocalUserId,
-    token_: String,
-  ) -> Result<PasswordResetRequest, Error> {
-    let form = PasswordResetRequestForm {
-      local_user_id: from_local_user_id,
-      token: token_,
-    };
+    pub async fn create_token(
+        pool: &mut DbPool<'_>,
+        from_local_user_id: LocalUserId,
+        token_: String,
+    ) -> Result<PasswordResetRequest, Error> {
+        let form = PasswordResetRequestForm {
+            local_user_id: from_local_user_id,
+            token: token_,
+        };
 
-    Self::create(pool, &form).await
-  }
-  pub async fn read_from_token(
-    pool: &mut DbPool<'_>,
-    token_: &str,
-  ) -> Result<PasswordResetRequest, Error> {
-    let conn = &mut get_conn(pool).await?;
-    password_reset_request
-      .filter(token.eq(token_))
-      .filter(published.gt(now.into_sql::<Timestamptz>() - 1.days()))
-      .first::<Self>(conn)
-      .await
-  }
+        Self::create(pool, &form).await
+    }
+    pub async fn read_from_token(
+        pool: &mut DbPool<'_>,
+        token_: &str,
+    ) -> Result<PasswordResetRequest, Error> {
+        let conn = &mut get_conn(pool).await?;
+        password_reset_request
+            .filter(token.eq(token_))
+            .filter(published.gt(now.into_sql::<Timestamptz>() - 1.days()))
+            .first::<Self>(conn)
+            .await
+    }
 
-  pub async fn get_recent_password_resets_count(
-    pool: &mut DbPool<'_>,
-    user_id: LocalUserId,
-  ) -> Result<i64, Error> {
-    let conn = &mut get_conn(pool).await?;
-    password_reset_request
-      .filter(local_user_id.eq(user_id))
-      .filter(published.gt(now.into_sql::<Timestamptz>() - 1.days()))
-      .count()
-      .get_result(conn)
-      .await
-  }
+    pub async fn get_recent_password_resets_count(
+        pool: &mut DbPool<'_>,
+        user_id: LocalUserId,
+    ) -> Result<i64, Error> {
+        let conn = &mut get_conn(pool).await?;
+        password_reset_request
+            .filter(local_user_id.eq(user_id))
+            .filter(published.gt(now.into_sql::<Timestamptz>() - 1.days()))
+            .count()
+            .get_result(conn)
+            .await
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::{
-    source::{
-      instance::Instance,
-      local_user::{LocalUser, LocalUserInsertForm},
-      password_reset_request::PasswordResetRequest,
-      person::{Person, PersonInsertForm},
-    },
-    traits::Crud,
-    utils::build_db_pool_for_tests,
-  };
-  use serial_test::serial;
-
-  #[tokio::test]
-  #[serial]
-  async fn test_crud() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-
-    let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
-      .await
-      .unwrap();
-
-    let new_person = PersonInsertForm::builder()
-      .name("thommy prw".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_person = Person::create(pool, &new_person).await.unwrap();
-
-    let new_local_user = LocalUserInsertForm::builder()
-      .person_id(inserted_person.id)
-      .password_encrypted("pass".to_string())
-      .build();
-
-    let inserted_local_user = LocalUser::create(pool, &new_local_user).await.unwrap();
-
-    let token = "nope";
-
-    let inserted_password_reset_request =
-      PasswordResetRequest::create_token(pool, inserted_local_user.id, token.to_string())
-        .await
-        .unwrap();
-
-    let expected_password_reset_request = PasswordResetRequest {
-      id: inserted_password_reset_request.id,
-      local_user_id: inserted_local_user.id,
-      token: token.to_string(),
-      published: inserted_password_reset_request.published,
+    use crate::{
+        source::{
+            instance::Instance,
+            local_user::{LocalUser, LocalUserInsertForm},
+            password_reset_request::PasswordResetRequest,
+            person::{Person, PersonInsertForm},
+        },
+        traits::Crud,
+        utils::build_db_pool_for_tests,
     };
+    use serial_test::serial;
 
-    let read_password_reset_request = PasswordResetRequest::read_from_token(pool, token)
-      .await
-      .unwrap();
-    let num_deleted = Person::delete(pool, inserted_person.id).await.unwrap();
-    Instance::delete(pool, inserted_instance.id).await.unwrap();
+    #[tokio::test]
+    #[serial]
+    async fn test_crud() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
 
-    assert_eq!(expected_password_reset_request, read_password_reset_request);
-    assert_eq!(
-      expected_password_reset_request,
-      inserted_password_reset_request
-    );
-    assert_eq!(1, num_deleted);
-  }
+        let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
+            .await
+            .unwrap();
+
+        let new_person = PersonInsertForm::builder()
+            .name("thommy prw".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
+
+        let inserted_person = Person::create(pool, &new_person).await.unwrap();
+
+        let new_local_user = LocalUserInsertForm::builder()
+            .person_id(inserted_person.id)
+            .password_encrypted("pass".to_string())
+            .build();
+
+        let inserted_local_user = LocalUser::create(pool, &new_local_user).await.unwrap();
+
+        let token = "nope";
+
+        let inserted_password_reset_request =
+            PasswordResetRequest::create_token(pool, inserted_local_user.id, token.to_string())
+                .await
+                .unwrap();
+
+        let expected_password_reset_request = PasswordResetRequest {
+            id: inserted_password_reset_request.id,
+            local_user_id: inserted_local_user.id,
+            token: token.to_string(),
+            published: inserted_password_reset_request.published,
+        };
+
+        let read_password_reset_request = PasswordResetRequest::read_from_token(pool, token)
+            .await
+            .unwrap();
+        let num_deleted = Person::delete(pool, inserted_person.id).await.unwrap();
+        Instance::delete(pool, inserted_instance.id).await.unwrap();
+
+        assert_eq!(expected_password_reset_request, read_password_reset_request);
+        assert_eq!(
+            expected_password_reset_request,
+            inserted_password_reset_request
+        );
+        assert_eq!(1, num_deleted);
+    }
 }

--- a/crates/db_schema/src/impls/person.rs
+++ b/crates/db_schema/src/impls/person.rs
@@ -1,15 +1,11 @@
 use crate::{
-  newtypes::{CommunityId, DbUrl, PersonId},
-  schema::{instance, local_user, person, person_follower},
-  source::person::{
-    Person,
-    PersonFollower,
-    PersonFollowerForm,
-    PersonInsertForm,
-    PersonUpdateForm,
-  },
-  traits::{ApubActor, Crud, Followable},
-  utils::{functions::lower, get_conn, naive_now, DbPool},
+    newtypes::{CommunityId, DbUrl, PersonId},
+    schema::{instance, local_user, person, person_follower},
+    source::person::{
+        Person, PersonFollower, PersonFollowerForm, PersonInsertForm, PersonUpdateForm,
+    },
+    traits::{ApubActor, Crud, Followable},
+    utils::{functions::lower, get_conn, naive_now, DbPool},
 };
 use chrono::{DateTime, Utc};
 use diesel::{dsl::insert_into, result::Error, ExpressionMethods, JoinOnDsl, QueryDsl};
@@ -17,297 +13,304 @@ use diesel_async::RunQueryDsl;
 
 #[async_trait]
 impl Crud for Person {
-  type InsertForm = PersonInsertForm;
-  type UpdateForm = PersonUpdateForm;
-  type IdType = PersonId;
-  async fn read(pool: &mut DbPool<'_>, person_id: PersonId) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    person::table
-      .filter(person::deleted.eq(false))
-      .find(person_id)
-      .first::<Self>(conn)
-      .await
-  }
+    type InsertForm = PersonInsertForm;
+    type UpdateForm = PersonUpdateForm;
+    type IdType = PersonId;
+    async fn read(pool: &mut DbPool<'_>, person_id: PersonId) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        person::table
+            .filter(person::deleted.eq(false))
+            .find(person_id)
+            .first::<Self>(conn)
+            .await
+    }
 
-  async fn create(pool: &mut DbPool<'_>, form: &PersonInsertForm) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    insert_into(person::table)
-      .values(form)
-      .get_result::<Self>(conn)
-      .await
-  }
-  async fn update(
-    pool: &mut DbPool<'_>,
-    person_id: PersonId,
-    form: &PersonUpdateForm,
-  ) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(person::table.find(person_id))
-      .set(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn create(pool: &mut DbPool<'_>, form: &PersonInsertForm) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        insert_into(person::table)
+            .values(form)
+            .get_result::<Self>(conn)
+            .await
+    }
+    async fn update(
+        pool: &mut DbPool<'_>,
+        person_id: PersonId,
+        form: &PersonUpdateForm,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(person::table.find(person_id))
+            .set(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 }
 
 impl Person {
-  /// Update or insert the person.
-  ///
-  /// This is necessary for federation, because Activitypub doesnt distinguish between these actions.
-  pub async fn upsert(pool: &mut DbPool<'_>, form: &PersonInsertForm) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    insert_into(person::table)
-      .values(form)
-      .on_conflict(person::actor_id)
-      .do_update()
-      .set(form)
-      .get_result::<Self>(conn)
-      .await
-  }
-  pub async fn delete_account(pool: &mut DbPool<'_>, person_id: PersonId) -> Result<Person, Error> {
-    let conn = &mut get_conn(pool).await?;
+    /// Update or insert the person.
+    ///
+    /// This is necessary for federation, because Activitypub doesnt distinguish between these actions.
+    pub async fn upsert(pool: &mut DbPool<'_>, form: &PersonInsertForm) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        insert_into(person::table)
+            .values(form)
+            .on_conflict(person::actor_id)
+            .do_update()
+            .set(form)
+            .get_result::<Self>(conn)
+            .await
+    }
+    pub async fn delete_account(
+        pool: &mut DbPool<'_>,
+        person_id: PersonId,
+    ) -> Result<Person, Error> {
+        let conn = &mut get_conn(pool).await?;
 
-    // Set the local user info to none
-    diesel::update(local_user::table.filter(local_user::person_id.eq(person_id)))
-      .set((
-        local_user::email.eq::<Option<String>>(None),
-        local_user::validator_time.eq(naive_now()),
-      ))
-      .execute(conn)
-      .await?;
+        // Set the local user info to none
+        diesel::update(local_user::table.filter(local_user::person_id.eq(person_id)))
+            .set((
+                local_user::email.eq::<Option<String>>(None),
+                local_user::validator_time.eq(naive_now()),
+            ))
+            .execute(conn)
+            .await?;
 
-    diesel::update(person::table.find(person_id))
-      .set((
-        person::display_name.eq::<Option<String>>(None),
-        person::avatar.eq::<Option<String>>(None),
-        person::banner.eq::<Option<String>>(None),
-        person::bio.eq::<Option<String>>(None),
-        person::matrix_user_id.eq::<Option<String>>(None),
-        person::deleted.eq(true),
-        person::updated.eq(naive_now()),
-      ))
-      .get_result::<Self>(conn)
-      .await
-  }
+        diesel::update(person::table.find(person_id))
+            .set((
+                person::display_name.eq::<Option<String>>(None),
+                person::avatar.eq::<Option<String>>(None),
+                person::banner.eq::<Option<String>>(None),
+                person::bio.eq::<Option<String>>(None),
+                person::matrix_user_id.eq::<Option<String>>(None),
+                person::deleted.eq(true),
+                person::updated.eq(naive_now()),
+            ))
+            .get_result::<Self>(conn)
+            .await
+    }
 }
 
 pub fn is_banned(banned_: bool, expires: Option<DateTime<Utc>>) -> bool {
-  if let Some(expires) = expires {
-    banned_ && expires.gt(&naive_now())
-  } else {
-    banned_
-  }
+    if let Some(expires) = expires {
+        banned_ && expires.gt(&naive_now())
+    } else {
+        banned_
+    }
 }
 
 #[async_trait]
 impl ApubActor for Person {
-  async fn read_from_apub_id(
-    pool: &mut DbPool<'_>,
-    object_id: &DbUrl,
-  ) -> Result<Option<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    Ok(
-      person::table
-        .filter(person::deleted.eq(false))
-        .filter(person::actor_id.eq(object_id))
-        .first::<Person>(conn)
-        .await
-        .ok()
-        .map(Into::into),
-    )
-  }
-
-  async fn read_from_name(
-    pool: &mut DbPool<'_>,
-    from_name: &str,
-    include_deleted: bool,
-  ) -> Result<Person, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let mut q = person::table
-      .into_boxed()
-      .filter(person::local.eq(true))
-      .filter(lower(person::name).eq(from_name.to_lowercase()));
-    if !include_deleted {
-      q = q.filter(person::deleted.eq(false))
+    async fn read_from_apub_id(
+        pool: &mut DbPool<'_>,
+        object_id: &DbUrl,
+    ) -> Result<Option<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        Ok(person::table
+            .filter(person::deleted.eq(false))
+            .filter(person::actor_id.eq(object_id))
+            .first::<Person>(conn)
+            .await
+            .ok()
+            .map(Into::into))
     }
-    q.first::<Self>(conn).await
-  }
 
-  async fn read_from_name_and_domain(
-    pool: &mut DbPool<'_>,
-    person_name: &str,
-    for_domain: &str,
-  ) -> Result<Person, Error> {
-    let conn = &mut get_conn(pool).await?;
+    async fn read_from_name(
+        pool: &mut DbPool<'_>,
+        from_name: &str,
+        include_deleted: bool,
+    ) -> Result<Person, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let mut q = person::table
+            .into_boxed()
+            .filter(person::local.eq(true))
+            .filter(lower(person::name).eq(from_name.to_lowercase()));
+        if !include_deleted {
+            q = q.filter(person::deleted.eq(false))
+        }
+        q.first::<Self>(conn).await
+    }
 
-    person::table
-      .inner_join(instance::table)
-      .filter(lower(person::name).eq(person_name.to_lowercase()))
-      .filter(lower(instance::domain).eq(for_domain.to_lowercase()))
-      .select(person::all_columns)
-      .first::<Self>(conn)
-      .await
-  }
+    async fn read_from_name_and_domain(
+        pool: &mut DbPool<'_>,
+        person_name: &str,
+        for_domain: &str,
+    ) -> Result<Person, Error> {
+        let conn = &mut get_conn(pool).await?;
+
+        person::table
+            .inner_join(instance::table)
+            .filter(lower(person::name).eq(person_name.to_lowercase()))
+            .filter(lower(instance::domain).eq(for_domain.to_lowercase()))
+            .select(person::all_columns)
+            .first::<Self>(conn)
+            .await
+    }
 }
 
 #[async_trait]
 impl Followable for PersonFollower {
-  type Form = PersonFollowerForm;
-  async fn follow(pool: &mut DbPool<'_>, form: &PersonFollowerForm) -> Result<Self, Error> {
-    use crate::schema::person_follower::dsl::{follower_id, person_follower, person_id};
-    let conn = &mut get_conn(pool).await?;
-    insert_into(person_follower)
-      .values(form)
-      .on_conflict((follower_id, person_id))
-      .do_update()
-      .set(form)
-      .get_result::<Self>(conn)
-      .await
-  }
-  async fn follow_accepted(_: &mut DbPool<'_>, _: CommunityId, _: PersonId) -> Result<Self, Error> {
-    unimplemented!()
-  }
-  async fn unfollow(pool: &mut DbPool<'_>, form: &PersonFollowerForm) -> Result<usize, Error> {
-    use crate::schema::person_follower::dsl::{follower_id, person_follower, person_id};
-    let conn = &mut get_conn(pool).await?;
-    diesel::delete(
-      person_follower
-        .filter(follower_id.eq(&form.follower_id))
-        .filter(person_id.eq(&form.person_id)),
-    )
-    .execute(conn)
-    .await
-  }
+    type Form = PersonFollowerForm;
+    async fn follow(pool: &mut DbPool<'_>, form: &PersonFollowerForm) -> Result<Self, Error> {
+        use crate::schema::person_follower::dsl::{follower_id, person_follower, person_id};
+        let conn = &mut get_conn(pool).await?;
+        insert_into(person_follower)
+            .values(form)
+            .on_conflict((follower_id, person_id))
+            .do_update()
+            .set(form)
+            .get_result::<Self>(conn)
+            .await
+    }
+    async fn follow_accepted(
+        _: &mut DbPool<'_>,
+        _: CommunityId,
+        _: PersonId,
+    ) -> Result<Self, Error> {
+        unimplemented!()
+    }
+    async fn unfollow(pool: &mut DbPool<'_>, form: &PersonFollowerForm) -> Result<usize, Error> {
+        use crate::schema::person_follower::dsl::{follower_id, person_follower, person_id};
+        let conn = &mut get_conn(pool).await?;
+        diesel::delete(
+            person_follower
+                .filter(follower_id.eq(&form.follower_id))
+                .filter(person_id.eq(&form.person_id)),
+        )
+        .execute(conn)
+        .await
+    }
 }
 
 impl PersonFollower {
-  pub async fn list_followers(
-    pool: &mut DbPool<'_>,
-    for_person_id: PersonId,
-  ) -> Result<Vec<Person>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    person_follower::table
-      .inner_join(person::table.on(person_follower::follower_id.eq(person::id)))
-      .filter(person_follower::person_id.eq(for_person_id))
-      .select(person::all_columns)
-      .load(conn)
-      .await
-  }
+    pub async fn list_followers(
+        pool: &mut DbPool<'_>,
+        for_person_id: PersonId,
+    ) -> Result<Vec<Person>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        person_follower::table
+            .inner_join(person::table.on(person_follower::follower_id.eq(person::id)))
+            .filter(person_follower::person_id.eq(for_person_id))
+            .select(person::all_columns)
+            .load(conn)
+            .await
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::{
-    source::{
-      instance::Instance,
-      person::{Person, PersonFollower, PersonFollowerForm, PersonInsertForm, PersonUpdateForm},
-    },
-    traits::{Crud, Followable},
-    utils::build_db_pool_for_tests,
-  };
-  use serial_test::serial;
-
-  #[tokio::test]
-  #[serial]
-  async fn test_crud() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-
-    let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
-      .await
-      .unwrap();
-
-    let new_person = PersonInsertForm::builder()
-      .name("holly".into())
-      .public_key("nada".to_owned())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_person = Person::create(pool, &new_person).await.unwrap();
-
-    let expected_person = Person {
-      id: inserted_person.id,
-      name: "holly".into(),
-      display_name: None,
-      avatar: None,
-      banner: None,
-      banned: false,
-      deleted: false,
-      published: inserted_person.published,
-      updated: None,
-      actor_id: inserted_person.actor_id.clone(),
-      bio: None,
-      local: true,
-      bot_account: false,
-      private_key: None,
-      public_key: "nada".to_owned(),
-      last_refreshed_at: inserted_person.published,
-      inbox_url: inserted_person.inbox_url.clone(),
-      shared_inbox_url: None,
-      matrix_user_id: None,
-      ban_expires: None,
-      instance_id: inserted_instance.id,
+    use crate::{
+        source::{
+            instance::Instance,
+            person::{
+                Person, PersonFollower, PersonFollowerForm, PersonInsertForm, PersonUpdateForm,
+            },
+        },
+        traits::{Crud, Followable},
+        utils::build_db_pool_for_tests,
     };
+    use serial_test::serial;
 
-    let read_person = Person::read(pool, inserted_person.id).await.unwrap();
+    #[tokio::test]
+    #[serial]
+    async fn test_crud() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
 
-    let update_person_form = PersonUpdateForm {
-      actor_id: Some(inserted_person.actor_id.clone()),
-      ..Default::default()
-    };
-    let updated_person = Person::update(pool, inserted_person.id, &update_person_form)
-      .await
-      .unwrap();
+        let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
+            .await
+            .unwrap();
 
-    let num_deleted = Person::delete(pool, inserted_person.id).await.unwrap();
-    Instance::delete(pool, inserted_instance.id).await.unwrap();
+        let new_person = PersonInsertForm::builder()
+            .name("holly".into())
+            .public_key("nada".to_owned())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    assert_eq!(expected_person, read_person);
-    assert_eq!(expected_person, inserted_person);
-    assert_eq!(expected_person, updated_person);
-    assert_eq!(1, num_deleted);
-  }
+        let inserted_person = Person::create(pool, &new_person).await.unwrap();
 
-  #[tokio::test]
-  #[serial]
-  async fn follow() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-    let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
-      .await
-      .unwrap();
+        let expected_person = Person {
+            id: inserted_person.id,
+            name: "holly".into(),
+            display_name: None,
+            avatar: None,
+            banner: None,
+            banned: false,
+            deleted: false,
+            published: inserted_person.published,
+            updated: None,
+            actor_id: inserted_person.actor_id.clone(),
+            bio: None,
+            local: true,
+            bot_account: false,
+            private_key: None,
+            public_key: "nada".to_owned(),
+            last_refreshed_at: inserted_person.published,
+            inbox_url: inserted_person.inbox_url.clone(),
+            shared_inbox_url: None,
+            matrix_user_id: None,
+            ban_expires: None,
+            instance_id: inserted_instance.id,
+        };
 
-    let person_form_1 = PersonInsertForm::builder()
-      .name("erich".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-    let person_1 = Person::create(pool, &person_form_1).await.unwrap();
-    let person_form_2 = PersonInsertForm::builder()
-      .name("michele".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-    let person_2 = Person::create(pool, &person_form_2).await.unwrap();
+        let read_person = Person::read(pool, inserted_person.id).await.unwrap();
 
-    let follow_form = PersonFollowerForm {
-      person_id: person_1.id,
-      follower_id: person_2.id,
-      pending: false,
-    };
-    let person_follower = PersonFollower::follow(pool, &follow_form).await.unwrap();
-    assert_eq!(person_1.id, person_follower.person_id);
-    assert_eq!(person_2.id, person_follower.follower_id);
-    assert!(!person_follower.pending);
+        let update_person_form = PersonUpdateForm {
+            actor_id: Some(inserted_person.actor_id.clone()),
+            ..Default::default()
+        };
+        let updated_person = Person::update(pool, inserted_person.id, &update_person_form)
+            .await
+            .unwrap();
 
-    let followers = PersonFollower::list_followers(pool, person_1.id)
-      .await
-      .unwrap();
-    assert_eq!(vec![person_2], followers);
+        let num_deleted = Person::delete(pool, inserted_person.id).await.unwrap();
+        Instance::delete(pool, inserted_instance.id).await.unwrap();
 
-    let unfollow = PersonFollower::unfollow(pool, &follow_form).await.unwrap();
-    assert_eq!(1, unfollow);
-  }
+        assert_eq!(expected_person, read_person);
+        assert_eq!(expected_person, inserted_person);
+        assert_eq!(expected_person, updated_person);
+        assert_eq!(1, num_deleted);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn follow() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
+        let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
+            .await
+            .unwrap();
+
+        let person_form_1 = PersonInsertForm::builder()
+            .name("erich".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
+        let person_1 = Person::create(pool, &person_form_1).await.unwrap();
+        let person_form_2 = PersonInsertForm::builder()
+            .name("michele".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
+        let person_2 = Person::create(pool, &person_form_2).await.unwrap();
+
+        let follow_form = PersonFollowerForm {
+            person_id: person_1.id,
+            follower_id: person_2.id,
+            pending: false,
+        };
+        let person_follower = PersonFollower::follow(pool, &follow_form).await.unwrap();
+        assert_eq!(person_1.id, person_follower.person_id);
+        assert_eq!(person_2.id, person_follower.follower_id);
+        assert!(!person_follower.pending);
+
+        let followers = PersonFollower::list_followers(pool, person_1.id)
+            .await
+            .unwrap();
+        assert_eq!(vec![person_2], followers);
+
+        let unfollow = PersonFollower::unfollow(pool, &follow_form).await.unwrap();
+        assert_eq!(1, unfollow);
+    }
 }

--- a/crates/db_schema/src/impls/person_block.rs
+++ b/crates/db_schema/src/impls/person_block.rs
@@ -1,52 +1,55 @@
 use crate::{
-  newtypes::PersonId,
-  schema::person_block::dsl::{person_block, person_id, target_id},
-  source::person_block::{PersonBlock, PersonBlockForm},
-  traits::Blockable,
-  utils::{get_conn, DbPool},
+    newtypes::PersonId,
+    schema::person_block::dsl::{person_block, person_id, target_id},
+    source::person_block::{PersonBlock, PersonBlockForm},
+    traits::Blockable,
+    utils::{get_conn, DbPool},
 };
 use diesel::{dsl::insert_into, result::Error, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 
 impl PersonBlock {
-  pub async fn read(
-    pool: &mut DbPool<'_>,
-    for_person_id: PersonId,
-    for_recipient_id: PersonId,
-  ) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    person_block
-      .filter(person_id.eq(for_person_id))
-      .filter(target_id.eq(for_recipient_id))
-      .first::<Self>(conn)
-      .await
-  }
+    pub async fn read(
+        pool: &mut DbPool<'_>,
+        for_person_id: PersonId,
+        for_recipient_id: PersonId,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        person_block
+            .filter(person_id.eq(for_person_id))
+            .filter(target_id.eq(for_recipient_id))
+            .first::<Self>(conn)
+            .await
+    }
 }
 
 #[async_trait]
 impl Blockable for PersonBlock {
-  type Form = PersonBlockForm;
-  async fn block(
-    pool: &mut DbPool<'_>,
-    person_block_form: &PersonBlockForm,
-  ) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    insert_into(person_block)
-      .values(person_block_form)
-      .on_conflict((person_id, target_id))
-      .do_update()
-      .set(person_block_form)
-      .get_result::<Self>(conn)
-      .await
-  }
-  async fn unblock(pool: &mut DbPool<'_>, person_block_form: &Self::Form) -> Result<usize, Error> {
-    let conn = &mut get_conn(pool).await?;
-    diesel::delete(
-      person_block
-        .filter(person_id.eq(person_block_form.person_id))
-        .filter(target_id.eq(person_block_form.target_id)),
-    )
-    .execute(conn)
-    .await
-  }
+    type Form = PersonBlockForm;
+    async fn block(
+        pool: &mut DbPool<'_>,
+        person_block_form: &PersonBlockForm,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        insert_into(person_block)
+            .values(person_block_form)
+            .on_conflict((person_id, target_id))
+            .do_update()
+            .set(person_block_form)
+            .get_result::<Self>(conn)
+            .await
+    }
+    async fn unblock(
+        pool: &mut DbPool<'_>,
+        person_block_form: &Self::Form,
+    ) -> Result<usize, Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::delete(
+            person_block
+                .filter(person_id.eq(person_block_form.person_id))
+                .filter(target_id.eq(person_block_form.target_id)),
+        )
+        .execute(conn)
+        .await
+    }
 }

--- a/crates/db_schema/src/impls/person_mention.rs
+++ b/crates/db_schema/src/impls/person_mention.rs
@@ -1,186 +1,186 @@
 use crate::{
-  newtypes::{CommentId, PersonId, PersonMentionId},
-  schema::person_mention::dsl::{comment_id, person_mention, read, recipient_id},
-  source::person_mention::{PersonMention, PersonMentionInsertForm, PersonMentionUpdateForm},
-  traits::Crud,
-  utils::{get_conn, DbPool},
+    newtypes::{CommentId, PersonId, PersonMentionId},
+    schema::person_mention::dsl::{comment_id, person_mention, read, recipient_id},
+    source::person_mention::{PersonMention, PersonMentionInsertForm, PersonMentionUpdateForm},
+    traits::Crud,
+    utils::{get_conn, DbPool},
 };
 use diesel::{dsl::insert_into, result::Error, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 
 #[async_trait]
 impl Crud for PersonMention {
-  type InsertForm = PersonMentionInsertForm;
-  type UpdateForm = PersonMentionUpdateForm;
-  type IdType = PersonMentionId;
+    type InsertForm = PersonMentionInsertForm;
+    type UpdateForm = PersonMentionUpdateForm;
+    type IdType = PersonMentionId;
 
-  async fn create(
-    pool: &mut DbPool<'_>,
-    person_mention_form: &Self::InsertForm,
-  ) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    // since the return here isnt utilized, we dont need to do an update
-    // but get_result doesnt return the existing row here
-    insert_into(person_mention)
-      .values(person_mention_form)
-      .on_conflict((recipient_id, comment_id))
-      .do_update()
-      .set(person_mention_form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn create(
+        pool: &mut DbPool<'_>,
+        person_mention_form: &Self::InsertForm,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        // since the return here isnt utilized, we dont need to do an update
+        // but get_result doesnt return the existing row here
+        insert_into(person_mention)
+            .values(person_mention_form)
+            .on_conflict((recipient_id, comment_id))
+            .do_update()
+            .set(person_mention_form)
+            .get_result::<Self>(conn)
+            .await
+    }
 
-  async fn update(
-    pool: &mut DbPool<'_>,
-    person_mention_id: PersonMentionId,
-    person_mention_form: &Self::UpdateForm,
-  ) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(person_mention.find(person_mention_id))
-      .set(person_mention_form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn update(
+        pool: &mut DbPool<'_>,
+        person_mention_id: PersonMentionId,
+        person_mention_form: &Self::UpdateForm,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(person_mention.find(person_mention_id))
+            .set(person_mention_form)
+            .get_result::<Self>(conn)
+            .await
+    }
 }
 
 impl PersonMention {
-  pub async fn mark_all_as_read(
-    pool: &mut DbPool<'_>,
-    for_recipient_id: PersonId,
-  ) -> Result<Vec<PersonMention>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(
-      person_mention
-        .filter(recipient_id.eq(for_recipient_id))
-        .filter(read.eq(false)),
-    )
-    .set(read.eq(true))
-    .get_results::<Self>(conn)
-    .await
-  }
+    pub async fn mark_all_as_read(
+        pool: &mut DbPool<'_>,
+        for_recipient_id: PersonId,
+    ) -> Result<Vec<PersonMention>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(
+            person_mention
+                .filter(recipient_id.eq(for_recipient_id))
+                .filter(read.eq(false)),
+        )
+        .set(read.eq(true))
+        .get_results::<Self>(conn)
+        .await
+    }
 
-  pub async fn read_by_comment_and_person(
-    pool: &mut DbPool<'_>,
-    for_comment_id: CommentId,
-    for_recipient_id: PersonId,
-  ) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    person_mention
-      .filter(comment_id.eq(for_comment_id))
-      .filter(recipient_id.eq(for_recipient_id))
-      .first::<Self>(conn)
-      .await
-  }
+    pub async fn read_by_comment_and_person(
+        pool: &mut DbPool<'_>,
+        for_comment_id: CommentId,
+        for_recipient_id: PersonId,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        person_mention
+            .filter(comment_id.eq(for_comment_id))
+            .filter(recipient_id.eq(for_recipient_id))
+            .first::<Self>(conn)
+            .await
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::{
-    source::{
-      comment::{Comment, CommentInsertForm},
-      community::{Community, CommunityInsertForm},
-      instance::Instance,
-      person::{Person, PersonInsertForm},
-      person_mention::{PersonMention, PersonMentionInsertForm, PersonMentionUpdateForm},
-      post::{Post, PostInsertForm},
-    },
-    traits::Crud,
-    utils::build_db_pool_for_tests,
-  };
-  use serial_test::serial;
-
-  #[tokio::test]
-  #[serial]
-  async fn test_crud() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-
-    let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
-      .await
-      .unwrap();
-
-    let new_person = PersonInsertForm::builder()
-      .name("terrylake".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_person = Person::create(pool, &new_person).await.unwrap();
-
-    let recipient_form = PersonInsertForm::builder()
-      .name("terrylakes recipient".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_recipient = Person::create(pool, &recipient_form).await.unwrap();
-
-    let new_community = CommunityInsertForm::builder()
-      .name("test community lake".to_string())
-      .title("nada".to_owned())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_community = Community::create(pool, &new_community).await.unwrap();
-
-    let new_post = PostInsertForm::builder()
-      .name("A test post".into())
-      .creator_id(inserted_person.id)
-      .community_id(inserted_community.id)
-      .build();
-
-    let inserted_post = Post::create(pool, &new_post).await.unwrap();
-
-    let comment_form = CommentInsertForm::builder()
-      .content("A test comment".into())
-      .creator_id(inserted_person.id)
-      .post_id(inserted_post.id)
-      .build();
-
-    let inserted_comment = Comment::create(pool, &comment_form, None).await.unwrap();
-
-    let person_mention_form = PersonMentionInsertForm {
-      recipient_id: inserted_recipient.id,
-      comment_id: inserted_comment.id,
-      read: None,
+    use crate::{
+        source::{
+            comment::{Comment, CommentInsertForm},
+            community::{Community, CommunityInsertForm},
+            instance::Instance,
+            person::{Person, PersonInsertForm},
+            person_mention::{PersonMention, PersonMentionInsertForm, PersonMentionUpdateForm},
+            post::{Post, PostInsertForm},
+        },
+        traits::Crud,
+        utils::build_db_pool_for_tests,
     };
+    use serial_test::serial;
 
-    let inserted_mention = PersonMention::create(pool, &person_mention_form)
-      .await
-      .unwrap();
+    #[tokio::test]
+    #[serial]
+    async fn test_crud() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
 
-    let expected_mention = PersonMention {
-      id: inserted_mention.id,
-      recipient_id: inserted_mention.recipient_id,
-      comment_id: inserted_mention.comment_id,
-      read: false,
-      published: inserted_mention.published,
-    };
+        let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
+            .await
+            .unwrap();
 
-    let read_mention = PersonMention::read(pool, inserted_mention.id)
-      .await
-      .unwrap();
+        let new_person = PersonInsertForm::builder()
+            .name("terrylake".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let person_mention_update_form = PersonMentionUpdateForm { read: Some(false) };
-    let updated_mention =
-      PersonMention::update(pool, inserted_mention.id, &person_mention_update_form)
-        .await
-        .unwrap();
-    Comment::delete(pool, inserted_comment.id).await.unwrap();
-    Post::delete(pool, inserted_post.id).await.unwrap();
-    Community::delete(pool, inserted_community.id)
-      .await
-      .unwrap();
-    Person::delete(pool, inserted_person.id).await.unwrap();
-    Person::delete(pool, inserted_recipient.id).await.unwrap();
-    Instance::delete(pool, inserted_instance.id).await.unwrap();
+        let inserted_person = Person::create(pool, &new_person).await.unwrap();
 
-    assert_eq!(expected_mention, read_mention);
-    assert_eq!(expected_mention, inserted_mention);
-    assert_eq!(expected_mention, updated_mention);
-  }
+        let recipient_form = PersonInsertForm::builder()
+            .name("terrylakes recipient".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
+
+        let inserted_recipient = Person::create(pool, &recipient_form).await.unwrap();
+
+        let new_community = CommunityInsertForm::builder()
+            .name("test community lake".to_string())
+            .title("nada".to_owned())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
+
+        let inserted_community = Community::create(pool, &new_community).await.unwrap();
+
+        let new_post = PostInsertForm::builder()
+            .name("A test post".into())
+            .creator_id(inserted_person.id)
+            .community_id(inserted_community.id)
+            .build();
+
+        let inserted_post = Post::create(pool, &new_post).await.unwrap();
+
+        let comment_form = CommentInsertForm::builder()
+            .content("A test comment".into())
+            .creator_id(inserted_person.id)
+            .post_id(inserted_post.id)
+            .build();
+
+        let inserted_comment = Comment::create(pool, &comment_form, None).await.unwrap();
+
+        let person_mention_form = PersonMentionInsertForm {
+            recipient_id: inserted_recipient.id,
+            comment_id: inserted_comment.id,
+            read: None,
+        };
+
+        let inserted_mention = PersonMention::create(pool, &person_mention_form)
+            .await
+            .unwrap();
+
+        let expected_mention = PersonMention {
+            id: inserted_mention.id,
+            recipient_id: inserted_mention.recipient_id,
+            comment_id: inserted_mention.comment_id,
+            read: false,
+            published: inserted_mention.published,
+        };
+
+        let read_mention = PersonMention::read(pool, inserted_mention.id)
+            .await
+            .unwrap();
+
+        let person_mention_update_form = PersonMentionUpdateForm { read: Some(false) };
+        let updated_mention =
+            PersonMention::update(pool, inserted_mention.id, &person_mention_update_form)
+                .await
+                .unwrap();
+        Comment::delete(pool, inserted_comment.id).await.unwrap();
+        Post::delete(pool, inserted_post.id).await.unwrap();
+        Community::delete(pool, inserted_community.id)
+            .await
+            .unwrap();
+        Person::delete(pool, inserted_person.id).await.unwrap();
+        Person::delete(pool, inserted_recipient.id).await.unwrap();
+        Instance::delete(pool, inserted_instance.id).await.unwrap();
+
+        assert_eq!(expected_mention, read_mention);
+        assert_eq!(expected_mention, inserted_mention);
+        assert_eq!(expected_mention, updated_mention);
+    }
 }

--- a/crates/db_schema/src/impls/post.rs
+++ b/crates/db_schema/src/impls/post.rs
@@ -1,35 +1,16 @@
 use super::instance::coalesce;
 use crate::{
-  newtypes::{CommunityId, DbUrl, PersonId, PostId},
-  schema::post::dsl::{
-    ap_id,
-    body,
-    community_id,
-    creator_id,
-    deleted,
-    featured_community,
-    local,
-    name,
-    post,
-    published,
-    removed,
-    thumbnail_url,
-    updated,
-    url,
-  },
-  source::post::{
-    Post,
-    PostInsertForm,
-    PostLike,
-    PostLikeForm,
-    PostRead,
-    PostReadForm,
-    PostSaved,
-    PostSavedForm,
-    PostUpdateForm,
-  },
-  traits::{Crud, Likeable, Readable, Saveable},
-  utils::{get_conn, naive_now, DbPool, DELETED_REPLACEMENT_TEXT, FETCH_LIMIT_MAX},
+    newtypes::{CommunityId, DbUrl, PersonId, PostId},
+    schema::post::dsl::{
+        ap_id, body, community_id, creator_id, deleted, featured_community, local, name, post,
+        published, removed, thumbnail_url, updated, url,
+    },
+    source::post::{
+        Post, PostInsertForm, PostLike, PostLikeForm, PostRead, PostReadForm, PostSaved,
+        PostSavedForm, PostUpdateForm,
+    },
+    traits::{Crud, Likeable, Readable, Saveable},
+    utils::{get_conn, naive_now, DbPool, DELETED_REPLACEMENT_TEXT, FETCH_LIMIT_MAX},
 };
 use ::url::Url;
 use chrono::{Duration, Utc};
@@ -38,470 +19,457 @@ use diesel_async::RunQueryDsl;
 
 #[async_trait]
 impl Crud for Post {
-  type InsertForm = PostInsertForm;
-  type UpdateForm = PostUpdateForm;
-  type IdType = PostId;
+    type InsertForm = PostInsertForm;
+    type UpdateForm = PostUpdateForm;
+    type IdType = PostId;
 
-  async fn create(pool: &mut DbPool<'_>, form: &Self::InsertForm) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    insert_into(post)
-      .values(form)
-      .on_conflict(ap_id)
-      .do_update()
-      .set(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn create(pool: &mut DbPool<'_>, form: &Self::InsertForm) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        insert_into(post)
+            .values(form)
+            .on_conflict(ap_id)
+            .do_update()
+            .set(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 
-  async fn update(
-    pool: &mut DbPool<'_>,
-    post_id: PostId,
-    new_post: &Self::UpdateForm,
-  ) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(post.find(post_id))
-      .set(new_post)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn update(
+        pool: &mut DbPool<'_>,
+        post_id: PostId,
+        new_post: &Self::UpdateForm,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(post.find(post_id))
+            .set(new_post)
+            .get_result::<Self>(conn)
+            .await
+    }
 }
 
 impl Post {
-  pub async fn list_for_community(
-    pool: &mut DbPool<'_>,
-    the_community_id: CommunityId,
-  ) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    post
-      .filter(community_id.eq(the_community_id))
-      .filter(deleted.eq(false))
-      .filter(removed.eq(false))
-      .then_order_by(featured_community.desc())
-      .then_order_by(published.desc())
-      .limit(FETCH_LIMIT_MAX)
-      .load::<Self>(conn)
-      .await
-  }
-
-  pub async fn list_featured_for_community(
-    pool: &mut DbPool<'_>,
-    the_community_id: CommunityId,
-  ) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    post
-      .filter(community_id.eq(the_community_id))
-      .filter(deleted.eq(false))
-      .filter(removed.eq(false))
-      .filter(featured_community.eq(true))
-      .then_order_by(published.desc())
-      .limit(FETCH_LIMIT_MAX)
-      .load::<Self>(conn)
-      .await
-  }
-
-  pub async fn list_for_sitemap(
-    pool: &mut DbPool<'_>,
-  ) -> Result<Vec<(DbUrl, chrono::DateTime<Utc>)>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    post
-      .select((ap_id, coalesce(updated, published)))
-      .filter(local.eq(true))
-      .filter(deleted.eq(false))
-      .filter(removed.eq(false))
-      .filter(published.ge(Utc::now().naive_utc() - Duration::days(1)))
-      .order(published.desc())
-      .load::<(DbUrl, chrono::DateTime<Utc>)>(conn)
-      .await
-  }
-
-  pub async fn permadelete_for_creator(
-    pool: &mut DbPool<'_>,
-    for_creator_id: PersonId,
-  ) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-
-    diesel::update(post.filter(creator_id.eq(for_creator_id)))
-      .set((
-        name.eq(DELETED_REPLACEMENT_TEXT),
-        url.eq(Option::<&str>::None),
-        body.eq(DELETED_REPLACEMENT_TEXT),
-        deleted.eq(true),
-        updated.eq(naive_now()),
-      ))
-      .get_results::<Self>(conn)
-      .await
-  }
-
-  pub async fn update_removed_for_creator(
-    pool: &mut DbPool<'_>,
-    for_creator_id: PersonId,
-    for_community_id: Option<CommunityId>,
-    new_removed: bool,
-  ) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-
-    let mut update = diesel::update(post).into_boxed();
-    update = update.filter(creator_id.eq(for_creator_id));
-
-    if let Some(for_community_id) = for_community_id {
-      update = update.filter(community_id.eq(for_community_id));
+    pub async fn list_for_community(
+        pool: &mut DbPool<'_>,
+        the_community_id: CommunityId,
+    ) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        post.filter(community_id.eq(the_community_id))
+            .filter(deleted.eq(false))
+            .filter(removed.eq(false))
+            .then_order_by(featured_community.desc())
+            .then_order_by(published.desc())
+            .limit(FETCH_LIMIT_MAX)
+            .load::<Self>(conn)
+            .await
     }
 
-    update
-      .set((removed.eq(new_removed), updated.eq(naive_now())))
-      .get_results::<Self>(conn)
-      .await
-  }
+    pub async fn list_featured_for_community(
+        pool: &mut DbPool<'_>,
+        the_community_id: CommunityId,
+    ) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        post.filter(community_id.eq(the_community_id))
+            .filter(deleted.eq(false))
+            .filter(removed.eq(false))
+            .filter(featured_community.eq(true))
+            .then_order_by(published.desc())
+            .limit(FETCH_LIMIT_MAX)
+            .load::<Self>(conn)
+            .await
+    }
 
-  pub fn is_post_creator(person_id: PersonId, post_creator_id: PersonId) -> bool {
-    person_id == post_creator_id
-  }
+    pub async fn list_for_sitemap(
+        pool: &mut DbPool<'_>,
+    ) -> Result<Vec<(DbUrl, chrono::DateTime<Utc>)>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        post.select((ap_id, coalesce(updated, published)))
+            .filter(local.eq(true))
+            .filter(deleted.eq(false))
+            .filter(removed.eq(false))
+            .filter(published.ge(Utc::now().naive_utc() - Duration::days(1)))
+            .order(published.desc())
+            .load::<(DbUrl, chrono::DateTime<Utc>)>(conn)
+            .await
+    }
 
-  pub async fn read_from_apub_id(
-    pool: &mut DbPool<'_>,
-    object_id: Url,
-  ) -> Result<Option<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let object_id: DbUrl = object_id.into();
-    Ok(
-      post
-        .filter(ap_id.eq(object_id))
-        .first::<Post>(conn)
+    pub async fn permadelete_for_creator(
+        pool: &mut DbPool<'_>,
+        for_creator_id: PersonId,
+    ) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+
+        diesel::update(post.filter(creator_id.eq(for_creator_id)))
+            .set((
+                name.eq(DELETED_REPLACEMENT_TEXT),
+                url.eq(Option::<&str>::None),
+                body.eq(DELETED_REPLACEMENT_TEXT),
+                deleted.eq(true),
+                updated.eq(naive_now()),
+            ))
+            .get_results::<Self>(conn)
+            .await
+    }
+
+    pub async fn update_removed_for_creator(
+        pool: &mut DbPool<'_>,
+        for_creator_id: PersonId,
+        for_community_id: Option<CommunityId>,
+        new_removed: bool,
+    ) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+
+        let mut update = diesel::update(post).into_boxed();
+        update = update.filter(creator_id.eq(for_creator_id));
+
+        if let Some(for_community_id) = for_community_id {
+            update = update.filter(community_id.eq(for_community_id));
+        }
+
+        update
+            .set((removed.eq(new_removed), updated.eq(naive_now())))
+            .get_results::<Self>(conn)
+            .await
+    }
+
+    pub fn is_post_creator(person_id: PersonId, post_creator_id: PersonId) -> bool {
+        person_id == post_creator_id
+    }
+
+    pub async fn read_from_apub_id(
+        pool: &mut DbPool<'_>,
+        object_id: Url,
+    ) -> Result<Option<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let object_id: DbUrl = object_id.into();
+        Ok(post
+            .filter(ap_id.eq(object_id))
+            .first::<Post>(conn)
+            .await
+            .ok()
+            .map(Into::into))
+    }
+
+    pub async fn fetch_pictrs_posts_for_creator(
+        pool: &mut DbPool<'_>,
+        for_creator_id: PersonId,
+    ) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let pictrs_search = "%pictrs/image%";
+
+        post.filter(creator_id.eq(for_creator_id))
+            .filter(url.like(pictrs_search))
+            .load::<Self>(conn)
+            .await
+    }
+
+    /// Sets the url and thumbnails fields to None
+    pub async fn remove_pictrs_post_images_and_thumbnails_for_creator(
+        pool: &mut DbPool<'_>,
+        for_creator_id: PersonId,
+    ) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let pictrs_search = "%pictrs/image%";
+
+        diesel::update(
+            post.filter(creator_id.eq(for_creator_id))
+                .filter(url.like(pictrs_search)),
+        )
+        .set((
+            url.eq::<Option<String>>(None),
+            thumbnail_url.eq::<Option<String>>(None),
+        ))
+        .get_results::<Self>(conn)
         .await
-        .ok()
-        .map(Into::into),
-    )
-  }
+    }
 
-  pub async fn fetch_pictrs_posts_for_creator(
-    pool: &mut DbPool<'_>,
-    for_creator_id: PersonId,
-  ) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let pictrs_search = "%pictrs/image%";
+    pub async fn fetch_pictrs_posts_for_community(
+        pool: &mut DbPool<'_>,
+        for_community_id: CommunityId,
+    ) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let pictrs_search = "%pictrs/image%";
+        post.filter(community_id.eq(for_community_id))
+            .filter(url.like(pictrs_search))
+            .load::<Self>(conn)
+            .await
+    }
 
-    post
-      .filter(creator_id.eq(for_creator_id))
-      .filter(url.like(pictrs_search))
-      .load::<Self>(conn)
-      .await
-  }
+    /// Sets the url and thumbnails fields to None
+    pub async fn remove_pictrs_post_images_and_thumbnails_for_community(
+        pool: &mut DbPool<'_>,
+        for_community_id: CommunityId,
+    ) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let pictrs_search = "%pictrs/image%";
 
-  /// Sets the url and thumbnails fields to None
-  pub async fn remove_pictrs_post_images_and_thumbnails_for_creator(
-    pool: &mut DbPool<'_>,
-    for_creator_id: PersonId,
-  ) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let pictrs_search = "%pictrs/image%";
-
-    diesel::update(
-      post
-        .filter(creator_id.eq(for_creator_id))
-        .filter(url.like(pictrs_search)),
-    )
-    .set((
-      url.eq::<Option<String>>(None),
-      thumbnail_url.eq::<Option<String>>(None),
-    ))
-    .get_results::<Self>(conn)
-    .await
-  }
-
-  pub async fn fetch_pictrs_posts_for_community(
-    pool: &mut DbPool<'_>,
-    for_community_id: CommunityId,
-  ) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let pictrs_search = "%pictrs/image%";
-    post
-      .filter(community_id.eq(for_community_id))
-      .filter(url.like(pictrs_search))
-      .load::<Self>(conn)
-      .await
-  }
-
-  /// Sets the url and thumbnails fields to None
-  pub async fn remove_pictrs_post_images_and_thumbnails_for_community(
-    pool: &mut DbPool<'_>,
-    for_community_id: CommunityId,
-  ) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let pictrs_search = "%pictrs/image%";
-
-    diesel::update(
-      post
-        .filter(community_id.eq(for_community_id))
-        .filter(url.like(pictrs_search)),
-    )
-    .set((
-      url.eq::<Option<String>>(None),
-      thumbnail_url.eq::<Option<String>>(None),
-    ))
-    .get_results::<Self>(conn)
-    .await
-  }
+        diesel::update(
+            post.filter(community_id.eq(for_community_id))
+                .filter(url.like(pictrs_search)),
+        )
+        .set((
+            url.eq::<Option<String>>(None),
+            thumbnail_url.eq::<Option<String>>(None),
+        ))
+        .get_results::<Self>(conn)
+        .await
+    }
 }
 
 #[async_trait]
 impl Likeable for PostLike {
-  type Form = PostLikeForm;
-  type IdType = PostId;
-  async fn like(pool: &mut DbPool<'_>, post_like_form: &PostLikeForm) -> Result<Self, Error> {
-    use crate::schema::post_like::dsl::{person_id, post_id, post_like};
-    let conn = &mut get_conn(pool).await?;
-    insert_into(post_like)
-      .values(post_like_form)
-      .on_conflict((post_id, person_id))
-      .do_update()
-      .set(post_like_form)
-      .get_result::<Self>(conn)
-      .await
-  }
-  async fn remove(
-    pool: &mut DbPool<'_>,
-    person_id: PersonId,
-    post_id: PostId,
-  ) -> Result<usize, Error> {
-    use crate::schema::post_like::dsl;
-    let conn = &mut get_conn(pool).await?;
-    diesel::delete(
-      dsl::post_like
-        .filter(dsl::post_id.eq(post_id))
-        .filter(dsl::person_id.eq(person_id)),
-    )
-    .execute(conn)
-    .await
-  }
+    type Form = PostLikeForm;
+    type IdType = PostId;
+    async fn like(pool: &mut DbPool<'_>, post_like_form: &PostLikeForm) -> Result<Self, Error> {
+        use crate::schema::post_like::dsl::{person_id, post_id, post_like};
+        let conn = &mut get_conn(pool).await?;
+        insert_into(post_like)
+            .values(post_like_form)
+            .on_conflict((post_id, person_id))
+            .do_update()
+            .set(post_like_form)
+            .get_result::<Self>(conn)
+            .await
+    }
+    async fn remove(
+        pool: &mut DbPool<'_>,
+        person_id: PersonId,
+        post_id: PostId,
+    ) -> Result<usize, Error> {
+        use crate::schema::post_like::dsl;
+        let conn = &mut get_conn(pool).await?;
+        diesel::delete(
+            dsl::post_like
+                .filter(dsl::post_id.eq(post_id))
+                .filter(dsl::person_id.eq(person_id)),
+        )
+        .execute(conn)
+        .await
+    }
 }
 
 #[async_trait]
 impl Saveable for PostSaved {
-  type Form = PostSavedForm;
-  async fn save(pool: &mut DbPool<'_>, post_saved_form: &PostSavedForm) -> Result<Self, Error> {
-    use crate::schema::post_saved::dsl::{person_id, post_id, post_saved};
-    let conn = &mut get_conn(pool).await?;
-    insert_into(post_saved)
-      .values(post_saved_form)
-      .on_conflict((post_id, person_id))
-      .do_update()
-      .set(post_saved_form)
-      .get_result::<Self>(conn)
-      .await
-  }
-  async fn unsave(pool: &mut DbPool<'_>, post_saved_form: &PostSavedForm) -> Result<usize, Error> {
-    use crate::schema::post_saved::dsl::{person_id, post_id, post_saved};
-    let conn = &mut get_conn(pool).await?;
-    diesel::delete(
-      post_saved
-        .filter(post_id.eq(post_saved_form.post_id))
-        .filter(person_id.eq(post_saved_form.person_id)),
-    )
-    .execute(conn)
-    .await
-  }
+    type Form = PostSavedForm;
+    async fn save(pool: &mut DbPool<'_>, post_saved_form: &PostSavedForm) -> Result<Self, Error> {
+        use crate::schema::post_saved::dsl::{person_id, post_id, post_saved};
+        let conn = &mut get_conn(pool).await?;
+        insert_into(post_saved)
+            .values(post_saved_form)
+            .on_conflict((post_id, person_id))
+            .do_update()
+            .set(post_saved_form)
+            .get_result::<Self>(conn)
+            .await
+    }
+    async fn unsave(
+        pool: &mut DbPool<'_>,
+        post_saved_form: &PostSavedForm,
+    ) -> Result<usize, Error> {
+        use crate::schema::post_saved::dsl::{person_id, post_id, post_saved};
+        let conn = &mut get_conn(pool).await?;
+        diesel::delete(
+            post_saved
+                .filter(post_id.eq(post_saved_form.post_id))
+                .filter(person_id.eq(post_saved_form.person_id)),
+        )
+        .execute(conn)
+        .await
+    }
 }
 
 #[async_trait]
 impl Readable for PostRead {
-  type Form = PostReadForm;
-  async fn mark_as_read(
-    pool: &mut DbPool<'_>,
-    post_read_form: &PostReadForm,
-  ) -> Result<Self, Error> {
-    use crate::schema::post_read::dsl::{person_id, post_id, post_read};
-    let conn = &mut get_conn(pool).await?;
-    insert_into(post_read)
-      .values(post_read_form)
-      .on_conflict((post_id, person_id))
-      .do_update()
-      .set(post_read_form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    type Form = PostReadForm;
+    async fn mark_as_read(
+        pool: &mut DbPool<'_>,
+        post_read_form: &PostReadForm,
+    ) -> Result<Self, Error> {
+        use crate::schema::post_read::dsl::{person_id, post_id, post_read};
+        let conn = &mut get_conn(pool).await?;
+        insert_into(post_read)
+            .values(post_read_form)
+            .on_conflict((post_id, person_id))
+            .do_update()
+            .set(post_read_form)
+            .get_result::<Self>(conn)
+            .await
+    }
 
-  async fn mark_as_unread(
-    pool: &mut DbPool<'_>,
-    post_read_form: &PostReadForm,
-  ) -> Result<usize, Error> {
-    use crate::schema::post_read::dsl::{person_id, post_id, post_read};
-    let conn = &mut get_conn(pool).await?;
-    diesel::delete(
-      post_read
-        .filter(post_id.eq(post_read_form.post_id))
-        .filter(person_id.eq(post_read_form.person_id)),
-    )
-    .execute(conn)
-    .await
-  }
+    async fn mark_as_unread(
+        pool: &mut DbPool<'_>,
+        post_read_form: &PostReadForm,
+    ) -> Result<usize, Error> {
+        use crate::schema::post_read::dsl::{person_id, post_id, post_read};
+        let conn = &mut get_conn(pool).await?;
+        diesel::delete(
+            post_read
+                .filter(post_id.eq(post_read_form.post_id))
+                .filter(person_id.eq(post_read_form.person_id)),
+        )
+        .execute(conn)
+        .await
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::{
-    source::{
-      community::{Community, CommunityInsertForm},
-      instance::Instance,
-      person::{Person, PersonInsertForm},
-      post::{
-        Post,
-        PostInsertForm,
-        PostLike,
-        PostLikeForm,
-        PostRead,
-        PostReadForm,
-        PostSaved,
-        PostSavedForm,
-        PostUpdateForm,
-      },
-    },
-    traits::{Crud, Likeable, Readable, Saveable},
-    utils::build_db_pool_for_tests,
-  };
-  use serial_test::serial;
-
-  #[tokio::test]
-  #[serial]
-  async fn test_crud() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-
-    let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
-      .await
-      .unwrap();
-
-    let new_person = PersonInsertForm::builder()
-      .name("jim".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_person = Person::create(pool, &new_person).await.unwrap();
-
-    let new_community = CommunityInsertForm::builder()
-      .name("test community_3".to_string())
-      .title("nada".to_owned())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_community = Community::create(pool, &new_community).await.unwrap();
-
-    let new_post = PostInsertForm::builder()
-      .name("A test post".into())
-      .creator_id(inserted_person.id)
-      .community_id(inserted_community.id)
-      .build();
-
-    let inserted_post = Post::create(pool, &new_post).await.unwrap();
-
-    let expected_post = Post {
-      id: inserted_post.id,
-      name: "A test post".into(),
-      url: None,
-      body: None,
-      creator_id: inserted_person.id,
-      community_id: inserted_community.id,
-      published: inserted_post.published,
-      removed: false,
-      locked: false,
-      nsfw: false,
-      deleted: false,
-      updated: None,
-      embed_title: None,
-      embed_description: None,
-      embed_video_url: None,
-      thumbnail_url: None,
-      ap_id: inserted_post.ap_id.clone(),
-      local: true,
-      language_id: Default::default(),
-      featured_community: false,
-      featured_local: false,
+    use crate::{
+        source::{
+            community::{Community, CommunityInsertForm},
+            instance::Instance,
+            person::{Person, PersonInsertForm},
+            post::{
+                Post, PostInsertForm, PostLike, PostLikeForm, PostRead, PostReadForm, PostSaved,
+                PostSavedForm, PostUpdateForm,
+            },
+        },
+        traits::{Crud, Likeable, Readable, Saveable},
+        utils::build_db_pool_for_tests,
     };
+    use serial_test::serial;
 
-    // Post Like
-    let post_like_form = PostLikeForm {
-      post_id: inserted_post.id,
-      person_id: inserted_person.id,
-      score: 1,
-    };
+    #[tokio::test]
+    #[serial]
+    async fn test_crud() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
 
-    let inserted_post_like = PostLike::like(pool, &post_like_form).await.unwrap();
+        let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
+            .await
+            .unwrap();
 
-    let expected_post_like = PostLike {
-      id: inserted_post_like.id,
-      post_id: inserted_post.id,
-      person_id: inserted_person.id,
-      published: inserted_post_like.published,
-      score: 1,
-    };
+        let new_person = PersonInsertForm::builder()
+            .name("jim".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    // Post Save
-    let post_saved_form = PostSavedForm {
-      post_id: inserted_post.id,
-      person_id: inserted_person.id,
-    };
+        let inserted_person = Person::create(pool, &new_person).await.unwrap();
 
-    let inserted_post_saved = PostSaved::save(pool, &post_saved_form).await.unwrap();
+        let new_community = CommunityInsertForm::builder()
+            .name("test community_3".to_string())
+            .title("nada".to_owned())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let expected_post_saved = PostSaved {
-      id: inserted_post_saved.id,
-      post_id: inserted_post.id,
-      person_id: inserted_person.id,
-      published: inserted_post_saved.published,
-    };
+        let inserted_community = Community::create(pool, &new_community).await.unwrap();
 
-    // Post Read
-    let post_read_form = PostReadForm {
-      post_id: inserted_post.id,
-      person_id: inserted_person.id,
-    };
+        let new_post = PostInsertForm::builder()
+            .name("A test post".into())
+            .creator_id(inserted_person.id)
+            .community_id(inserted_community.id)
+            .build();
 
-    let inserted_post_read = PostRead::mark_as_read(pool, &post_read_form).await.unwrap();
+        let inserted_post = Post::create(pool, &new_post).await.unwrap();
 
-    let expected_post_read = PostRead {
-      id: inserted_post_read.id,
-      post_id: inserted_post.id,
-      person_id: inserted_person.id,
-      published: inserted_post_read.published,
-    };
+        let expected_post = Post {
+            id: inserted_post.id,
+            name: "A test post".into(),
+            url: None,
+            body: None,
+            creator_id: inserted_person.id,
+            community_id: inserted_community.id,
+            published: inserted_post.published,
+            removed: false,
+            locked: false,
+            nsfw: false,
+            deleted: false,
+            updated: None,
+            embed_title: None,
+            embed_description: None,
+            embed_video_url: None,
+            thumbnail_url: None,
+            ap_id: inserted_post.ap_id.clone(),
+            local: true,
+            language_id: Default::default(),
+            featured_community: false,
+            featured_local: false,
+        };
 
-    let read_post = Post::read(pool, inserted_post.id).await.unwrap();
+        // Post Like
+        let post_like_form = PostLikeForm {
+            post_id: inserted_post.id,
+            person_id: inserted_person.id,
+            score: 1,
+        };
 
-    let new_post_update = PostUpdateForm {
-      name: Some("A test post".into()),
-      ..Default::default()
-    };
-    let updated_post = Post::update(pool, inserted_post.id, &new_post_update)
-      .await
-      .unwrap();
+        let inserted_post_like = PostLike::like(pool, &post_like_form).await.unwrap();
 
-    let like_removed = PostLike::remove(pool, inserted_person.id, inserted_post.id)
-      .await
-      .unwrap();
-    let saved_removed = PostSaved::unsave(pool, &post_saved_form).await.unwrap();
-    let read_removed = PostRead::mark_as_unread(pool, &post_read_form)
-      .await
-      .unwrap();
-    let num_deleted = Post::delete(pool, inserted_post.id).await.unwrap();
-    Community::delete(pool, inserted_community.id)
-      .await
-      .unwrap();
-    Person::delete(pool, inserted_person.id).await.unwrap();
-    Instance::delete(pool, inserted_instance.id).await.unwrap();
+        let expected_post_like = PostLike {
+            id: inserted_post_like.id,
+            post_id: inserted_post.id,
+            person_id: inserted_person.id,
+            published: inserted_post_like.published,
+            score: 1,
+        };
 
-    assert_eq!(expected_post, read_post);
-    assert_eq!(expected_post, inserted_post);
-    assert_eq!(expected_post, updated_post);
-    assert_eq!(expected_post_like, inserted_post_like);
-    assert_eq!(expected_post_saved, inserted_post_saved);
-    assert_eq!(expected_post_read, inserted_post_read);
-    assert_eq!(1, like_removed);
-    assert_eq!(1, saved_removed);
-    assert_eq!(1, read_removed);
-    assert_eq!(1, num_deleted);
-  }
+        // Post Save
+        let post_saved_form = PostSavedForm {
+            post_id: inserted_post.id,
+            person_id: inserted_person.id,
+        };
+
+        let inserted_post_saved = PostSaved::save(pool, &post_saved_form).await.unwrap();
+
+        let expected_post_saved = PostSaved {
+            id: inserted_post_saved.id,
+            post_id: inserted_post.id,
+            person_id: inserted_person.id,
+            published: inserted_post_saved.published,
+        };
+
+        // Post Read
+        let post_read_form = PostReadForm {
+            post_id: inserted_post.id,
+            person_id: inserted_person.id,
+        };
+
+        let inserted_post_read = PostRead::mark_as_read(pool, &post_read_form).await.unwrap();
+
+        let expected_post_read = PostRead {
+            id: inserted_post_read.id,
+            post_id: inserted_post.id,
+            person_id: inserted_person.id,
+            published: inserted_post_read.published,
+        };
+
+        let read_post = Post::read(pool, inserted_post.id).await.unwrap();
+
+        let new_post_update = PostUpdateForm {
+            name: Some("A test post".into()),
+            ..Default::default()
+        };
+        let updated_post = Post::update(pool, inserted_post.id, &new_post_update)
+            .await
+            .unwrap();
+
+        let like_removed = PostLike::remove(pool, inserted_person.id, inserted_post.id)
+            .await
+            .unwrap();
+        let saved_removed = PostSaved::unsave(pool, &post_saved_form).await.unwrap();
+        let read_removed = PostRead::mark_as_unread(pool, &post_read_form)
+            .await
+            .unwrap();
+        let num_deleted = Post::delete(pool, inserted_post.id).await.unwrap();
+        Community::delete(pool, inserted_community.id)
+            .await
+            .unwrap();
+        Person::delete(pool, inserted_person.id).await.unwrap();
+        Instance::delete(pool, inserted_instance.id).await.unwrap();
+
+        assert_eq!(expected_post, read_post);
+        assert_eq!(expected_post, inserted_post);
+        assert_eq!(expected_post, updated_post);
+        assert_eq!(expected_post_like, inserted_post_like);
+        assert_eq!(expected_post_saved, inserted_post_saved);
+        assert_eq!(expected_post_read, inserted_post_read);
+        assert_eq!(1, like_removed);
+        assert_eq!(1, saved_removed);
+        assert_eq!(1, read_removed);
+        assert_eq!(1, num_deleted);
+    }
 }

--- a/crates/db_schema/src/impls/post_report.rs
+++ b/crates/db_schema/src/impls/post_report.rs
@@ -1,137 +1,139 @@
 use crate::{
-  newtypes::{PersonId, PostReportId},
-  schema::post_report::dsl::{post_report, resolved, resolver_id, updated},
-  source::post_report::{PostReport, PostReportForm},
-  traits::Reportable,
-  utils::{get_conn, naive_now, DbPool},
+    newtypes::{PersonId, PostReportId},
+    schema::post_report::dsl::{post_report, resolved, resolver_id, updated},
+    source::post_report::{PostReport, PostReportForm},
+    traits::Reportable,
+    utils::{get_conn, naive_now, DbPool},
 };
 use diesel::{
-  dsl::{insert_into, update},
-  result::Error,
-  ExpressionMethods,
-  QueryDsl,
+    dsl::{insert_into, update},
+    result::Error,
+    ExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 
 #[async_trait]
 impl Reportable for PostReport {
-  type Form = PostReportForm;
-  type IdType = PostReportId;
+    type Form = PostReportForm;
+    type IdType = PostReportId;
 
-  async fn report(pool: &mut DbPool<'_>, post_report_form: &PostReportForm) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    insert_into(post_report)
-      .values(post_report_form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn report(
+        pool: &mut DbPool<'_>,
+        post_report_form: &PostReportForm,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        insert_into(post_report)
+            .values(post_report_form)
+            .get_result::<Self>(conn)
+            .await
+    }
 
-  async fn resolve(
-    pool: &mut DbPool<'_>,
-    report_id: Self::IdType,
-    by_resolver_id: PersonId,
-  ) -> Result<usize, Error> {
-    let conn = &mut get_conn(pool).await?;
-    update(post_report.find(report_id))
-      .set((
-        resolved.eq(true),
-        resolver_id.eq(by_resolver_id),
-        updated.eq(naive_now()),
-      ))
-      .execute(conn)
-      .await
-  }
+    async fn resolve(
+        pool: &mut DbPool<'_>,
+        report_id: Self::IdType,
+        by_resolver_id: PersonId,
+    ) -> Result<usize, Error> {
+        let conn = &mut get_conn(pool).await?;
+        update(post_report.find(report_id))
+            .set((
+                resolved.eq(true),
+                resolver_id.eq(by_resolver_id),
+                updated.eq(naive_now()),
+            ))
+            .execute(conn)
+            .await
+    }
 
-  async fn unresolve(
-    pool: &mut DbPool<'_>,
-    report_id: Self::IdType,
-    by_resolver_id: PersonId,
-  ) -> Result<usize, Error> {
-    let conn = &mut get_conn(pool).await?;
-    update(post_report.find(report_id))
-      .set((
-        resolved.eq(false),
-        resolver_id.eq(by_resolver_id),
-        updated.eq(naive_now()),
-      ))
-      .execute(conn)
-      .await
-  }
+    async fn unresolve(
+        pool: &mut DbPool<'_>,
+        report_id: Self::IdType,
+        by_resolver_id: PersonId,
+    ) -> Result<usize, Error> {
+        let conn = &mut get_conn(pool).await?;
+        update(post_report.find(report_id))
+            .set((
+                resolved.eq(false),
+                resolver_id.eq(by_resolver_id),
+                updated.eq(naive_now()),
+            ))
+            .execute(conn)
+            .await
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use super::*;
-  use crate::{
-    source::{
-      community::{Community, CommunityInsertForm},
-      instance::Instance,
-      person::{Person, PersonInsertForm},
-      post::{Post, PostInsertForm},
-    },
-    traits::Crud,
-    utils::build_db_pool_for_tests,
-  };
-  use serial_test::serial;
-
-  async fn init(pool: &mut DbPool<'_>) -> (Person, PostReport) {
-    let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
-      .await
-      .unwrap();
-    let person_form = PersonInsertForm::builder()
-      .name("jim".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-    let person = Person::create(pool, &person_form).await.unwrap();
-
-    let community_form = CommunityInsertForm::builder()
-      .name("test community_4".to_string())
-      .title("nada".to_owned())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-    let community = Community::create(pool, &community_form).await.unwrap();
-
-    let form = PostInsertForm::builder()
-      .name("A test post".into())
-      .creator_id(person.id)
-      .community_id(community.id)
-      .build();
-    let post = Post::create(pool, &form).await.unwrap();
-
-    let report_form = PostReportForm {
-      post_id: post.id,
-      creator_id: person.id,
-      reason: "my reason".to_string(),
-      ..Default::default()
+    use super::*;
+    use crate::{
+        source::{
+            community::{Community, CommunityInsertForm},
+            instance::Instance,
+            person::{Person, PersonInsertForm},
+            post::{Post, PostInsertForm},
+        },
+        traits::Crud,
+        utils::build_db_pool_for_tests,
     };
-    let report = PostReport::report(pool, &report_form).await.unwrap();
-    (person, report)
-  }
+    use serial_test::serial;
 
-  #[tokio::test]
-  #[serial]
-  async fn test_resolve_post_report() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
+    async fn init(pool: &mut DbPool<'_>) -> (Person, PostReport) {
+        let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
+            .await
+            .unwrap();
+        let person_form = PersonInsertForm::builder()
+            .name("jim".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
+        let person = Person::create(pool, &person_form).await.unwrap();
 
-    let (person, report) = init(pool).await;
+        let community_form = CommunityInsertForm::builder()
+            .name("test community_4".to_string())
+            .title("nada".to_owned())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
+        let community = Community::create(pool, &community_form).await.unwrap();
 
-    let resolved_count = PostReport::resolve(pool, report.id, person.id)
-      .await
-      .unwrap();
-    assert_eq!(resolved_count, 1);
+        let form = PostInsertForm::builder()
+            .name("A test post".into())
+            .creator_id(person.id)
+            .community_id(community.id)
+            .build();
+        let post = Post::create(pool, &form).await.unwrap();
 
-    let unresolved_count = PostReport::unresolve(pool, report.id, person.id)
-      .await
-      .unwrap();
-    assert_eq!(unresolved_count, 1);
+        let report_form = PostReportForm {
+            post_id: post.id,
+            creator_id: person.id,
+            reason: "my reason".to_string(),
+            ..Default::default()
+        };
+        let report = PostReport::report(pool, &report_form).await.unwrap();
+        (person, report)
+    }
 
-    Person::delete(pool, person.id).await.unwrap();
-    Post::delete(pool, report.post_id).await.unwrap();
-  }
+    #[tokio::test]
+    #[serial]
+    async fn test_resolve_post_report() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
+
+        let (person, report) = init(pool).await;
+
+        let resolved_count = PostReport::resolve(pool, report.id, person.id)
+            .await
+            .unwrap();
+        assert_eq!(resolved_count, 1);
+
+        let unresolved_count = PostReport::unresolve(pool, report.id, person.id)
+            .await
+            .unwrap();
+        assert_eq!(unresolved_count, 1);
+
+        Person::delete(pool, person.id).await.unwrap();
+        Post::delete(pool, report.post_id).await.unwrap();
+    }
 }

--- a/crates/db_schema/src/impls/private_message.rs
+++ b/crates/db_schema/src/impls/private_message.rs
@@ -1,9 +1,9 @@
 use crate::{
-  newtypes::{DbUrl, PersonId, PrivateMessageId},
-  schema::private_message::dsl::{ap_id, private_message, read, recipient_id},
-  source::private_message::{PrivateMessage, PrivateMessageInsertForm, PrivateMessageUpdateForm},
-  traits::Crud,
-  utils::{get_conn, DbPool},
+    newtypes::{DbUrl, PersonId, PrivateMessageId},
+    schema::private_message::dsl::{ap_id, private_message, read, recipient_id},
+    source::private_message::{PrivateMessage, PrivateMessageInsertForm, PrivateMessageUpdateForm},
+    traits::Crud,
+    utils::{get_conn, DbPool},
 };
 use diesel::{dsl::insert_into, result::Error, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
@@ -12,176 +12,174 @@ use url::Url;
 
 #[async_trait]
 impl Crud for PrivateMessage {
-  type InsertForm = PrivateMessageInsertForm;
-  type UpdateForm = PrivateMessageUpdateForm;
-  type IdType = PrivateMessageId;
+    type InsertForm = PrivateMessageInsertForm;
+    type UpdateForm = PrivateMessageUpdateForm;
+    type IdType = PrivateMessageId;
 
-  async fn create(pool: &mut DbPool<'_>, form: &Self::InsertForm) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    insert_into(private_message)
-      .values(form)
-      .on_conflict(ap_id)
-      .do_update()
-      .set(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn create(pool: &mut DbPool<'_>, form: &Self::InsertForm) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        insert_into(private_message)
+            .values(form)
+            .on_conflict(ap_id)
+            .do_update()
+            .set(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 
-  async fn update(
-    pool: &mut DbPool<'_>,
-    private_message_id: PrivateMessageId,
-    form: &Self::UpdateForm,
-  ) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(private_message.find(private_message_id))
-      .set(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn update(
+        pool: &mut DbPool<'_>,
+        private_message_id: PrivateMessageId,
+        form: &Self::UpdateForm,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(private_message.find(private_message_id))
+            .set(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 }
 
 impl PrivateMessage {
-  pub async fn mark_all_as_read(
-    pool: &mut DbPool<'_>,
-    for_recipient_id: PersonId,
-  ) -> Result<Vec<PrivateMessage>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(
-      private_message
-        .filter(recipient_id.eq(for_recipient_id))
-        .filter(read.eq(false)),
-    )
-    .set(read.eq(true))
-    .get_results::<Self>(conn)
-    .await
-  }
-
-  pub async fn read_from_apub_id(
-    pool: &mut DbPool<'_>,
-    object_id: Url,
-  ) -> Result<Option<Self>, LemmyError> {
-    let conn = &mut get_conn(pool).await?;
-    let object_id: DbUrl = object_id.into();
-    Ok(
-      private_message
-        .filter(ap_id.eq(object_id))
-        .first::<PrivateMessage>(conn)
+    pub async fn mark_all_as_read(
+        pool: &mut DbPool<'_>,
+        for_recipient_id: PersonId,
+    ) -> Result<Vec<PrivateMessage>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(
+            private_message
+                .filter(recipient_id.eq(for_recipient_id))
+                .filter(read.eq(false)),
+        )
+        .set(read.eq(true))
+        .get_results::<Self>(conn)
         .await
-        .ok()
-        .map(Into::into),
-    )
-  }
+    }
+
+    pub async fn read_from_apub_id(
+        pool: &mut DbPool<'_>,
+        object_id: Url,
+    ) -> Result<Option<Self>, LemmyError> {
+        let conn = &mut get_conn(pool).await?;
+        let object_id: DbUrl = object_id.into();
+        Ok(private_message
+            .filter(ap_id.eq(object_id))
+            .first::<PrivateMessage>(conn)
+            .await
+            .ok()
+            .map(Into::into))
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::{
-    source::{
-      instance::Instance,
-      person::{Person, PersonInsertForm},
-      private_message::{PrivateMessage, PrivateMessageInsertForm, PrivateMessageUpdateForm},
-    },
-    traits::Crud,
-    utils::build_db_pool_for_tests,
-  };
-  use serial_test::serial;
-
-  #[tokio::test]
-  #[serial]
-  async fn test_crud() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-
-    let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
-      .await
-      .unwrap();
-
-    let creator_form = PersonInsertForm::builder()
-      .name("creator_pm".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_creator = Person::create(pool, &creator_form).await.unwrap();
-
-    let recipient_form = PersonInsertForm::builder()
-      .name("recipient_pm".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_recipient = Person::create(pool, &recipient_form).await.unwrap();
-
-    let private_message_form = PrivateMessageInsertForm::builder()
-      .content("A test private message".into())
-      .creator_id(inserted_creator.id)
-      .recipient_id(inserted_recipient.id)
-      .build();
-
-    let inserted_private_message = PrivateMessage::create(pool, &private_message_form)
-      .await
-      .unwrap();
-
-    let expected_private_message = PrivateMessage {
-      id: inserted_private_message.id,
-      content: "A test private message".into(),
-      creator_id: inserted_creator.id,
-      recipient_id: inserted_recipient.id,
-      deleted: false,
-      read: false,
-      updated: None,
-      published: inserted_private_message.published,
-      ap_id: inserted_private_message.ap_id.clone(),
-      local: true,
+    use crate::{
+        source::{
+            instance::Instance,
+            person::{Person, PersonInsertForm},
+            private_message::{PrivateMessage, PrivateMessageInsertForm, PrivateMessageUpdateForm},
+        },
+        traits::Crud,
+        utils::build_db_pool_for_tests,
     };
+    use serial_test::serial;
 
-    let read_private_message = PrivateMessage::read(pool, inserted_private_message.id)
-      .await
-      .unwrap();
+    #[tokio::test]
+    #[serial]
+    async fn test_crud() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
 
-    let private_message_update_form = PrivateMessageUpdateForm {
-      content: Some("A test private message".into()),
-      ..Default::default()
-    };
-    let updated_private_message = PrivateMessage::update(
-      pool,
-      inserted_private_message.id,
-      &private_message_update_form,
-    )
-    .await
-    .unwrap();
+        let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
+            .await
+            .unwrap();
 
-    let deleted_private_message = PrivateMessage::update(
-      pool,
-      inserted_private_message.id,
-      &PrivateMessageUpdateForm {
-        deleted: Some(true),
-        ..Default::default()
-      },
-    )
-    .await
-    .unwrap();
-    let marked_read_private_message = PrivateMessage::update(
-      pool,
-      inserted_private_message.id,
-      &PrivateMessageUpdateForm {
-        read: Some(true),
-        ..Default::default()
-      },
-    )
-    .await
-    .unwrap();
-    Person::delete(pool, inserted_creator.id).await.unwrap();
-    Person::delete(pool, inserted_recipient.id).await.unwrap();
-    Instance::delete(pool, inserted_instance.id).await.unwrap();
+        let creator_form = PersonInsertForm::builder()
+            .name("creator_pm".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    assert_eq!(expected_private_message, read_private_message);
-    assert_eq!(expected_private_message, updated_private_message);
-    assert_eq!(expected_private_message, inserted_private_message);
-    assert!(deleted_private_message.deleted);
-    assert!(marked_read_private_message.read);
-  }
+        let inserted_creator = Person::create(pool, &creator_form).await.unwrap();
+
+        let recipient_form = PersonInsertForm::builder()
+            .name("recipient_pm".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
+
+        let inserted_recipient = Person::create(pool, &recipient_form).await.unwrap();
+
+        let private_message_form = PrivateMessageInsertForm::builder()
+            .content("A test private message".into())
+            .creator_id(inserted_creator.id)
+            .recipient_id(inserted_recipient.id)
+            .build();
+
+        let inserted_private_message = PrivateMessage::create(pool, &private_message_form)
+            .await
+            .unwrap();
+
+        let expected_private_message = PrivateMessage {
+            id: inserted_private_message.id,
+            content: "A test private message".into(),
+            creator_id: inserted_creator.id,
+            recipient_id: inserted_recipient.id,
+            deleted: false,
+            read: false,
+            updated: None,
+            published: inserted_private_message.published,
+            ap_id: inserted_private_message.ap_id.clone(),
+            local: true,
+        };
+
+        let read_private_message = PrivateMessage::read(pool, inserted_private_message.id)
+            .await
+            .unwrap();
+
+        let private_message_update_form = PrivateMessageUpdateForm {
+            content: Some("A test private message".into()),
+            ..Default::default()
+        };
+        let updated_private_message = PrivateMessage::update(
+            pool,
+            inserted_private_message.id,
+            &private_message_update_form,
+        )
+        .await
+        .unwrap();
+
+        let deleted_private_message = PrivateMessage::update(
+            pool,
+            inserted_private_message.id,
+            &PrivateMessageUpdateForm {
+                deleted: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let marked_read_private_message = PrivateMessage::update(
+            pool,
+            inserted_private_message.id,
+            &PrivateMessageUpdateForm {
+                read: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        Person::delete(pool, inserted_creator.id).await.unwrap();
+        Person::delete(pool, inserted_recipient.id).await.unwrap();
+        Instance::delete(pool, inserted_instance.id).await.unwrap();
+
+        assert_eq!(expected_private_message, read_private_message);
+        assert_eq!(expected_private_message, updated_private_message);
+        assert_eq!(expected_private_message, inserted_private_message);
+        assert!(deleted_private_message.deleted);
+        assert!(marked_read_private_message.read);
+    }
 }

--- a/crates/db_schema/src/impls/private_message_report.rs
+++ b/crates/db_schema/src/impls/private_message_report.rs
@@ -1,63 +1,62 @@
 use crate::{
-  newtypes::{PersonId, PrivateMessageReportId},
-  schema::private_message_report::dsl::{private_message_report, resolved, resolver_id, updated},
-  source::private_message_report::{PrivateMessageReport, PrivateMessageReportForm},
-  traits::Reportable,
-  utils::{get_conn, naive_now, DbPool},
+    newtypes::{PersonId, PrivateMessageReportId},
+    schema::private_message_report::dsl::{private_message_report, resolved, resolver_id, updated},
+    source::private_message_report::{PrivateMessageReport, PrivateMessageReportForm},
+    traits::Reportable,
+    utils::{get_conn, naive_now, DbPool},
 };
 use diesel::{
-  dsl::{insert_into, update},
-  result::Error,
-  ExpressionMethods,
-  QueryDsl,
+    dsl::{insert_into, update},
+    result::Error,
+    ExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 
 #[async_trait]
 impl Reportable for PrivateMessageReport {
-  type Form = PrivateMessageReportForm;
-  type IdType = PrivateMessageReportId;
+    type Form = PrivateMessageReportForm;
+    type IdType = PrivateMessageReportId;
 
-  async fn report(
-    pool: &mut DbPool<'_>,
-    pm_report_form: &PrivateMessageReportForm,
-  ) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    insert_into(private_message_report)
-      .values(pm_report_form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn report(
+        pool: &mut DbPool<'_>,
+        pm_report_form: &PrivateMessageReportForm,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        insert_into(private_message_report)
+            .values(pm_report_form)
+            .get_result::<Self>(conn)
+            .await
+    }
 
-  async fn resolve(
-    pool: &mut DbPool<'_>,
-    report_id: Self::IdType,
-    by_resolver_id: PersonId,
-  ) -> Result<usize, Error> {
-    let conn = &mut get_conn(pool).await?;
-    update(private_message_report.find(report_id))
-      .set((
-        resolved.eq(true),
-        resolver_id.eq(by_resolver_id),
-        updated.eq(naive_now()),
-      ))
-      .execute(conn)
-      .await
-  }
+    async fn resolve(
+        pool: &mut DbPool<'_>,
+        report_id: Self::IdType,
+        by_resolver_id: PersonId,
+    ) -> Result<usize, Error> {
+        let conn = &mut get_conn(pool).await?;
+        update(private_message_report.find(report_id))
+            .set((
+                resolved.eq(true),
+                resolver_id.eq(by_resolver_id),
+                updated.eq(naive_now()),
+            ))
+            .execute(conn)
+            .await
+    }
 
-  async fn unresolve(
-    pool: &mut DbPool<'_>,
-    report_id: Self::IdType,
-    by_resolver_id: PersonId,
-  ) -> Result<usize, Error> {
-    let conn = &mut get_conn(pool).await?;
-    update(private_message_report.find(report_id))
-      .set((
-        resolved.eq(false),
-        resolver_id.eq(by_resolver_id),
-        updated.eq(naive_now()),
-      ))
-      .execute(conn)
-      .await
-  }
+    async fn unresolve(
+        pool: &mut DbPool<'_>,
+        report_id: Self::IdType,
+        by_resolver_id: PersonId,
+    ) -> Result<usize, Error> {
+        let conn = &mut get_conn(pool).await?;
+        update(private_message_report.find(report_id))
+            .set((
+                resolved.eq(false),
+                resolver_id.eq(by_resolver_id),
+                updated.eq(naive_now()),
+            ))
+            .execute(conn)
+            .await
+    }
 }

--- a/crates/db_schema/src/impls/registration_application.rs
+++ b/crates/db_schema/src/impls/registration_application.rs
@@ -1,53 +1,52 @@
 use crate::{
-  newtypes::LocalUserId,
-  schema::registration_application::dsl::{local_user_id, registration_application},
-  source::registration_application::{
-    RegistrationApplication,
-    RegistrationApplicationInsertForm,
-    RegistrationApplicationUpdateForm,
-  },
-  traits::Crud,
-  utils::{get_conn, DbPool},
+    newtypes::LocalUserId,
+    schema::registration_application::dsl::{local_user_id, registration_application},
+    source::registration_application::{
+        RegistrationApplication, RegistrationApplicationInsertForm,
+        RegistrationApplicationUpdateForm,
+    },
+    traits::Crud,
+    utils::{get_conn, DbPool},
 };
 use diesel::{insert_into, result::Error, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 
 #[async_trait]
 impl Crud for RegistrationApplication {
-  type InsertForm = RegistrationApplicationInsertForm;
-  type UpdateForm = RegistrationApplicationUpdateForm;
-  type IdType = i32;
+    type InsertForm = RegistrationApplicationInsertForm;
+    type UpdateForm = RegistrationApplicationUpdateForm;
+    type IdType = i32;
 
-  async fn create(pool: &mut DbPool<'_>, form: &Self::InsertForm) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    insert_into(registration_application)
-      .values(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn create(pool: &mut DbPool<'_>, form: &Self::InsertForm) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        insert_into(registration_application)
+            .values(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 
-  async fn update(
-    pool: &mut DbPool<'_>,
-    id_: Self::IdType,
-    form: &Self::UpdateForm,
-  ) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(registration_application.find(id_))
-      .set(form)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn update(
+        pool: &mut DbPool<'_>,
+        id_: Self::IdType,
+        form: &Self::UpdateForm,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(registration_application.find(id_))
+            .set(form)
+            .get_result::<Self>(conn)
+            .await
+    }
 }
 
 impl RegistrationApplication {
-  pub async fn find_by_local_user_id(
-    pool: &mut DbPool<'_>,
-    local_user_id_: LocalUserId,
-  ) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    registration_application
-      .filter(local_user_id.eq(local_user_id_))
-      .first::<Self>(conn)
-      .await
-  }
+    pub async fn find_by_local_user_id(
+        pool: &mut DbPool<'_>,
+        local_user_id_: LocalUserId,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        registration_application
+            .filter(local_user_id.eq(local_user_id_))
+            .first::<Self>(conn)
+            .await
+    }
 }

--- a/crates/db_schema/src/impls/secret.rs
+++ b/crates/db_schema/src/impls/secret.rs
@@ -1,20 +1,20 @@
 use crate::{
-  schema::secret::dsl::secret,
-  source::secret::Secret,
-  utils::{get_conn, DbPool},
+    schema::secret::dsl::secret,
+    source::secret::Secret,
+    utils::{get_conn, DbPool},
 };
 use diesel::result::Error;
 use diesel_async::RunQueryDsl;
 
 impl Secret {
-  /// Initialize the Secrets from the DB.
-  /// Warning: You should only call this once.
-  pub async fn init(pool: &mut DbPool<'_>) -> Result<Secret, Error> {
-    Self::read_secrets(pool).await
-  }
+    /// Initialize the Secrets from the DB.
+    /// Warning: You should only call this once.
+    pub async fn init(pool: &mut DbPool<'_>) -> Result<Secret, Error> {
+        Self::read_secrets(pool).await
+    }
 
-  async fn read_secrets(pool: &mut DbPool<'_>) -> Result<Secret, Error> {
-    let conn = &mut get_conn(pool).await?;
-    secret.first::<Secret>(conn).await
-  }
+    async fn read_secrets(pool: &mut DbPool<'_>) -> Result<Secret, Error> {
+        let conn = &mut get_conn(pool).await?;
+        secret.first::<Secret>(conn).await
+    }
 }

--- a/crates/db_schema/src/impls/site.rs
+++ b/crates/db_schema/src/impls/site.rs
@@ -1,12 +1,12 @@
 use crate::{
-  newtypes::{DbUrl, SiteId},
-  schema::site::dsl::{actor_id, id, site},
-  source::{
-    actor_language::SiteLanguage,
-    site::{Site, SiteInsertForm, SiteUpdateForm},
-  },
-  traits::Crud,
-  utils::{get_conn, DbPool},
+    newtypes::{DbUrl, SiteId},
+    schema::site::dsl::{actor_id, id, site},
+    source::{
+        actor_language::SiteLanguage,
+        site::{Site, SiteInsertForm, SiteUpdateForm},
+    },
+    traits::Crud,
+    utils::{get_conn, DbPool},
 };
 use diesel::{dsl::insert_into, result::Error, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
@@ -14,79 +14,77 @@ use url::Url;
 
 #[async_trait]
 impl Crud for Site {
-  type InsertForm = SiteInsertForm;
-  type UpdateForm = SiteUpdateForm;
-  type IdType = SiteId;
+    type InsertForm = SiteInsertForm;
+    type UpdateForm = SiteUpdateForm;
+    type IdType = SiteId;
 
-  /// Use SiteView::read_local, or Site::read_from_apub_id instead
-  async fn read(_pool: &mut DbPool<'_>, _site_id: SiteId) -> Result<Self, Error> {
-    unimplemented!()
-  }
-
-  async fn create(pool: &mut DbPool<'_>, form: &Self::InsertForm) -> Result<Self, Error> {
-    let is_new_site = match &form.actor_id {
-      Some(id_) => Site::read_from_apub_id(pool, id_).await?.is_none(),
-      None => true,
-    };
-    let conn = &mut get_conn(pool).await?;
-
-    // Can't do separate insert/update commands because InsertForm/UpdateForm aren't convertible
-    let site_ = insert_into(site)
-      .values(form)
-      .on_conflict(actor_id)
-      .do_update()
-      .set(form)
-      .get_result::<Self>(conn)
-      .await?;
-
-    // initialize languages if site is newly created
-    if is_new_site {
-      // initialize with all languages
-      SiteLanguage::update(pool, vec![], &site_).await?;
+    /// Use SiteView::read_local, or Site::read_from_apub_id instead
+    async fn read(_pool: &mut DbPool<'_>, _site_id: SiteId) -> Result<Self, Error> {
+        unimplemented!()
     }
-    Ok(site_)
-  }
 
-  async fn update(
-    pool: &mut DbPool<'_>,
-    site_id: SiteId,
-    new_site: &Self::UpdateForm,
-  ) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    diesel::update(site.find(site_id))
-      .set(new_site)
-      .get_result::<Self>(conn)
-      .await
-  }
+    async fn create(pool: &mut DbPool<'_>, form: &Self::InsertForm) -> Result<Self, Error> {
+        let is_new_site = match &form.actor_id {
+            Some(id_) => Site::read_from_apub_id(pool, id_).await?.is_none(),
+            None => true,
+        };
+        let conn = &mut get_conn(pool).await?;
+
+        // Can't do separate insert/update commands because InsertForm/UpdateForm aren't convertible
+        let site_ = insert_into(site)
+            .values(form)
+            .on_conflict(actor_id)
+            .do_update()
+            .set(form)
+            .get_result::<Self>(conn)
+            .await?;
+
+        // initialize languages if site is newly created
+        if is_new_site {
+            // initialize with all languages
+            SiteLanguage::update(pool, vec![], &site_).await?;
+        }
+        Ok(site_)
+    }
+
+    async fn update(
+        pool: &mut DbPool<'_>,
+        site_id: SiteId,
+        new_site: &Self::UpdateForm,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(site.find(site_id))
+            .set(new_site)
+            .get_result::<Self>(conn)
+            .await
+    }
 }
 
 impl Site {
-  pub async fn read_from_apub_id(
-    pool: &mut DbPool<'_>,
-    object_id: &DbUrl,
-  ) -> Result<Option<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    Ok(
-      site
-        .filter(actor_id.eq(object_id))
-        .first::<Site>(conn)
-        .await
-        .ok()
-        .map(Into::into),
-    )
-  }
+    pub async fn read_from_apub_id(
+        pool: &mut DbPool<'_>,
+        object_id: &DbUrl,
+    ) -> Result<Option<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        Ok(site
+            .filter(actor_id.eq(object_id))
+            .first::<Site>(conn)
+            .await
+            .ok()
+            .map(Into::into))
+    }
 
-  pub async fn read_remote_sites(pool: &mut DbPool<'_>) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    site.order_by(id).offset(1).get_results::<Self>(conn).await
-  }
+    pub async fn read_remote_sites(pool: &mut DbPool<'_>) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        site.order_by(id).offset(1).get_results::<Self>(conn).await
+    }
 
-  /// Instance actor is at the root path, so we simply need to clear the path and other unnecessary
-  /// parts of the url.
-  pub fn instance_actor_id_from_url(mut url: Url) -> Url {
-    url.set_fragment(None);
-    url.set_path("");
-    url.set_query(None);
-    url
-  }
+    /// Instance actor is at the root path, so we simply need to clear the path and other unnecessary
+    /// parts of the url.
+    pub fn instance_actor_id_from_url(mut url: Url) -> Url {
+        url.set_fragment(None);
+        url.set_path("");
+        url.set_query(None);
+        url
+    }
 }

--- a/crates/db_schema/src/impls/tagline.rs
+++ b/crates/db_schema/src/impls/tagline.rs
@@ -1,58 +1,57 @@
 use crate::{
-  newtypes::LocalSiteId,
-  schema::tagline::dsl::{local_site_id, tagline},
-  source::tagline::{Tagline, TaglineForm},
-  utils::{get_conn, DbPool},
+    newtypes::LocalSiteId,
+    schema::tagline::dsl::{local_site_id, tagline},
+    source::tagline::{Tagline, TaglineForm},
+    utils::{get_conn, DbPool},
 };
 use diesel::{insert_into, result::Error, ExpressionMethods, QueryDsl};
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 
 impl Tagline {
-  pub async fn replace(
-    pool: &mut DbPool<'_>,
-    for_local_site_id: LocalSiteId,
-    list_content: Option<Vec<String>>,
-  ) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    if let Some(list) = list_content {
-      conn
-        .build_transaction()
-        .run(|conn| {
-          Box::pin(async move {
-            Self::clear(conn).await?;
+    pub async fn replace(
+        pool: &mut DbPool<'_>,
+        for_local_site_id: LocalSiteId,
+        list_content: Option<Vec<String>>,
+    ) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        if let Some(list) = list_content {
+            conn.build_transaction()
+                .run(|conn| {
+                    Box::pin(async move {
+                        Self::clear(conn).await?;
 
-            for item in list {
-              let form = TaglineForm {
-                local_site_id: for_local_site_id,
-                content: item,
-                updated: None,
-              };
-              insert_into(tagline)
-                .values(form)
-                .get_result::<Self>(conn)
-                .await?;
-            }
+                        for item in list {
+                            let form = TaglineForm {
+                                local_site_id: for_local_site_id,
+                                content: item,
+                                updated: None,
+                            };
+                            insert_into(tagline)
+                                .values(form)
+                                .get_result::<Self>(conn)
+                                .await?;
+                        }
+                        Self::get_all(&mut conn.into(), for_local_site_id).await
+                    }) as _
+                })
+                .await
+        } else {
             Self::get_all(&mut conn.into(), for_local_site_id).await
-          }) as _
-        })
-        .await
-    } else {
-      Self::get_all(&mut conn.into(), for_local_site_id).await
+        }
     }
-  }
 
-  async fn clear(conn: &mut AsyncPgConnection) -> Result<usize, Error> {
-    diesel::delete(tagline).execute(conn).await
-  }
+    async fn clear(conn: &mut AsyncPgConnection) -> Result<usize, Error> {
+        diesel::delete(tagline).execute(conn).await
+    }
 
-  pub async fn get_all(
-    pool: &mut DbPool<'_>,
-    for_local_site_id: LocalSiteId,
-  ) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    tagline
-      .filter(local_site_id.eq(for_local_site_id))
-      .get_results::<Self>(conn)
-      .await
-  }
+    pub async fn get_all(
+        pool: &mut DbPool<'_>,
+        for_local_site_id: LocalSiteId,
+    ) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        tagline
+            .filter(local_site_id.eq(for_local_site_id))
+            .get_results::<Self>(conn)
+            .await
+    }
 }

--- a/crates/db_schema/src/lib.rs
+++ b/crates/db_schema/src/lib.rs
@@ -30,8 +30,8 @@ pub mod newtypes;
 pub mod schema;
 #[cfg(feature = "full")]
 pub mod aliases {
-  use crate::schema::person;
-  diesel::alias!(person as person1: Person1, person as person2: Person2);
+    use crate::schema::person;
+    diesel::alias!(person as person1: Person1, person as person2: Person2);
 }
 pub mod source;
 #[cfg(feature = "full")]
@@ -45,36 +45,36 @@ use strum_macros::{Display, EnumString};
 use ts_rs::TS;
 
 #[derive(
-  EnumString, Display, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Default,
+    EnumString, Display, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Default,
 )]
 #[cfg_attr(feature = "full", derive(DbEnum, TS))]
 #[cfg_attr(
-  feature = "full",
-  ExistingTypePath = "crate::schema::sql_types::SortTypeEnum"
+    feature = "full",
+    ExistingTypePath = "crate::schema::sql_types::SortTypeEnum"
 )]
 #[cfg_attr(feature = "full", DbValueStyle = "verbatim")]
 #[cfg_attr(feature = "full", ts(export))]
 /// The post sort types. See here for descriptions: https://join-lemmy.org/docs/en/users/03-votes-and-ranking.html
 pub enum SortType {
-  #[default]
-  Active,
-  Hot,
-  New,
-  Old,
-  TopDay,
-  TopWeek,
-  TopMonth,
-  TopYear,
-  TopAll,
-  MostComments,
-  NewComments,
-  TopHour,
-  TopSixHour,
-  TopTwelveHour,
-  TopThreeMonths,
-  TopSixMonths,
-  TopNineMonths,
-  Controversial,
+    #[default]
+    Active,
+    Hot,
+    New,
+    Old,
+    TopDay,
+    TopWeek,
+    TopMonth,
+    TopYear,
+    TopAll,
+    MostComments,
+    NewComments,
+    TopHour,
+    TopSixHour,
+    TopTwelveHour,
+    TopThreeMonths,
+    TopSixMonths,
+    TopNineMonths,
+    Controversial,
 }
 
 #[derive(EnumString, Display, Debug, Serialize, Deserialize, Clone, Copy)]
@@ -82,11 +82,11 @@ pub enum SortType {
 #[cfg_attr(feature = "full", ts(export))]
 /// The comment sort types. See here for descriptions: https://join-lemmy.org/docs/en/users/03-votes-and-ranking.html
 pub enum CommentSortType {
-  Hot,
-  Top,
-  New,
-  Old,
-  Controversial,
+    Hot,
+    Top,
+    New,
+    Old,
+    Controversial,
 }
 
 #[derive(EnumString, Display, Debug, Serialize, Deserialize, Clone, Copy)]
@@ -94,71 +94,71 @@ pub enum CommentSortType {
 #[cfg_attr(feature = "full", ts(export))]
 /// The person sort types. See here for descriptions: https://join-lemmy.org/docs/en/users/03-votes-and-ranking.html
 pub enum PersonSortType {
-  New,
-  Old,
-  MostComments,
-  CommentScore,
-  PostScore,
-  PostCount,
+    New,
+    Old,
+    MostComments,
+    CommentScore,
+    PostScore,
+    PostCount,
 }
 
 #[derive(
-  EnumString, Display, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Default,
+    EnumString, Display, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Default,
 )]
 #[cfg_attr(feature = "full", derive(DbEnum, TS))]
 #[cfg_attr(
-  feature = "full",
-  ExistingTypePath = "crate::schema::sql_types::ListingTypeEnum"
+    feature = "full",
+    ExistingTypePath = "crate::schema::sql_types::ListingTypeEnum"
 )]
 #[cfg_attr(feature = "full", DbValueStyle = "verbatim")]
 #[cfg_attr(feature = "full", ts(export))]
 /// A listing type for post and comment list fetches.
 pub enum ListingType {
-  /// Content from your own site, as well as all connected / federated sites.
-  All,
-  /// Content from your site only.
-  #[default]
-  Local,
-  /// Content only from communities you've subscribed to.
-  Subscribed,
-  /// Content that you can moderate (because you are a moderator of the community it is posted to)
-  ModeratorView,
+    /// Content from your own site, as well as all connected / federated sites.
+    All,
+    /// Content from your site only.
+    #[default]
+    Local,
+    /// Content only from communities you've subscribed to.
+    Subscribed,
+    /// Content that you can moderate (because you are a moderator of the community it is posted to)
+    ModeratorView,
 }
 
 #[derive(EnumString, Display, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "full", derive(DbEnum, TS))]
 #[cfg_attr(
-  feature = "full",
-  ExistingTypePath = "crate::schema::sql_types::RegistrationModeEnum"
+    feature = "full",
+    ExistingTypePath = "crate::schema::sql_types::RegistrationModeEnum"
 )]
 #[cfg_attr(feature = "full", DbValueStyle = "verbatim")]
 #[cfg_attr(feature = "full", ts(export))]
 /// The registration mode for your site. Determines what happens after a user signs up.
 pub enum RegistrationMode {
-  /// Closed to public.
-  Closed,
-  /// Open, but pending approval of a registration application.
-  RequireApplication,
-  /// Open to all.
-  Open,
+    /// Closed to public.
+    Closed,
+    /// Open, but pending approval of a registration application.
+    RequireApplication,
+    /// Open to all.
+    Open,
 }
 
 #[derive(EnumString, Display, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "full", derive(DbEnum, TS))]
 #[cfg_attr(
-  feature = "full",
-  ExistingTypePath = "crate::schema::sql_types::PostListingModeEnum"
+    feature = "full",
+    ExistingTypePath = "crate::schema::sql_types::PostListingModeEnum"
 )]
 #[cfg_attr(feature = "full", DbValueStyle = "verbatim")]
 #[cfg_attr(feature = "full", ts(export))]
 /// A post-view mode that changes how multiple post listings look.
 pub enum PostListingMode {
-  /// A compact, list-type view.
-  List,
-  /// A larger card-type view.
-  Card,
-  /// A smaller card-type view, usually with images as thumbnails
-  SmallCard,
+    /// A compact, list-type view.
+    List,
+    /// A larger card-type view.
+    Card,
+    /// A smaller card-type view, usually with images as thumbnails
+    SmallCard,
 }
 
 #[derive(EnumString, Display, Debug, Serialize, Deserialize, Clone, Copy)]
@@ -166,12 +166,12 @@ pub enum PostListingMode {
 #[cfg_attr(feature = "full", ts(export))]
 /// The type of content returned from a search.
 pub enum SearchType {
-  All,
-  Comments,
-  Posts,
-  Communities,
-  Users,
-  Url,
+    All,
+    Comments,
+    Posts,
+    Communities,
+    Users,
+    Url,
 }
 
 #[derive(EnumString, Display, Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Copy)]
@@ -179,9 +179,9 @@ pub enum SearchType {
 #[cfg_attr(feature = "full", ts(export))]
 /// A type / status for a community subscribe.
 pub enum SubscribedType {
-  Subscribed,
-  NotSubscribed,
-  Pending,
+    Subscribed,
+    NotSubscribed,
+    Pending,
 }
 
 #[derive(EnumString, Display, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
@@ -189,34 +189,34 @@ pub enum SubscribedType {
 #[cfg_attr(feature = "full", ts(export))]
 /// A list of possible types for the various modlog actions.
 pub enum ModlogActionType {
-  All,
-  ModRemovePost,
-  ModLockPost,
-  ModFeaturePost,
-  ModRemoveComment,
-  ModRemoveCommunity,
-  ModBanFromCommunity,
-  ModAddCommunity,
-  ModTransferCommunity,
-  ModAdd,
-  ModBan,
-  ModHideCommunity,
-  AdminPurgePerson,
-  AdminPurgeCommunity,
-  AdminPurgePost,
-  AdminPurgeComment,
+    All,
+    ModRemovePost,
+    ModLockPost,
+    ModFeaturePost,
+    ModRemoveComment,
+    ModRemoveCommunity,
+    ModBanFromCommunity,
+    ModAddCommunity,
+    ModTransferCommunity,
+    ModAdd,
+    ModBan,
+    ModHideCommunity,
+    AdminPurgePerson,
+    AdminPurgeCommunity,
+    AdminPurgePost,
+    AdminPurgeComment,
 }
 
 #[derive(
-  EnumString, Display, Debug, Serialize, Deserialize, Clone, Copy, Default, PartialEq, Eq,
+    EnumString, Display, Debug, Serialize, Deserialize, Clone, Copy, Default, PartialEq, Eq,
 )]
 #[cfg_attr(feature = "full", derive(TS))]
 #[cfg_attr(feature = "full", ts(export))]
 /// The feature type for a post.
 pub enum PostFeatureType {
-  #[default]
-  /// Features to the top of your site.
-  Local,
-  /// Features to the top of the community.
-  Community,
+    #[default]
+    /// Features to the top of your site.
+    Local,
+    /// Features to the top of the community.
+    Community,
 }

--- a/crates/db_schema/src/newtypes.rs
+++ b/crates/db_schema/src/newtypes.rs
@@ -1,17 +1,15 @@
 #[cfg(feature = "full")]
 use activitypub_federation::{
-  fetch::collection_id::CollectionId,
-  fetch::object_id::ObjectId,
-  traits::Collection,
-  traits::Object,
+    fetch::collection_id::CollectionId, fetch::object_id::ObjectId, traits::Collection,
+    traits::Object,
 };
 #[cfg(feature = "full")]
 use diesel_ltree::Ltree;
 use serde::{Deserialize, Serialize};
 use std::{
-  fmt,
-  fmt::{Display, Formatter},
-  ops::Deref,
+    fmt,
+    fmt::{Display, Formatter},
+    ops::Deref,
 };
 #[cfg(feature = "full")]
 use ts_rs::TS;
@@ -24,9 +22,9 @@ use url::Url;
 pub struct PostId(pub i32);
 
 impl fmt::Display for PostId {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    write!(f, "{}", self.0)
-  }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
 }
 
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Default, Serialize, Deserialize)]
@@ -42,9 +40,9 @@ pub struct PersonId(pub i32);
 pub struct CommentId(pub i32);
 
 impl fmt::Display for CommentId {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    write!(f, "{}", self.0)
-  }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
 }
 
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Default, Serialize, Deserialize)]
@@ -66,9 +64,9 @@ pub struct LocalUserId(pub i32);
 pub struct PrivateMessageId(i32);
 
 impl fmt::Display for PrivateMessageId {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    write!(f, "{}", self.0)
-  }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
 }
 
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize, Default)]
@@ -168,84 +166,84 @@ pub struct LtreeDef(pub String);
 pub struct DbUrl(pub(crate) Box<Url>);
 
 impl DbUrl {
-  pub fn inner(&self) -> &Url {
-    &self.0
-  }
+    pub fn inner(&self) -> &Url {
+        &self.0
+    }
 }
 
 impl Display for DbUrl {
-  fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-    self.clone().0.fmt(f)
-  }
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.clone().0.fmt(f)
+    }
 }
 
 // the project doesnt compile with From
 #[allow(clippy::from_over_into)]
 impl Into<DbUrl> for Url {
-  fn into(self) -> DbUrl {
-    DbUrl(Box::new(self))
-  }
+    fn into(self) -> DbUrl {
+        DbUrl(Box::new(self))
+    }
 }
 #[allow(clippy::from_over_into)]
 impl Into<Url> for DbUrl {
-  fn into(self) -> Url {
-    *self.0
-  }
+    fn into(self) -> Url {
+        *self.0
+    }
 }
 
 #[cfg(feature = "full")]
 impl<T> From<DbUrl> for ObjectId<T>
 where
-  T: Object + Send + 'static,
-  for<'de2> <T as Object>::Kind: Deserialize<'de2>,
+    T: Object + Send + 'static,
+    for<'de2> <T as Object>::Kind: Deserialize<'de2>,
 {
-  fn from(value: DbUrl) -> Self {
-    let url: Url = value.into();
-    ObjectId::from(url)
-  }
+    fn from(value: DbUrl) -> Self {
+        let url: Url = value.into();
+        ObjectId::from(url)
+    }
 }
 
 #[cfg(feature = "full")]
 impl<T> From<DbUrl> for CollectionId<T>
 where
-  T: Collection + Send + 'static,
-  for<'de2> <T as Collection>::Kind: Deserialize<'de2>,
+    T: Collection + Send + 'static,
+    for<'de2> <T as Collection>::Kind: Deserialize<'de2>,
 {
-  fn from(value: DbUrl) -> Self {
-    let url: Url = value.into();
-    CollectionId::from(url)
-  }
+    fn from(value: DbUrl) -> Self {
+        let url: Url = value.into();
+        CollectionId::from(url)
+    }
 }
 
 #[cfg(feature = "full")]
 impl<T> From<CollectionId<T>> for DbUrl
 where
-  T: Collection,
-  for<'de2> <T as Collection>::Kind: Deserialize<'de2>,
+    T: Collection,
+    for<'de2> <T as Collection>::Kind: Deserialize<'de2>,
 {
-  fn from(value: CollectionId<T>) -> Self {
-    let url: Url = value.into();
-    url.into()
-  }
+    fn from(value: CollectionId<T>) -> Self {
+        let url: Url = value.into();
+        url.into()
+    }
 }
 
 impl Deref for DbUrl {
-  type Target = Url;
+    type Target = Url;
 
-  fn deref(&self) -> &Self::Target {
-    &self.0
-  }
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 #[cfg(feature = "full")]
 impl TS for DbUrl {
-  fn name() -> String {
-    "string".to_string()
-  }
-  fn dependencies() -> Vec<ts_rs::Dependency> {
-    Vec::new()
-  }
-  fn transparent() -> bool {
-    true
-  }
+    fn name() -> String {
+        "string".to_string()
+    }
+    fn dependencies() -> Vec<ts_rs::Dependency> {
+        Vec::new()
+    }
+    fn transparent() -> bool {
+        true
+    }
 }

--- a/crates/db_schema/src/source/activity.rs
+++ b/crates/db_schema/src/source/activity.rs
@@ -6,24 +6,24 @@ use std::fmt::Debug;
 #[derive(PartialEq, Eq, Debug, Queryable)]
 #[diesel(table_name = sent_activity)]
 pub struct SentActivity {
-  pub id: i64,
-  pub ap_id: DbUrl,
-  pub data: Value,
-  pub sensitive: bool,
-  pub published: DateTime<Utc>,
+    pub id: i64,
+    pub ap_id: DbUrl,
+    pub data: Value,
+    pub sensitive: bool,
+    pub published: DateTime<Utc>,
 }
 #[derive(Insertable)]
 #[diesel(table_name = sent_activity)]
 pub struct SentActivityForm {
-  pub ap_id: DbUrl,
-  pub data: Value,
-  pub sensitive: bool,
+    pub ap_id: DbUrl,
+    pub data: Value,
+    pub sensitive: bool,
 }
 
 #[derive(PartialEq, Eq, Debug, Queryable)]
 #[diesel(table_name = received_activity)]
 pub struct ReceivedActivity {
-  pub id: i64,
-  pub ap_id: DbUrl,
-  pub published: DateTime<Utc>,
+    pub id: i64,
+    pub ap_id: DbUrl,
+    pub published: DateTime<Utc>,
 }

--- a/crates/db_schema/src/source/actor_language.rs
+++ b/crates/db_schema/src/source/actor_language.rs
@@ -1,11 +1,6 @@
 use crate::newtypes::{
-  CommunityId,
-  CommunityLanguageId,
-  LanguageId,
-  LocalUserId,
-  LocalUserLanguageId,
-  SiteId,
-  SiteLanguageId,
+    CommunityId, CommunityLanguageId, LanguageId, LocalUserId, LocalUserLanguageId, SiteId,
+    SiteLanguageId,
 };
 #[cfg(feature = "full")]
 use crate::schema::local_user_language;
@@ -15,18 +10,18 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "full", derive(Queryable, Identifiable))]
 #[cfg_attr(feature = "full", diesel(table_name = local_user_language))]
 pub struct LocalUserLanguage {
-  #[serde(skip)]
-  pub id: LocalUserLanguageId,
-  pub local_user_id: LocalUserId,
-  pub language_id: LanguageId,
+    #[serde(skip)]
+    pub id: LocalUserLanguageId,
+    pub local_user_id: LocalUserId,
+    pub language_id: LanguageId,
 }
 
 #[derive(Clone)]
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = local_user_language))]
 pub struct LocalUserLanguageForm {
-  pub local_user_id: LocalUserId,
-  pub language_id: LanguageId,
+    pub local_user_id: LocalUserId,
+    pub language_id: LanguageId,
 }
 
 #[cfg(feature = "full")]
@@ -36,18 +31,18 @@ use crate::schema::community_language;
 #[cfg_attr(feature = "full", derive(Queryable, Identifiable))]
 #[cfg_attr(feature = "full", diesel(table_name = community_language))]
 pub struct CommunityLanguage {
-  #[serde(skip)]
-  pub id: CommunityLanguageId,
-  pub community_id: CommunityId,
-  pub language_id: LanguageId,
+    #[serde(skip)]
+    pub id: CommunityLanguageId,
+    pub community_id: CommunityId,
+    pub language_id: LanguageId,
 }
 
 #[derive(Clone)]
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = community_language))]
 pub struct CommunityLanguageForm {
-  pub community_id: CommunityId,
-  pub language_id: LanguageId,
+    pub community_id: CommunityId,
+    pub language_id: LanguageId,
 }
 
 #[cfg(feature = "full")]
@@ -57,16 +52,16 @@ use crate::schema::site_language;
 #[cfg_attr(feature = "full", derive(Queryable, Identifiable))]
 #[cfg_attr(feature = "full", diesel(table_name = site_language))]
 pub struct SiteLanguage {
-  #[serde(skip)]
-  pub id: SiteLanguageId,
-  pub site_id: SiteId,
-  pub language_id: LanguageId,
+    #[serde(skip)]
+    pub id: SiteLanguageId,
+    pub site_id: SiteId,
+    pub language_id: LanguageId,
 }
 
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = site_language))]
 pub struct SiteLanguageForm {
-  pub site_id: SiteId,
-  pub language_id: LanguageId,
+    pub site_id: SiteId,
+    pub language_id: LanguageId,
 }

--- a/crates/db_schema/src/source/captcha_answer.rs
+++ b/crates/db_schema/src/source/captcha_answer.rs
@@ -10,10 +10,10 @@ use uuid::Uuid;
 #[cfg_attr(feature = "full", derive(Queryable))]
 #[cfg_attr(feature = "full", diesel(table_name = captcha_answer))]
 pub struct CaptchaAnswer {
-  pub id: i32,
-  pub uuid: Uuid,
-  pub answer: String,
-  pub published: DateTime<Utc>,
+    pub id: i32,
+    pub uuid: Uuid,
+    pub answer: String,
+    pub published: DateTime<Utc>,
 }
 
 #[skip_serializing_none]
@@ -21,8 +21,8 @@ pub struct CaptchaAnswer {
 #[cfg_attr(feature = "full", derive(Queryable))]
 #[cfg_attr(feature = "full", diesel(table_name = captcha_answer))]
 pub struct CheckCaptchaAnswer {
-  pub uuid: Uuid,
-  pub answer: String,
+    pub uuid: Uuid,
+    pub answer: String,
 }
 
 #[skip_serializing_none]
@@ -30,5 +30,5 @@ pub struct CheckCaptchaAnswer {
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = captcha_answer))]
 pub struct CaptchaAnswerForm {
-  pub answer: String,
+    pub answer: String,
 }

--- a/crates/db_schema/src/source/comment.rs
+++ b/crates/db_schema/src/source/comment.rs
@@ -20,30 +20,30 @@ use typed_builder::TypedBuilder;
 #[cfg_attr(feature = "full", diesel(table_name = comment))]
 /// A comment.
 pub struct Comment {
-  pub id: CommentId,
-  pub creator_id: PersonId,
-  pub post_id: PostId,
-  pub content: String,
-  /// Whether the comment has been removed.
-  pub removed: bool,
-  pub published: DateTime<Utc>,
-  pub updated: Option<DateTime<Utc>>,
-  /// Whether the comment has been deleted by its creator.
-  pub deleted: bool,
-  /// The federated activity id / ap_id.
-  pub ap_id: DbUrl,
-  /// Whether the comment is local.
-  pub local: bool,
-  #[cfg(feature = "full")]
-  #[cfg_attr(feature = "full", serde(with = "LtreeDef"))]
-  #[cfg_attr(feature = "full", ts(type = "string"))]
-  /// The path / tree location of a comment, separated by dots, ending with the comment's id. Ex: 0.24.27
-  pub path: Ltree,
-  #[cfg(not(feature = "full"))]
-  pub path: String,
-  /// Whether the comment has been distinguished(speaking officially) by a mod.
-  pub distinguished: bool,
-  pub language_id: LanguageId,
+    pub id: CommentId,
+    pub creator_id: PersonId,
+    pub post_id: PostId,
+    pub content: String,
+    /// Whether the comment has been removed.
+    pub removed: bool,
+    pub published: DateTime<Utc>,
+    pub updated: Option<DateTime<Utc>>,
+    /// Whether the comment has been deleted by its creator.
+    pub deleted: bool,
+    /// The federated activity id / ap_id.
+    pub ap_id: DbUrl,
+    /// Whether the comment is local.
+    pub local: bool,
+    #[cfg(feature = "full")]
+    #[cfg_attr(feature = "full", serde(with = "LtreeDef"))]
+    #[cfg_attr(feature = "full", ts(type = "string"))]
+    /// The path / tree location of a comment, separated by dots, ending with the comment's id. Ex: 0.24.27
+    pub path: Ltree,
+    #[cfg(not(feature = "full"))]
+    pub path: String,
+    /// Whether the comment has been distinguished(speaking officially) by a mod.
+    pub distinguished: bool,
+    pub language_id: LanguageId,
 }
 
 #[derive(Debug, Clone, TypedBuilder)]
@@ -51,35 +51,35 @@ pub struct Comment {
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = comment))]
 pub struct CommentInsertForm {
-  #[builder(!default)]
-  pub creator_id: PersonId,
-  #[builder(!default)]
-  pub post_id: PostId,
-  #[builder(!default)]
-  pub content: String,
-  pub removed: Option<bool>,
-  pub published: Option<DateTime<Utc>>,
-  pub updated: Option<DateTime<Utc>>,
-  pub deleted: Option<bool>,
-  pub ap_id: Option<DbUrl>,
-  pub local: Option<bool>,
-  pub distinguished: Option<bool>,
-  pub language_id: Option<LanguageId>,
+    #[builder(!default)]
+    pub creator_id: PersonId,
+    #[builder(!default)]
+    pub post_id: PostId,
+    #[builder(!default)]
+    pub content: String,
+    pub removed: Option<bool>,
+    pub published: Option<DateTime<Utc>>,
+    pub updated: Option<DateTime<Utc>>,
+    pub deleted: Option<bool>,
+    pub ap_id: Option<DbUrl>,
+    pub local: Option<bool>,
+    pub distinguished: Option<bool>,
+    pub language_id: Option<LanguageId>,
 }
 
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "full", derive(AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = comment))]
 pub struct CommentUpdateForm {
-  pub content: Option<String>,
-  pub removed: Option<bool>,
-  // Don't use a default naive_now here, because the create function does a lot of comment updates
-  pub updated: Option<Option<DateTime<Utc>>>,
-  pub deleted: Option<bool>,
-  pub ap_id: Option<DbUrl>,
-  pub local: Option<bool>,
-  pub distinguished: Option<bool>,
-  pub language_id: Option<LanguageId>,
+    pub content: Option<String>,
+    pub removed: Option<bool>,
+    // Don't use a default naive_now here, because the create function does a lot of comment updates
+    pub updated: Option<Option<DateTime<Utc>>>,
+    pub deleted: Option<bool>,
+    pub ap_id: Option<DbUrl>,
+    pub local: Option<bool>,
+    pub distinguished: Option<bool>,
+    pub language_id: Option<LanguageId>,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]
@@ -87,22 +87,22 @@ pub struct CommentUpdateForm {
 #[cfg_attr(feature = "full", diesel(belongs_to(crate::source::comment::Comment)))]
 #[cfg_attr(feature = "full", diesel(table_name = comment_like))]
 pub struct CommentLike {
-  pub id: i32,
-  pub person_id: PersonId,
-  pub comment_id: CommentId,
-  pub post_id: PostId, // TODO this is redundant
-  pub score: i16,
-  pub published: DateTime<Utc>,
+    pub id: i32,
+    pub person_id: PersonId,
+    pub comment_id: CommentId,
+    pub post_id: PostId, // TODO this is redundant
+    pub score: i16,
+    pub published: DateTime<Utc>,
 }
 
 #[derive(Clone)]
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = comment_like))]
 pub struct CommentLikeForm {
-  pub person_id: PersonId,
-  pub comment_id: CommentId,
-  pub post_id: PostId, // TODO this is redundant
-  pub score: i16,
+    pub person_id: PersonId,
+    pub comment_id: CommentId,
+    pub post_id: PostId, // TODO this is redundant
+    pub score: i16,
 }
 
 #[derive(PartialEq, Eq, Debug)]
@@ -110,15 +110,15 @@ pub struct CommentLikeForm {
 #[cfg_attr(feature = "full", diesel(belongs_to(crate::source::comment::Comment)))]
 #[cfg_attr(feature = "full", diesel(table_name = comment_saved))]
 pub struct CommentSaved {
-  pub id: i32,
-  pub comment_id: CommentId,
-  pub person_id: PersonId,
-  pub published: DateTime<Utc>,
+    pub id: i32,
+    pub comment_id: CommentId,
+    pub person_id: PersonId,
+    pub published: DateTime<Utc>,
 }
 
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = comment_saved))]
 pub struct CommentSavedForm {
-  pub comment_id: CommentId,
-  pub person_id: PersonId,
+    pub comment_id: CommentId,
+    pub person_id: PersonId,
 }

--- a/crates/db_schema/src/source/comment_reply.rs
+++ b/crates/db_schema/src/source/comment_reply.rs
@@ -13,23 +13,23 @@ use ts_rs::TS;
 #[cfg_attr(feature = "full", ts(export))]
 /// A comment reply.
 pub struct CommentReply {
-  pub id: CommentReplyId,
-  pub recipient_id: PersonId,
-  pub comment_id: CommentId,
-  pub read: bool,
-  pub published: DateTime<Utc>,
+    pub id: CommentReplyId,
+    pub recipient_id: PersonId,
+    pub comment_id: CommentId,
+    pub read: bool,
+    pub published: DateTime<Utc>,
 }
 
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = comment_reply))]
 pub struct CommentReplyInsertForm {
-  pub recipient_id: PersonId,
-  pub comment_id: CommentId,
-  pub read: Option<bool>,
+    pub recipient_id: PersonId,
+    pub comment_id: CommentId,
+    pub read: Option<bool>,
 }
 
 #[cfg_attr(feature = "full", derive(AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = comment_reply))]
 pub struct CommentReplyUpdateForm {
-  pub read: Option<bool>,
+    pub read: Option<bool>,
 }

--- a/crates/db_schema/src/source/comment_report.rs
+++ b/crates/db_schema/src/source/comment_report.rs
@@ -15,23 +15,23 @@ use ts_rs::TS;
 #[cfg_attr(feature = "full", ts(export))]
 /// A comment report.
 pub struct CommentReport {
-  pub id: CommentReportId,
-  pub creator_id: PersonId,
-  pub comment_id: CommentId,
-  pub original_comment_text: String,
-  pub reason: String,
-  pub resolved: bool,
-  pub resolver_id: Option<PersonId>,
-  pub published: DateTime<Utc>,
-  pub updated: Option<DateTime<Utc>>,
+    pub id: CommentReportId,
+    pub creator_id: PersonId,
+    pub comment_id: CommentId,
+    pub original_comment_text: String,
+    pub reason: String,
+    pub resolved: bool,
+    pub resolver_id: Option<PersonId>,
+    pub published: DateTime<Utc>,
+    pub updated: Option<DateTime<Utc>>,
 }
 
 #[derive(Clone)]
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = comment_report))]
 pub struct CommentReportForm {
-  pub creator_id: PersonId,
-  pub comment_id: CommentId,
-  pub original_comment_text: String,
-  pub reason: String,
+    pub creator_id: PersonId,
+    pub comment_id: CommentId,
+    pub original_comment_text: String,
+    pub reason: String,
 }

--- a/crates/db_schema/src/source/community.rs
+++ b/crates/db_schema/src/source/community.rs
@@ -1,8 +1,8 @@
 #[cfg(feature = "full")]
 use crate::schema::{community, community_follower, community_moderator, community_person_ban};
 use crate::{
-  newtypes::{CommunityId, DbUrl, InstanceId, PersonId},
-  source::placeholder_apub_url,
+    newtypes::{CommunityId, DbUrl, InstanceId, PersonId},
+    source::placeholder_apub_url,
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -18,51 +18,51 @@ use typed_builder::TypedBuilder;
 #[cfg_attr(feature = "full", ts(export))]
 /// A community.
 pub struct Community {
-  pub id: CommunityId,
-  pub name: String,
-  /// A longer title, that can contain other characters, and doesn't have to be unique.
-  pub title: String,
-  /// A sidebar / markdown description.
-  pub description: Option<String>,
-  /// Whether the community is removed by a mod.
-  pub removed: bool,
-  pub published: DateTime<Utc>,
-  pub updated: Option<DateTime<Utc>>,
-  /// Whether the community has been deleted by its creator.
-  pub deleted: bool,
-  /// Whether its an NSFW community.
-  pub nsfw: bool,
-  /// The federated actor_id.
-  pub actor_id: DbUrl,
-  /// Whether the community is local.
-  pub local: bool,
-  #[serde(skip)]
-  pub private_key: Option<String>,
-  #[serde(skip)]
-  pub public_key: String,
-  #[serde(skip)]
-  pub last_refreshed_at: DateTime<Utc>,
-  /// A URL for an icon.
-  pub icon: Option<DbUrl>,
-  /// A URL for a banner.
-  pub banner: Option<DbUrl>,
-  #[serde(skip, default = "placeholder_apub_url")]
-  pub followers_url: DbUrl,
-  #[serde(skip, default = "placeholder_apub_url")]
-  pub inbox_url: DbUrl,
-  #[serde(skip)]
-  pub shared_inbox_url: Option<DbUrl>,
-  /// Whether the community is hidden.
-  pub hidden: bool,
-  /// Whether posting is restricted to mods only.
-  pub posting_restricted_to_mods: bool,
-  pub instance_id: InstanceId,
-  /// Url where moderators collection is served over Activitypub
-  #[serde(skip)]
-  pub moderators_url: Option<DbUrl>,
-  /// Url where featured posts collection is served over Activitypub
-  #[serde(skip)]
-  pub featured_url: Option<DbUrl>,
+    pub id: CommunityId,
+    pub name: String,
+    /// A longer title, that can contain other characters, and doesn't have to be unique.
+    pub title: String,
+    /// A sidebar / markdown description.
+    pub description: Option<String>,
+    /// Whether the community is removed by a mod.
+    pub removed: bool,
+    pub published: DateTime<Utc>,
+    pub updated: Option<DateTime<Utc>>,
+    /// Whether the community has been deleted by its creator.
+    pub deleted: bool,
+    /// Whether its an NSFW community.
+    pub nsfw: bool,
+    /// The federated actor_id.
+    pub actor_id: DbUrl,
+    /// Whether the community is local.
+    pub local: bool,
+    #[serde(skip)]
+    pub private_key: Option<String>,
+    #[serde(skip)]
+    pub public_key: String,
+    #[serde(skip)]
+    pub last_refreshed_at: DateTime<Utc>,
+    /// A URL for an icon.
+    pub icon: Option<DbUrl>,
+    /// A URL for a banner.
+    pub banner: Option<DbUrl>,
+    #[serde(skip, default = "placeholder_apub_url")]
+    pub followers_url: DbUrl,
+    #[serde(skip, default = "placeholder_apub_url")]
+    pub inbox_url: DbUrl,
+    #[serde(skip)]
+    pub shared_inbox_url: Option<DbUrl>,
+    /// Whether the community is hidden.
+    pub hidden: bool,
+    /// Whether posting is restricted to mods only.
+    pub posting_restricted_to_mods: bool,
+    pub instance_id: InstanceId,
+    /// Url where moderators collection is served over Activitypub
+    #[serde(skip)]
+    pub moderators_url: Option<DbUrl>,
+    /// Url where featured posts collection is served over Activitypub
+    #[serde(skip)]
+    pub featured_url: Option<DbUrl>,
 }
 
 #[derive(Debug, Clone, TypedBuilder)]
@@ -70,127 +70,127 @@ pub struct Community {
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = community))]
 pub struct CommunityInsertForm {
-  #[builder(!default)]
-  pub name: String,
-  #[builder(!default)]
-  pub title: String,
-  pub description: Option<String>,
-  pub removed: Option<bool>,
-  pub published: Option<DateTime<Utc>>,
-  pub updated: Option<DateTime<Utc>>,
-  pub deleted: Option<bool>,
-  pub nsfw: Option<bool>,
-  pub actor_id: Option<DbUrl>,
-  pub local: Option<bool>,
-  pub private_key: Option<String>,
-  pub public_key: String,
-  pub last_refreshed_at: Option<DateTime<Utc>>,
-  pub icon: Option<DbUrl>,
-  pub banner: Option<DbUrl>,
-  pub followers_url: Option<DbUrl>,
-  pub inbox_url: Option<DbUrl>,
-  pub shared_inbox_url: Option<DbUrl>,
-  pub moderators_url: Option<DbUrl>,
-  pub featured_url: Option<DbUrl>,
-  pub hidden: Option<bool>,
-  pub posting_restricted_to_mods: Option<bool>,
-  #[builder(!default)]
-  pub instance_id: InstanceId,
+    #[builder(!default)]
+    pub name: String,
+    #[builder(!default)]
+    pub title: String,
+    pub description: Option<String>,
+    pub removed: Option<bool>,
+    pub published: Option<DateTime<Utc>>,
+    pub updated: Option<DateTime<Utc>>,
+    pub deleted: Option<bool>,
+    pub nsfw: Option<bool>,
+    pub actor_id: Option<DbUrl>,
+    pub local: Option<bool>,
+    pub private_key: Option<String>,
+    pub public_key: String,
+    pub last_refreshed_at: Option<DateTime<Utc>>,
+    pub icon: Option<DbUrl>,
+    pub banner: Option<DbUrl>,
+    pub followers_url: Option<DbUrl>,
+    pub inbox_url: Option<DbUrl>,
+    pub shared_inbox_url: Option<DbUrl>,
+    pub moderators_url: Option<DbUrl>,
+    pub featured_url: Option<DbUrl>,
+    pub hidden: Option<bool>,
+    pub posting_restricted_to_mods: Option<bool>,
+    #[builder(!default)]
+    pub instance_id: InstanceId,
 }
 
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "full", derive(AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = community))]
 pub struct CommunityUpdateForm {
-  pub title: Option<String>,
-  pub description: Option<Option<String>>,
-  pub removed: Option<bool>,
-  pub published: Option<DateTime<Utc>>,
-  pub updated: Option<Option<DateTime<Utc>>>,
-  pub deleted: Option<bool>,
-  pub nsfw: Option<bool>,
-  pub actor_id: Option<DbUrl>,
-  pub local: Option<bool>,
-  pub public_key: Option<String>,
-  pub private_key: Option<Option<String>>,
-  pub last_refreshed_at: Option<DateTime<Utc>>,
-  pub icon: Option<Option<DbUrl>>,
-  pub banner: Option<Option<DbUrl>>,
-  pub followers_url: Option<DbUrl>,
-  pub inbox_url: Option<DbUrl>,
-  pub shared_inbox_url: Option<Option<DbUrl>>,
-  pub moderators_url: Option<DbUrl>,
-  pub featured_url: Option<DbUrl>,
-  pub hidden: Option<bool>,
-  pub posting_restricted_to_mods: Option<bool>,
+    pub title: Option<String>,
+    pub description: Option<Option<String>>,
+    pub removed: Option<bool>,
+    pub published: Option<DateTime<Utc>>,
+    pub updated: Option<Option<DateTime<Utc>>>,
+    pub deleted: Option<bool>,
+    pub nsfw: Option<bool>,
+    pub actor_id: Option<DbUrl>,
+    pub local: Option<bool>,
+    pub public_key: Option<String>,
+    pub private_key: Option<Option<String>>,
+    pub last_refreshed_at: Option<DateTime<Utc>>,
+    pub icon: Option<Option<DbUrl>>,
+    pub banner: Option<Option<DbUrl>>,
+    pub followers_url: Option<DbUrl>,
+    pub inbox_url: Option<DbUrl>,
+    pub shared_inbox_url: Option<Option<DbUrl>>,
+    pub moderators_url: Option<DbUrl>,
+    pub featured_url: Option<DbUrl>,
+    pub hidden: Option<bool>,
+    pub posting_restricted_to_mods: Option<bool>,
 }
 
 #[derive(PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "full", derive(Identifiable, Queryable, Associations))]
 #[cfg_attr(
-  feature = "full",
-  diesel(belongs_to(crate::source::community::Community))
+    feature = "full",
+    diesel(belongs_to(crate::source::community::Community))
 )]
 #[cfg_attr(feature = "full", diesel(table_name = community_moderator))]
 pub struct CommunityModerator {
-  pub id: i32,
-  pub community_id: CommunityId,
-  pub person_id: PersonId,
-  pub published: DateTime<Utc>,
+    pub id: i32,
+    pub community_id: CommunityId,
+    pub person_id: PersonId,
+    pub published: DateTime<Utc>,
 }
 
 #[derive(Clone)]
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = community_moderator))]
 pub struct CommunityModeratorForm {
-  pub community_id: CommunityId,
-  pub person_id: PersonId,
+    pub community_id: CommunityId,
+    pub person_id: PersonId,
 }
 
 #[derive(PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "full", derive(Identifiable, Queryable, Associations))]
 #[cfg_attr(
-  feature = "full",
-  diesel(belongs_to(crate::source::community::Community))
+    feature = "full",
+    diesel(belongs_to(crate::source::community::Community))
 )]
 #[cfg_attr(feature = "full", diesel(table_name = community_person_ban))]
 pub struct CommunityPersonBan {
-  pub id: i32,
-  pub community_id: CommunityId,
-  pub person_id: PersonId,
-  pub published: DateTime<Utc>,
-  pub expires: Option<DateTime<Utc>>,
+    pub id: i32,
+    pub community_id: CommunityId,
+    pub person_id: PersonId,
+    pub published: DateTime<Utc>,
+    pub expires: Option<DateTime<Utc>>,
 }
 
 #[derive(Clone)]
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = community_person_ban))]
 pub struct CommunityPersonBanForm {
-  pub community_id: CommunityId,
-  pub person_id: PersonId,
-  pub expires: Option<Option<DateTime<Utc>>>,
+    pub community_id: CommunityId,
+    pub person_id: PersonId,
+    pub expires: Option<Option<DateTime<Utc>>>,
 }
 
 #[derive(PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "full", derive(Identifiable, Queryable, Associations))]
 #[cfg_attr(
-  feature = "full",
-  diesel(belongs_to(crate::source::community::Community))
+    feature = "full",
+    diesel(belongs_to(crate::source::community::Community))
 )]
 #[cfg_attr(feature = "full", diesel(table_name = community_follower))]
 pub struct CommunityFollower {
-  pub id: i32,
-  pub community_id: CommunityId,
-  pub person_id: PersonId,
-  pub published: DateTime<Utc>,
-  pub pending: bool,
+    pub id: i32,
+    pub community_id: CommunityId,
+    pub person_id: PersonId,
+    pub published: DateTime<Utc>,
+    pub pending: bool,
 }
 
 #[derive(Clone)]
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = community_follower))]
 pub struct CommunityFollowerForm {
-  pub community_id: CommunityId,
-  pub person_id: PersonId,
-  pub pending: bool,
+    pub community_id: CommunityId,
+    pub person_id: PersonId,
+    pub pending: bool,
 }

--- a/crates/db_schema/src/source/community_block.rs
+++ b/crates/db_schema/src/source/community_block.rs
@@ -7,20 +7,20 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(Queryable, Associations, Identifiable))]
 #[cfg_attr(
-  feature = "full",
-  diesel(belongs_to(crate::source::community::Community))
+    feature = "full",
+    diesel(belongs_to(crate::source::community::Community))
 )]
 #[cfg_attr(feature = "full", diesel(table_name = community_block))]
 pub struct CommunityBlock {
-  pub id: CommunityBlockId,
-  pub person_id: PersonId,
-  pub community_id: CommunityId,
-  pub published: DateTime<Utc>,
+    pub id: CommunityBlockId,
+    pub person_id: PersonId,
+    pub community_id: CommunityId,
+    pub published: DateTime<Utc>,
 }
 
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = community_block))]
 pub struct CommunityBlockForm {
-  pub person_id: PersonId,
-  pub community_id: CommunityId,
+    pub person_id: PersonId,
+    pub community_id: CommunityId,
 }

--- a/crates/db_schema/src/source/custom_emoji.rs
+++ b/crates/db_schema/src/source/custom_emoji.rs
@@ -13,39 +13,39 @@ use typed_builder::TypedBuilder;
 #[cfg_attr(feature = "full", derive(Queryable, Associations, Identifiable, TS))]
 #[cfg_attr(feature = "full", diesel(table_name = custom_emoji))]
 #[cfg_attr(
-  feature = "full",
-  diesel(belongs_to(crate::source::local_site::LocalSite))
+    feature = "full",
+    diesel(belongs_to(crate::source::local_site::LocalSite))
 )]
 #[cfg_attr(feature = "full", ts(export))]
 /// A custom emoji.
 pub struct CustomEmoji {
-  pub id: CustomEmojiId,
-  pub local_site_id: LocalSiteId,
-  pub shortcode: String,
-  pub image_url: DbUrl,
-  pub alt_text: String,
-  pub category: String,
-  pub published: DateTime<Utc>,
-  pub updated: Option<DateTime<Utc>>,
+    pub id: CustomEmojiId,
+    pub local_site_id: LocalSiteId,
+    pub shortcode: String,
+    pub image_url: DbUrl,
+    pub alt_text: String,
+    pub category: String,
+    pub published: DateTime<Utc>,
+    pub updated: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Clone, TypedBuilder)]
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = custom_emoji))]
 pub struct CustomEmojiInsertForm {
-  pub local_site_id: LocalSiteId,
-  pub shortcode: String,
-  pub image_url: DbUrl,
-  pub alt_text: String,
-  pub category: String,
+    pub local_site_id: LocalSiteId,
+    pub shortcode: String,
+    pub image_url: DbUrl,
+    pub alt_text: String,
+    pub category: String,
 }
 
 #[derive(Debug, Clone, TypedBuilder)]
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = custom_emoji))]
 pub struct CustomEmojiUpdateForm {
-  pub local_site_id: LocalSiteId,
-  pub image_url: DbUrl,
-  pub alt_text: String,
-  pub category: String,
+    pub local_site_id: LocalSiteId,
+    pub image_url: DbUrl,
+    pub alt_text: String,
+    pub category: String,
 }

--- a/crates/db_schema/src/source/custom_emoji_keyword.rs
+++ b/crates/db_schema/src/source/custom_emoji_keyword.rs
@@ -10,21 +10,21 @@ use typed_builder::TypedBuilder;
 #[cfg_attr(feature = "full", derive(Queryable, Associations, Identifiable, TS))]
 #[cfg_attr(feature = "full", diesel(table_name = custom_emoji_keyword))]
 #[cfg_attr(
-  feature = "full",
-  diesel(belongs_to(crate::source::custom_emoji::CustomEmoji))
+    feature = "full",
+    diesel(belongs_to(crate::source::custom_emoji::CustomEmoji))
 )]
 #[cfg_attr(feature = "full", ts(export))]
 /// A custom keyword for an emoji.
 pub struct CustomEmojiKeyword {
-  pub id: i32,
-  pub custom_emoji_id: CustomEmojiId,
-  pub keyword: String,
+    pub id: i32,
+    pub custom_emoji_id: CustomEmojiId,
+    pub keyword: String,
 }
 
 #[derive(Debug, Clone, TypedBuilder)]
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = custom_emoji_keyword))]
 pub struct CustomEmojiKeywordInsertForm {
-  pub custom_emoji_id: CustomEmojiId,
-  pub keyword: String,
+    pub custom_emoji_id: CustomEmojiId,
+    pub keyword: String,
 }

--- a/crates/db_schema/src/source/email_verification.rs
+++ b/crates/db_schema/src/source/email_verification.rs
@@ -7,17 +7,17 @@ use chrono::{DateTime, Utc};
 #[cfg_attr(feature = "full", derive(Queryable, Identifiable))]
 #[cfg_attr(feature = "full", diesel(table_name = email_verification))]
 pub struct EmailVerification {
-  pub id: i32,
-  pub local_user_id: LocalUserId,
-  pub email: String,
-  pub verification_code: String,
-  pub published: DateTime<Utc>,
+    pub id: i32,
+    pub local_user_id: LocalUserId,
+    pub email: String,
+    pub verification_code: String,
+    pub published: DateTime<Utc>,
 }
 
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = email_verification))]
 pub struct EmailVerificationForm {
-  pub local_user_id: LocalUserId,
-  pub email: String,
-  pub verification_token: String,
+    pub local_user_id: LocalUserId,
+    pub email: String,
+    pub verification_token: String,
 }

--- a/crates/db_schema/src/source/federation_allowlist.rs
+++ b/crates/db_schema/src/source/federation_allowlist.rs
@@ -8,21 +8,21 @@ use std::fmt::Debug;
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(Queryable, Associations, Identifiable))]
 #[cfg_attr(
-  feature = "full",
-  diesel(belongs_to(crate::source::instance::Instance))
+    feature = "full",
+    diesel(belongs_to(crate::source::instance::Instance))
 )]
 #[cfg_attr(feature = "full", diesel(table_name = federation_allowlist))]
 pub struct FederationAllowList {
-  pub id: i32,
-  pub instance_id: InstanceId,
-  pub published: DateTime<Utc>,
-  pub updated: Option<DateTime<Utc>>,
+    pub id: i32,
+    pub instance_id: InstanceId,
+    pub published: DateTime<Utc>,
+    pub updated: Option<DateTime<Utc>>,
 }
 
 #[derive(Clone, Default)]
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = federation_allowlist))]
 pub struct FederationAllowListForm {
-  pub instance_id: InstanceId,
-  pub updated: Option<DateTime<Utc>>,
+    pub instance_id: InstanceId,
+    pub updated: Option<DateTime<Utc>>,
 }

--- a/crates/db_schema/src/source/federation_blocklist.rs
+++ b/crates/db_schema/src/source/federation_blocklist.rs
@@ -8,21 +8,21 @@ use std::fmt::Debug;
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(Queryable, Associations, Identifiable))]
 #[cfg_attr(
-  feature = "full",
-  diesel(belongs_to(crate::source::instance::Instance))
+    feature = "full",
+    diesel(belongs_to(crate::source::instance::Instance))
 )]
 #[cfg_attr(feature = "full", diesel(table_name = federation_blocklist))]
 pub struct FederationBlockList {
-  pub id: i32,
-  pub instance_id: InstanceId,
-  pub published: DateTime<Utc>,
-  pub updated: Option<DateTime<Utc>>,
+    pub id: i32,
+    pub instance_id: InstanceId,
+    pub published: DateTime<Utc>,
+    pub updated: Option<DateTime<Utc>>,
 }
 
 #[derive(Clone, Default)]
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = federation_blocklist))]
 pub struct FederationBlockListForm {
-  pub instance_id: InstanceId,
-  pub updated: Option<DateTime<Utc>>,
+    pub instance_id: InstanceId,
+    pub updated: Option<DateTime<Utc>>,
 }

--- a/crates/db_schema/src/source/instance.rs
+++ b/crates/db_schema/src/source/instance.rs
@@ -16,12 +16,12 @@ use typed_builder::TypedBuilder;
 #[cfg_attr(feature = "full", ts(export))]
 /// A federated instance / site.
 pub struct Instance {
-  pub id: InstanceId,
-  pub domain: String,
-  pub published: DateTime<Utc>,
-  pub updated: Option<DateTime<Utc>>,
-  pub software: Option<String>,
-  pub version: Option<String>,
+    pub id: InstanceId,
+    pub domain: String,
+    pub published: DateTime<Utc>,
+    pub updated: Option<DateTime<Utc>>,
+    pub software: Option<String>,
+    pub version: Option<String>,
 }
 
 #[derive(Clone, TypedBuilder)]
@@ -29,9 +29,9 @@ pub struct Instance {
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = instance))]
 pub struct InstanceForm {
-  #[builder(!default)]
-  pub domain: String,
-  pub software: Option<String>,
-  pub version: Option<String>,
-  pub updated: Option<DateTime<Utc>>,
+    #[builder(!default)]
+    pub domain: String,
+    pub software: Option<String>,
+    pub version: Option<String>,
+    pub updated: Option<DateTime<Utc>>,
 }

--- a/crates/db_schema/src/source/language.rs
+++ b/crates/db_schema/src/source/language.rs
@@ -11,7 +11,7 @@ use ts_rs::TS;
 #[cfg_attr(feature = "full", ts(export))]
 /// A language.
 pub struct Language {
-  pub id: LanguageId,
-  pub code: String,
-  pub name: String,
+    pub id: LanguageId,
+    pub code: String,
+    pub name: String,
 }

--- a/crates/db_schema/src/source/local_site.rs
+++ b/crates/db_schema/src/source/local_site.rs
@@ -1,9 +1,8 @@
 #[cfg(feature = "full")]
 use crate::schema::local_site;
 use crate::{
-  newtypes::{LocalSiteId, SiteId},
-  ListingType,
-  RegistrationMode,
+    newtypes::{LocalSiteId, SiteId},
+    ListingType, RegistrationMode,
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -20,46 +19,46 @@ use typed_builder::TypedBuilder;
 #[cfg_attr(feature = "full", ts(export))]
 /// The local site.
 pub struct LocalSite {
-  pub id: LocalSiteId,
-  pub site_id: SiteId,
-  /// True if the site is set up.
-  pub site_setup: bool,
-  /// Whether downvotes are enabled.
-  pub enable_downvotes: bool,
-  /// Whether NSFW is enabled.
-  pub enable_nsfw: bool,
-  /// Whether only admins can create communities.
-  pub community_creation_admin_only: bool,
-  /// Whether emails are required.
-  pub require_email_verification: bool,
-  /// An optional registration application questionnaire in markdown.
-  pub application_question: Option<String>,
-  /// Whether the instance is private or public.
-  pub private_instance: bool,
-  /// The default front-end theme.
-  pub default_theme: String,
-  pub default_post_listing_type: ListingType,
-  /// An optional legal disclaimer page.
-  pub legal_information: Option<String>,
-  /// Whether to hide mod names on the modlog.
-  pub hide_modlog_mod_names: bool,
-  /// Whether new applications email admins.
-  pub application_email_admins: bool,
-  /// An optional regex to filter words.
-  pub slur_filter_regex: Option<String>,
-  /// The max actor name length.
-  pub actor_name_max_length: i32,
-  /// Whether federation is enabled.
-  pub federation_enabled: bool,
-  /// Whether captcha is enabled.
-  pub captcha_enabled: bool,
-  /// The captcha difficulty.
-  pub captcha_difficulty: String,
-  pub published: DateTime<Utc>,
-  pub updated: Option<DateTime<Utc>>,
-  pub registration_mode: RegistrationMode,
-  /// Whether to email admins on new reports.
-  pub reports_email_admins: bool,
+    pub id: LocalSiteId,
+    pub site_id: SiteId,
+    /// True if the site is set up.
+    pub site_setup: bool,
+    /// Whether downvotes are enabled.
+    pub enable_downvotes: bool,
+    /// Whether NSFW is enabled.
+    pub enable_nsfw: bool,
+    /// Whether only admins can create communities.
+    pub community_creation_admin_only: bool,
+    /// Whether emails are required.
+    pub require_email_verification: bool,
+    /// An optional registration application questionnaire in markdown.
+    pub application_question: Option<String>,
+    /// Whether the instance is private or public.
+    pub private_instance: bool,
+    /// The default front-end theme.
+    pub default_theme: String,
+    pub default_post_listing_type: ListingType,
+    /// An optional legal disclaimer page.
+    pub legal_information: Option<String>,
+    /// Whether to hide mod names on the modlog.
+    pub hide_modlog_mod_names: bool,
+    /// Whether new applications email admins.
+    pub application_email_admins: bool,
+    /// An optional regex to filter words.
+    pub slur_filter_regex: Option<String>,
+    /// The max actor name length.
+    pub actor_name_max_length: i32,
+    /// Whether federation is enabled.
+    pub federation_enabled: bool,
+    /// Whether captcha is enabled.
+    pub captcha_enabled: bool,
+    /// The captcha difficulty.
+    pub captcha_difficulty: String,
+    pub published: DateTime<Utc>,
+    pub updated: Option<DateTime<Utc>>,
+    pub registration_mode: RegistrationMode,
+    /// Whether to email admins on new reports.
+    pub reports_email_admins: bool,
 }
 
 #[derive(Clone, TypedBuilder)]
@@ -67,51 +66,51 @@ pub struct LocalSite {
 #[cfg_attr(feature = "full", derive(Insertable))]
 #[cfg_attr(feature = "full", diesel(table_name = local_site))]
 pub struct LocalSiteInsertForm {
-  #[builder(!default)]
-  pub site_id: SiteId,
-  pub site_setup: Option<bool>,
-  pub enable_downvotes: Option<bool>,
-  pub enable_nsfw: Option<bool>,
-  pub community_creation_admin_only: Option<bool>,
-  pub require_email_verification: Option<bool>,
-  pub application_question: Option<String>,
-  pub private_instance: Option<bool>,
-  pub default_theme: Option<String>,
-  pub default_post_listing_type: Option<ListingType>,
-  pub legal_information: Option<String>,
-  pub hide_modlog_mod_names: Option<bool>,
-  pub application_email_admins: Option<bool>,
-  pub slur_filter_regex: Option<String>,
-  pub actor_name_max_length: Option<i32>,
-  pub federation_enabled: Option<bool>,
-  pub captcha_enabled: Option<bool>,
-  pub captcha_difficulty: Option<String>,
-  pub registration_mode: Option<RegistrationMode>,
-  pub reports_email_admins: Option<bool>,
+    #[builder(!default)]
+    pub site_id: SiteId,
+    pub site_setup: Option<bool>,
+    pub enable_downvotes: Option<bool>,
+    pub enable_nsfw: Option<bool>,
+    pub community_creation_admin_only: Option<bool>,
+    pub require_email_verification: Option<bool>,
+    pub application_question: Option<String>,
+    pub private_instance: Option<bool>,
+    pub default_theme: Option<String>,
+    pub default_post_listing_type: Option<ListingType>,
+    pub legal_information: Option<String>,
+    pub hide_modlog_mod_names: Option<bool>,
+    pub application_email_admins: Option<bool>,
+    pub slur_filter_regex: Option<String>,
+    pub actor_name_max_length: Option<i32>,
+    pub federation_enabled: Option<bool>,
+    pub captcha_enabled: Option<bool>,
+    pub captcha_difficulty: Option<String>,
+    pub registration_mode: Option<RegistrationMode>,
+    pub reports_email_admins: Option<bool>,
 }
 
 #[derive(Clone, Default)]
 #[cfg_attr(feature = "full", derive(AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = local_site))]
 pub struct LocalSiteUpdateForm {
-  pub site_setup: Option<bool>,
-  pub enable_downvotes: Option<bool>,
-  pub enable_nsfw: Option<bool>,
-  pub community_creation_admin_only: Option<bool>,
-  pub require_email_verification: Option<bool>,
-  pub application_question: Option<Option<String>>,
-  pub private_instance: Option<bool>,
-  pub default_theme: Option<String>,
-  pub default_post_listing_type: Option<ListingType>,
-  pub legal_information: Option<Option<String>>,
-  pub hide_modlog_mod_names: Option<bool>,
-  pub application_email_admins: Option<bool>,
-  pub slur_filter_regex: Option<Option<String>>,
-  pub actor_name_max_length: Option<i32>,
-  pub federation_enabled: Option<bool>,
-  pub captcha_enabled: Option<bool>,
-  pub captcha_difficulty: Option<String>,
-  pub registration_mode: Option<RegistrationMode>,
-  pub reports_email_admins: Option<bool>,
-  pub updated: Option<Option<DateTime<Utc>>>,
+    pub site_setup: Option<bool>,
+    pub enable_downvotes: Option<bool>,
+    pub enable_nsfw: Option<bool>,
+    pub community_creation_admin_only: Option<bool>,
+    pub require_email_verification: Option<bool>,
+    pub application_question: Option<Option<String>>,
+    pub private_instance: Option<bool>,
+    pub default_theme: Option<String>,
+    pub default_post_listing_type: Option<ListingType>,
+    pub legal_information: Option<Option<String>>,
+    pub hide_modlog_mod_names: Option<bool>,
+    pub application_email_admins: Option<bool>,
+    pub slur_filter_regex: Option<Option<String>>,
+    pub actor_name_max_length: Option<i32>,
+    pub federation_enabled: Option<bool>,
+    pub captcha_enabled: Option<bool>,
+    pub captcha_difficulty: Option<String>,
+    pub registration_mode: Option<RegistrationMode>,
+    pub reports_email_admins: Option<bool>,
+    pub updated: Option<Option<DateTime<Utc>>>,
 }

--- a/crates/db_schema/src/source/local_site_rate_limit.rs
+++ b/crates/db_schema/src/source/local_site_rate_limit.rs
@@ -13,28 +13,28 @@ use typed_builder::TypedBuilder;
 #[cfg_attr(feature = "full", derive(Queryable, Identifiable, TS))]
 #[cfg_attr(feature = "full", diesel(table_name = local_site_rate_limit))]
 #[cfg_attr(
-  feature = "full",
-  diesel(belongs_to(crate::source::local_site::LocalSite))
+    feature = "full",
+    diesel(belongs_to(crate::source::local_site::LocalSite))
 )]
 #[cfg_attr(feature = "full", ts(export))]
 /// Rate limits for your site. Given in count / length of time.
 pub struct LocalSiteRateLimit {
-  pub id: i32,
-  pub local_site_id: LocalSiteId,
-  pub message: i32,
-  pub message_per_second: i32,
-  pub post: i32,
-  pub post_per_second: i32,
-  pub register: i32,
-  pub register_per_second: i32,
-  pub image: i32,
-  pub image_per_second: i32,
-  pub comment: i32,
-  pub comment_per_second: i32,
-  pub search: i32,
-  pub search_per_second: i32,
-  pub published: DateTime<Utc>,
-  pub updated: Option<DateTime<Utc>>,
+    pub id: i32,
+    pub local_site_id: LocalSiteId,
+    pub message: i32,
+    pub message_per_second: i32,
+    pub post: i32,
+    pub post_per_second: i32,
+    pub register: i32,
+    pub register_per_second: i32,
+    pub image: i32,
+    pub image_per_second: i32,
+    pub comment: i32,
+    pub comment_per_second: i32,
+    pub search: i32,
+    pub search_per_second: i32,
+    pub published: DateTime<Utc>,
+    pub updated: Option<DateTime<Utc>>,
 }
 
 #[derive(Clone, TypedBuilder)]
@@ -42,37 +42,37 @@ pub struct LocalSiteRateLimit {
 #[cfg_attr(feature = "full", derive(Insertable))]
 #[cfg_attr(feature = "full", diesel(table_name = local_site_rate_limit))]
 pub struct LocalSiteRateLimitInsertForm {
-  #[builder(!default)]
-  pub local_site_id: LocalSiteId,
-  pub message: Option<i32>,
-  pub message_per_second: Option<i32>,
-  pub post: Option<i32>,
-  pub post_per_second: Option<i32>,
-  pub register: Option<i32>,
-  pub register_per_second: Option<i32>,
-  pub image: Option<i32>,
-  pub image_per_second: Option<i32>,
-  pub comment: Option<i32>,
-  pub comment_per_second: Option<i32>,
-  pub search: Option<i32>,
-  pub search_per_second: Option<i32>,
+    #[builder(!default)]
+    pub local_site_id: LocalSiteId,
+    pub message: Option<i32>,
+    pub message_per_second: Option<i32>,
+    pub post: Option<i32>,
+    pub post_per_second: Option<i32>,
+    pub register: Option<i32>,
+    pub register_per_second: Option<i32>,
+    pub image: Option<i32>,
+    pub image_per_second: Option<i32>,
+    pub comment: Option<i32>,
+    pub comment_per_second: Option<i32>,
+    pub search: Option<i32>,
+    pub search_per_second: Option<i32>,
 }
 
 #[derive(Clone, Default)]
 #[cfg_attr(feature = "full", derive(AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = local_site_rate_limit))]
 pub struct LocalSiteRateLimitUpdateForm {
-  pub message: Option<i32>,
-  pub message_per_second: Option<i32>,
-  pub post: Option<i32>,
-  pub post_per_second: Option<i32>,
-  pub register: Option<i32>,
-  pub register_per_second: Option<i32>,
-  pub image: Option<i32>,
-  pub image_per_second: Option<i32>,
-  pub comment: Option<i32>,
-  pub comment_per_second: Option<i32>,
-  pub search: Option<i32>,
-  pub search_per_second: Option<i32>,
-  pub updated: Option<Option<DateTime<Utc>>>,
+    pub message: Option<i32>,
+    pub message_per_second: Option<i32>,
+    pub post: Option<i32>,
+    pub post_per_second: Option<i32>,
+    pub register: Option<i32>,
+    pub register_per_second: Option<i32>,
+    pub image: Option<i32>,
+    pub image_per_second: Option<i32>,
+    pub comment: Option<i32>,
+    pub comment_per_second: Option<i32>,
+    pub search: Option<i32>,
+    pub search_per_second: Option<i32>,
+    pub updated: Option<Option<DateTime<Utc>>>,
 }

--- a/crates/db_schema/src/source/local_user.rs
+++ b/crates/db_schema/src/source/local_user.rs
@@ -1,10 +1,8 @@
 #[cfg(feature = "full")]
 use crate::schema::local_user;
 use crate::{
-  newtypes::{LocalUserId, PersonId},
-  ListingType,
-  PostListingMode,
-  SortType,
+    newtypes::{LocalUserId, PersonId},
+    ListingType, PostListingMode, SortType,
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -20,48 +18,48 @@ use typed_builder::TypedBuilder;
 #[cfg_attr(feature = "full", ts(export))]
 /// A local user.
 pub struct LocalUser {
-  pub id: LocalUserId,
-  /// The person_id for the local user.
-  pub person_id: PersonId,
-  #[serde(skip)]
-  pub password_encrypted: String,
-  pub email: Option<String>,
-  /// Whether to show NSFW content.
-  pub show_nsfw: bool,
-  pub theme: String,
-  pub default_sort_type: SortType,
-  pub default_listing_type: ListingType,
-  pub interface_language: String,
-  /// Whether to show avatars.
-  pub show_avatars: bool,
-  pub send_notifications_to_email: bool,
-  /// A validation ID used in logging out sessions.
-  pub validator_time: DateTime<Utc>,
-  /// Whether to show comment / post scores.
-  pub show_scores: bool,
-  /// Whether to show bot accounts.
-  pub show_bot_accounts: bool,
-  /// Whether to show read posts.
-  pub show_read_posts: bool,
-  /// Whether to show new posts as notifications.
-  pub show_new_post_notifs: bool,
-  /// Whether their email has been verified.
-  pub email_verified: bool,
-  /// Whether their registration application has been accepted.
-  pub accepted_application: bool,
-  #[serde(skip)]
-  pub totp_2fa_secret: Option<String>,
-  /// A URL to add their 2-factor auth.
-  pub totp_2fa_url: Option<String>,
-  /// Open links in a new tab.
-  pub open_links_in_new_tab: bool,
-  pub blur_nsfw: bool,
-  pub auto_expand: bool,
-  /// Whether infinite scroll is enabled.
-  pub infinite_scroll_enabled: bool,
-  /// Whether the person is an admin.
-  pub admin: bool,
-  pub post_listing_mode: PostListingMode,
+    pub id: LocalUserId,
+    /// The person_id for the local user.
+    pub person_id: PersonId,
+    #[serde(skip)]
+    pub password_encrypted: String,
+    pub email: Option<String>,
+    /// Whether to show NSFW content.
+    pub show_nsfw: bool,
+    pub theme: String,
+    pub default_sort_type: SortType,
+    pub default_listing_type: ListingType,
+    pub interface_language: String,
+    /// Whether to show avatars.
+    pub show_avatars: bool,
+    pub send_notifications_to_email: bool,
+    /// A validation ID used in logging out sessions.
+    pub validator_time: DateTime<Utc>,
+    /// Whether to show comment / post scores.
+    pub show_scores: bool,
+    /// Whether to show bot accounts.
+    pub show_bot_accounts: bool,
+    /// Whether to show read posts.
+    pub show_read_posts: bool,
+    /// Whether to show new posts as notifications.
+    pub show_new_post_notifs: bool,
+    /// Whether their email has been verified.
+    pub email_verified: bool,
+    /// Whether their registration application has been accepted.
+    pub accepted_application: bool,
+    #[serde(skip)]
+    pub totp_2fa_secret: Option<String>,
+    /// A URL to add their 2-factor auth.
+    pub totp_2fa_url: Option<String>,
+    /// Open links in a new tab.
+    pub open_links_in_new_tab: bool,
+    pub blur_nsfw: bool,
+    pub auto_expand: bool,
+    /// Whether infinite scroll is enabled.
+    pub infinite_scroll_enabled: bool,
+    /// Whether the person is an admin.
+    pub admin: bool,
+    pub post_listing_mode: PostListingMode,
 }
 
 #[derive(Clone, TypedBuilder)]
@@ -69,59 +67,59 @@ pub struct LocalUser {
 #[cfg_attr(feature = "full", derive(Insertable))]
 #[cfg_attr(feature = "full", diesel(table_name = local_user))]
 pub struct LocalUserInsertForm {
-  #[builder(!default)]
-  pub person_id: PersonId,
-  #[builder(!default)]
-  pub password_encrypted: String,
-  pub email: Option<String>,
-  pub show_nsfw: Option<bool>,
-  pub theme: Option<String>,
-  pub default_sort_type: Option<SortType>,
-  pub default_listing_type: Option<ListingType>,
-  pub interface_language: Option<String>,
-  pub show_avatars: Option<bool>,
-  pub send_notifications_to_email: Option<bool>,
-  pub show_bot_accounts: Option<bool>,
-  pub show_scores: Option<bool>,
-  pub show_read_posts: Option<bool>,
-  pub show_new_post_notifs: Option<bool>,
-  pub email_verified: Option<bool>,
-  pub accepted_application: Option<bool>,
-  pub totp_2fa_secret: Option<Option<String>>,
-  pub totp_2fa_url: Option<Option<String>>,
-  pub open_links_in_new_tab: Option<bool>,
-  pub blur_nsfw: Option<bool>,
-  pub auto_expand: Option<bool>,
-  pub infinite_scroll_enabled: Option<bool>,
-  pub admin: Option<bool>,
-  pub post_listing_mode: Option<PostListingMode>,
+    #[builder(!default)]
+    pub person_id: PersonId,
+    #[builder(!default)]
+    pub password_encrypted: String,
+    pub email: Option<String>,
+    pub show_nsfw: Option<bool>,
+    pub theme: Option<String>,
+    pub default_sort_type: Option<SortType>,
+    pub default_listing_type: Option<ListingType>,
+    pub interface_language: Option<String>,
+    pub show_avatars: Option<bool>,
+    pub send_notifications_to_email: Option<bool>,
+    pub show_bot_accounts: Option<bool>,
+    pub show_scores: Option<bool>,
+    pub show_read_posts: Option<bool>,
+    pub show_new_post_notifs: Option<bool>,
+    pub email_verified: Option<bool>,
+    pub accepted_application: Option<bool>,
+    pub totp_2fa_secret: Option<Option<String>>,
+    pub totp_2fa_url: Option<Option<String>>,
+    pub open_links_in_new_tab: Option<bool>,
+    pub blur_nsfw: Option<bool>,
+    pub auto_expand: Option<bool>,
+    pub infinite_scroll_enabled: Option<bool>,
+    pub admin: Option<bool>,
+    pub post_listing_mode: Option<PostListingMode>,
 }
 
 #[derive(Clone, Default)]
 #[cfg_attr(feature = "full", derive(AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = local_user))]
 pub struct LocalUserUpdateForm {
-  pub password_encrypted: Option<String>,
-  pub email: Option<Option<String>>,
-  pub show_nsfw: Option<bool>,
-  pub theme: Option<String>,
-  pub default_sort_type: Option<SortType>,
-  pub default_listing_type: Option<ListingType>,
-  pub interface_language: Option<String>,
-  pub show_avatars: Option<bool>,
-  pub send_notifications_to_email: Option<bool>,
-  pub show_bot_accounts: Option<bool>,
-  pub show_scores: Option<bool>,
-  pub show_read_posts: Option<bool>,
-  pub show_new_post_notifs: Option<bool>,
-  pub email_verified: Option<bool>,
-  pub accepted_application: Option<bool>,
-  pub totp_2fa_secret: Option<Option<String>>,
-  pub totp_2fa_url: Option<Option<String>>,
-  pub open_links_in_new_tab: Option<bool>,
-  pub blur_nsfw: Option<bool>,
-  pub auto_expand: Option<bool>,
-  pub infinite_scroll_enabled: Option<bool>,
-  pub admin: Option<bool>,
-  pub post_listing_mode: Option<PostListingMode>,
+    pub password_encrypted: Option<String>,
+    pub email: Option<Option<String>>,
+    pub show_nsfw: Option<bool>,
+    pub theme: Option<String>,
+    pub default_sort_type: Option<SortType>,
+    pub default_listing_type: Option<ListingType>,
+    pub interface_language: Option<String>,
+    pub show_avatars: Option<bool>,
+    pub send_notifications_to_email: Option<bool>,
+    pub show_bot_accounts: Option<bool>,
+    pub show_scores: Option<bool>,
+    pub show_read_posts: Option<bool>,
+    pub show_new_post_notifs: Option<bool>,
+    pub email_verified: Option<bool>,
+    pub accepted_application: Option<bool>,
+    pub totp_2fa_secret: Option<Option<String>>,
+    pub totp_2fa_url: Option<Option<String>>,
+    pub open_links_in_new_tab: Option<bool>,
+    pub blur_nsfw: Option<bool>,
+    pub auto_expand: Option<bool>,
+    pub infinite_scroll_enabled: Option<bool>,
+    pub admin: Option<bool>,
+    pub post_listing_mode: Option<PostListingMode>,
 }

--- a/crates/db_schema/src/source/mod.rs
+++ b/crates/db_schema/src/source/mod.rs
@@ -39,7 +39,7 @@ pub mod tagline;
 /// This is necessary so they can be successfully deserialized from API responses, even though the
 /// value is not sent by Lemmy. Necessary for crates which rely on Rust API such as lemmy-stats-crawler.
 fn placeholder_apub_url() -> DbUrl {
-  DbUrl(Box::new(
-    Url::parse("http://example.com").expect("parse placeholer url"),
-  ))
+    DbUrl(Box::new(
+        Url::parse("http://example.com").expect("parse placeholer url"),
+    ))
 }

--- a/crates/db_schema/src/source/moderator.rs
+++ b/crates/db_schema/src/source/moderator.rs
@@ -1,21 +1,10 @@
 use crate::newtypes::{CommentId, CommunityId, PersonId, PostId};
 #[cfg(feature = "full")]
 use crate::schema::{
-  admin_purge_comment,
-  admin_purge_community,
-  admin_purge_person,
-  admin_purge_post,
-  mod_add,
-  mod_add_community,
-  mod_ban,
-  mod_ban_from_community,
-  mod_feature_post,
-  mod_hide_community,
-  mod_lock_post,
-  mod_remove_comment,
-  mod_remove_community,
-  mod_remove_post,
-  mod_transfer_community,
+    admin_purge_comment, admin_purge_community, admin_purge_person, admin_purge_post, mod_add,
+    mod_add_community, mod_ban, mod_ban_from_community, mod_feature_post, mod_hide_community,
+    mod_lock_post, mod_remove_comment, mod_remove_community, mod_remove_post,
+    mod_transfer_community,
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -30,21 +19,21 @@ use ts_rs::TS;
 #[cfg_attr(feature = "full", ts(export))]
 /// When a moderator removes a post.
 pub struct ModRemovePost {
-  pub id: i32,
-  pub mod_person_id: PersonId,
-  pub post_id: PostId,
-  pub reason: Option<String>,
-  pub removed: bool,
-  pub when_: DateTime<Utc>,
+    pub id: i32,
+    pub mod_person_id: PersonId,
+    pub post_id: PostId,
+    pub reason: Option<String>,
+    pub removed: bool,
+    pub when_: DateTime<Utc>,
 }
 
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = mod_remove_post))]
 pub struct ModRemovePostForm {
-  pub mod_person_id: PersonId,
-  pub post_id: PostId,
-  pub reason: Option<String>,
-  pub removed: Option<bool>,
+    pub mod_person_id: PersonId,
+    pub post_id: PostId,
+    pub reason: Option<String>,
+    pub removed: Option<bool>,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
@@ -53,19 +42,19 @@ pub struct ModRemovePostForm {
 #[cfg_attr(feature = "full", ts(export))]
 /// When a moderator locks a post (prevents new comments being made).
 pub struct ModLockPost {
-  pub id: i32,
-  pub mod_person_id: PersonId,
-  pub post_id: PostId,
-  pub locked: bool,
-  pub when_: DateTime<Utc>,
+    pub id: i32,
+    pub mod_person_id: PersonId,
+    pub post_id: PostId,
+    pub locked: bool,
+    pub when_: DateTime<Utc>,
 }
 
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = mod_lock_post))]
 pub struct ModLockPostForm {
-  pub mod_person_id: PersonId,
-  pub post_id: PostId,
-  pub locked: Option<bool>,
+    pub mod_person_id: PersonId,
+    pub post_id: PostId,
+    pub locked: Option<bool>,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
@@ -74,21 +63,21 @@ pub struct ModLockPostForm {
 #[cfg_attr(feature = "full", ts(export))]
 /// When a moderator features a post on a community (pins it to the top).
 pub struct ModFeaturePost {
-  pub id: i32,
-  pub mod_person_id: PersonId,
-  pub post_id: PostId,
-  pub featured: bool,
-  pub when_: DateTime<Utc>,
-  pub is_featured_community: bool,
+    pub id: i32,
+    pub mod_person_id: PersonId,
+    pub post_id: PostId,
+    pub featured: bool,
+    pub when_: DateTime<Utc>,
+    pub is_featured_community: bool,
 }
 
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = mod_feature_post))]
 pub struct ModFeaturePostForm {
-  pub mod_person_id: PersonId,
-  pub post_id: PostId,
-  pub featured: bool,
-  pub is_featured_community: bool,
+    pub mod_person_id: PersonId,
+    pub post_id: PostId,
+    pub featured: bool,
+    pub is_featured_community: bool,
 }
 
 #[skip_serializing_none]
@@ -98,21 +87,21 @@ pub struct ModFeaturePostForm {
 #[cfg_attr(feature = "full", ts(export))]
 /// When a moderator removes a comment.
 pub struct ModRemoveComment {
-  pub id: i32,
-  pub mod_person_id: PersonId,
-  pub comment_id: CommentId,
-  pub reason: Option<String>,
-  pub removed: bool,
-  pub when_: DateTime<Utc>,
+    pub id: i32,
+    pub mod_person_id: PersonId,
+    pub comment_id: CommentId,
+    pub reason: Option<String>,
+    pub removed: bool,
+    pub when_: DateTime<Utc>,
 }
 
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = mod_remove_comment))]
 pub struct ModRemoveCommentForm {
-  pub mod_person_id: PersonId,
-  pub comment_id: CommentId,
-  pub reason: Option<String>,
-  pub removed: Option<bool>,
+    pub mod_person_id: PersonId,
+    pub comment_id: CommentId,
+    pub reason: Option<String>,
+    pub removed: Option<bool>,
 }
 
 #[skip_serializing_none]
@@ -122,23 +111,23 @@ pub struct ModRemoveCommentForm {
 #[cfg_attr(feature = "full", ts(export))]
 /// When a moderator removes a community.
 pub struct ModRemoveCommunity {
-  pub id: i32,
-  pub mod_person_id: PersonId,
-  pub community_id: CommunityId,
-  pub reason: Option<String>,
-  pub removed: bool,
-  pub expires: Option<DateTime<Utc>>,
-  pub when_: DateTime<Utc>,
+    pub id: i32,
+    pub mod_person_id: PersonId,
+    pub community_id: CommunityId,
+    pub reason: Option<String>,
+    pub removed: bool,
+    pub expires: Option<DateTime<Utc>>,
+    pub when_: DateTime<Utc>,
 }
 
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = mod_remove_community))]
 pub struct ModRemoveCommunityForm {
-  pub mod_person_id: PersonId,
-  pub community_id: CommunityId,
-  pub reason: Option<String>,
-  pub removed: Option<bool>,
-  pub expires: Option<DateTime<Utc>>,
+    pub mod_person_id: PersonId,
+    pub community_id: CommunityId,
+    pub reason: Option<String>,
+    pub removed: Option<bool>,
+    pub expires: Option<DateTime<Utc>>,
 }
 
 #[skip_serializing_none]
@@ -148,25 +137,25 @@ pub struct ModRemoveCommunityForm {
 #[cfg_attr(feature = "full", ts(export))]
 /// When someone is banned from a community.
 pub struct ModBanFromCommunity {
-  pub id: i32,
-  pub mod_person_id: PersonId,
-  pub other_person_id: PersonId,
-  pub community_id: CommunityId,
-  pub reason: Option<String>,
-  pub banned: bool,
-  pub expires: Option<DateTime<Utc>>,
-  pub when_: DateTime<Utc>,
+    pub id: i32,
+    pub mod_person_id: PersonId,
+    pub other_person_id: PersonId,
+    pub community_id: CommunityId,
+    pub reason: Option<String>,
+    pub banned: bool,
+    pub expires: Option<DateTime<Utc>>,
+    pub when_: DateTime<Utc>,
 }
 
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = mod_ban_from_community))]
 pub struct ModBanFromCommunityForm {
-  pub mod_person_id: PersonId,
-  pub other_person_id: PersonId,
-  pub community_id: CommunityId,
-  pub reason: Option<String>,
-  pub banned: Option<bool>,
-  pub expires: Option<DateTime<Utc>>,
+    pub mod_person_id: PersonId,
+    pub other_person_id: PersonId,
+    pub community_id: CommunityId,
+    pub reason: Option<String>,
+    pub banned: Option<bool>,
+    pub expires: Option<DateTime<Utc>>,
 }
 
 #[skip_serializing_none]
@@ -176,22 +165,22 @@ pub struct ModBanFromCommunityForm {
 #[cfg_attr(feature = "full", ts(export))]
 /// When someone is banned from the site.
 pub struct ModBan {
-  pub id: i32,
-  pub mod_person_id: PersonId,
-  pub other_person_id: PersonId,
-  pub reason: Option<String>,
-  pub banned: bool,
-  pub expires: Option<DateTime<Utc>>,
-  pub when_: DateTime<Utc>,
+    pub id: i32,
+    pub mod_person_id: PersonId,
+    pub other_person_id: PersonId,
+    pub reason: Option<String>,
+    pub banned: bool,
+    pub expires: Option<DateTime<Utc>>,
+    pub when_: DateTime<Utc>,
 }
 
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = mod_hide_community))]
 pub struct ModHideCommunityForm {
-  pub community_id: CommunityId,
-  pub mod_person_id: PersonId,
-  pub hidden: Option<bool>,
-  pub reason: Option<String>,
+    pub community_id: CommunityId,
+    pub mod_person_id: PersonId,
+    pub hidden: Option<bool>,
+    pub reason: Option<String>,
 }
 
 #[skip_serializing_none]
@@ -201,22 +190,22 @@ pub struct ModHideCommunityForm {
 #[cfg_attr(feature = "full", ts(export))]
 /// When a community is hidden from public view.
 pub struct ModHideCommunity {
-  pub id: i32,
-  pub community_id: CommunityId,
-  pub mod_person_id: PersonId,
-  pub when_: DateTime<Utc>,
-  pub reason: Option<String>,
-  pub hidden: bool,
+    pub id: i32,
+    pub community_id: CommunityId,
+    pub mod_person_id: PersonId,
+    pub when_: DateTime<Utc>,
+    pub reason: Option<String>,
+    pub hidden: bool,
 }
 
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = mod_ban))]
 pub struct ModBanForm {
-  pub mod_person_id: PersonId,
-  pub other_person_id: PersonId,
-  pub reason: Option<String>,
-  pub banned: Option<bool>,
-  pub expires: Option<DateTime<Utc>>,
+    pub mod_person_id: PersonId,
+    pub other_person_id: PersonId,
+    pub reason: Option<String>,
+    pub banned: Option<bool>,
+    pub expires: Option<DateTime<Utc>>,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
@@ -225,21 +214,21 @@ pub struct ModBanForm {
 #[cfg_attr(feature = "full", ts(export))]
 /// When someone is added as a community moderator.
 pub struct ModAddCommunity {
-  pub id: i32,
-  pub mod_person_id: PersonId,
-  pub other_person_id: PersonId,
-  pub community_id: CommunityId,
-  pub removed: bool,
-  pub when_: DateTime<Utc>,
+    pub id: i32,
+    pub mod_person_id: PersonId,
+    pub other_person_id: PersonId,
+    pub community_id: CommunityId,
+    pub removed: bool,
+    pub when_: DateTime<Utc>,
 }
 
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = mod_add_community))]
 pub struct ModAddCommunityForm {
-  pub mod_person_id: PersonId,
-  pub other_person_id: PersonId,
-  pub community_id: CommunityId,
-  pub removed: Option<bool>,
+    pub mod_person_id: PersonId,
+    pub other_person_id: PersonId,
+    pub community_id: CommunityId,
+    pub removed: Option<bool>,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
@@ -248,19 +237,19 @@ pub struct ModAddCommunityForm {
 #[cfg_attr(feature = "full", ts(export))]
 /// When a moderator transfers a community to a new owner.
 pub struct ModTransferCommunity {
-  pub id: i32,
-  pub mod_person_id: PersonId,
-  pub other_person_id: PersonId,
-  pub community_id: CommunityId,
-  pub when_: DateTime<Utc>,
+    pub id: i32,
+    pub mod_person_id: PersonId,
+    pub other_person_id: PersonId,
+    pub community_id: CommunityId,
+    pub when_: DateTime<Utc>,
 }
 
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = mod_transfer_community))]
 pub struct ModTransferCommunityForm {
-  pub mod_person_id: PersonId,
-  pub other_person_id: PersonId,
-  pub community_id: CommunityId,
+    pub mod_person_id: PersonId,
+    pub other_person_id: PersonId,
+    pub community_id: CommunityId,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
@@ -269,19 +258,19 @@ pub struct ModTransferCommunityForm {
 #[cfg_attr(feature = "full", ts(export))]
 /// When someone is added as a site moderator.
 pub struct ModAdd {
-  pub id: i32,
-  pub mod_person_id: PersonId,
-  pub other_person_id: PersonId,
-  pub removed: bool,
-  pub when_: DateTime<Utc>,
+    pub id: i32,
+    pub mod_person_id: PersonId,
+    pub other_person_id: PersonId,
+    pub removed: bool,
+    pub when_: DateTime<Utc>,
 }
 
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = mod_add))]
 pub struct ModAddForm {
-  pub mod_person_id: PersonId,
-  pub other_person_id: PersonId,
-  pub removed: Option<bool>,
+    pub mod_person_id: PersonId,
+    pub other_person_id: PersonId,
+    pub removed: Option<bool>,
 }
 
 #[skip_serializing_none]
@@ -291,17 +280,17 @@ pub struct ModAddForm {
 #[cfg_attr(feature = "full", ts(export))]
 /// When an admin purges a person.
 pub struct AdminPurgePerson {
-  pub id: i32,
-  pub admin_person_id: PersonId,
-  pub reason: Option<String>,
-  pub when_: DateTime<Utc>,
+    pub id: i32,
+    pub admin_person_id: PersonId,
+    pub reason: Option<String>,
+    pub when_: DateTime<Utc>,
 }
 
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = admin_purge_person))]
 pub struct AdminPurgePersonForm {
-  pub admin_person_id: PersonId,
-  pub reason: Option<String>,
+    pub admin_person_id: PersonId,
+    pub reason: Option<String>,
 }
 
 #[skip_serializing_none]
@@ -311,17 +300,17 @@ pub struct AdminPurgePersonForm {
 #[cfg_attr(feature = "full", ts(export))]
 /// When an admin purges a community.
 pub struct AdminPurgeCommunity {
-  pub id: i32,
-  pub admin_person_id: PersonId,
-  pub reason: Option<String>,
-  pub when_: DateTime<Utc>,
+    pub id: i32,
+    pub admin_person_id: PersonId,
+    pub reason: Option<String>,
+    pub when_: DateTime<Utc>,
 }
 
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = admin_purge_community))]
 pub struct AdminPurgeCommunityForm {
-  pub admin_person_id: PersonId,
-  pub reason: Option<String>,
+    pub admin_person_id: PersonId,
+    pub reason: Option<String>,
 }
 
 #[skip_serializing_none]
@@ -331,19 +320,19 @@ pub struct AdminPurgeCommunityForm {
 #[cfg_attr(feature = "full", ts(export))]
 /// When an admin purges a post.
 pub struct AdminPurgePost {
-  pub id: i32,
-  pub admin_person_id: PersonId,
-  pub community_id: CommunityId,
-  pub reason: Option<String>,
-  pub when_: DateTime<Utc>,
+    pub id: i32,
+    pub admin_person_id: PersonId,
+    pub community_id: CommunityId,
+    pub reason: Option<String>,
+    pub when_: DateTime<Utc>,
 }
 
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = admin_purge_post))]
 pub struct AdminPurgePostForm {
-  pub admin_person_id: PersonId,
-  pub community_id: CommunityId,
-  pub reason: Option<String>,
+    pub admin_person_id: PersonId,
+    pub community_id: CommunityId,
+    pub reason: Option<String>,
 }
 
 #[skip_serializing_none]
@@ -353,17 +342,17 @@ pub struct AdminPurgePostForm {
 #[cfg_attr(feature = "full", ts(export))]
 /// When an admin purges a comment.
 pub struct AdminPurgeComment {
-  pub id: i32,
-  pub admin_person_id: PersonId,
-  pub post_id: PostId,
-  pub reason: Option<String>,
-  pub when_: DateTime<Utc>,
+    pub id: i32,
+    pub admin_person_id: PersonId,
+    pub post_id: PostId,
+    pub reason: Option<String>,
+    pub when_: DateTime<Utc>,
 }
 
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = admin_purge_comment))]
 pub struct AdminPurgeCommentForm {
-  pub admin_person_id: PersonId,
-  pub post_id: PostId,
-  pub reason: Option<String>,
+    pub admin_person_id: PersonId,
+    pub post_id: PostId,
+    pub reason: Option<String>,
 }

--- a/crates/db_schema/src/source/password_reset_request.rs
+++ b/crates/db_schema/src/source/password_reset_request.rs
@@ -7,15 +7,15 @@ use chrono::{DateTime, Utc};
 #[cfg_attr(feature = "full", derive(Queryable, Identifiable))]
 #[cfg_attr(feature = "full", diesel(table_name = password_reset_request))]
 pub struct PasswordResetRequest {
-  pub id: i32,
-  pub token: String,
-  pub published: DateTime<Utc>,
-  pub local_user_id: LocalUserId,
+    pub id: i32,
+    pub token: String,
+    pub published: DateTime<Utc>,
+    pub local_user_id: LocalUserId,
 }
 
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = password_reset_request))]
 pub struct PasswordResetRequestForm {
-  pub local_user_id: LocalUserId,
-  pub token: String,
+    pub local_user_id: LocalUserId,
+    pub token: String,
 }

--- a/crates/db_schema/src/source/person.rs
+++ b/crates/db_schema/src/source/person.rs
@@ -1,8 +1,8 @@
 #[cfg(feature = "full")]
 use crate::schema::{person, person_follower};
 use crate::{
-  newtypes::{DbUrl, InstanceId, PersonId},
-  source::placeholder_apub_url,
+    newtypes::{DbUrl, InstanceId, PersonId},
+    source::placeholder_apub_url,
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -18,43 +18,43 @@ use typed_builder::TypedBuilder;
 #[cfg_attr(feature = "full", ts(export))]
 /// A person.
 pub struct Person {
-  pub id: PersonId,
-  pub name: String,
-  /// A shorter display name.
-  pub display_name: Option<String>,
-  /// A URL for an avatar.
-  pub avatar: Option<DbUrl>,
-  /// Whether the person is banned.
-  pub banned: bool,
-  pub published: DateTime<Utc>,
-  pub updated: Option<DateTime<Utc>>,
-  /// The federated actor_id.
-  pub actor_id: DbUrl,
-  /// An optional bio, in markdown.
-  pub bio: Option<String>,
-  /// Whether the person is local to our site.
-  pub local: bool,
-  #[serde(skip)]
-  pub private_key: Option<String>,
-  #[serde(skip)]
-  pub public_key: String,
-  #[serde(skip)]
-  pub last_refreshed_at: DateTime<Utc>,
-  /// A URL for a banner.
-  pub banner: Option<DbUrl>,
-  /// Whether the person is deleted.
-  pub deleted: bool,
-  #[serde(skip, default = "placeholder_apub_url")]
-  pub inbox_url: DbUrl,
-  #[serde(skip)]
-  pub shared_inbox_url: Option<DbUrl>,
-  /// A matrix id, usually given an @person:matrix.org
-  pub matrix_user_id: Option<String>,
-  /// Whether the person is a bot account.
-  pub bot_account: bool,
-  /// When their ban, if it exists, expires, if at all.
-  pub ban_expires: Option<DateTime<Utc>>,
-  pub instance_id: InstanceId,
+    pub id: PersonId,
+    pub name: String,
+    /// A shorter display name.
+    pub display_name: Option<String>,
+    /// A URL for an avatar.
+    pub avatar: Option<DbUrl>,
+    /// Whether the person is banned.
+    pub banned: bool,
+    pub published: DateTime<Utc>,
+    pub updated: Option<DateTime<Utc>>,
+    /// The federated actor_id.
+    pub actor_id: DbUrl,
+    /// An optional bio, in markdown.
+    pub bio: Option<String>,
+    /// Whether the person is local to our site.
+    pub local: bool,
+    #[serde(skip)]
+    pub private_key: Option<String>,
+    #[serde(skip)]
+    pub public_key: String,
+    #[serde(skip)]
+    pub last_refreshed_at: DateTime<Utc>,
+    /// A URL for a banner.
+    pub banner: Option<DbUrl>,
+    /// Whether the person is deleted.
+    pub deleted: bool,
+    #[serde(skip, default = "placeholder_apub_url")]
+    pub inbox_url: DbUrl,
+    #[serde(skip)]
+    pub shared_inbox_url: Option<DbUrl>,
+    /// A matrix id, usually given an @person:matrix.org
+    pub matrix_user_id: Option<String>,
+    /// Whether the person is a bot account.
+    pub bot_account: bool,
+    /// When their ban, if it exists, expires, if at all.
+    pub ban_expires: Option<DateTime<Utc>>,
+    pub instance_id: InstanceId,
 }
 
 #[derive(Clone, TypedBuilder)]
@@ -62,52 +62,52 @@ pub struct Person {
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = person))]
 pub struct PersonInsertForm {
-  #[builder(!default)]
-  pub name: String,
-  #[builder(!default)]
-  pub public_key: String,
-  #[builder(!default)]
-  pub instance_id: InstanceId,
-  pub display_name: Option<String>,
-  pub avatar: Option<DbUrl>,
-  pub banned: Option<bool>,
-  pub published: Option<DateTime<Utc>>,
-  pub updated: Option<DateTime<Utc>>,
-  pub actor_id: Option<DbUrl>,
-  pub bio: Option<String>,
-  pub local: Option<bool>,
-  pub private_key: Option<String>,
-  pub last_refreshed_at: Option<DateTime<Utc>>,
-  pub banner: Option<DbUrl>,
-  pub deleted: Option<bool>,
-  pub inbox_url: Option<DbUrl>,
-  pub shared_inbox_url: Option<DbUrl>,
-  pub matrix_user_id: Option<String>,
-  pub bot_account: Option<bool>,
-  pub ban_expires: Option<DateTime<Utc>>,
+    #[builder(!default)]
+    pub name: String,
+    #[builder(!default)]
+    pub public_key: String,
+    #[builder(!default)]
+    pub instance_id: InstanceId,
+    pub display_name: Option<String>,
+    pub avatar: Option<DbUrl>,
+    pub banned: Option<bool>,
+    pub published: Option<DateTime<Utc>>,
+    pub updated: Option<DateTime<Utc>>,
+    pub actor_id: Option<DbUrl>,
+    pub bio: Option<String>,
+    pub local: Option<bool>,
+    pub private_key: Option<String>,
+    pub last_refreshed_at: Option<DateTime<Utc>>,
+    pub banner: Option<DbUrl>,
+    pub deleted: Option<bool>,
+    pub inbox_url: Option<DbUrl>,
+    pub shared_inbox_url: Option<DbUrl>,
+    pub matrix_user_id: Option<String>,
+    pub bot_account: Option<bool>,
+    pub ban_expires: Option<DateTime<Utc>>,
 }
 
 #[derive(Clone, Default)]
 #[cfg_attr(feature = "full", derive(AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = person))]
 pub struct PersonUpdateForm {
-  pub display_name: Option<Option<String>>,
-  pub avatar: Option<Option<DbUrl>>,
-  pub banned: Option<bool>,
-  pub updated: Option<Option<DateTime<Utc>>>,
-  pub actor_id: Option<DbUrl>,
-  pub bio: Option<Option<String>>,
-  pub local: Option<bool>,
-  pub public_key: Option<String>,
-  pub private_key: Option<Option<String>>,
-  pub last_refreshed_at: Option<DateTime<Utc>>,
-  pub banner: Option<Option<DbUrl>>,
-  pub deleted: Option<bool>,
-  pub inbox_url: Option<DbUrl>,
-  pub shared_inbox_url: Option<Option<DbUrl>>,
-  pub matrix_user_id: Option<Option<String>>,
-  pub bot_account: Option<bool>,
-  pub ban_expires: Option<Option<DateTime<Utc>>>,
+    pub display_name: Option<Option<String>>,
+    pub avatar: Option<Option<DbUrl>>,
+    pub banned: Option<bool>,
+    pub updated: Option<Option<DateTime<Utc>>>,
+    pub actor_id: Option<DbUrl>,
+    pub bio: Option<Option<String>>,
+    pub local: Option<bool>,
+    pub public_key: Option<String>,
+    pub private_key: Option<Option<String>>,
+    pub last_refreshed_at: Option<DateTime<Utc>>,
+    pub banner: Option<Option<DbUrl>>,
+    pub deleted: Option<bool>,
+    pub inbox_url: Option<DbUrl>,
+    pub shared_inbox_url: Option<Option<DbUrl>>,
+    pub matrix_user_id: Option<Option<String>>,
+    pub bot_account: Option<bool>,
+    pub ban_expires: Option<Option<DateTime<Utc>>>,
 }
 
 #[derive(PartialEq, Eq, Debug)]
@@ -115,18 +115,18 @@ pub struct PersonUpdateForm {
 #[cfg_attr(feature = "full", diesel(belongs_to(crate::source::person::Person)))]
 #[cfg_attr(feature = "full", diesel(table_name = person_follower))]
 pub struct PersonFollower {
-  pub id: i32,
-  pub person_id: PersonId,
-  pub follower_id: PersonId,
-  pub published: DateTime<Utc>,
-  pub pending: bool,
+    pub id: i32,
+    pub person_id: PersonId,
+    pub follower_id: PersonId,
+    pub published: DateTime<Utc>,
+    pub pending: bool,
 }
 
 #[derive(Clone)]
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = person_follower))]
 pub struct PersonFollowerForm {
-  pub person_id: PersonId,
-  pub follower_id: PersonId,
-  pub pending: bool,
+    pub person_id: PersonId,
+    pub follower_id: PersonId,
+    pub pending: bool,
 }

--- a/crates/db_schema/src/source/person_block.rs
+++ b/crates/db_schema/src/source/person_block.rs
@@ -9,15 +9,15 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "full", diesel(belongs_to(crate::source::person::Person)))]
 #[cfg_attr(feature = "full", diesel(table_name = person_block))]
 pub struct PersonBlock {
-  pub id: PersonBlockId,
-  pub person_id: PersonId,
-  pub target_id: PersonId,
-  pub published: DateTime<Utc>,
+    pub id: PersonBlockId,
+    pub person_id: PersonId,
+    pub target_id: PersonId,
+    pub published: DateTime<Utc>,
 }
 
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = person_block))]
 pub struct PersonBlockForm {
-  pub person_id: PersonId,
-  pub target_id: PersonId,
+    pub person_id: PersonId,
+    pub target_id: PersonId,
 }

--- a/crates/db_schema/src/source/person_mention.rs
+++ b/crates/db_schema/src/source/person_mention.rs
@@ -13,23 +13,23 @@ use ts_rs::TS;
 #[cfg_attr(feature = "full", ts(export))]
 /// A person mention.
 pub struct PersonMention {
-  pub id: PersonMentionId,
-  pub recipient_id: PersonId,
-  pub comment_id: CommentId,
-  pub read: bool,
-  pub published: DateTime<Utc>,
+    pub id: PersonMentionId,
+    pub recipient_id: PersonId,
+    pub comment_id: CommentId,
+    pub read: bool,
+    pub published: DateTime<Utc>,
 }
 
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = person_mention))]
 pub struct PersonMentionInsertForm {
-  pub recipient_id: PersonId,
-  pub comment_id: CommentId,
-  pub read: Option<bool>,
+    pub recipient_id: PersonId,
+    pub comment_id: CommentId,
+    pub read: Option<bool>,
 }
 
 #[cfg_attr(feature = "full", derive(AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = person_mention))]
 pub struct PersonMentionUpdateForm {
-  pub read: Option<bool>,
+    pub read: Option<bool>,
 }

--- a/crates/db_schema/src/source/post.rs
+++ b/crates/db_schema/src/source/post.rs
@@ -15,45 +15,45 @@ use typed_builder::TypedBuilder;
 #[cfg_attr(feature = "full", ts(export))]
 /// A post.
 pub struct Post {
-  pub id: PostId,
-  pub name: String,
-  #[cfg_attr(feature = "full", ts(type = "string"))]
-  /// An optional link / url for the post.
-  pub url: Option<DbUrl>,
-  /// An optional post body, in markdown.
-  pub body: Option<String>,
-  pub creator_id: PersonId,
-  pub community_id: CommunityId,
-  /// Whether the post is removed.
-  pub removed: bool,
-  /// Whether the post is locked.
-  pub locked: bool,
-  pub published: DateTime<Utc>,
-  pub updated: Option<DateTime<Utc>>,
-  /// Whether the post is deleted.
-  pub deleted: bool,
-  /// Whether the post is NSFW.
-  pub nsfw: bool,
-  /// A title for the link.
-  pub embed_title: Option<String>,
-  /// A description for the link.
-  pub embed_description: Option<String>,
-  #[cfg_attr(feature = "full", ts(type = "string"))]
-  /// A thumbnail picture url.
-  pub thumbnail_url: Option<DbUrl>,
-  #[cfg_attr(feature = "full", ts(type = "string"))]
-  /// The federated activity id / ap_id.
-  pub ap_id: DbUrl,
-  /// Whether the post is local.
-  pub local: bool,
-  #[cfg_attr(feature = "full", ts(type = "string"))]
-  /// A video url for the link.
-  pub embed_video_url: Option<DbUrl>,
-  pub language_id: LanguageId,
-  /// Whether the post is featured to its community.
-  pub featured_community: bool,
-  /// Whether the post is featured to its site.
-  pub featured_local: bool,
+    pub id: PostId,
+    pub name: String,
+    #[cfg_attr(feature = "full", ts(type = "string"))]
+    /// An optional link / url for the post.
+    pub url: Option<DbUrl>,
+    /// An optional post body, in markdown.
+    pub body: Option<String>,
+    pub creator_id: PersonId,
+    pub community_id: CommunityId,
+    /// Whether the post is removed.
+    pub removed: bool,
+    /// Whether the post is locked.
+    pub locked: bool,
+    pub published: DateTime<Utc>,
+    pub updated: Option<DateTime<Utc>>,
+    /// Whether the post is deleted.
+    pub deleted: bool,
+    /// Whether the post is NSFW.
+    pub nsfw: bool,
+    /// A title for the link.
+    pub embed_title: Option<String>,
+    /// A description for the link.
+    pub embed_description: Option<String>,
+    #[cfg_attr(feature = "full", ts(type = "string"))]
+    /// A thumbnail picture url.
+    pub thumbnail_url: Option<DbUrl>,
+    #[cfg_attr(feature = "full", ts(type = "string"))]
+    /// The federated activity id / ap_id.
+    pub ap_id: DbUrl,
+    /// Whether the post is local.
+    pub local: bool,
+    #[cfg_attr(feature = "full", ts(type = "string"))]
+    /// A video url for the link.
+    pub embed_video_url: Option<DbUrl>,
+    pub language_id: LanguageId,
+    /// Whether the post is featured to its community.
+    pub featured_community: bool,
+    /// Whether the post is featured to its site.
+    pub featured_local: bool,
 }
 
 #[derive(Debug, Clone, TypedBuilder)]
@@ -61,53 +61,53 @@ pub struct Post {
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = post))]
 pub struct PostInsertForm {
-  #[builder(!default)]
-  pub name: String,
-  #[builder(!default)]
-  pub creator_id: PersonId,
-  #[builder(!default)]
-  pub community_id: CommunityId,
-  pub nsfw: Option<bool>,
-  pub url: Option<DbUrl>,
-  pub body: Option<String>,
-  pub removed: Option<bool>,
-  pub locked: Option<bool>,
-  pub updated: Option<DateTime<Utc>>,
-  pub published: Option<DateTime<Utc>>,
-  pub deleted: Option<bool>,
-  pub embed_title: Option<String>,
-  pub embed_description: Option<String>,
-  pub embed_video_url: Option<DbUrl>,
-  pub thumbnail_url: Option<DbUrl>,
-  pub ap_id: Option<DbUrl>,
-  pub local: Option<bool>,
-  pub language_id: Option<LanguageId>,
-  pub featured_community: Option<bool>,
-  pub featured_local: Option<bool>,
+    #[builder(!default)]
+    pub name: String,
+    #[builder(!default)]
+    pub creator_id: PersonId,
+    #[builder(!default)]
+    pub community_id: CommunityId,
+    pub nsfw: Option<bool>,
+    pub url: Option<DbUrl>,
+    pub body: Option<String>,
+    pub removed: Option<bool>,
+    pub locked: Option<bool>,
+    pub updated: Option<DateTime<Utc>>,
+    pub published: Option<DateTime<Utc>>,
+    pub deleted: Option<bool>,
+    pub embed_title: Option<String>,
+    pub embed_description: Option<String>,
+    pub embed_video_url: Option<DbUrl>,
+    pub thumbnail_url: Option<DbUrl>,
+    pub ap_id: Option<DbUrl>,
+    pub local: Option<bool>,
+    pub language_id: Option<LanguageId>,
+    pub featured_community: Option<bool>,
+    pub featured_local: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "full", derive(AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = post))]
 pub struct PostUpdateForm {
-  pub name: Option<String>,
-  pub nsfw: Option<bool>,
-  pub url: Option<Option<DbUrl>>,
-  pub body: Option<Option<String>>,
-  pub removed: Option<bool>,
-  pub locked: Option<bool>,
-  pub published: Option<DateTime<Utc>>,
-  pub updated: Option<Option<DateTime<Utc>>>,
-  pub deleted: Option<bool>,
-  pub embed_title: Option<Option<String>>,
-  pub embed_description: Option<Option<String>>,
-  pub embed_video_url: Option<Option<DbUrl>>,
-  pub thumbnail_url: Option<Option<DbUrl>>,
-  pub ap_id: Option<DbUrl>,
-  pub local: Option<bool>,
-  pub language_id: Option<LanguageId>,
-  pub featured_community: Option<bool>,
-  pub featured_local: Option<bool>,
+    pub name: Option<String>,
+    pub nsfw: Option<bool>,
+    pub url: Option<Option<DbUrl>>,
+    pub body: Option<Option<String>>,
+    pub removed: Option<bool>,
+    pub locked: Option<bool>,
+    pub published: Option<DateTime<Utc>>,
+    pub updated: Option<Option<DateTime<Utc>>>,
+    pub deleted: Option<bool>,
+    pub embed_title: Option<Option<String>>,
+    pub embed_description: Option<Option<String>>,
+    pub embed_video_url: Option<Option<DbUrl>>,
+    pub thumbnail_url: Option<Option<DbUrl>>,
+    pub ap_id: Option<DbUrl>,
+    pub local: Option<bool>,
+    pub language_id: Option<LanguageId>,
+    pub featured_community: Option<bool>,
+    pub featured_local: Option<bool>,
 }
 
 #[derive(PartialEq, Eq, Debug)]
@@ -115,20 +115,20 @@ pub struct PostUpdateForm {
 #[cfg_attr(feature = "full", diesel(belongs_to(crate::source::post::Post)))]
 #[cfg_attr(feature = "full", diesel(table_name = post_like))]
 pub struct PostLike {
-  pub id: i32,
-  pub post_id: PostId,
-  pub person_id: PersonId,
-  pub score: i16,
-  pub published: DateTime<Utc>,
+    pub id: i32,
+    pub post_id: PostId,
+    pub person_id: PersonId,
+    pub score: i16,
+    pub published: DateTime<Utc>,
 }
 
 #[derive(Clone)]
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = post_like))]
 pub struct PostLikeForm {
-  pub post_id: PostId,
-  pub person_id: PersonId,
-  pub score: i16,
+    pub post_id: PostId,
+    pub person_id: PersonId,
+    pub score: i16,
 }
 
 #[derive(PartialEq, Eq, Debug)]
@@ -136,17 +136,17 @@ pub struct PostLikeForm {
 #[cfg_attr(feature = "full", diesel(belongs_to(crate::source::post::Post)))]
 #[cfg_attr(feature = "full", diesel(table_name = post_saved))]
 pub struct PostSaved {
-  pub id: i32,
-  pub post_id: PostId,
-  pub person_id: PersonId,
-  pub published: DateTime<Utc>,
+    pub id: i32,
+    pub post_id: PostId,
+    pub person_id: PersonId,
+    pub published: DateTime<Utc>,
 }
 
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = post_saved))]
 pub struct PostSavedForm {
-  pub post_id: PostId,
-  pub person_id: PersonId,
+    pub post_id: PostId,
+    pub person_id: PersonId,
 }
 
 #[derive(PartialEq, Eq, Debug)]
@@ -154,15 +154,15 @@ pub struct PostSavedForm {
 #[cfg_attr(feature = "full", diesel(belongs_to(crate::source::post::Post)))]
 #[cfg_attr(feature = "full", diesel(table_name = post_read))]
 pub struct PostRead {
-  pub id: i32,
-  pub post_id: PostId,
-  pub person_id: PersonId,
-  pub published: DateTime<Utc>,
+    pub id: i32,
+    pub post_id: PostId,
+    pub person_id: PersonId,
+    pub published: DateTime<Utc>,
 }
 
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = post_read))]
 pub struct PostReadForm {
-  pub post_id: PostId,
-  pub person_id: PersonId,
+    pub post_id: PostId,
+    pub person_id: PersonId,
 }

--- a/crates/db_schema/src/source/post_report.rs
+++ b/crates/db_schema/src/source/post_report.rs
@@ -15,30 +15,30 @@ use ts_rs::TS;
 #[cfg_attr(feature = "full", ts(export))]
 /// A post report.
 pub struct PostReport {
-  pub id: PostReportId,
-  pub creator_id: PersonId,
-  pub post_id: PostId,
-  /// The original post title.
-  pub original_post_name: String,
-  /// The original post url.
-  pub original_post_url: Option<DbUrl>,
-  /// The original post body.
-  pub original_post_body: Option<String>,
-  pub reason: String,
-  pub resolved: bool,
-  pub resolver_id: Option<PersonId>,
-  pub published: DateTime<Utc>,
-  pub updated: Option<DateTime<Utc>>,
+    pub id: PostReportId,
+    pub creator_id: PersonId,
+    pub post_id: PostId,
+    /// The original post title.
+    pub original_post_name: String,
+    /// The original post url.
+    pub original_post_url: Option<DbUrl>,
+    /// The original post body.
+    pub original_post_body: Option<String>,
+    pub reason: String,
+    pub resolved: bool,
+    pub resolver_id: Option<PersonId>,
+    pub published: DateTime<Utc>,
+    pub updated: Option<DateTime<Utc>>,
 }
 
 #[derive(Clone, Default)]
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = post_report))]
 pub struct PostReportForm {
-  pub creator_id: PersonId,
-  pub post_id: PostId,
-  pub original_post_name: String,
-  pub original_post_url: Option<DbUrl>,
-  pub original_post_body: Option<String>,
-  pub reason: String,
+    pub creator_id: PersonId,
+    pub post_id: PostId,
+    pub original_post_name: String,
+    pub original_post_url: Option<DbUrl>,
+    pub original_post_body: Option<String>,
+    pub reason: String,
 }

--- a/crates/db_schema/src/source/private_message.rs
+++ b/crates/db_schema/src/source/private_message.rs
@@ -19,16 +19,16 @@ use typed_builder::TypedBuilder;
 #[cfg_attr(feature = "full", ts(export))]
 /// A private message.
 pub struct PrivateMessage {
-  pub id: PrivateMessageId,
-  pub creator_id: PersonId,
-  pub recipient_id: PersonId,
-  pub content: String,
-  pub deleted: bool,
-  pub read: bool,
-  pub published: DateTime<Utc>,
-  pub updated: Option<DateTime<Utc>>,
-  pub ap_id: DbUrl,
-  pub local: bool,
+    pub id: PrivateMessageId,
+    pub creator_id: PersonId,
+    pub recipient_id: PersonId,
+    pub content: String,
+    pub deleted: bool,
+    pub read: bool,
+    pub published: DateTime<Utc>,
+    pub updated: Option<DateTime<Utc>>,
+    pub ap_id: DbUrl,
+    pub local: bool,
 }
 
 #[derive(Clone, TypedBuilder)]
@@ -36,29 +36,29 @@ pub struct PrivateMessage {
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = private_message))]
 pub struct PrivateMessageInsertForm {
-  #[builder(!default)]
-  pub creator_id: PersonId,
-  #[builder(!default)]
-  pub recipient_id: PersonId,
-  #[builder(!default)]
-  pub content: String,
-  pub deleted: Option<bool>,
-  pub read: Option<bool>,
-  pub published: Option<DateTime<Utc>>,
-  pub updated: Option<DateTime<Utc>>,
-  pub ap_id: Option<DbUrl>,
-  pub local: Option<bool>,
+    #[builder(!default)]
+    pub creator_id: PersonId,
+    #[builder(!default)]
+    pub recipient_id: PersonId,
+    #[builder(!default)]
+    pub content: String,
+    pub deleted: Option<bool>,
+    pub read: Option<bool>,
+    pub published: Option<DateTime<Utc>>,
+    pub updated: Option<DateTime<Utc>>,
+    pub ap_id: Option<DbUrl>,
+    pub local: Option<bool>,
 }
 
 #[derive(Clone, Default)]
 #[cfg_attr(feature = "full", derive(AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = private_message))]
 pub struct PrivateMessageUpdateForm {
-  pub content: Option<String>,
-  pub deleted: Option<bool>,
-  pub read: Option<bool>,
-  pub published: Option<DateTime<Utc>>,
-  pub updated: Option<Option<DateTime<Utc>>>,
-  pub ap_id: Option<DbUrl>,
-  pub local: Option<bool>,
+    pub content: Option<String>,
+    pub deleted: Option<bool>,
+    pub read: Option<bool>,
+    pub published: Option<DateTime<Utc>>,
+    pub updated: Option<Option<DateTime<Utc>>>,
+    pub ap_id: Option<DbUrl>,
+    pub local: Option<bool>,
 }

--- a/crates/db_schema/src/source/private_message_report.rs
+++ b/crates/db_schema/src/source/private_message_report.rs
@@ -11,31 +11,31 @@ use ts_rs::TS;
 #[derive(PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
 #[cfg_attr(feature = "full", derive(Queryable, Associations, Identifiable, TS))]
 #[cfg_attr(
-  feature = "full",
-  diesel(belongs_to(crate::source::private_message::PrivateMessage))
+    feature = "full",
+    diesel(belongs_to(crate::source::private_message::PrivateMessage))
 )]
 #[cfg_attr(feature = "full", diesel(table_name = private_message_report))]
 #[cfg_attr(feature = "full", ts(export))]
 /// The private message report.
 pub struct PrivateMessageReport {
-  pub id: PrivateMessageReportId,
-  pub creator_id: PersonId,
-  pub private_message_id: PrivateMessageId,
-  /// The original text.
-  pub original_pm_text: String,
-  pub reason: String,
-  pub resolved: bool,
-  pub resolver_id: Option<PersonId>,
-  pub published: DateTime<Utc>,
-  pub updated: Option<DateTime<Utc>>,
+    pub id: PrivateMessageReportId,
+    pub creator_id: PersonId,
+    pub private_message_id: PrivateMessageId,
+    /// The original text.
+    pub original_pm_text: String,
+    pub reason: String,
+    pub resolved: bool,
+    pub resolver_id: Option<PersonId>,
+    pub published: DateTime<Utc>,
+    pub updated: Option<DateTime<Utc>>,
 }
 
 #[derive(Clone)]
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = private_message_report))]
 pub struct PrivateMessageReportForm {
-  pub creator_id: PersonId,
-  pub private_message_id: PrivateMessageId,
-  pub original_pm_text: String,
-  pub reason: String,
+    pub creator_id: PersonId,
+    pub private_message_id: PrivateMessageId,
+    pub original_pm_text: String,
+    pub reason: String,
 }

--- a/crates/db_schema/src/source/registration_application.rs
+++ b/crates/db_schema/src/source/registration_application.rs
@@ -14,24 +14,24 @@ use ts_rs::TS;
 #[cfg_attr(feature = "full", ts(export))]
 /// A registration application.
 pub struct RegistrationApplication {
-  pub id: i32,
-  pub local_user_id: LocalUserId,
-  pub answer: String,
-  pub admin_id: Option<PersonId>,
-  pub deny_reason: Option<String>,
-  pub published: DateTime<Utc>,
+    pub id: i32,
+    pub local_user_id: LocalUserId,
+    pub answer: String,
+    pub admin_id: Option<PersonId>,
+    pub deny_reason: Option<String>,
+    pub published: DateTime<Utc>,
 }
 
 #[cfg_attr(feature = "full", derive(Insertable))]
 #[cfg_attr(feature = "full", diesel(table_name = registration_application))]
 pub struct RegistrationApplicationInsertForm {
-  pub local_user_id: LocalUserId,
-  pub answer: String,
+    pub local_user_id: LocalUserId,
+    pub answer: String,
 }
 
 #[cfg_attr(feature = "full", derive(AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = registration_application))]
 pub struct RegistrationApplicationUpdateForm {
-  pub admin_id: Option<Option<PersonId>>,
-  pub deny_reason: Option<Option<String>>,
+    pub admin_id: Option<Option<PersonId>>,
+    pub deny_reason: Option<Option<String>>,
 }

--- a/crates/db_schema/src/source/secret.rs
+++ b/crates/db_schema/src/source/secret.rs
@@ -5,6 +5,6 @@ use crate::schema::secret;
 #[cfg_attr(feature = "full", derive(Queryable, Identifiable))]
 #[cfg_attr(feature = "full", diesel(table_name = secret))]
 pub struct Secret {
-  pub id: i32,
-  pub jwt_secret: String,
+    pub id: i32,
+    pub jwt_secret: String,
 }

--- a/crates/db_schema/src/source/site.rs
+++ b/crates/db_schema/src/source/site.rs
@@ -15,27 +15,27 @@ use typed_builder::TypedBuilder;
 #[cfg_attr(feature = "full", ts(export))]
 /// The site.
 pub struct Site {
-  pub id: SiteId,
-  pub name: String,
-  /// A sidebar for the site in markdown.
-  pub sidebar: Option<String>,
-  pub published: DateTime<Utc>,
-  pub updated: Option<DateTime<Utc>>,
-  /// An icon URL.
-  pub icon: Option<DbUrl>,
-  /// A banner url.
-  pub banner: Option<DbUrl>,
-  /// A shorter, one-line description of the site.
-  pub description: Option<String>,
-  /// The federated actor_id.
-  pub actor_id: DbUrl,
-  /// The time the site was last refreshed.
-  pub last_refreshed_at: DateTime<Utc>,
-  /// The site inbox
-  pub inbox_url: DbUrl,
-  pub private_key: Option<String>,
-  pub public_key: String,
-  pub instance_id: InstanceId,
+    pub id: SiteId,
+    pub name: String,
+    /// A sidebar for the site in markdown.
+    pub sidebar: Option<String>,
+    pub published: DateTime<Utc>,
+    pub updated: Option<DateTime<Utc>>,
+    /// An icon URL.
+    pub icon: Option<DbUrl>,
+    /// A banner url.
+    pub banner: Option<DbUrl>,
+    /// A shorter, one-line description of the site.
+    pub description: Option<String>,
+    /// The federated actor_id.
+    pub actor_id: DbUrl,
+    /// The time the site was last refreshed.
+    pub last_refreshed_at: DateTime<Utc>,
+    /// The site inbox
+    pub inbox_url: DbUrl,
+    pub private_key: Option<String>,
+    pub public_key: String,
+    pub instance_id: InstanceId,
 }
 
 #[derive(Clone, TypedBuilder)]
@@ -43,36 +43,36 @@ pub struct Site {
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = site))]
 pub struct SiteInsertForm {
-  #[builder(!default)]
-  pub name: String,
-  pub sidebar: Option<String>,
-  pub updated: Option<DateTime<Utc>>,
-  pub icon: Option<DbUrl>,
-  pub banner: Option<DbUrl>,
-  pub description: Option<String>,
-  pub actor_id: Option<DbUrl>,
-  pub last_refreshed_at: Option<DateTime<Utc>>,
-  pub inbox_url: Option<DbUrl>,
-  pub private_key: Option<String>,
-  pub public_key: Option<String>,
-  #[builder(!default)]
-  pub instance_id: InstanceId,
+    #[builder(!default)]
+    pub name: String,
+    pub sidebar: Option<String>,
+    pub updated: Option<DateTime<Utc>>,
+    pub icon: Option<DbUrl>,
+    pub banner: Option<DbUrl>,
+    pub description: Option<String>,
+    pub actor_id: Option<DbUrl>,
+    pub last_refreshed_at: Option<DateTime<Utc>>,
+    pub inbox_url: Option<DbUrl>,
+    pub private_key: Option<String>,
+    pub public_key: Option<String>,
+    #[builder(!default)]
+    pub instance_id: InstanceId,
 }
 
 #[derive(Clone, Default)]
 #[cfg_attr(feature = "full", derive(AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = site))]
 pub struct SiteUpdateForm {
-  pub name: Option<String>,
-  pub sidebar: Option<Option<String>>,
-  pub updated: Option<Option<DateTime<Utc>>>,
-  // when you want to null out a column, you have to send Some(None)), since sending None means you just don't want to update that column.
-  pub icon: Option<Option<DbUrl>>,
-  pub banner: Option<Option<DbUrl>>,
-  pub description: Option<Option<String>>,
-  pub actor_id: Option<DbUrl>,
-  pub last_refreshed_at: Option<DateTime<Utc>>,
-  pub inbox_url: Option<DbUrl>,
-  pub private_key: Option<Option<String>>,
-  pub public_key: Option<String>,
+    pub name: Option<String>,
+    pub sidebar: Option<Option<String>>,
+    pub updated: Option<Option<DateTime<Utc>>>,
+    // when you want to null out a column, you have to send Some(None)), since sending None means you just don't want to update that column.
+    pub icon: Option<Option<DbUrl>>,
+    pub banner: Option<Option<DbUrl>>,
+    pub description: Option<Option<String>>,
+    pub actor_id: Option<DbUrl>,
+    pub last_refreshed_at: Option<DateTime<Utc>>,
+    pub inbox_url: Option<DbUrl>,
+    pub private_key: Option<Option<String>>,
+    pub public_key: Option<String>,
 }

--- a/crates/db_schema/src/source/tagline.rs
+++ b/crates/db_schema/src/source/tagline.rs
@@ -12,24 +12,24 @@ use ts_rs::TS;
 #[cfg_attr(feature = "full", derive(Queryable, Associations, Identifiable, TS))]
 #[cfg_attr(feature = "full", diesel(table_name = tagline))]
 #[cfg_attr(
-  feature = "full",
-  diesel(belongs_to(crate::source::local_site::LocalSite))
+    feature = "full",
+    diesel(belongs_to(crate::source::local_site::LocalSite))
 )]
 #[cfg_attr(feature = "full", ts(export))]
 /// A tagline, shown at the top of your site.
 pub struct Tagline {
-  pub id: i32,
-  pub local_site_id: LocalSiteId,
-  pub content: String,
-  pub published: DateTime<Utc>,
-  pub updated: Option<DateTime<Utc>>,
+    pub id: i32,
+    pub local_site_id: LocalSiteId,
+    pub content: String,
+    pub published: DateTime<Utc>,
+    pub updated: Option<DateTime<Utc>>,
 }
 
 #[derive(Clone, Default)]
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = tagline))]
 pub struct TaglineForm {
-  pub local_site_id: LocalSiteId,
-  pub content: String,
-  pub updated: Option<DateTime<Utc>>,
+    pub local_site_id: LocalSiteId,
+    pub content: String,
+    pub updated: Option<DateTime<Utc>>,
 }

--- a/crates/db_schema/src/traits.rs
+++ b/crates/db_schema/src/traits.rs
@@ -1,19 +1,18 @@
 use crate::{
-  newtypes::{CommunityId, DbUrl, PersonId},
-  utils::{get_conn, DbPool},
+    newtypes::{CommunityId, DbUrl, PersonId},
+    utils::{get_conn, DbPool},
 };
 use diesel::{
-  associations::HasTable,
-  dsl,
-  query_builder::{DeleteStatement, IntoUpdateTarget},
-  query_dsl::methods::{FindDsl, LimitDsl},
-  result::Error,
-  Table,
+    associations::HasTable,
+    dsl,
+    query_builder::{DeleteStatement, IntoUpdateTarget},
+    query_dsl::methods::{FindDsl, LimitDsl},
+    result::Error,
+    Table,
 };
 use diesel_async::{
-  methods::{ExecuteDsl, LoadQuery},
-  AsyncPgConnection,
-  RunQueryDsl,
+    methods::{ExecuteDsl, LoadQuery},
+    AsyncPgConnection, RunQueryDsl,
 };
 
 /// Returned by `diesel::delete`
@@ -29,173 +28,173 @@ pub type PrimaryKey<T> = <<T as HasTable>::Table as Table>::PrimaryKey;
 #[async_trait]
 pub trait Crud: HasTable + Sized
 where
-  Self::Table: FindDsl<Self::IdType>,
-  Find<Self>: LimitDsl + IntoUpdateTarget + Send,
-  Delete<Find<Self>>: ExecuteDsl<AsyncPgConnection> + Send + 'static,
+    Self::Table: FindDsl<Self::IdType>,
+    Find<Self>: LimitDsl + IntoUpdateTarget + Send,
+    Delete<Find<Self>>: ExecuteDsl<AsyncPgConnection> + Send + 'static,
 
-  // Used by `RunQueryDsl::first`
-  dsl::Limit<Find<Self>>: LoadQuery<'static, AsyncPgConnection, Self> + Send + 'static,
+    // Used by `RunQueryDsl::first`
+    dsl::Limit<Find<Self>>: LoadQuery<'static, AsyncPgConnection, Self> + Send + 'static,
 {
-  type InsertForm;
-  type UpdateForm;
-  type IdType: Send;
+    type InsertForm;
+    type UpdateForm;
+    type IdType: Send;
 
-  async fn create(pool: &mut DbPool<'_>, form: &Self::InsertForm) -> Result<Self, Error>;
+    async fn create(pool: &mut DbPool<'_>, form: &Self::InsertForm) -> Result<Self, Error>;
 
-  async fn read(pool: &mut DbPool<'_>, id: Self::IdType) -> Result<Self, Error> {
-    let query: Find<Self> = Self::table().find(id);
-    let conn = &mut *get_conn(pool).await?;
-    query.first::<Self>(conn).await
-  }
+    async fn read(pool: &mut DbPool<'_>, id: Self::IdType) -> Result<Self, Error> {
+        let query: Find<Self> = Self::table().find(id);
+        let conn = &mut *get_conn(pool).await?;
+        query.first::<Self>(conn).await
+    }
 
-  /// when you want to null out a column, you have to send Some(None)), since sending None means you just don't want to update that column.
-  async fn update(
-    pool: &mut DbPool<'_>,
-    id: Self::IdType,
-    form: &Self::UpdateForm,
-  ) -> Result<Self, Error>;
+    /// when you want to null out a column, you have to send Some(None)), since sending None means you just don't want to update that column.
+    async fn update(
+        pool: &mut DbPool<'_>,
+        id: Self::IdType,
+        form: &Self::UpdateForm,
+    ) -> Result<Self, Error>;
 
-  async fn delete(pool: &mut DbPool<'_>, id: Self::IdType) -> Result<usize, Error> {
-    let query: Delete<Find<Self>> = diesel::delete(Self::table().find(id));
-    let conn = &mut *get_conn(pool).await?;
-    query.execute(conn).await
-  }
+    async fn delete(pool: &mut DbPool<'_>, id: Self::IdType) -> Result<usize, Error> {
+        let query: Delete<Find<Self>> = diesel::delete(Self::table().find(id));
+        let conn = &mut *get_conn(pool).await?;
+        query.execute(conn).await
+    }
 }
 
 #[async_trait]
 pub trait Followable {
-  type Form;
-  async fn follow(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<Self, Error>
-  where
-    Self: Sized;
-  async fn follow_accepted(
-    pool: &mut DbPool<'_>,
-    community_id: CommunityId,
-    person_id: PersonId,
-  ) -> Result<Self, Error>
-  where
-    Self: Sized;
-  async fn unfollow(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<usize, Error>
-  where
-    Self: Sized;
+    type Form;
+    async fn follow(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<Self, Error>
+    where
+        Self: Sized;
+    async fn follow_accepted(
+        pool: &mut DbPool<'_>,
+        community_id: CommunityId,
+        person_id: PersonId,
+    ) -> Result<Self, Error>
+    where
+        Self: Sized;
+    async fn unfollow(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<usize, Error>
+    where
+        Self: Sized;
 }
 
 #[async_trait]
 pub trait Joinable {
-  type Form;
-  async fn join(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<Self, Error>
-  where
-    Self: Sized;
-  async fn leave(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<usize, Error>
-  where
-    Self: Sized;
+    type Form;
+    async fn join(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<Self, Error>
+    where
+        Self: Sized;
+    async fn leave(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<usize, Error>
+    where
+        Self: Sized;
 }
 
 #[async_trait]
 pub trait Likeable {
-  type Form;
-  type IdType;
-  async fn like(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<Self, Error>
-  where
-    Self: Sized;
-  async fn remove(
-    pool: &mut DbPool<'_>,
-    person_id: PersonId,
-    item_id: Self::IdType,
-  ) -> Result<usize, Error>
-  where
-    Self: Sized;
+    type Form;
+    type IdType;
+    async fn like(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<Self, Error>
+    where
+        Self: Sized;
+    async fn remove(
+        pool: &mut DbPool<'_>,
+        person_id: PersonId,
+        item_id: Self::IdType,
+    ) -> Result<usize, Error>
+    where
+        Self: Sized;
 }
 
 #[async_trait]
 pub trait Bannable {
-  type Form;
-  async fn ban(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<Self, Error>
-  where
-    Self: Sized;
-  async fn unban(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<usize, Error>
-  where
-    Self: Sized;
+    type Form;
+    async fn ban(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<Self, Error>
+    where
+        Self: Sized;
+    async fn unban(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<usize, Error>
+    where
+        Self: Sized;
 }
 
 #[async_trait]
 pub trait Saveable {
-  type Form;
-  async fn save(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<Self, Error>
-  where
-    Self: Sized;
-  async fn unsave(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<usize, Error>
-  where
-    Self: Sized;
+    type Form;
+    async fn save(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<Self, Error>
+    where
+        Self: Sized;
+    async fn unsave(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<usize, Error>
+    where
+        Self: Sized;
 }
 
 #[async_trait]
 pub trait Blockable {
-  type Form;
-  async fn block(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<Self, Error>
-  where
-    Self: Sized;
-  async fn unblock(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<usize, Error>
-  where
-    Self: Sized;
+    type Form;
+    async fn block(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<Self, Error>
+    where
+        Self: Sized;
+    async fn unblock(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<usize, Error>
+    where
+        Self: Sized;
 }
 
 #[async_trait]
 pub trait Readable {
-  type Form;
-  async fn mark_as_read(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<Self, Error>
-  where
-    Self: Sized;
-  async fn mark_as_unread(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<usize, Error>
-  where
-    Self: Sized;
+    type Form;
+    async fn mark_as_read(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<Self, Error>
+    where
+        Self: Sized;
+    async fn mark_as_unread(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<usize, Error>
+    where
+        Self: Sized;
 }
 
 #[async_trait]
 pub trait Reportable {
-  type Form;
-  type IdType;
-  async fn report(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<Self, Error>
-  where
-    Self: Sized;
-  async fn resolve(
-    pool: &mut DbPool<'_>,
-    report_id: Self::IdType,
-    resolver_id: PersonId,
-  ) -> Result<usize, Error>
-  where
-    Self: Sized;
-  async fn unresolve(
-    pool: &mut DbPool<'_>,
-    report_id: Self::IdType,
-    resolver_id: PersonId,
-  ) -> Result<usize, Error>
-  where
-    Self: Sized;
+    type Form;
+    type IdType;
+    async fn report(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<Self, Error>
+    where
+        Self: Sized;
+    async fn resolve(
+        pool: &mut DbPool<'_>,
+        report_id: Self::IdType,
+        resolver_id: PersonId,
+    ) -> Result<usize, Error>
+    where
+        Self: Sized;
+    async fn unresolve(
+        pool: &mut DbPool<'_>,
+        report_id: Self::IdType,
+        resolver_id: PersonId,
+    ) -> Result<usize, Error>
+    where
+        Self: Sized;
 }
 
 #[async_trait]
 pub trait ApubActor {
-  async fn read_from_apub_id(
-    pool: &mut DbPool<'_>,
-    object_id: &DbUrl,
-  ) -> Result<Option<Self>, Error>
-  where
-    Self: Sized;
-  /// - actor_name is the name of the community or user to read.
-  /// - include_deleted, if true, will return communities or users that were deleted/removed
-  async fn read_from_name(
-    pool: &mut DbPool<'_>,
-    actor_name: &str,
-    include_deleted: bool,
-  ) -> Result<Self, Error>
-  where
-    Self: Sized;
-  async fn read_from_name_and_domain(
-    pool: &mut DbPool<'_>,
-    actor_name: &str,
-    protocol_domain: &str,
-  ) -> Result<Self, Error>
-  where
-    Self: Sized;
+    async fn read_from_apub_id(
+        pool: &mut DbPool<'_>,
+        object_id: &DbUrl,
+    ) -> Result<Option<Self>, Error>
+    where
+        Self: Sized;
+    /// - actor_name is the name of the community or user to read.
+    /// - include_deleted, if true, will return communities or users that were deleted/removed
+    async fn read_from_name(
+        pool: &mut DbPool<'_>,
+        actor_name: &str,
+        include_deleted: bool,
+    ) -> Result<Self, Error>
+    where
+        Self: Sized;
+    async fn read_from_name_and_domain(
+        pool: &mut DbPool<'_>,
+        actor_name: &str,
+        protocol_domain: &str,
+    ) -> Result<Self, Error>
+    where
+        Self: Sized;
 }

--- a/crates/db_schema/src/utils.rs
+++ b/crates/db_schema/src/utils.rs
@@ -1,50 +1,45 @@
 use crate::{
-  diesel::Connection,
-  diesel_migrations::MigrationHarness,
-  newtypes::DbUrl,
-  CommentSortType,
-  PersonSortType,
-  SortType,
+    diesel::Connection, diesel_migrations::MigrationHarness, newtypes::DbUrl, CommentSortType,
+    PersonSortType, SortType,
 };
 use activitypub_federation::{fetch::object_id::ObjectId, traits::Object};
 use chrono::{DateTime, Utc};
 use deadpool::Runtime;
 use diesel::{
-  backend::Backend,
-  deserialize::FromSql,
-  helper_types::AsExprOf,
-  pg::Pg,
-  result::{ConnectionError, ConnectionResult, Error as DieselError, Error::QueryBuilderError},
-  serialize::{Output, ToSql},
-  sql_types::{Text, Timestamptz},
-  IntoSql,
-  PgConnection,
+    backend::Backend,
+    deserialize::FromSql,
+    helper_types::AsExprOf,
+    pg::Pg,
+    result::{ConnectionError, ConnectionResult, Error as DieselError, Error::QueryBuilderError},
+    serialize::{Output, ToSql},
+    sql_types::{Text, Timestamptz},
+    IntoSql, PgConnection,
 };
 use diesel_async::{
-  pg::AsyncPgConnection,
-  pooled_connection::{
-    deadpool::{Object as PooledConnection, Pool},
-    AsyncDieselConnectionManager,
-  },
+    pg::AsyncPgConnection,
+    pooled_connection::{
+        deadpool::{Object as PooledConnection, Pool},
+        AsyncDieselConnectionManager,
+    },
 };
 use diesel_migrations::EmbeddedMigrations;
 use futures_util::{future::BoxFuture, Future, FutureExt};
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
-  settings::structs::Settings,
+    error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+    settings::structs::Settings,
 };
 use once_cell::sync::Lazy;
 use regex::Regex;
 use rustls::{
-  client::{ServerCertVerified, ServerCertVerifier},
-  ServerName,
+    client::{ServerCertVerified, ServerCertVerifier},
+    ServerName,
 };
 use std::{
-  env,
-  env::VarError,
-  ops::{Deref, DerefMut},
-  sync::Arc,
-  time::{Duration, SystemTime},
+    env,
+    env::VarError,
+    ops::{Deref, DerefMut},
+    sync::Arc,
+    time::{Duration, SystemTime},
 };
 use tracing::{error, info};
 use url::Url;
@@ -59,59 +54,61 @@ pub type ActualDbPool = Pool<AsyncPgConnection>;
 ///
 /// https://github.com/rust-lang/rfcs/issues/1403
 pub enum DbPool<'a> {
-  Pool(&'a ActualDbPool),
-  Conn(&'a mut AsyncPgConnection),
+    Pool(&'a ActualDbPool),
+    Conn(&'a mut AsyncPgConnection),
 }
 
 pub enum DbConn<'a> {
-  Pool(PooledConnection<AsyncPgConnection>),
-  Conn(&'a mut AsyncPgConnection),
+    Pool(PooledConnection<AsyncPgConnection>),
+    Conn(&'a mut AsyncPgConnection),
 }
 
 pub async fn get_conn<'a, 'b: 'a>(pool: &'a mut DbPool<'b>) -> Result<DbConn<'a>, DieselError> {
-  Ok(match pool {
-    DbPool::Pool(pool) => DbConn::Pool(pool.get().await.map_err(|e| QueryBuilderError(e.into()))?),
-    DbPool::Conn(conn) => DbConn::Conn(conn),
-  })
+    Ok(match pool {
+        DbPool::Pool(pool) => {
+            DbConn::Pool(pool.get().await.map_err(|e| QueryBuilderError(e.into()))?)
+        }
+        DbPool::Conn(conn) => DbConn::Conn(conn),
+    })
 }
 
 impl<'a> Deref for DbConn<'a> {
-  type Target = AsyncPgConnection;
+    type Target = AsyncPgConnection;
 
-  fn deref(&self) -> &Self::Target {
-    match self {
-      DbConn::Pool(conn) => conn.deref(),
-      DbConn::Conn(conn) => conn.deref(),
+    fn deref(&self) -> &Self::Target {
+        match self {
+            DbConn::Pool(conn) => conn.deref(),
+            DbConn::Conn(conn) => conn.deref(),
+        }
     }
-  }
 }
 
 impl<'a> DerefMut for DbConn<'a> {
-  fn deref_mut(&mut self) -> &mut Self::Target {
-    match self {
-      DbConn::Pool(conn) => conn.deref_mut(),
-      DbConn::Conn(conn) => conn.deref_mut(),
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            DbConn::Pool(conn) => conn.deref_mut(),
+            DbConn::Conn(conn) => conn.deref_mut(),
+        }
     }
-  }
 }
 
 // Allows functions that take `DbPool<'_>` to be called in a transaction by passing `&mut conn.into()`
 impl<'a> From<&'a mut AsyncPgConnection> for DbPool<'a> {
-  fn from(value: &'a mut AsyncPgConnection) -> Self {
-    DbPool::Conn(value)
-  }
+    fn from(value: &'a mut AsyncPgConnection) -> Self {
+        DbPool::Conn(value)
+    }
 }
 
 impl<'a, 'b: 'a> From<&'a mut DbConn<'b>> for DbPool<'a> {
-  fn from(value: &'a mut DbConn<'b>) -> Self {
-    DbPool::Conn(value.deref_mut())
-  }
+    fn from(value: &'a mut DbConn<'b>) -> Self {
+        DbPool::Conn(value.deref_mut())
+    }
 }
 
 impl<'a> From<&'a ActualDbPool> for DbPool<'a> {
-  fn from(value: &'a ActualDbPool) -> Self {
-    DbPool::Pool(value)
-  }
+    fn from(value: &'a ActualDbPool) -> Self {
+        DbPool::Pool(value)
+    }
 }
 
 /// Runs multiple async functions that take `&mut DbPool<'_>` as input and return `Result`. Only works when the  `futures` crate is listed in `Cargo.toml`.
@@ -151,280 +148,283 @@ macro_rules! try_join_with_pool {
 }
 
 pub fn get_database_url_from_env() -> Result<String, VarError> {
-  env::var("LEMMY_DATABASE_URL")
+    env::var("LEMMY_DATABASE_URL")
 }
 
 pub fn fuzzy_search(q: &str) -> String {
-  let replaced = q.replace('%', "\\%").replace('_', "\\_").replace(' ', "%");
-  format!("%{replaced}%")
+    let replaced = q.replace('%', "\\%").replace('_', "\\_").replace(' ', "%");
+    format!("%{replaced}%")
 }
 
 pub fn limit_and_offset(
-  page: Option<i64>,
-  limit: Option<i64>,
+    page: Option<i64>,
+    limit: Option<i64>,
 ) -> Result<(i64, i64), diesel::result::Error> {
-  let page = match page {
-    Some(page) => {
-      if page < 1 {
-        return Err(QueryBuilderError("Page is < 1".into()));
-      } else {
-        page
-      }
-    }
-    None => 1,
-  };
-  let limit = match limit {
-    Some(limit) => {
-      if !(1..=FETCH_LIMIT_MAX).contains(&limit) {
-        return Err(QueryBuilderError(
-          format!("Fetch limit is > {FETCH_LIMIT_MAX}").into(),
-        ));
-      } else {
-        limit
-      }
-    }
-    None => FETCH_LIMIT_DEFAULT,
-  };
-  let offset = limit * (page - 1);
-  Ok((limit, offset))
+    let page = match page {
+        Some(page) => {
+            if page < 1 {
+                return Err(QueryBuilderError("Page is < 1".into()));
+            } else {
+                page
+            }
+        }
+        None => 1,
+    };
+    let limit = match limit {
+        Some(limit) => {
+            if !(1..=FETCH_LIMIT_MAX).contains(&limit) {
+                return Err(QueryBuilderError(
+                    format!("Fetch limit is > {FETCH_LIMIT_MAX}").into(),
+                ));
+            } else {
+                limit
+            }
+        }
+        None => FETCH_LIMIT_DEFAULT,
+    };
+    let offset = limit * (page - 1);
+    Ok((limit, offset))
 }
 
 pub fn limit_and_offset_unlimited(page: Option<i64>, limit: Option<i64>) -> (i64, i64) {
-  let limit = limit.unwrap_or(FETCH_LIMIT_DEFAULT);
-  let offset = limit * (page.unwrap_or(1) - 1);
-  (limit, offset)
+    let limit = limit.unwrap_or(FETCH_LIMIT_DEFAULT);
+    let offset = limit * (page.unwrap_or(1) - 1);
+    (limit, offset)
 }
 
 pub fn is_email_regex(test: &str) -> bool {
-  EMAIL_REGEX.is_match(test)
+    EMAIL_REGEX.is_match(test)
 }
 
 pub fn diesel_option_overwrite(opt: Option<String>) -> Option<Option<String>> {
-  match opt {
-    // An empty string is an erase
-    Some(unwrapped) => {
-      if !unwrapped.eq("") {
-        Some(Some(unwrapped))
-      } else {
-        Some(None)
-      }
+    match opt {
+        // An empty string is an erase
+        Some(unwrapped) => {
+            if !unwrapped.eq("") {
+                Some(Some(unwrapped))
+            } else {
+                Some(None)
+            }
+        }
+        None => None,
     }
-    None => None,
-  }
 }
 
 pub fn diesel_option_overwrite_to_url(
-  opt: &Option<String>,
+    opt: &Option<String>,
 ) -> Result<Option<Option<DbUrl>>, LemmyError> {
-  match opt.as_ref().map(String::as_str) {
-    // An empty string is an erase
-    Some("") => Ok(Some(None)),
-    Some(str_url) => Url::parse(str_url)
-      .map(|u| Some(Some(u.into())))
-      .with_lemmy_type(LemmyErrorType::InvalidUrl),
-    None => Ok(None),
-  }
+    match opt.as_ref().map(String::as_str) {
+        // An empty string is an erase
+        Some("") => Ok(Some(None)),
+        Some(str_url) => Url::parse(str_url)
+            .map(|u| Some(Some(u.into())))
+            .with_lemmy_type(LemmyErrorType::InvalidUrl),
+        None => Ok(None),
+    }
 }
 
 pub fn diesel_option_overwrite_to_url_create(
-  opt: &Option<String>,
+    opt: &Option<String>,
 ) -> Result<Option<DbUrl>, LemmyError> {
-  match opt.as_ref().map(String::as_str) {
-    // An empty string is nothing
-    Some("") => Ok(None),
-    Some(str_url) => Url::parse(str_url)
-      .map(|u| Some(u.into()))
-      .with_lemmy_type(LemmyErrorType::InvalidUrl),
-    None => Ok(None),
-  }
+    match opt.as_ref().map(String::as_str) {
+        // An empty string is nothing
+        Some("") => Ok(None),
+        Some(str_url) => Url::parse(str_url)
+            .map(|u| Some(u.into()))
+            .with_lemmy_type(LemmyErrorType::InvalidUrl),
+        None => Ok(None),
+    }
 }
 
 async fn build_db_pool_settings_opt(
-  settings: Option<&Settings>,
+    settings: Option<&Settings>,
 ) -> Result<ActualDbPool, LemmyError> {
-  let db_url = get_database_url(settings);
-  let pool_size = settings.map(|s| s.database.pool_size).unwrap_or(5);
-  // We only support TLS with sslmode=require currently
-  let tls_enabled = db_url.contains("sslmode=require");
-  let manager = if tls_enabled {
-    // diesel-async does not support any TLS connections out of the box, so we need to manually
-    // provide a setup function which handles creating the connection
-    AsyncDieselConnectionManager::<AsyncPgConnection>::new_with_setup(&db_url, establish_connection)
-  } else {
-    AsyncDieselConnectionManager::<AsyncPgConnection>::new(&db_url)
-  };
-  let pool = Pool::builder(manager)
-    .max_size(pool_size)
-    .wait_timeout(POOL_TIMEOUT)
-    .create_timeout(POOL_TIMEOUT)
-    .recycle_timeout(POOL_TIMEOUT)
-    .runtime(Runtime::Tokio1)
-    .build()?;
+    let db_url = get_database_url(settings);
+    let pool_size = settings.map(|s| s.database.pool_size).unwrap_or(5);
+    // We only support TLS with sslmode=require currently
+    let tls_enabled = db_url.contains("sslmode=require");
+    let manager = if tls_enabled {
+        // diesel-async does not support any TLS connections out of the box, so we need to manually
+        // provide a setup function which handles creating the connection
+        AsyncDieselConnectionManager::<AsyncPgConnection>::new_with_setup(
+            &db_url,
+            establish_connection,
+        )
+    } else {
+        AsyncDieselConnectionManager::<AsyncPgConnection>::new(&db_url)
+    };
+    let pool = Pool::builder(manager)
+        .max_size(pool_size)
+        .wait_timeout(POOL_TIMEOUT)
+        .create_timeout(POOL_TIMEOUT)
+        .recycle_timeout(POOL_TIMEOUT)
+        .runtime(Runtime::Tokio1)
+        .build()?;
 
-  // If there's no settings, that means its a unit test, and migrations need to be run
-  if settings.is_none() {
-    run_migrations(&db_url);
-  }
+    // If there's no settings, that means its a unit test, and migrations need to be run
+    if settings.is_none() {
+        run_migrations(&db_url);
+    }
 
-  Ok(pool)
+    Ok(pool)
 }
 
 fn establish_connection(config: &str) -> BoxFuture<ConnectionResult<AsyncPgConnection>> {
-  let fut = async {
-    let rustls_config = rustls::ClientConfig::builder()
-      .with_safe_defaults()
-      .with_custom_certificate_verifier(Arc::new(NoCertVerifier {}))
-      .with_no_client_auth();
+    let fut = async {
+        let rustls_config = rustls::ClientConfig::builder()
+            .with_safe_defaults()
+            .with_custom_certificate_verifier(Arc::new(NoCertVerifier {}))
+            .with_no_client_auth();
 
-    let tls = tokio_postgres_rustls::MakeRustlsConnect::new(rustls_config);
-    let (client, conn) = tokio_postgres::connect(config, tls)
-      .await
-      .map_err(|e| ConnectionError::BadConnection(e.to_string()))?;
-    tokio::spawn(async move {
-      if let Err(e) = conn.await {
-        error!("Database connection failed: {e}");
-      }
-    });
-    AsyncPgConnection::try_from(client).await
-  };
-  fut.boxed()
+        let tls = tokio_postgres_rustls::MakeRustlsConnect::new(rustls_config);
+        let (client, conn) = tokio_postgres::connect(config, tls)
+            .await
+            .map_err(|e| ConnectionError::BadConnection(e.to_string()))?;
+        tokio::spawn(async move {
+            if let Err(e) = conn.await {
+                error!("Database connection failed: {e}");
+            }
+        });
+        AsyncPgConnection::try_from(client).await
+    };
+    fut.boxed()
 }
 
 struct NoCertVerifier {}
 
 impl ServerCertVerifier for NoCertVerifier {
-  fn verify_server_cert(
-    &self,
-    _end_entity: &rustls::Certificate,
-    _intermediates: &[rustls::Certificate],
-    _server_name: &ServerName,
-    _scts: &mut dyn Iterator<Item = &[u8]>,
-    _ocsp_response: &[u8],
-    _now: SystemTime,
-  ) -> Result<ServerCertVerified, rustls::Error> {
-    // Will verify all (even invalid) certs without any checks (sslmode=require)
-    Ok(ServerCertVerified::assertion())
-  }
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::Certificate,
+        _intermediates: &[rustls::Certificate],
+        _server_name: &ServerName,
+        _scts: &mut dyn Iterator<Item = &[u8]>,
+        _ocsp_response: &[u8],
+        _now: SystemTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        // Will verify all (even invalid) certs without any checks (sslmode=require)
+        Ok(ServerCertVerified::assertion())
+    }
 }
 
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
 
 pub fn run_migrations(db_url: &str) {
-  // Needs to be a sync connection
-  let mut conn =
-    PgConnection::establish(db_url).unwrap_or_else(|e| panic!("Error connecting to {db_url}: {e}"));
-  info!("Running Database migrations (This may take a long time)...");
-  let _ = &mut conn
-    .run_pending_migrations(MIGRATIONS)
-    .unwrap_or_else(|e| panic!("Couldn't run DB Migrations: {e}"));
-  info!("Database migrations complete.");
+    // Needs to be a sync connection
+    let mut conn = PgConnection::establish(db_url)
+        .unwrap_or_else(|e| panic!("Error connecting to {db_url}: {e}"));
+    info!("Running Database migrations (This may take a long time)...");
+    let _ = &mut conn
+        .run_pending_migrations(MIGRATIONS)
+        .unwrap_or_else(|e| panic!("Couldn't run DB Migrations: {e}"));
+    info!("Database migrations complete.");
 }
 
 pub async fn build_db_pool(settings: &Settings) -> Result<ActualDbPool, LemmyError> {
-  build_db_pool_settings_opt(Some(settings)).await
+    build_db_pool_settings_opt(Some(settings)).await
 }
 
 pub async fn build_db_pool_for_tests() -> ActualDbPool {
-  build_db_pool_settings_opt(None)
-    .await
-    .expect("db pool missing")
+    build_db_pool_settings_opt(None)
+        .await
+        .expect("db pool missing")
 }
 
 pub fn get_database_url(settings: Option<&Settings>) -> String {
-  // The env var should override anything in the settings config
-  match get_database_url_from_env() {
-    Ok(url) => url,
-    Err(e) => match settings {
-      Some(settings) => settings.get_database_url(),
-      None => panic!("Failed to read database URL from env var LEMMY_DATABASE_URL: {e}"),
-    },
-  }
+    // The env var should override anything in the settings config
+    match get_database_url_from_env() {
+        Ok(url) => url,
+        Err(e) => match settings {
+            Some(settings) => settings.get_database_url(),
+            None => panic!("Failed to read database URL from env var LEMMY_DATABASE_URL: {e}"),
+        },
+    }
 }
 
 pub fn naive_now() -> DateTime<Utc> {
-  chrono::prelude::Utc::now()
+    chrono::prelude::Utc::now()
 }
 
 pub fn post_to_comment_sort_type(sort: SortType) -> CommentSortType {
-  match sort {
-    SortType::Active | SortType::Hot => CommentSortType::Hot,
-    SortType::New | SortType::NewComments | SortType::MostComments => CommentSortType::New,
-    SortType::Old => CommentSortType::Old,
-    SortType::Controversial => CommentSortType::Controversial,
-    SortType::TopHour
-    | SortType::TopSixHour
-    | SortType::TopTwelveHour
-    | SortType::TopDay
-    | SortType::TopAll
-    | SortType::TopWeek
-    | SortType::TopYear
-    | SortType::TopMonth
-    | SortType::TopThreeMonths
-    | SortType::TopSixMonths
-    | SortType::TopNineMonths => CommentSortType::Top,
-  }
+    match sort {
+        SortType::Active | SortType::Hot => CommentSortType::Hot,
+        SortType::New | SortType::NewComments | SortType::MostComments => CommentSortType::New,
+        SortType::Old => CommentSortType::Old,
+        SortType::Controversial => CommentSortType::Controversial,
+        SortType::TopHour
+        | SortType::TopSixHour
+        | SortType::TopTwelveHour
+        | SortType::TopDay
+        | SortType::TopAll
+        | SortType::TopWeek
+        | SortType::TopYear
+        | SortType::TopMonth
+        | SortType::TopThreeMonths
+        | SortType::TopSixMonths
+        | SortType::TopNineMonths => CommentSortType::Top,
+    }
 }
 
 pub fn post_to_person_sort_type(sort: SortType) -> PersonSortType {
-  match sort {
-    SortType::Active | SortType::Hot | SortType::Controversial => PersonSortType::CommentScore,
-    SortType::New | SortType::NewComments => PersonSortType::New,
-    SortType::MostComments => PersonSortType::MostComments,
-    SortType::Old => PersonSortType::Old,
-    _ => PersonSortType::CommentScore,
-  }
+    match sort {
+        SortType::Active | SortType::Hot | SortType::Controversial => PersonSortType::CommentScore,
+        SortType::New | SortType::NewComments => PersonSortType::New,
+        SortType::MostComments => PersonSortType::MostComments,
+        SortType::Old => PersonSortType::Old,
+        _ => PersonSortType::CommentScore,
+    }
 }
 
 static EMAIL_REGEX: Lazy<Regex> = Lazy::new(|| {
-  Regex::new(r"^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$")
-    .expect("compile email regex")
+    Regex::new(r"^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$")
+        .expect("compile email regex")
 });
 
 pub mod functions {
-  use diesel::sql_types::{BigInt, Text, Timestamptz};
+    use diesel::sql_types::{BigInt, Text, Timestamptz};
 
-  sql_function! {
-    fn hot_rank(score: BigInt, time: Timestamptz) -> Integer;
-  }
+    sql_function! {
+      fn hot_rank(score: BigInt, time: Timestamptz) -> Integer;
+    }
 
-  sql_function! {
-    fn controversy_rank(upvotes: BigInt, downvotes: BigInt, score: BigInt) -> Double;
-  }
+    sql_function! {
+      fn controversy_rank(upvotes: BigInt, downvotes: BigInt, score: BigInt) -> Double;
+    }
 
-  sql_function!(fn lower(x: Text) -> Text);
+    sql_function!(fn lower(x: Text) -> Text);
 }
 
 pub const DELETED_REPLACEMENT_TEXT: &str = "*Permanently Deleted*";
 
 impl ToSql<Text, Pg> for DbUrl {
-  fn to_sql(&self, out: &mut Output<Pg>) -> diesel::serialize::Result {
-    <std::string::String as ToSql<Text, Pg>>::to_sql(&self.0.to_string(), &mut out.reborrow())
-  }
+    fn to_sql(&self, out: &mut Output<Pg>) -> diesel::serialize::Result {
+        <std::string::String as ToSql<Text, Pg>>::to_sql(&self.0.to_string(), &mut out.reborrow())
+    }
 }
 
 impl<DB: Backend> FromSql<Text, DB> for DbUrl
 where
-  String: FromSql<Text, DB>,
+    String: FromSql<Text, DB>,
 {
-  fn from_sql(value: DB::RawValue<'_>) -> diesel::deserialize::Result<Self> {
-    let str = String::from_sql(value)?;
-    Ok(DbUrl(Box::new(Url::parse(&str)?)))
-  }
+    fn from_sql(value: DB::RawValue<'_>) -> diesel::deserialize::Result<Self> {
+        let str = String::from_sql(value)?;
+        Ok(DbUrl(Box::new(Url::parse(&str)?)))
+    }
 }
 
 impl<Kind> From<ObjectId<Kind>> for DbUrl
 where
-  Kind: Object + Send + 'static,
-  for<'de2> <Kind as Object>::Kind: serde::Deserialize<'de2>,
+    Kind: Object + Send + 'static,
+    for<'de2> <Kind as Object>::Kind: serde::Deserialize<'de2>,
 {
-  fn from(id: ObjectId<Kind>) -> Self {
-    DbUrl(Box::new(id.into()))
-  }
+    fn from(id: ObjectId<Kind>) -> Self {
+        DbUrl(Box::new(id.into()))
+    }
 }
 
 pub fn now() -> AsExprOf<diesel::dsl::now, diesel::sql_types::Timestamptz> {
-  // https://github.com/diesel-rs/diesel/issues/1514
-  diesel::dsl::now.into_sql::<Timestamptz>()
+    // https://github.com/diesel-rs/diesel/issues/1514
+    diesel::dsl::now.into_sql::<Timestamptz>()
 }
 
 pub type ResultFuture<'a, T> = BoxFuture<'a, Result<T, DieselError>>;
@@ -439,100 +439,100 @@ impl<'a, T, Args, F: Fn(DbConn<'a>, Args) -> ResultFuture<'a, Vec<T>>> ListFn<'a
 
 /// Allows read and list functions to capture a shared closure that has an inferred return type, which is useful for join logic
 pub struct Queries<RF, LF> {
-  pub read_fn: RF,
-  pub list_fn: LF,
+    pub read_fn: RF,
+    pub list_fn: LF,
 }
 
 // `()` is used to prevent type inference error
 impl Queries<(), ()> {
-  pub fn new<'a, RFut, LFut, RT, LT, RA, LA, RF2, LF2>(
-    read_fn: RF2,
-    list_fn: LF2,
-  ) -> Queries<impl ReadFn<'a, RT, RA>, impl ListFn<'a, LT, LA>>
-  where
-    RFut: Future<Output = Result<RT, DieselError>> + Sized + Send + 'a,
-    LFut: Future<Output = Result<Vec<LT>, DieselError>> + Sized + Send + 'a,
-    RF2: Fn(DbConn<'a>, RA) -> RFut,
-    LF2: Fn(DbConn<'a>, LA) -> LFut,
-  {
-    Queries {
-      read_fn: move |conn, args| read_fn(conn, args).boxed(),
-      list_fn: move |conn, args| list_fn(conn, args).boxed(),
+    pub fn new<'a, RFut, LFut, RT, LT, RA, LA, RF2, LF2>(
+        read_fn: RF2,
+        list_fn: LF2,
+    ) -> Queries<impl ReadFn<'a, RT, RA>, impl ListFn<'a, LT, LA>>
+    where
+        RFut: Future<Output = Result<RT, DieselError>> + Sized + Send + 'a,
+        LFut: Future<Output = Result<Vec<LT>, DieselError>> + Sized + Send + 'a,
+        RF2: Fn(DbConn<'a>, RA) -> RFut,
+        LF2: Fn(DbConn<'a>, LA) -> LFut,
+    {
+        Queries {
+            read_fn: move |conn, args| read_fn(conn, args).boxed(),
+            list_fn: move |conn, args| list_fn(conn, args).boxed(),
+        }
     }
-  }
 }
 
 impl<RF, LF> Queries<RF, LF> {
-  pub async fn read<'a, T, Args>(
-    self,
-    pool: &'a mut DbPool<'_>,
-    args: Args,
-  ) -> Result<T, DieselError>
-  where
-    RF: ReadFn<'a, T, Args>,
-  {
-    let conn = get_conn(pool).await?;
-    (self.read_fn)(conn, args).await
-  }
+    pub async fn read<'a, T, Args>(
+        self,
+        pool: &'a mut DbPool<'_>,
+        args: Args,
+    ) -> Result<T, DieselError>
+    where
+        RF: ReadFn<'a, T, Args>,
+    {
+        let conn = get_conn(pool).await?;
+        (self.read_fn)(conn, args).await
+    }
 
-  pub async fn list<'a, T, Args>(
-    self,
-    pool: &'a mut DbPool<'_>,
-    args: Args,
-  ) -> Result<Vec<T>, DieselError>
-  where
-    LF: ListFn<'a, T, Args>,
-  {
-    let conn = get_conn(pool).await?;
-    (self.list_fn)(conn, args).await
-  }
+    pub async fn list<'a, T, Args>(
+        self,
+        pool: &'a mut DbPool<'_>,
+        args: Args,
+    ) -> Result<Vec<T>, DieselError>
+    where
+        LF: ListFn<'a, T, Args>,
+    {
+        let conn = get_conn(pool).await?;
+        (self.list_fn)(conn, args).await
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use super::{fuzzy_search, *};
-  use crate::utils::is_email_regex;
+    use super::{fuzzy_search, *};
+    use crate::utils::is_email_regex;
 
-  #[test]
-  fn test_fuzzy_search() {
-    let test = "This %is% _a_ fuzzy search";
-    assert_eq!(
-      fuzzy_search(test),
-      "%This%\\%is\\%%\\_a\\_%fuzzy%search%".to_string()
-    );
-  }
+    #[test]
+    fn test_fuzzy_search() {
+        let test = "This %is% _a_ fuzzy search";
+        assert_eq!(
+            fuzzy_search(test),
+            "%This%\\%is\\%%\\_a\\_%fuzzy%search%".to_string()
+        );
+    }
 
-  #[test]
-  fn test_email() {
-    assert!(is_email_regex("gush@gmail.com"));
-    assert!(!is_email_regex("nada_neutho"));
-  }
+    #[test]
+    fn test_email() {
+        assert!(is_email_regex("gush@gmail.com"));
+        assert!(!is_email_regex("nada_neutho"));
+    }
 
-  #[test]
-  fn test_diesel_option_overwrite() {
-    assert_eq!(diesel_option_overwrite(None), None);
-    assert_eq!(diesel_option_overwrite(Some(String::new())), Some(None));
-    assert_eq!(
-      diesel_option_overwrite(Some("test".to_string())),
-      Some(Some("test".to_string()))
-    );
-  }
+    #[test]
+    fn test_diesel_option_overwrite() {
+        assert_eq!(diesel_option_overwrite(None), None);
+        assert_eq!(diesel_option_overwrite(Some(String::new())), Some(None));
+        assert_eq!(
+            diesel_option_overwrite(Some("test".to_string())),
+            Some(Some("test".to_string()))
+        );
+    }
 
-  #[test]
-  fn test_diesel_option_overwrite_to_url() {
-    assert!(matches!(diesel_option_overwrite_to_url(&None), Ok(None)));
-    assert!(matches!(
-      diesel_option_overwrite_to_url(&Some(String::new())),
-      Ok(Some(None))
-    ));
-    assert!(diesel_option_overwrite_to_url(&Some("invalid_url".to_string())).is_err());
-    let example_url = "https://example.com";
-    assert!(matches!(
-      diesel_option_overwrite_to_url(&Some(example_url.to_string())),
-      Ok(Some(Some(url))) if url == Url::parse(example_url).unwrap().into()
-    ));
-  }
+    #[test]
+    fn test_diesel_option_overwrite_to_url() {
+        assert!(matches!(diesel_option_overwrite_to_url(&None), Ok(None)));
+        assert!(matches!(
+            diesel_option_overwrite_to_url(&Some(String::new())),
+            Ok(Some(None))
+        ));
+        assert!(diesel_option_overwrite_to_url(&Some("invalid_url".to_string())).is_err());
+        let example_url = "https://example.com";
+        assert!(matches!(
+          diesel_option_overwrite_to_url(&Some(example_url.to_string())),
+          Ok(Some(Some(url))) if url == Url::parse(example_url).unwrap().into()
+        ));
+    }
 }

--- a/crates/db_views/src/comment_report_view.rs
+++ b/crates/db_views/src/comment_report_view.rs
@@ -1,567 +1,551 @@
 use crate::structs::{CommentReportView, LocalUserView};
 use diesel::{
-  dsl::now,
-  pg::Pg,
-  result::Error,
-  BoolExpressionMethods,
-  ExpressionMethods,
-  JoinOnDsl,
-  NullableExpressionMethods,
-  QueryDsl,
+    dsl::now, pg::Pg, result::Error, BoolExpressionMethods, ExpressionMethods, JoinOnDsl,
+    NullableExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  aliases,
-  newtypes::{CommentReportId, CommunityId, PersonId},
-  schema::{
-    comment,
-    comment_aggregates,
-    comment_like,
-    comment_report,
-    community,
-    community_moderator,
-    community_person_ban,
-    person,
-    post,
-  },
-  utils::{get_conn, limit_and_offset, DbConn, DbPool, ListFn, Queries, ReadFn},
+    aliases,
+    newtypes::{CommentReportId, CommunityId, PersonId},
+    schema::{
+        comment, comment_aggregates, comment_like, comment_report, community, community_moderator,
+        community_person_ban, person, post,
+    },
+    utils::{get_conn, limit_and_offset, DbConn, DbPool, ListFn, Queries, ReadFn},
 };
 
 fn queries<'a>() -> Queries<
-  impl ReadFn<'a, CommentReportView, (CommentReportId, PersonId)>,
-  impl ListFn<'a, CommentReportView, (CommentReportQuery, &'a LocalUserView)>,
+    impl ReadFn<'a, CommentReportView, (CommentReportId, PersonId)>,
+    impl ListFn<'a, CommentReportView, (CommentReportQuery, &'a LocalUserView)>,
 > {
-  let all_joins = |query: comment_report::BoxedQuery<'a, Pg>, my_person_id: PersonId| {
-    query
-      .inner_join(comment::table)
-      .inner_join(post::table.on(comment::post_id.eq(post::id)))
-      .inner_join(community::table.on(post::community_id.eq(community::id)))
-      .inner_join(person::table.on(comment_report::creator_id.eq(person::id)))
-      .inner_join(aliases::person1.on(comment::creator_id.eq(aliases::person1.field(person::id))))
-      .inner_join(
-        comment_aggregates::table.on(comment_report::comment_id.eq(comment_aggregates::comment_id)),
-      )
-      .left_join(
-        comment_like::table.on(
-          comment::id
-            .eq(comment_like::comment_id)
-            .and(comment_like::person_id.eq(my_person_id)),
-        ),
-      )
-      .left_join(
-        aliases::person2
-          .on(comment_report::resolver_id.eq(aliases::person2.field(person::id).nullable())),
-      )
-  };
+    let all_joins =
+        |query: comment_report::BoxedQuery<'a, Pg>, my_person_id: PersonId| {
+            query
+                .inner_join(comment::table)
+                .inner_join(post::table.on(comment::post_id.eq(post::id)))
+                .inner_join(community::table.on(post::community_id.eq(community::id)))
+                .inner_join(person::table.on(comment_report::creator_id.eq(person::id)))
+                .inner_join(
+                    aliases::person1.on(comment::creator_id.eq(aliases::person1.field(person::id))),
+                )
+                .inner_join(
+                    comment_aggregates::table
+                        .on(comment_report::comment_id.eq(comment_aggregates::comment_id)),
+                )
+                .left_join(
+                    comment_like::table.on(comment::id
+                        .eq(comment_like::comment_id)
+                        .and(comment_like::person_id.eq(my_person_id))),
+                )
+                .left_join(aliases::person2.on(
+                    comment_report::resolver_id.eq(aliases::person2.field(person::id).nullable()),
+                ))
+        };
 
-  let selection = (
-    comment_report::all_columns,
-    comment::all_columns,
-    post::all_columns,
-    community::all_columns,
-    person::all_columns,
-    aliases::person1.fields(person::all_columns),
-    comment_aggregates::all_columns,
-    community_person_ban::id.nullable().is_not_null(),
-    comment_like::score.nullable(),
-    aliases::person2.fields(person::all_columns).nullable(),
-  );
+    let selection = (
+        comment_report::all_columns,
+        comment::all_columns,
+        post::all_columns,
+        community::all_columns,
+        person::all_columns,
+        aliases::person1.fields(person::all_columns),
+        comment_aggregates::all_columns,
+        community_person_ban::id.nullable().is_not_null(),
+        comment_like::score.nullable(),
+        aliases::person2.fields(person::all_columns).nullable(),
+    );
 
-  let read = move |mut conn: DbConn<'a>, (report_id, my_person_id): (CommentReportId, PersonId)| async move {
-    all_joins(
-      comment_report::table.find(report_id).into_boxed(),
-      my_person_id,
-    )
-    .left_join(
-      community_person_ban::table.on(
-        community::id
-          .eq(community_person_ban::community_id)
-          .and(community_person_ban::person_id.eq(comment::creator_id)),
-      ),
-    )
-    .select(selection)
-    .first::<CommentReportView>(&mut conn)
-    .await
-  };
-
-  let list = move |mut conn: DbConn<'a>,
-                   (options, user): (CommentReportQuery, &'a LocalUserView)| async move {
-    let mut query = all_joins(comment_report::table.into_boxed(), user.person.id)
-      .left_join(
-        community_person_ban::table.on(
-          community::id
-            .eq(community_person_ban::community_id)
-            .and(community_person_ban::person_id.eq(comment::creator_id))
-            .and(
-              community_person_ban::expires
-                .is_null()
-                .or(community_person_ban::expires.gt(now)),
-            ),
-        ),
-      )
-      .select(selection);
-
-    if let Some(community_id) = options.community_id {
-      query = query.filter(post::community_id.eq(community_id));
-    }
-
-    if options.unresolved_only {
-      query = query.filter(comment_report::resolved.eq(false));
-    }
-
-    let (limit, offset) = limit_and_offset(options.page, options.limit)?;
-
-    query = query
-      .order_by(comment_report::published.desc())
-      .limit(limit)
-      .offset(offset);
-
-    // If its not an admin, get only the ones you mod
-    if !user.local_user.admin {
-      query
-        .inner_join(
-          community_moderator::table.on(
-            community_moderator::community_id
-              .eq(post::community_id)
-              .and(community_moderator::person_id.eq(user.person.id)),
-          ),
+    let read = move |mut conn: DbConn<'a>,
+                     (report_id, my_person_id): (CommentReportId, PersonId)| async move {
+        all_joins(
+            comment_report::table.find(report_id).into_boxed(),
+            my_person_id,
         )
-        .load::<CommentReportView>(&mut conn)
+        .left_join(
+            community_person_ban::table.on(community::id
+                .eq(community_person_ban::community_id)
+                .and(community_person_ban::person_id.eq(comment::creator_id))),
+        )
+        .select(selection)
+        .first::<CommentReportView>(&mut conn)
         .await
-    } else {
-      query.load::<CommentReportView>(&mut conn).await
-    }
-  };
+    };
 
-  Queries::new(read, list)
+    let list = move |mut conn: DbConn<'a>,
+                     (options, user): (CommentReportQuery, &'a LocalUserView)| async move {
+        let mut query = all_joins(comment_report::table.into_boxed(), user.person.id)
+            .left_join(
+                community_person_ban::table.on(community::id
+                    .eq(community_person_ban::community_id)
+                    .and(community_person_ban::person_id.eq(comment::creator_id))
+                    .and(
+                        community_person_ban::expires
+                            .is_null()
+                            .or(community_person_ban::expires.gt(now)),
+                    )),
+            )
+            .select(selection);
+
+        if let Some(community_id) = options.community_id {
+            query = query.filter(post::community_id.eq(community_id));
+        }
+
+        if options.unresolved_only {
+            query = query.filter(comment_report::resolved.eq(false));
+        }
+
+        let (limit, offset) = limit_and_offset(options.page, options.limit)?;
+
+        query = query
+            .order_by(comment_report::published.desc())
+            .limit(limit)
+            .offset(offset);
+
+        // If its not an admin, get only the ones you mod
+        if !user.local_user.admin {
+            query
+                .inner_join(
+                    community_moderator::table.on(community_moderator::community_id
+                        .eq(post::community_id)
+                        .and(community_moderator::person_id.eq(user.person.id))),
+                )
+                .load::<CommentReportView>(&mut conn)
+                .await
+        } else {
+            query.load::<CommentReportView>(&mut conn).await
+        }
+    };
+
+    Queries::new(read, list)
 }
 
 impl CommentReportView {
-  /// returns the CommentReportView for the provided report_id
-  ///
-  /// * `report_id` - the report id to obtain
-  pub async fn read(
-    pool: &mut DbPool<'_>,
-    report_id: CommentReportId,
-    my_person_id: PersonId,
-  ) -> Result<Self, Error> {
-    queries().read(pool, (report_id, my_person_id)).await
-  }
-
-  /// Returns the current unresolved post report count for the communities you mod
-  pub async fn get_report_count(
-    pool: &mut DbPool<'_>,
-    my_person_id: PersonId,
-    admin: bool,
-    community_id: Option<CommunityId>,
-  ) -> Result<i64, Error> {
-    use diesel::dsl::count;
-
-    let conn = &mut get_conn(pool).await?;
-
-    let mut query = comment_report::table
-      .inner_join(comment::table)
-      .inner_join(post::table.on(comment::post_id.eq(post::id)))
-      .filter(comment_report::resolved.eq(false))
-      .into_boxed();
-
-    if let Some(community_id) = community_id {
-      query = query.filter(post::community_id.eq(community_id))
+    /// returns the CommentReportView for the provided report_id
+    ///
+    /// * `report_id` - the report id to obtain
+    pub async fn read(
+        pool: &mut DbPool<'_>,
+        report_id: CommentReportId,
+        my_person_id: PersonId,
+    ) -> Result<Self, Error> {
+        queries().read(pool, (report_id, my_person_id)).await
     }
 
-    // If its not an admin, get only the ones you mod
-    if !admin {
-      query
-        .inner_join(
-          community_moderator::table.on(
-            community_moderator::community_id
-              .eq(post::community_id)
-              .and(community_moderator::person_id.eq(my_person_id)),
-          ),
-        )
-        .select(count(comment_report::id))
-        .first::<i64>(conn)
-        .await
-    } else {
-      query
-        .select(count(comment_report::id))
-        .first::<i64>(conn)
-        .await
+    /// Returns the current unresolved post report count for the communities you mod
+    pub async fn get_report_count(
+        pool: &mut DbPool<'_>,
+        my_person_id: PersonId,
+        admin: bool,
+        community_id: Option<CommunityId>,
+    ) -> Result<i64, Error> {
+        use diesel::dsl::count;
+
+        let conn = &mut get_conn(pool).await?;
+
+        let mut query = comment_report::table
+            .inner_join(comment::table)
+            .inner_join(post::table.on(comment::post_id.eq(post::id)))
+            .filter(comment_report::resolved.eq(false))
+            .into_boxed();
+
+        if let Some(community_id) = community_id {
+            query = query.filter(post::community_id.eq(community_id))
+        }
+
+        // If its not an admin, get only the ones you mod
+        if !admin {
+            query
+                .inner_join(
+                    community_moderator::table.on(community_moderator::community_id
+                        .eq(post::community_id)
+                        .and(community_moderator::person_id.eq(my_person_id))),
+                )
+                .select(count(comment_report::id))
+                .first::<i64>(conn)
+                .await
+        } else {
+            query
+                .select(count(comment_report::id))
+                .first::<i64>(conn)
+                .await
+        }
     }
-  }
 }
 
 #[derive(Default)]
 pub struct CommentReportQuery {
-  pub community_id: Option<CommunityId>,
-  pub page: Option<i64>,
-  pub limit: Option<i64>,
-  pub unresolved_only: bool,
+    pub community_id: Option<CommunityId>,
+    pub page: Option<i64>,
+    pub limit: Option<i64>,
+    pub unresolved_only: bool,
 }
 
 impl CommentReportQuery {
-  pub async fn list(
-    self,
-    pool: &mut DbPool<'_>,
-    user: &LocalUserView,
-  ) -> Result<Vec<CommentReportView>, Error> {
-    queries().list(pool, (self, user)).await
-  }
+    pub async fn list(
+        self,
+        pool: &mut DbPool<'_>,
+        user: &LocalUserView,
+    ) -> Result<Vec<CommentReportView>, Error> {
+        queries().list(pool, (self, user)).await
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::{
-    comment_report_view::{CommentReportQuery, CommentReportView},
-    structs::LocalUserView,
-  };
-  use lemmy_db_schema::{
-    aggregates::structs::CommentAggregates,
-    source::{
-      comment::{Comment, CommentInsertForm},
-      comment_report::{CommentReport, CommentReportForm},
-      community::{Community, CommunityInsertForm, CommunityModerator, CommunityModeratorForm},
-      instance::Instance,
-      local_user::{LocalUser, LocalUserInsertForm},
-      person::{Person, PersonInsertForm},
-      post::{Post, PostInsertForm},
-    },
-    traits::{Crud, Joinable, Reportable},
-    utils::build_db_pool_for_tests,
-  };
-  use serial_test::serial;
-
-  #[tokio::test]
-  #[serial]
-  async fn test_crud() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-
-    let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
-      .await
-      .unwrap();
-
-    let new_person = PersonInsertForm::builder()
-      .name("timmy_crv".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_timmy = Person::create(pool, &new_person).await.unwrap();
-
-    let new_local_user = LocalUserInsertForm::builder()
-      .person_id(inserted_timmy.id)
-      .password_encrypted("123".to_string())
-      .build();
-    let timmy_local_user = LocalUser::create(pool, &new_local_user).await.unwrap();
-    let timmy_view = LocalUserView {
-      local_user: timmy_local_user,
-      person: inserted_timmy.clone(),
-      counts: Default::default(),
+    use crate::{
+        comment_report_view::{CommentReportQuery, CommentReportView},
+        structs::LocalUserView,
     };
-
-    let new_person_2 = PersonInsertForm::builder()
-      .name("sara_crv".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_sara = Person::create(pool, &new_person_2).await.unwrap();
-
-    // Add a third person, since new ppl can only report something once.
-    let new_person_3 = PersonInsertForm::builder()
-      .name("jessica_crv".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_jessica = Person::create(pool, &new_person_3).await.unwrap();
-
-    let new_community = CommunityInsertForm::builder()
-      .name("test community crv".to_string())
-      .title("nada".to_owned())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_community = Community::create(pool, &new_community).await.unwrap();
-
-    // Make timmy a mod
-    let timmy_moderator_form = CommunityModeratorForm {
-      community_id: inserted_community.id,
-      person_id: inserted_timmy.id,
+    use lemmy_db_schema::{
+        aggregates::structs::CommentAggregates,
+        source::{
+            comment::{Comment, CommentInsertForm},
+            comment_report::{CommentReport, CommentReportForm},
+            community::{
+                Community, CommunityInsertForm, CommunityModerator, CommunityModeratorForm,
+            },
+            instance::Instance,
+            local_user::{LocalUser, LocalUserInsertForm},
+            person::{Person, PersonInsertForm},
+            post::{Post, PostInsertForm},
+        },
+        traits::{Crud, Joinable, Reportable},
+        utils::build_db_pool_for_tests,
     };
+    use serial_test::serial;
 
-    let _inserted_moderator = CommunityModerator::join(pool, &timmy_moderator_form)
-      .await
-      .unwrap();
+    #[tokio::test]
+    #[serial]
+    async fn test_crud() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
 
-    let new_post = PostInsertForm::builder()
-      .name("A test post crv".into())
-      .creator_id(inserted_timmy.id)
-      .community_id(inserted_community.id)
-      .build();
+        let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
+            .await
+            .unwrap();
 
-    let inserted_post = Post::create(pool, &new_post).await.unwrap();
+        let new_person = PersonInsertForm::builder()
+            .name("timmy_crv".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let comment_form = CommentInsertForm::builder()
-      .content("A test comment 32".into())
-      .creator_id(inserted_timmy.id)
-      .post_id(inserted_post.id)
-      .build();
+        let inserted_timmy = Person::create(pool, &new_person).await.unwrap();
 
-    let inserted_comment = Comment::create(pool, &comment_form, None).await.unwrap();
+        let new_local_user = LocalUserInsertForm::builder()
+            .person_id(inserted_timmy.id)
+            .password_encrypted("123".to_string())
+            .build();
+        let timmy_local_user = LocalUser::create(pool, &new_local_user).await.unwrap();
+        let timmy_view = LocalUserView {
+            local_user: timmy_local_user,
+            person: inserted_timmy.clone(),
+            counts: Default::default(),
+        };
 
-    // sara reports
-    let sara_report_form = CommentReportForm {
-      creator_id: inserted_sara.id,
-      comment_id: inserted_comment.id,
-      original_comment_text: "this was it at time of creation".into(),
-      reason: "from sara".into(),
-    };
+        let new_person_2 = PersonInsertForm::builder()
+            .name("sara_crv".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let inserted_sara_report = CommentReport::report(pool, &sara_report_form)
-      .await
-      .unwrap();
+        let inserted_sara = Person::create(pool, &new_person_2).await.unwrap();
 
-    // jessica reports
-    let jessica_report_form = CommentReportForm {
-      creator_id: inserted_jessica.id,
-      comment_id: inserted_comment.id,
-      original_comment_text: "this was it at time of creation".into(),
-      reason: "from jessica".into(),
-    };
+        // Add a third person, since new ppl can only report something once.
+        let new_person_3 = PersonInsertForm::builder()
+            .name("jessica_crv".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let inserted_jessica_report = CommentReport::report(pool, &jessica_report_form)
-      .await
-      .unwrap();
+        let inserted_jessica = Person::create(pool, &new_person_3).await.unwrap();
 
-    let agg = CommentAggregates::read(pool, inserted_comment.id)
-      .await
-      .unwrap();
+        let new_community = CommunityInsertForm::builder()
+            .name("test community crv".to_string())
+            .title("nada".to_owned())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let read_jessica_report_view =
-      CommentReportView::read(pool, inserted_jessica_report.id, inserted_timmy.id)
+        let inserted_community = Community::create(pool, &new_community).await.unwrap();
+
+        // Make timmy a mod
+        let timmy_moderator_form = CommunityModeratorForm {
+            community_id: inserted_community.id,
+            person_id: inserted_timmy.id,
+        };
+
+        let _inserted_moderator = CommunityModerator::join(pool, &timmy_moderator_form)
+            .await
+            .unwrap();
+
+        let new_post = PostInsertForm::builder()
+            .name("A test post crv".into())
+            .creator_id(inserted_timmy.id)
+            .community_id(inserted_community.id)
+            .build();
+
+        let inserted_post = Post::create(pool, &new_post).await.unwrap();
+
+        let comment_form = CommentInsertForm::builder()
+            .content("A test comment 32".into())
+            .creator_id(inserted_timmy.id)
+            .post_id(inserted_post.id)
+            .build();
+
+        let inserted_comment = Comment::create(pool, &comment_form, None).await.unwrap();
+
+        // sara reports
+        let sara_report_form = CommentReportForm {
+            creator_id: inserted_sara.id,
+            comment_id: inserted_comment.id,
+            original_comment_text: "this was it at time of creation".into(),
+            reason: "from sara".into(),
+        };
+
+        let inserted_sara_report = CommentReport::report(pool, &sara_report_form)
+            .await
+            .unwrap();
+
+        // jessica reports
+        let jessica_report_form = CommentReportForm {
+            creator_id: inserted_jessica.id,
+            comment_id: inserted_comment.id,
+            original_comment_text: "this was it at time of creation".into(),
+            reason: "from jessica".into(),
+        };
+
+        let inserted_jessica_report = CommentReport::report(pool, &jessica_report_form)
+            .await
+            .unwrap();
+
+        let agg = CommentAggregates::read(pool, inserted_comment.id)
+            .await
+            .unwrap();
+
+        let read_jessica_report_view =
+            CommentReportView::read(pool, inserted_jessica_report.id, inserted_timmy.id)
+                .await
+                .unwrap();
+        let expected_jessica_report_view = CommentReportView {
+            comment_report: inserted_jessica_report.clone(),
+            comment: inserted_comment.clone(),
+            post: inserted_post,
+            community: Community {
+                id: inserted_community.id,
+                name: inserted_community.name,
+                icon: None,
+                removed: false,
+                deleted: false,
+                nsfw: false,
+                actor_id: inserted_community.actor_id.clone(),
+                local: true,
+                title: inserted_community.title,
+                description: None,
+                updated: None,
+                banner: None,
+                hidden: false,
+                posting_restricted_to_mods: false,
+                published: inserted_community.published,
+                private_key: inserted_community.private_key,
+                public_key: inserted_community.public_key,
+                last_refreshed_at: inserted_community.last_refreshed_at,
+                followers_url: inserted_community.followers_url,
+                inbox_url: inserted_community.inbox_url,
+                shared_inbox_url: inserted_community.shared_inbox_url,
+                moderators_url: inserted_community.moderators_url,
+                featured_url: inserted_community.featured_url,
+                instance_id: inserted_instance.id,
+            },
+            creator: Person {
+                id: inserted_jessica.id,
+                name: inserted_jessica.name,
+                display_name: None,
+                published: inserted_jessica.published,
+                avatar: None,
+                actor_id: inserted_jessica.actor_id.clone(),
+                local: true,
+                banned: false,
+                deleted: false,
+                bot_account: false,
+                bio: None,
+                banner: None,
+                updated: None,
+                inbox_url: inserted_jessica.inbox_url.clone(),
+                shared_inbox_url: None,
+                matrix_user_id: None,
+                ban_expires: None,
+                instance_id: inserted_instance.id,
+                private_key: inserted_jessica.private_key,
+                public_key: inserted_jessica.public_key,
+                last_refreshed_at: inserted_jessica.last_refreshed_at,
+            },
+            comment_creator: Person {
+                id: inserted_timmy.id,
+                name: inserted_timmy.name.clone(),
+                display_name: None,
+                published: inserted_timmy.published,
+                avatar: None,
+                actor_id: inserted_timmy.actor_id.clone(),
+                local: true,
+                banned: false,
+                deleted: false,
+                bot_account: false,
+                bio: None,
+                banner: None,
+                updated: None,
+                inbox_url: inserted_timmy.inbox_url.clone(),
+                shared_inbox_url: None,
+                matrix_user_id: None,
+                ban_expires: None,
+                instance_id: inserted_instance.id,
+                private_key: inserted_timmy.private_key.clone(),
+                public_key: inserted_timmy.public_key.clone(),
+                last_refreshed_at: inserted_timmy.last_refreshed_at,
+            },
+            creator_banned_from_community: false,
+            counts: CommentAggregates {
+                id: agg.id,
+                comment_id: inserted_comment.id,
+                score: 0,
+                upvotes: 0,
+                downvotes: 0,
+                published: agg.published,
+                child_count: 0,
+                hot_rank: 1728,
+                controversy_rank: 0.0,
+            },
+            my_vote: None,
+            resolver: None,
+        };
+
+        assert_eq!(read_jessica_report_view, expected_jessica_report_view);
+
+        let mut expected_sara_report_view = expected_jessica_report_view.clone();
+        expected_sara_report_view.comment_report = inserted_sara_report;
+        expected_sara_report_view.creator = Person {
+            id: inserted_sara.id,
+            name: inserted_sara.name,
+            display_name: None,
+            published: inserted_sara.published,
+            avatar: None,
+            actor_id: inserted_sara.actor_id.clone(),
+            local: true,
+            banned: false,
+            deleted: false,
+            bot_account: false,
+            bio: None,
+            banner: None,
+            updated: None,
+            inbox_url: inserted_sara.inbox_url.clone(),
+            shared_inbox_url: None,
+            matrix_user_id: None,
+            ban_expires: None,
+            instance_id: inserted_instance.id,
+            private_key: inserted_sara.private_key,
+            public_key: inserted_sara.public_key,
+            last_refreshed_at: inserted_sara.last_refreshed_at,
+        };
+
+        // Do a batch read of timmys reports
+        let reports = CommentReportQuery::default()
+            .list(pool, &timmy_view)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            reports,
+            [
+                expected_jessica_report_view.clone(),
+                expected_sara_report_view.clone()
+            ]
+        );
+
+        // Make sure the counts are correct
+        let report_count =
+            CommentReportView::get_report_count(pool, inserted_timmy.id, false, None)
+                .await
+                .unwrap();
+        assert_eq!(2, report_count);
+
+        // Try to resolve the report
+        CommentReport::resolve(pool, inserted_jessica_report.id, inserted_timmy.id)
+            .await
+            .unwrap();
+        let read_jessica_report_view_after_resolve =
+            CommentReportView::read(pool, inserted_jessica_report.id, inserted_timmy.id)
+                .await
+                .unwrap();
+
+        let mut expected_jessica_report_view_after_resolve = expected_jessica_report_view;
+        expected_jessica_report_view_after_resolve
+            .comment_report
+            .resolved = true;
+        expected_jessica_report_view_after_resolve
+            .comment_report
+            .resolver_id = Some(inserted_timmy.id);
+        expected_jessica_report_view_after_resolve
+            .comment_report
+            .updated = read_jessica_report_view_after_resolve
+            .comment_report
+            .updated;
+        expected_jessica_report_view_after_resolve.resolver = Some(Person {
+            id: inserted_timmy.id,
+            name: inserted_timmy.name.clone(),
+            display_name: None,
+            published: inserted_timmy.published,
+            avatar: None,
+            actor_id: inserted_timmy.actor_id.clone(),
+            local: true,
+            banned: false,
+            deleted: false,
+            bot_account: false,
+            bio: None,
+            banner: None,
+            updated: None,
+            inbox_url: inserted_timmy.inbox_url.clone(),
+            private_key: inserted_timmy.private_key.clone(),
+            public_key: inserted_timmy.public_key.clone(),
+            last_refreshed_at: inserted_timmy.last_refreshed_at,
+            shared_inbox_url: None,
+            matrix_user_id: None,
+            ban_expires: None,
+            instance_id: inserted_instance.id,
+        });
+
+        assert_eq!(
+            read_jessica_report_view_after_resolve,
+            expected_jessica_report_view_after_resolve
+        );
+
+        // Do a batch read of timmys reports
+        // It should only show saras, which is unresolved
+        let reports_after_resolve = CommentReportQuery {
+            unresolved_only: (true),
+            ..Default::default()
+        }
+        .list(pool, &timmy_view)
         .await
         .unwrap();
-    let expected_jessica_report_view = CommentReportView {
-      comment_report: inserted_jessica_report.clone(),
-      comment: inserted_comment.clone(),
-      post: inserted_post,
-      community: Community {
-        id: inserted_community.id,
-        name: inserted_community.name,
-        icon: None,
-        removed: false,
-        deleted: false,
-        nsfw: false,
-        actor_id: inserted_community.actor_id.clone(),
-        local: true,
-        title: inserted_community.title,
-        description: None,
-        updated: None,
-        banner: None,
-        hidden: false,
-        posting_restricted_to_mods: false,
-        published: inserted_community.published,
-        private_key: inserted_community.private_key,
-        public_key: inserted_community.public_key,
-        last_refreshed_at: inserted_community.last_refreshed_at,
-        followers_url: inserted_community.followers_url,
-        inbox_url: inserted_community.inbox_url,
-        shared_inbox_url: inserted_community.shared_inbox_url,
-        moderators_url: inserted_community.moderators_url,
-        featured_url: inserted_community.featured_url,
-        instance_id: inserted_instance.id,
-      },
-      creator: Person {
-        id: inserted_jessica.id,
-        name: inserted_jessica.name,
-        display_name: None,
-        published: inserted_jessica.published,
-        avatar: None,
-        actor_id: inserted_jessica.actor_id.clone(),
-        local: true,
-        banned: false,
-        deleted: false,
-        bot_account: false,
-        bio: None,
-        banner: None,
-        updated: None,
-        inbox_url: inserted_jessica.inbox_url.clone(),
-        shared_inbox_url: None,
-        matrix_user_id: None,
-        ban_expires: None,
-        instance_id: inserted_instance.id,
-        private_key: inserted_jessica.private_key,
-        public_key: inserted_jessica.public_key,
-        last_refreshed_at: inserted_jessica.last_refreshed_at,
-      },
-      comment_creator: Person {
-        id: inserted_timmy.id,
-        name: inserted_timmy.name.clone(),
-        display_name: None,
-        published: inserted_timmy.published,
-        avatar: None,
-        actor_id: inserted_timmy.actor_id.clone(),
-        local: true,
-        banned: false,
-        deleted: false,
-        bot_account: false,
-        bio: None,
-        banner: None,
-        updated: None,
-        inbox_url: inserted_timmy.inbox_url.clone(),
-        shared_inbox_url: None,
-        matrix_user_id: None,
-        ban_expires: None,
-        instance_id: inserted_instance.id,
-        private_key: inserted_timmy.private_key.clone(),
-        public_key: inserted_timmy.public_key.clone(),
-        last_refreshed_at: inserted_timmy.last_refreshed_at,
-      },
-      creator_banned_from_community: false,
-      counts: CommentAggregates {
-        id: agg.id,
-        comment_id: inserted_comment.id,
-        score: 0,
-        upvotes: 0,
-        downvotes: 0,
-        published: agg.published,
-        child_count: 0,
-        hot_rank: 1728,
-        controversy_rank: 0.0,
-      },
-      my_vote: None,
-      resolver: None,
-    };
+        assert_eq!(reports_after_resolve[0], expected_sara_report_view);
+        assert_eq!(reports_after_resolve.len(), 1);
 
-    assert_eq!(read_jessica_report_view, expected_jessica_report_view);
+        // Make sure the counts are correct
+        let report_count_after_resolved =
+            CommentReportView::get_report_count(pool, inserted_timmy.id, false, None)
+                .await
+                .unwrap();
+        assert_eq!(1, report_count_after_resolved);
 
-    let mut expected_sara_report_view = expected_jessica_report_view.clone();
-    expected_sara_report_view.comment_report = inserted_sara_report;
-    expected_sara_report_view.creator = Person {
-      id: inserted_sara.id,
-      name: inserted_sara.name,
-      display_name: None,
-      published: inserted_sara.published,
-      avatar: None,
-      actor_id: inserted_sara.actor_id.clone(),
-      local: true,
-      banned: false,
-      deleted: false,
-      bot_account: false,
-      bio: None,
-      banner: None,
-      updated: None,
-      inbox_url: inserted_sara.inbox_url.clone(),
-      shared_inbox_url: None,
-      matrix_user_id: None,
-      ban_expires: None,
-      instance_id: inserted_instance.id,
-      private_key: inserted_sara.private_key,
-      public_key: inserted_sara.public_key,
-      last_refreshed_at: inserted_sara.last_refreshed_at,
-    };
-
-    // Do a batch read of timmys reports
-    let reports = CommentReportQuery::default()
-      .list(pool, &timmy_view)
-      .await
-      .unwrap();
-
-    assert_eq!(
-      reports,
-      [
-        expected_jessica_report_view.clone(),
-        expected_sara_report_view.clone()
-      ]
-    );
-
-    // Make sure the counts are correct
-    let report_count = CommentReportView::get_report_count(pool, inserted_timmy.id, false, None)
-      .await
-      .unwrap();
-    assert_eq!(2, report_count);
-
-    // Try to resolve the report
-    CommentReport::resolve(pool, inserted_jessica_report.id, inserted_timmy.id)
-      .await
-      .unwrap();
-    let read_jessica_report_view_after_resolve =
-      CommentReportView::read(pool, inserted_jessica_report.id, inserted_timmy.id)
-        .await
-        .unwrap();
-
-    let mut expected_jessica_report_view_after_resolve = expected_jessica_report_view;
-    expected_jessica_report_view_after_resolve
-      .comment_report
-      .resolved = true;
-    expected_jessica_report_view_after_resolve
-      .comment_report
-      .resolver_id = Some(inserted_timmy.id);
-    expected_jessica_report_view_after_resolve
-      .comment_report
-      .updated = read_jessica_report_view_after_resolve
-      .comment_report
-      .updated;
-    expected_jessica_report_view_after_resolve.resolver = Some(Person {
-      id: inserted_timmy.id,
-      name: inserted_timmy.name.clone(),
-      display_name: None,
-      published: inserted_timmy.published,
-      avatar: None,
-      actor_id: inserted_timmy.actor_id.clone(),
-      local: true,
-      banned: false,
-      deleted: false,
-      bot_account: false,
-      bio: None,
-      banner: None,
-      updated: None,
-      inbox_url: inserted_timmy.inbox_url.clone(),
-      private_key: inserted_timmy.private_key.clone(),
-      public_key: inserted_timmy.public_key.clone(),
-      last_refreshed_at: inserted_timmy.last_refreshed_at,
-      shared_inbox_url: None,
-      matrix_user_id: None,
-      ban_expires: None,
-      instance_id: inserted_instance.id,
-    });
-
-    assert_eq!(
-      read_jessica_report_view_after_resolve,
-      expected_jessica_report_view_after_resolve
-    );
-
-    // Do a batch read of timmys reports
-    // It should only show saras, which is unresolved
-    let reports_after_resolve = CommentReportQuery {
-      unresolved_only: (true),
-      ..Default::default()
+        Person::delete(pool, inserted_timmy.id).await.unwrap();
+        Person::delete(pool, inserted_sara.id).await.unwrap();
+        Person::delete(pool, inserted_jessica.id).await.unwrap();
+        Community::delete(pool, inserted_community.id)
+            .await
+            .unwrap();
+        Instance::delete(pool, inserted_instance.id).await.unwrap();
     }
-    .list(pool, &timmy_view)
-    .await
-    .unwrap();
-    assert_eq!(reports_after_resolve[0], expected_sara_report_view);
-    assert_eq!(reports_after_resolve.len(), 1);
-
-    // Make sure the counts are correct
-    let report_count_after_resolved =
-      CommentReportView::get_report_count(pool, inserted_timmy.id, false, None)
-        .await
-        .unwrap();
-    assert_eq!(1, report_count_after_resolved);
-
-    Person::delete(pool, inserted_timmy.id).await.unwrap();
-    Person::delete(pool, inserted_sara.id).await.unwrap();
-    Person::delete(pool, inserted_jessica.id).await.unwrap();
-    Community::delete(pool, inserted_community.id)
-      .await
-      .unwrap();
-    Instance::delete(pool, inserted_instance.id).await.unwrap();
-  }
 }

--- a/crates/db_views/src/comment_view.rs
+++ b/crates/db_views/src/comment_view.rs
@@ -1,894 +1,866 @@
 use crate::structs::{CommentView, LocalUserView};
 use diesel::{
-  pg::Pg,
-  result::Error,
-  BoolExpressionMethods,
-  ExpressionMethods,
-  JoinOnDsl,
-  NullableExpressionMethods,
-  PgTextExpressionMethods,
-  QueryDsl,
+    pg::Pg, result::Error, BoolExpressionMethods, ExpressionMethods, JoinOnDsl,
+    NullableExpressionMethods, PgTextExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use diesel_ltree::{nlevel, subpath, Ltree, LtreeExtensions};
 use lemmy_db_schema::{
-  newtypes::{CommentId, CommunityId, LocalUserId, PersonId, PostId},
-  schema::{
-    comment,
-    comment_aggregates,
-    comment_like,
-    comment_saved,
-    community,
-    community_block,
-    community_follower,
-    community_moderator,
-    community_person_ban,
-    local_user_language,
-    person,
-    person_block,
-    post,
-  },
-  source::community::CommunityFollower,
-  utils::{fuzzy_search, limit_and_offset, DbConn, DbPool, ListFn, Queries, ReadFn},
-  CommentSortType,
-  ListingType,
+    newtypes::{CommentId, CommunityId, LocalUserId, PersonId, PostId},
+    schema::{
+        comment, comment_aggregates, comment_like, comment_saved, community, community_block,
+        community_follower, community_moderator, community_person_ban, local_user_language, person,
+        person_block, post,
+    },
+    source::community::CommunityFollower,
+    utils::{fuzzy_search, limit_and_offset, DbConn, DbPool, ListFn, Queries, ReadFn},
+    CommentSortType, ListingType,
 };
 
 fn queries<'a>() -> Queries<
-  impl ReadFn<'a, CommentView, (CommentId, Option<PersonId>)>,
-  impl ListFn<'a, CommentView, CommentQuery<'a>>,
+    impl ReadFn<'a, CommentView, (CommentId, Option<PersonId>)>,
+    impl ListFn<'a, CommentView, CommentQuery<'a>>,
 > {
-  let all_joins = |query: comment::BoxedQuery<'a, Pg>, my_person_id: Option<PersonId>| {
-    // The left join below will return None in this case
-    let person_id_join = my_person_id.unwrap_or(PersonId(-1));
-    query
-      .inner_join(person::table)
-      .inner_join(post::table)
-      .inner_join(community::table.on(post::community_id.eq(community::id)))
-      .inner_join(comment_aggregates::table)
-      .left_join(
-        community_person_ban::table.on(
-          community::id
-            .eq(community_person_ban::community_id)
-            .and(community_person_ban::person_id.eq(comment::creator_id)),
-        ),
-      )
-      .left_join(
-        community_follower::table.on(
-          post::community_id
-            .eq(community_follower::community_id)
-            .and(community_follower::person_id.eq(person_id_join)),
-        ),
-      )
-      .left_join(
-        comment_saved::table.on(
-          comment::id
-            .eq(comment_saved::comment_id)
-            .and(comment_saved::person_id.eq(person_id_join)),
-        ),
-      )
-      .left_join(
-        person_block::table.on(
-          comment::creator_id
-            .eq(person_block::target_id)
-            .and(person_block::person_id.eq(person_id_join)),
-        ),
-      )
-      .left_join(
-        comment_like::table.on(
-          comment::id
-            .eq(comment_like::comment_id)
-            .and(comment_like::person_id.eq(person_id_join)),
-        ),
-      )
-      .left_join(
-        community_moderator::table.on(
-          post::id
-            .eq(comment::post_id)
-            .and(post::community_id.eq(community_moderator::community_id))
-            .and(community_moderator::person_id.eq(person_id_join)),
-        ),
-      )
-  };
-
-  let selection = (
-    comment::all_columns,
-    person::all_columns,
-    post::all_columns,
-    community::all_columns,
-    comment_aggregates::all_columns,
-    community_person_ban::id.nullable().is_not_null(),
-    CommunityFollower::select_subscribed_type(),
-    comment_saved::id.nullable().is_not_null(),
-    person_block::id.nullable().is_not_null(),
-    comment_like::score.nullable(),
-  );
-
-  let read = move |mut conn: DbConn<'a>,
-                   (comment_id, my_person_id): (CommentId, Option<PersonId>)| async move {
-    all_joins(comment::table.find(comment_id).into_boxed(), my_person_id)
-      .select(selection)
-      .first::<CommentView>(&mut conn)
-      .await
-  };
-
-  let list = move |mut conn: DbConn<'a>, options: CommentQuery<'a>| async move {
-    let person_id = options.local_user.map(|l| l.person.id);
-    let local_user_id = options.local_user.map(|l| l.local_user.id);
-
-    // The left join below will return None in this case
-    let person_id_join = person_id.unwrap_or(PersonId(-1));
-    let local_user_id_join = local_user_id.unwrap_or(LocalUserId(-1));
-
-    let mut query = all_joins(comment::table.into_boxed(), person_id)
-      .left_join(
-        community_block::table.on(
-          community::id
-            .eq(community_block::community_id)
-            .and(community_block::person_id.eq(person_id_join)),
-        ),
-      )
-      .left_join(
-        local_user_language::table.on(
-          comment::language_id
-            .eq(local_user_language::language_id)
-            .and(local_user_language::local_user_id.eq(local_user_id_join)),
-        ),
-      )
-      .select(selection);
-
-    if let Some(creator_id) = options.creator_id {
-      query = query.filter(comment::creator_id.eq(creator_id));
+    let all_joins = |query: comment::BoxedQuery<'a, Pg>, my_person_id: Option<PersonId>| {
+        // The left join below will return None in this case
+        let person_id_join = my_person_id.unwrap_or(PersonId(-1));
+        query
+            .inner_join(person::table)
+            .inner_join(post::table)
+            .inner_join(community::table.on(post::community_id.eq(community::id)))
+            .inner_join(comment_aggregates::table)
+            .left_join(
+                community_person_ban::table.on(community::id
+                    .eq(community_person_ban::community_id)
+                    .and(community_person_ban::person_id.eq(comment::creator_id))),
+            )
+            .left_join(
+                community_follower::table.on(post::community_id
+                    .eq(community_follower::community_id)
+                    .and(community_follower::person_id.eq(person_id_join))),
+            )
+            .left_join(
+                comment_saved::table.on(comment::id
+                    .eq(comment_saved::comment_id)
+                    .and(comment_saved::person_id.eq(person_id_join))),
+            )
+            .left_join(
+                person_block::table.on(comment::creator_id
+                    .eq(person_block::target_id)
+                    .and(person_block::person_id.eq(person_id_join))),
+            )
+            .left_join(
+                comment_like::table.on(comment::id
+                    .eq(comment_like::comment_id)
+                    .and(comment_like::person_id.eq(person_id_join))),
+            )
+            .left_join(
+                community_moderator::table.on(post::id
+                    .eq(comment::post_id)
+                    .and(post::community_id.eq(community_moderator::community_id))
+                    .and(community_moderator::person_id.eq(person_id_join))),
+            )
     };
 
-    if let Some(post_id) = options.post_id {
-      query = query.filter(comment::post_id.eq(post_id));
+    let selection = (
+        comment::all_columns,
+        person::all_columns,
+        post::all_columns,
+        community::all_columns,
+        comment_aggregates::all_columns,
+        community_person_ban::id.nullable().is_not_null(),
+        CommunityFollower::select_subscribed_type(),
+        comment_saved::id.nullable().is_not_null(),
+        person_block::id.nullable().is_not_null(),
+        comment_like::score.nullable(),
+    );
+
+    let read = move |mut conn: DbConn<'a>,
+                     (comment_id, my_person_id): (CommentId, Option<PersonId>)| async move {
+        all_joins(comment::table.find(comment_id).into_boxed(), my_person_id)
+            .select(selection)
+            .first::<CommentView>(&mut conn)
+            .await
     };
 
-    if let Some(parent_path) = options.parent_path.as_ref() {
-      query = query.filter(comment::path.contained_by(parent_path));
-    };
+    let list = move |mut conn: DbConn<'a>, options: CommentQuery<'a>| async move {
+        let person_id = options.local_user.map(|l| l.person.id);
+        let local_user_id = options.local_user.map(|l| l.local_user.id);
 
-    if let Some(search_term) = options.search_term {
-      query = query.filter(comment::content.ilike(fuzzy_search(&search_term)));
-    };
+        // The left join below will return None in this case
+        let person_id_join = person_id.unwrap_or(PersonId(-1));
+        let local_user_id_join = local_user_id.unwrap_or(LocalUserId(-1));
 
-    if let Some(community_id) = options.community_id {
-      query = query.filter(post::community_id.eq(community_id));
-    }
+        let mut query = all_joins(comment::table.into_boxed(), person_id)
+            .left_join(
+                community_block::table.on(community::id
+                    .eq(community_block::community_id)
+                    .and(community_block::person_id.eq(person_id_join))),
+            )
+            .left_join(
+                local_user_language::table.on(comment::language_id
+                    .eq(local_user_language::language_id)
+                    .and(local_user_language::local_user_id.eq(local_user_id_join))),
+            )
+            .select(selection);
 
-    if let Some(listing_type) = options.listing_type {
-      match listing_type {
-        ListingType::Subscribed => query = query.filter(community_follower::pending.is_not_null()), // TODO could be this: and(community_follower::person_id.eq(person_id_join)),
-        ListingType::Local => {
-          query = query.filter(community::local.eq(true)).filter(
-            community::hidden
-              .eq(false)
-              .or(community_follower::person_id.eq(person_id_join)),
-          )
+        if let Some(creator_id) = options.creator_id {
+            query = query.filter(comment::creator_id.eq(creator_id));
+        };
+
+        if let Some(post_id) = options.post_id {
+            query = query.filter(comment::post_id.eq(post_id));
+        };
+
+        if let Some(parent_path) = options.parent_path.as_ref() {
+            query = query.filter(comment::path.contained_by(parent_path));
+        };
+
+        if let Some(search_term) = options.search_term {
+            query = query.filter(comment::content.ilike(fuzzy_search(&search_term)));
+        };
+
+        if let Some(community_id) = options.community_id {
+            query = query.filter(post::community_id.eq(community_id));
         }
-        ListingType::All => {
-          query = query.filter(
-            community::hidden
-              .eq(false)
-              .or(community_follower::person_id.eq(person_id_join)),
-          )
+
+        if let Some(listing_type) = options.listing_type {
+            match listing_type {
+                ListingType::Subscribed => {
+                    query = query.filter(community_follower::pending.is_not_null())
+                } // TODO could be this: and(community_follower::person_id.eq(person_id_join)),
+                ListingType::Local => {
+                    query = query.filter(community::local.eq(true)).filter(
+                        community::hidden
+                            .eq(false)
+                            .or(community_follower::person_id.eq(person_id_join)),
+                    )
+                }
+                ListingType::All => {
+                    query = query.filter(
+                        community::hidden
+                            .eq(false)
+                            .or(community_follower::person_id.eq(person_id_join)),
+                    )
+                }
+                ListingType::ModeratorView => {
+                    query = query.filter(community_moderator::person_id.is_not_null());
+                }
+            }
         }
-        ListingType::ModeratorView => {
-          query = query.filter(community_moderator::person_id.is_not_null());
+
+        if options.saved_only {
+            query = query.filter(comment_saved::comment_id.is_not_null());
         }
-      }
-    }
 
-    if options.saved_only {
-      query = query.filter(comment_saved::comment_id.is_not_null());
-    }
+        if options.liked_only {
+            query = query.filter(comment_like::score.eq(1));
+        } else if options.disliked_only {
+            query = query.filter(comment_like::score.eq(-1));
+        }
 
-    if options.liked_only {
-      query = query.filter(comment_like::score.eq(1));
-    } else if options.disliked_only {
-      query = query.filter(comment_like::score.eq(-1));
-    }
+        let is_creator = options.creator_id == options.local_user.map(|l| l.person.id);
+        // only show deleted comments to creator
+        if !is_creator {
+            query = query.filter(comment::deleted.eq(false));
+        }
 
-    let is_creator = options.creator_id == options.local_user.map(|l| l.person.id);
-    // only show deleted comments to creator
-    if !is_creator {
-      query = query.filter(comment::deleted.eq(false));
-    }
+        let is_admin = options
+            .local_user
+            .map(|l| l.local_user.admin)
+            .unwrap_or(false);
+        // only show removed comments to admin when viewing user profile
+        if !(options.is_profile_view && is_admin) {
+            query = query.filter(comment::removed.eq(false));
+        }
 
-    let is_admin = options
-      .local_user
-      .map(|l| l.local_user.admin)
-      .unwrap_or(false);
-    // only show removed comments to admin when viewing user profile
-    if !(options.is_profile_view && is_admin) {
-      query = query.filter(comment::removed.eq(false));
-    }
+        if !options
+            .local_user
+            .map(|l| l.local_user.show_bot_accounts)
+            .unwrap_or(true)
+        {
+            query = query.filter(person::bot_account.eq(false));
+        };
 
-    if !options
-      .local_user
-      .map(|l| l.local_user.show_bot_accounts)
-      .unwrap_or(true)
-    {
-      query = query.filter(person::bot_account.eq(false));
+        if options.local_user.is_some()
+            && options.listing_type.unwrap_or_default() != ListingType::ModeratorView
+        {
+            // Filter out the rows with missing languages
+            query = query.filter(local_user_language::language_id.is_not_null());
+
+            // Don't show blocked communities or persons
+            if options.post_id.is_none() {
+                query = query.filter(community_block::person_id.is_null());
+            }
+            query = query.filter(person_block::person_id.is_null());
+        }
+
+        // A Max depth given means its a tree fetch
+        let (limit, offset) = if let Some(max_depth) = options.max_depth {
+            let depth_limit = if let Some(parent_path) = options.parent_path.as_ref() {
+                parent_path.0.split('.').count() as i32 + max_depth
+                // Add one because of root "0"
+            } else {
+                max_depth + 1
+            };
+
+            query = query.filter(nlevel(comment::path).le(depth_limit));
+
+            // only order if filtering by a post id, or parent_path. DOS potential otherwise and max_depth + !post_id isn't used anyways (afaik)
+            if options.post_id.is_some() || options.parent_path.is_some() {
+                // Always order by the parent path first
+                query = query.order_by(subpath(comment::path, 0, -1));
+            }
+
+            // TODO limit question. Limiting does not work for comment threads ATM, only max_depth
+            // For now, don't do any limiting for tree fetches
+            // https://stackoverflow.com/questions/72983614/postgres-ltree-how-to-limit-the-max-number-of-children-at-any-given-level
+
+            // Don't use the regular error-checking one, many more comments must ofter be fetched.
+            // This does not work for comment trees, and the limit should be manually set to a high number
+            //
+            // If a max depth is given, then you know its a tree fetch, and limits should be ignored
+            // TODO a kludge to prevent attacks. Limit comments to 300 for now.
+            // (i64::MAX, 0)
+            (300, 0)
+        } else {
+            // limit_and_offset_unlimited(options.page, options.limit)
+            limit_and_offset(options.page, options.limit)?
+        };
+
+        query = match options.sort.unwrap_or(CommentSortType::Hot) {
+            CommentSortType::Hot => query
+                .then_order_by(comment_aggregates::hot_rank.desc())
+                .then_order_by(comment_aggregates::score.desc()),
+            CommentSortType::Controversial => {
+                query.then_order_by(comment_aggregates::controversy_rank.desc())
+            }
+            CommentSortType::New => query.then_order_by(comment::published.desc()),
+            CommentSortType::Old => query.then_order_by(comment::published.asc()),
+            CommentSortType::Top => query.order_by(comment_aggregates::score.desc()),
+        };
+
+        // Note: deleted and removed comments are done on the front side
+        query
+            .limit(limit)
+            .offset(offset)
+            .load::<CommentView>(&mut conn)
+            .await
     };
 
-    if options.local_user.is_some()
-      && options.listing_type.unwrap_or_default() != ListingType::ModeratorView
-    {
-      // Filter out the rows with missing languages
-      query = query.filter(local_user_language::language_id.is_not_null());
-
-      // Don't show blocked communities or persons
-      if options.post_id.is_none() {
-        query = query.filter(community_block::person_id.is_null());
-      }
-      query = query.filter(person_block::person_id.is_null());
-    }
-
-    // A Max depth given means its a tree fetch
-    let (limit, offset) = if let Some(max_depth) = options.max_depth {
-      let depth_limit = if let Some(parent_path) = options.parent_path.as_ref() {
-        parent_path.0.split('.').count() as i32 + max_depth
-        // Add one because of root "0"
-      } else {
-        max_depth + 1
-      };
-
-      query = query.filter(nlevel(comment::path).le(depth_limit));
-
-      // only order if filtering by a post id, or parent_path. DOS potential otherwise and max_depth + !post_id isn't used anyways (afaik)
-      if options.post_id.is_some() || options.parent_path.is_some() {
-        // Always order by the parent path first
-        query = query.order_by(subpath(comment::path, 0, -1));
-      }
-
-      // TODO limit question. Limiting does not work for comment threads ATM, only max_depth
-      // For now, don't do any limiting for tree fetches
-      // https://stackoverflow.com/questions/72983614/postgres-ltree-how-to-limit-the-max-number-of-children-at-any-given-level
-
-      // Don't use the regular error-checking one, many more comments must ofter be fetched.
-      // This does not work for comment trees, and the limit should be manually set to a high number
-      //
-      // If a max depth is given, then you know its a tree fetch, and limits should be ignored
-      // TODO a kludge to prevent attacks. Limit comments to 300 for now.
-      // (i64::MAX, 0)
-      (300, 0)
-    } else {
-      // limit_and_offset_unlimited(options.page, options.limit)
-      limit_and_offset(options.page, options.limit)?
-    };
-
-    query = match options.sort.unwrap_or(CommentSortType::Hot) {
-      CommentSortType::Hot => query
-        .then_order_by(comment_aggregates::hot_rank.desc())
-        .then_order_by(comment_aggregates::score.desc()),
-      CommentSortType::Controversial => {
-        query.then_order_by(comment_aggregates::controversy_rank.desc())
-      }
-      CommentSortType::New => query.then_order_by(comment::published.desc()),
-      CommentSortType::Old => query.then_order_by(comment::published.asc()),
-      CommentSortType::Top => query.order_by(comment_aggregates::score.desc()),
-    };
-
-    // Note: deleted and removed comments are done on the front side
-    query
-      .limit(limit)
-      .offset(offset)
-      .load::<CommentView>(&mut conn)
-      .await
-  };
-
-  Queries::new(read, list)
+    Queries::new(read, list)
 }
 
 impl CommentView {
-  pub async fn read(
-    pool: &mut DbPool<'_>,
-    comment_id: CommentId,
-    my_person_id: Option<PersonId>,
-  ) -> Result<Self, Error> {
-    // If a person is given, then my_vote (res.9), if None, should be 0, not null
-    // Necessary to differentiate between other person's votes
-    let mut res = queries().read(pool, (comment_id, my_person_id)).await?;
-    if my_person_id.is_some() && res.my_vote.is_none() {
-      res.my_vote = Some(0);
+    pub async fn read(
+        pool: &mut DbPool<'_>,
+        comment_id: CommentId,
+        my_person_id: Option<PersonId>,
+    ) -> Result<Self, Error> {
+        // If a person is given, then my_vote (res.9), if None, should be 0, not null
+        // Necessary to differentiate between other person's votes
+        let mut res = queries().read(pool, (comment_id, my_person_id)).await?;
+        if my_person_id.is_some() && res.my_vote.is_none() {
+            res.my_vote = Some(0);
+        }
+        Ok(res)
     }
-    Ok(res)
-  }
 }
 
 #[derive(Default)]
 pub struct CommentQuery<'a> {
-  pub listing_type: Option<ListingType>,
-  pub sort: Option<CommentSortType>,
-  pub community_id: Option<CommunityId>,
-  pub post_id: Option<PostId>,
-  pub parent_path: Option<Ltree>,
-  pub creator_id: Option<PersonId>,
-  pub local_user: Option<&'a LocalUserView>,
-  pub search_term: Option<String>,
-  pub saved_only: bool,
-  pub liked_only: bool,
-  pub disliked_only: bool,
-  pub is_profile_view: bool,
-  pub page: Option<i64>,
-  pub limit: Option<i64>,
-  pub max_depth: Option<i32>,
+    pub listing_type: Option<ListingType>,
+    pub sort: Option<CommentSortType>,
+    pub community_id: Option<CommunityId>,
+    pub post_id: Option<PostId>,
+    pub parent_path: Option<Ltree>,
+    pub creator_id: Option<PersonId>,
+    pub local_user: Option<&'a LocalUserView>,
+    pub search_term: Option<String>,
+    pub saved_only: bool,
+    pub liked_only: bool,
+    pub disliked_only: bool,
+    pub is_profile_view: bool,
+    pub page: Option<i64>,
+    pub limit: Option<i64>,
+    pub max_depth: Option<i32>,
 }
 
 impl<'a> CommentQuery<'a> {
-  pub async fn list(self, pool: &mut DbPool<'_>) -> Result<Vec<CommentView>, Error> {
-    queries().list(pool, self).await
-  }
+    pub async fn list(self, pool: &mut DbPool<'_>) -> Result<Vec<CommentView>, Error> {
+        queries().list(pool, self).await
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::{
-    comment_view::{CommentQuery, CommentSortType, CommentView, DbPool},
-    structs::LocalUserView,
-  };
-  use lemmy_db_schema::{
-    aggregates::structs::CommentAggregates,
-    impls::actor_language::UNDETERMINED_ID,
-    newtypes::LanguageId,
-    source::{
-      actor_language::LocalUserLanguage,
-      comment::{Comment, CommentInsertForm, CommentLike, CommentLikeForm},
-      community::{Community, CommunityInsertForm},
-      instance::Instance,
-      language::Language,
-      local_user::{LocalUser, LocalUserInsertForm},
-      person::{Person, PersonInsertForm},
-      person_block::{PersonBlock, PersonBlockForm},
-      post::{Post, PostInsertForm},
-    },
-    traits::{Blockable, Crud, Likeable},
-    utils::build_db_pool_for_tests,
-    SubscribedType,
-  };
-  use serial_test::serial;
+    use crate::{
+        comment_view::{CommentQuery, CommentSortType, CommentView, DbPool},
+        structs::LocalUserView,
+    };
+    use lemmy_db_schema::{
+        aggregates::structs::CommentAggregates,
+        impls::actor_language::UNDETERMINED_ID,
+        newtypes::LanguageId,
+        source::{
+            actor_language::LocalUserLanguage,
+            comment::{Comment, CommentInsertForm, CommentLike, CommentLikeForm},
+            community::{Community, CommunityInsertForm},
+            instance::Instance,
+            language::Language,
+            local_user::{LocalUser, LocalUserInsertForm},
+            person::{Person, PersonInsertForm},
+            person_block::{PersonBlock, PersonBlockForm},
+            post::{Post, PostInsertForm},
+        },
+        traits::{Blockable, Crud, Likeable},
+        utils::build_db_pool_for_tests,
+        SubscribedType,
+    };
+    use serial_test::serial;
 
-  struct Data {
-    inserted_instance: Instance,
-    inserted_comment_0: Comment,
-    inserted_comment_1: Comment,
-    inserted_comment_2: Comment,
-    inserted_post: Post,
-    local_user_view: LocalUserView,
-    inserted_person_2: Person,
-    inserted_community: Community,
-  }
+    struct Data {
+        inserted_instance: Instance,
+        inserted_comment_0: Comment,
+        inserted_comment_1: Comment,
+        inserted_comment_2: Comment,
+        inserted_post: Post,
+        local_user_view: LocalUserView,
+        inserted_person_2: Person,
+        inserted_community: Community,
+    }
 
-  async fn init_data(pool: &mut DbPool<'_>) -> Data {
-    let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
-      .await
-      .unwrap();
+    async fn init_data(pool: &mut DbPool<'_>) -> Data {
+        let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
+            .await
+            .unwrap();
 
-    let new_person = PersonInsertForm::builder()
-      .name("timmy".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-    let inserted_person = Person::create(pool, &new_person).await.unwrap();
-    let local_user_form = LocalUserInsertForm::builder()
-      .person_id(inserted_person.id)
-      .password_encrypted(String::new())
-      .build();
-    let inserted_local_user = LocalUser::create(pool, &local_user_form).await.unwrap();
+        let new_person = PersonInsertForm::builder()
+            .name("timmy".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
+        let inserted_person = Person::create(pool, &new_person).await.unwrap();
+        let local_user_form = LocalUserInsertForm::builder()
+            .person_id(inserted_person.id)
+            .password_encrypted(String::new())
+            .build();
+        let inserted_local_user = LocalUser::create(pool, &local_user_form).await.unwrap();
 
-    let new_person_2 = PersonInsertForm::builder()
-      .name("sara".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-    let inserted_person_2 = Person::create(pool, &new_person_2).await.unwrap();
+        let new_person_2 = PersonInsertForm::builder()
+            .name("sara".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
+        let inserted_person_2 = Person::create(pool, &new_person_2).await.unwrap();
 
-    let new_community = CommunityInsertForm::builder()
-      .name("test community 5".to_string())
-      .title("nada".to_owned())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
+        let new_community = CommunityInsertForm::builder()
+            .name("test community 5".to_string())
+            .title("nada".to_owned())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let inserted_community = Community::create(pool, &new_community).await.unwrap();
+        let inserted_community = Community::create(pool, &new_community).await.unwrap();
 
-    let new_post = PostInsertForm::builder()
-      .name("A test post 2".into())
-      .creator_id(inserted_person.id)
-      .community_id(inserted_community.id)
-      .build();
+        let new_post = PostInsertForm::builder()
+            .name("A test post 2".into())
+            .creator_id(inserted_person.id)
+            .community_id(inserted_community.id)
+            .build();
 
-    let inserted_post = Post::create(pool, &new_post).await.unwrap();
-    let english_id = Language::read_id_from_code(pool, Some("en")).await.unwrap();
+        let inserted_post = Post::create(pool, &new_post).await.unwrap();
+        let english_id = Language::read_id_from_code(pool, Some("en")).await.unwrap();
 
-    // Create a comment tree with this hierarchy
-    //       0
-    //     \     \
-    //    1      2
-    //    \
-    //  3  4
-    //     \
-    //     5
-    let comment_form_0 = CommentInsertForm::builder()
-      .content("Comment 0".into())
-      .creator_id(inserted_person.id)
-      .post_id(inserted_post.id)
-      .language_id(english_id)
-      .build();
+        // Create a comment tree with this hierarchy
+        //       0
+        //     \     \
+        //    1      2
+        //    \
+        //  3  4
+        //     \
+        //     5
+        let comment_form_0 = CommentInsertForm::builder()
+            .content("Comment 0".into())
+            .creator_id(inserted_person.id)
+            .post_id(inserted_post.id)
+            .language_id(english_id)
+            .build();
 
-    let inserted_comment_0 = Comment::create(pool, &comment_form_0, None).await.unwrap();
+        let inserted_comment_0 = Comment::create(pool, &comment_form_0, None).await.unwrap();
 
-    let comment_form_1 = CommentInsertForm::builder()
-      .content("Comment 1, A test blocked comment".into())
-      .creator_id(inserted_person_2.id)
-      .post_id(inserted_post.id)
-      .language_id(english_id)
-      .build();
+        let comment_form_1 = CommentInsertForm::builder()
+            .content("Comment 1, A test blocked comment".into())
+            .creator_id(inserted_person_2.id)
+            .post_id(inserted_post.id)
+            .language_id(english_id)
+            .build();
 
-    let inserted_comment_1 = Comment::create(pool, &comment_form_1, Some(&inserted_comment_0.path))
-      .await
-      .unwrap();
+        let inserted_comment_1 =
+            Comment::create(pool, &comment_form_1, Some(&inserted_comment_0.path))
+                .await
+                .unwrap();
 
-    let finnish_id = Language::read_id_from_code(pool, Some("fi")).await.unwrap();
-    let comment_form_2 = CommentInsertForm::builder()
-      .content("Comment 2".into())
-      .creator_id(inserted_person.id)
-      .post_id(inserted_post.id)
-      .language_id(finnish_id)
-      .build();
+        let finnish_id = Language::read_id_from_code(pool, Some("fi")).await.unwrap();
+        let comment_form_2 = CommentInsertForm::builder()
+            .content("Comment 2".into())
+            .creator_id(inserted_person.id)
+            .post_id(inserted_post.id)
+            .language_id(finnish_id)
+            .build();
 
-    let inserted_comment_2 = Comment::create(pool, &comment_form_2, Some(&inserted_comment_0.path))
-      .await
-      .unwrap();
+        let inserted_comment_2 =
+            Comment::create(pool, &comment_form_2, Some(&inserted_comment_0.path))
+                .await
+                .unwrap();
 
-    let comment_form_3 = CommentInsertForm::builder()
-      .content("Comment 3".into())
-      .creator_id(inserted_person.id)
-      .post_id(inserted_post.id)
-      .language_id(english_id)
-      .build();
+        let comment_form_3 = CommentInsertForm::builder()
+            .content("Comment 3".into())
+            .creator_id(inserted_person.id)
+            .post_id(inserted_post.id)
+            .language_id(english_id)
+            .build();
 
-    let _inserted_comment_3 =
-      Comment::create(pool, &comment_form_3, Some(&inserted_comment_1.path))
+        let _inserted_comment_3 =
+            Comment::create(pool, &comment_form_3, Some(&inserted_comment_1.path))
+                .await
+                .unwrap();
+
+        let polish_id = Language::read_id_from_code(pool, Some("pl"))
+            .await
+            .unwrap()
+            .unwrap();
+        let comment_form_4 = CommentInsertForm::builder()
+            .content("Comment 4".into())
+            .creator_id(inserted_person.id)
+            .post_id(inserted_post.id)
+            .language_id(Some(polish_id))
+            .build();
+
+        let inserted_comment_4 =
+            Comment::create(pool, &comment_form_4, Some(&inserted_comment_1.path))
+                .await
+                .unwrap();
+
+        let comment_form_5 = CommentInsertForm::builder()
+            .content("Comment 5".into())
+            .creator_id(inserted_person.id)
+            .post_id(inserted_post.id)
+            .build();
+
+        let _inserted_comment_5 =
+            Comment::create(pool, &comment_form_5, Some(&inserted_comment_4.path))
+                .await
+                .unwrap();
+
+        let timmy_blocks_sara_form = PersonBlockForm {
+            person_id: inserted_person.id,
+            target_id: inserted_person_2.id,
+        };
+
+        let inserted_block = PersonBlock::block(pool, &timmy_blocks_sara_form)
+            .await
+            .unwrap();
+
+        let expected_block = PersonBlock {
+            id: inserted_block.id,
+            person_id: inserted_person.id,
+            target_id: inserted_person_2.id,
+            published: inserted_block.published,
+        };
+        assert_eq!(expected_block, inserted_block);
+
+        let comment_like_form = CommentLikeForm {
+            comment_id: inserted_comment_0.id,
+            post_id: inserted_post.id,
+            person_id: inserted_person.id,
+            score: 1,
+        };
+
+        let _inserted_comment_like = CommentLike::like(pool, &comment_like_form).await.unwrap();
+
+        let local_user_view = LocalUserView {
+            local_user: inserted_local_user.clone(),
+            person: inserted_person.clone(),
+            counts: Default::default(),
+        };
+        Data {
+            inserted_instance,
+            inserted_comment_0,
+            inserted_comment_1,
+            inserted_comment_2,
+            inserted_post,
+            local_user_view,
+            inserted_person_2,
+            inserted_community,
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_crud() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
+        let data = init_data(pool).await;
+
+        let expected_comment_view_no_person = expected_comment_view(&data, pool).await;
+
+        let mut expected_comment_view_with_person = expected_comment_view_no_person.clone();
+        expected_comment_view_with_person.my_vote = Some(1);
+
+        let read_comment_views_no_person = CommentQuery {
+            sort: (Some(CommentSortType::Old)),
+            post_id: (Some(data.inserted_post.id)),
+            ..Default::default()
+        }
+        .list(pool)
         .await
         .unwrap();
 
-    let polish_id = Language::read_id_from_code(pool, Some("pl"))
-      .await
-      .unwrap()
-      .unwrap();
-    let comment_form_4 = CommentInsertForm::builder()
-      .content("Comment 4".into())
-      .creator_id(inserted_person.id)
-      .post_id(inserted_post.id)
-      .language_id(Some(polish_id))
-      .build();
+        assert_eq!(
+            expected_comment_view_no_person,
+            read_comment_views_no_person[0]
+        );
 
-    let inserted_comment_4 = Comment::create(pool, &comment_form_4, Some(&inserted_comment_1.path))
-      .await
-      .unwrap();
-
-    let comment_form_5 = CommentInsertForm::builder()
-      .content("Comment 5".into())
-      .creator_id(inserted_person.id)
-      .post_id(inserted_post.id)
-      .build();
-
-    let _inserted_comment_5 =
-      Comment::create(pool, &comment_form_5, Some(&inserted_comment_4.path))
+        let read_comment_views_with_person = CommentQuery {
+            sort: (Some(CommentSortType::Old)),
+            post_id: (Some(data.inserted_post.id)),
+            local_user: (Some(&data.local_user_view)),
+            ..Default::default()
+        }
+        .list(pool)
         .await
         .unwrap();
 
-    let timmy_blocks_sara_form = PersonBlockForm {
-      person_id: inserted_person.id,
-      target_id: inserted_person_2.id,
-    };
+        assert_eq!(
+            expected_comment_view_with_person,
+            read_comment_views_with_person[0]
+        );
 
-    let inserted_block = PersonBlock::block(pool, &timmy_blocks_sara_form)
-      .await
-      .unwrap();
+        // Make sure its 1, not showing the blocked comment
+        assert_eq!(5, read_comment_views_with_person.len());
 
-    let expected_block = PersonBlock {
-      id: inserted_block.id,
-      person_id: inserted_person.id,
-      target_id: inserted_person_2.id,
-      published: inserted_block.published,
-    };
-    assert_eq!(expected_block, inserted_block);
+        let read_comment_from_blocked_person = CommentView::read(
+            pool,
+            data.inserted_comment_1.id,
+            Some(data.local_user_view.person.id),
+        )
+        .await
+        .unwrap();
 
-    let comment_like_form = CommentLikeForm {
-      comment_id: inserted_comment_0.id,
-      post_id: inserted_post.id,
-      person_id: inserted_person.id,
-      score: 1,
-    };
+        // Make sure block set the creator blocked
+        assert!(read_comment_from_blocked_person.creator_blocked);
 
-    let _inserted_comment_like = CommentLike::like(pool, &comment_like_form).await.unwrap();
+        let read_liked_comment_views = CommentQuery {
+            local_user: (Some(&data.local_user_view)),
+            liked_only: (true),
+            ..Default::default()
+        }
+        .list(pool)
+        .await
+        .unwrap();
 
-    let local_user_view = LocalUserView {
-      local_user: inserted_local_user.clone(),
-      person: inserted_person.clone(),
-      counts: Default::default(),
-    };
-    Data {
-      inserted_instance,
-      inserted_comment_0,
-      inserted_comment_1,
-      inserted_comment_2,
-      inserted_post,
-      local_user_view,
-      inserted_person_2,
-      inserted_community,
+        assert_eq!(
+            expected_comment_view_with_person,
+            read_liked_comment_views[0]
+        );
+
+        assert_eq!(1, read_liked_comment_views.len());
+
+        let read_disliked_comment_views: Vec<CommentView> = CommentQuery {
+            local_user: (Some(&data.local_user_view)),
+            disliked_only: (true),
+            ..Default::default()
+        }
+        .list(pool)
+        .await
+        .unwrap();
+
+        assert!(read_disliked_comment_views.is_empty());
+
+        cleanup(data, pool).await;
     }
-  }
 
-  #[tokio::test]
-  #[serial]
-  async fn test_crud() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-    let data = init_data(pool).await;
+    #[tokio::test]
+    #[serial]
+    async fn test_comment_tree() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
+        let data = init_data(pool).await;
 
-    let expected_comment_view_no_person = expected_comment_view(&data, pool).await;
+        let top_path = data.inserted_comment_0.path.clone();
+        let read_comment_views_top_path = CommentQuery {
+            post_id: (Some(data.inserted_post.id)),
+            parent_path: (Some(top_path)),
+            ..Default::default()
+        }
+        .list(pool)
+        .await
+        .unwrap();
 
-    let mut expected_comment_view_with_person = expected_comment_view_no_person.clone();
-    expected_comment_view_with_person.my_vote = Some(1);
+        let child_path = data.inserted_comment_1.path.clone();
+        let read_comment_views_child_path = CommentQuery {
+            post_id: (Some(data.inserted_post.id)),
+            parent_path: (Some(child_path)),
+            ..Default::default()
+        }
+        .list(pool)
+        .await
+        .unwrap();
 
-    let read_comment_views_no_person = CommentQuery {
-      sort: (Some(CommentSortType::Old)),
-      post_id: (Some(data.inserted_post.id)),
-      ..Default::default()
+        // Make sure the comment parent-limited fetch is correct
+        assert_eq!(6, read_comment_views_top_path.len());
+        assert_eq!(4, read_comment_views_child_path.len());
+
+        // Make sure it contains the parent, but not the comment from the other tree
+        let child_comments = read_comment_views_child_path
+            .into_iter()
+            .map(|c| c.comment)
+            .collect::<Vec<Comment>>();
+        assert!(child_comments.contains(&data.inserted_comment_1));
+        assert!(!child_comments.contains(&data.inserted_comment_2));
+
+        let read_comment_views_top_max_depth = CommentQuery {
+            post_id: (Some(data.inserted_post.id)),
+            max_depth: (Some(1)),
+            ..Default::default()
+        }
+        .list(pool)
+        .await
+        .unwrap();
+
+        // Make sure a depth limited one only has the top comment
+        assert_eq!(
+            expected_comment_view(&data, pool).await,
+            read_comment_views_top_max_depth[0]
+        );
+        assert_eq!(1, read_comment_views_top_max_depth.len());
+
+        let child_path = data.inserted_comment_1.path.clone();
+        let read_comment_views_parent_max_depth = CommentQuery {
+            post_id: (Some(data.inserted_post.id)),
+            parent_path: (Some(child_path)),
+            max_depth: (Some(1)),
+            sort: (Some(CommentSortType::New)),
+            ..Default::default()
+        }
+        .list(pool)
+        .await
+        .unwrap();
+
+        // Make sure a depth limited one, and given child comment 1, has 3
+        assert!(read_comment_views_parent_max_depth[2]
+            .comment
+            .content
+            .eq("Comment 3"));
+        assert_eq!(3, read_comment_views_parent_max_depth.len());
+
+        cleanup(data, pool).await;
     }
-    .list(pool)
-    .await
-    .unwrap();
 
-    assert_eq!(
-      expected_comment_view_no_person,
-      read_comment_views_no_person[0]
-    );
+    #[tokio::test]
+    #[serial]
+    async fn test_languages() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
+        let data = init_data(pool).await;
 
-    let read_comment_views_with_person = CommentQuery {
-      sort: (Some(CommentSortType::Old)),
-      post_id: (Some(data.inserted_post.id)),
-      local_user: (Some(&data.local_user_view)),
-      ..Default::default()
+        // by default, user has all languages enabled and should see all comments
+        // (except from blocked user)
+        let all_languages = CommentQuery {
+            local_user: (Some(&data.local_user_view)),
+            ..Default::default()
+        }
+        .list(pool)
+        .await
+        .unwrap();
+        assert_eq!(5, all_languages.len());
+
+        // change user lang to finnish, should only show one post in finnish and one undetermined
+        let finnish_id = Language::read_id_from_code(pool, Some("fi"))
+            .await
+            .unwrap()
+            .unwrap();
+        LocalUserLanguage::update(pool, vec![finnish_id], data.local_user_view.local_user.id)
+            .await
+            .unwrap();
+        let finnish_comments = CommentQuery {
+            local_user: (Some(&data.local_user_view)),
+            ..Default::default()
+        }
+        .list(pool)
+        .await
+        .unwrap();
+        assert_eq!(2, finnish_comments.len());
+        let finnish_comment = finnish_comments
+            .iter()
+            .find(|c| c.comment.language_id == finnish_id);
+        assert!(finnish_comment.is_some());
+        assert_eq!(
+            data.inserted_comment_2.content,
+            finnish_comment.unwrap().comment.content
+        );
+
+        // now show all comments with undetermined language (which is the default value)
+        LocalUserLanguage::update(
+            pool,
+            vec![UNDETERMINED_ID],
+            data.local_user_view.local_user.id,
+        )
+        .await
+        .unwrap();
+        let undetermined_comment = CommentQuery {
+            local_user: (Some(&data.local_user_view)),
+            ..Default::default()
+        }
+        .list(pool)
+        .await
+        .unwrap();
+        assert_eq!(1, undetermined_comment.len());
+
+        cleanup(data, pool).await;
     }
-    .list(pool)
-    .await
-    .unwrap();
 
-    assert_eq!(
-      expected_comment_view_with_person,
-      read_comment_views_with_person[0]
-    );
-
-    // Make sure its 1, not showing the blocked comment
-    assert_eq!(5, read_comment_views_with_person.len());
-
-    let read_comment_from_blocked_person = CommentView::read(
-      pool,
-      data.inserted_comment_1.id,
-      Some(data.local_user_view.person.id),
-    )
-    .await
-    .unwrap();
-
-    // Make sure block set the creator blocked
-    assert!(read_comment_from_blocked_person.creator_blocked);
-
-    let read_liked_comment_views = CommentQuery {
-      local_user: (Some(&data.local_user_view)),
-      liked_only: (true),
-      ..Default::default()
+    async fn cleanup(data: Data, pool: &mut DbPool<'_>) {
+        CommentLike::remove(
+            pool,
+            data.local_user_view.person.id,
+            data.inserted_comment_0.id,
+        )
+        .await
+        .unwrap();
+        Comment::delete(pool, data.inserted_comment_0.id)
+            .await
+            .unwrap();
+        Comment::delete(pool, data.inserted_comment_1.id)
+            .await
+            .unwrap();
+        Post::delete(pool, data.inserted_post.id).await.unwrap();
+        Community::delete(pool, data.inserted_community.id)
+            .await
+            .unwrap();
+        Person::delete(pool, data.local_user_view.person.id)
+            .await
+            .unwrap();
+        Person::delete(pool, data.inserted_person_2.id)
+            .await
+            .unwrap();
+        Instance::delete(pool, data.inserted_instance.id)
+            .await
+            .unwrap();
     }
-    .list(pool)
-    .await
-    .unwrap();
 
-    assert_eq!(
-      expected_comment_view_with_person,
-      read_liked_comment_views[0]
-    );
-
-    assert_eq!(1, read_liked_comment_views.len());
-
-    let read_disliked_comment_views: Vec<CommentView> = CommentQuery {
-      local_user: (Some(&data.local_user_view)),
-      disliked_only: (true),
-      ..Default::default()
+    async fn expected_comment_view(data: &Data, pool: &mut DbPool<'_>) -> CommentView {
+        let agg = CommentAggregates::read(pool, data.inserted_comment_0.id)
+            .await
+            .unwrap();
+        CommentView {
+            creator_banned_from_community: false,
+            my_vote: None,
+            subscribed: SubscribedType::NotSubscribed,
+            saved: false,
+            creator_blocked: false,
+            comment: Comment {
+                id: data.inserted_comment_0.id,
+                content: "Comment 0".into(),
+                creator_id: data.local_user_view.person.id,
+                post_id: data.inserted_post.id,
+                removed: false,
+                deleted: false,
+                published: data.inserted_comment_0.published,
+                ap_id: data.inserted_comment_0.ap_id.clone(),
+                updated: None,
+                local: true,
+                distinguished: false,
+                path: data.inserted_comment_0.clone().path,
+                language_id: LanguageId(37),
+            },
+            creator: Person {
+                id: data.local_user_view.person.id,
+                name: "timmy".into(),
+                display_name: None,
+                published: data.local_user_view.person.published,
+                avatar: None,
+                actor_id: data.local_user_view.person.actor_id.clone(),
+                local: true,
+                banned: false,
+                deleted: false,
+                bot_account: false,
+                bio: None,
+                banner: None,
+                updated: None,
+                inbox_url: data.local_user_view.person.inbox_url.clone(),
+                shared_inbox_url: None,
+                matrix_user_id: None,
+                ban_expires: None,
+                instance_id: data.inserted_instance.id,
+                private_key: data.local_user_view.person.private_key.clone(),
+                public_key: data.local_user_view.person.public_key.clone(),
+                last_refreshed_at: data.local_user_view.person.last_refreshed_at,
+            },
+            post: Post {
+                id: data.inserted_post.id,
+                name: data.inserted_post.name.clone(),
+                creator_id: data.local_user_view.person.id,
+                url: None,
+                body: None,
+                published: data.inserted_post.published,
+                updated: None,
+                community_id: data.inserted_community.id,
+                removed: false,
+                deleted: false,
+                locked: false,
+                nsfw: false,
+                embed_title: None,
+                embed_description: None,
+                embed_video_url: None,
+                thumbnail_url: None,
+                ap_id: data.inserted_post.ap_id.clone(),
+                local: true,
+                language_id: Default::default(),
+                featured_community: false,
+                featured_local: false,
+            },
+            community: Community {
+                id: data.inserted_community.id,
+                name: "test community 5".to_string(),
+                icon: None,
+                removed: false,
+                deleted: false,
+                nsfw: false,
+                actor_id: data.inserted_community.actor_id.clone(),
+                local: true,
+                title: "nada".to_owned(),
+                description: None,
+                updated: None,
+                banner: None,
+                hidden: false,
+                posting_restricted_to_mods: false,
+                published: data.inserted_community.published,
+                instance_id: data.inserted_instance.id,
+                private_key: data.inserted_community.private_key.clone(),
+                public_key: data.inserted_community.public_key.clone(),
+                last_refreshed_at: data.inserted_community.last_refreshed_at,
+                followers_url: data.inserted_community.followers_url.clone(),
+                inbox_url: data.inserted_community.inbox_url.clone(),
+                shared_inbox_url: data.inserted_community.shared_inbox_url.clone(),
+                moderators_url: data.inserted_community.moderators_url.clone(),
+                featured_url: data.inserted_community.featured_url.clone(),
+            },
+            counts: CommentAggregates {
+                id: agg.id,
+                comment_id: data.inserted_comment_0.id,
+                score: 1,
+                upvotes: 1,
+                downvotes: 0,
+                published: agg.published,
+                child_count: 5,
+                hot_rank: 1728,
+                controversy_rank: 0.0,
+            },
+        }
     }
-    .list(pool)
-    .await
-    .unwrap();
-
-    assert!(read_disliked_comment_views.is_empty());
-
-    cleanup(data, pool).await;
-  }
-
-  #[tokio::test]
-  #[serial]
-  async fn test_comment_tree() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-    let data = init_data(pool).await;
-
-    let top_path = data.inserted_comment_0.path.clone();
-    let read_comment_views_top_path = CommentQuery {
-      post_id: (Some(data.inserted_post.id)),
-      parent_path: (Some(top_path)),
-      ..Default::default()
-    }
-    .list(pool)
-    .await
-    .unwrap();
-
-    let child_path = data.inserted_comment_1.path.clone();
-    let read_comment_views_child_path = CommentQuery {
-      post_id: (Some(data.inserted_post.id)),
-      parent_path: (Some(child_path)),
-      ..Default::default()
-    }
-    .list(pool)
-    .await
-    .unwrap();
-
-    // Make sure the comment parent-limited fetch is correct
-    assert_eq!(6, read_comment_views_top_path.len());
-    assert_eq!(4, read_comment_views_child_path.len());
-
-    // Make sure it contains the parent, but not the comment from the other tree
-    let child_comments = read_comment_views_child_path
-      .into_iter()
-      .map(|c| c.comment)
-      .collect::<Vec<Comment>>();
-    assert!(child_comments.contains(&data.inserted_comment_1));
-    assert!(!child_comments.contains(&data.inserted_comment_2));
-
-    let read_comment_views_top_max_depth = CommentQuery {
-      post_id: (Some(data.inserted_post.id)),
-      max_depth: (Some(1)),
-      ..Default::default()
-    }
-    .list(pool)
-    .await
-    .unwrap();
-
-    // Make sure a depth limited one only has the top comment
-    assert_eq!(
-      expected_comment_view(&data, pool).await,
-      read_comment_views_top_max_depth[0]
-    );
-    assert_eq!(1, read_comment_views_top_max_depth.len());
-
-    let child_path = data.inserted_comment_1.path.clone();
-    let read_comment_views_parent_max_depth = CommentQuery {
-      post_id: (Some(data.inserted_post.id)),
-      parent_path: (Some(child_path)),
-      max_depth: (Some(1)),
-      sort: (Some(CommentSortType::New)),
-      ..Default::default()
-    }
-    .list(pool)
-    .await
-    .unwrap();
-
-    // Make sure a depth limited one, and given child comment 1, has 3
-    assert!(read_comment_views_parent_max_depth[2]
-      .comment
-      .content
-      .eq("Comment 3"));
-    assert_eq!(3, read_comment_views_parent_max_depth.len());
-
-    cleanup(data, pool).await;
-  }
-
-  #[tokio::test]
-  #[serial]
-  async fn test_languages() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-    let data = init_data(pool).await;
-
-    // by default, user has all languages enabled and should see all comments
-    // (except from blocked user)
-    let all_languages = CommentQuery {
-      local_user: (Some(&data.local_user_view)),
-      ..Default::default()
-    }
-    .list(pool)
-    .await
-    .unwrap();
-    assert_eq!(5, all_languages.len());
-
-    // change user lang to finnish, should only show one post in finnish and one undetermined
-    let finnish_id = Language::read_id_from_code(pool, Some("fi"))
-      .await
-      .unwrap()
-      .unwrap();
-    LocalUserLanguage::update(pool, vec![finnish_id], data.local_user_view.local_user.id)
-      .await
-      .unwrap();
-    let finnish_comments = CommentQuery {
-      local_user: (Some(&data.local_user_view)),
-      ..Default::default()
-    }
-    .list(pool)
-    .await
-    .unwrap();
-    assert_eq!(2, finnish_comments.len());
-    let finnish_comment = finnish_comments
-      .iter()
-      .find(|c| c.comment.language_id == finnish_id);
-    assert!(finnish_comment.is_some());
-    assert_eq!(
-      data.inserted_comment_2.content,
-      finnish_comment.unwrap().comment.content
-    );
-
-    // now show all comments with undetermined language (which is the default value)
-    LocalUserLanguage::update(
-      pool,
-      vec![UNDETERMINED_ID],
-      data.local_user_view.local_user.id,
-    )
-    .await
-    .unwrap();
-    let undetermined_comment = CommentQuery {
-      local_user: (Some(&data.local_user_view)),
-      ..Default::default()
-    }
-    .list(pool)
-    .await
-    .unwrap();
-    assert_eq!(1, undetermined_comment.len());
-
-    cleanup(data, pool).await;
-  }
-
-  async fn cleanup(data: Data, pool: &mut DbPool<'_>) {
-    CommentLike::remove(
-      pool,
-      data.local_user_view.person.id,
-      data.inserted_comment_0.id,
-    )
-    .await
-    .unwrap();
-    Comment::delete(pool, data.inserted_comment_0.id)
-      .await
-      .unwrap();
-    Comment::delete(pool, data.inserted_comment_1.id)
-      .await
-      .unwrap();
-    Post::delete(pool, data.inserted_post.id).await.unwrap();
-    Community::delete(pool, data.inserted_community.id)
-      .await
-      .unwrap();
-    Person::delete(pool, data.local_user_view.person.id)
-      .await
-      .unwrap();
-    Person::delete(pool, data.inserted_person_2.id)
-      .await
-      .unwrap();
-    Instance::delete(pool, data.inserted_instance.id)
-      .await
-      .unwrap();
-  }
-
-  async fn expected_comment_view(data: &Data, pool: &mut DbPool<'_>) -> CommentView {
-    let agg = CommentAggregates::read(pool, data.inserted_comment_0.id)
-      .await
-      .unwrap();
-    CommentView {
-      creator_banned_from_community: false,
-      my_vote: None,
-      subscribed: SubscribedType::NotSubscribed,
-      saved: false,
-      creator_blocked: false,
-      comment: Comment {
-        id: data.inserted_comment_0.id,
-        content: "Comment 0".into(),
-        creator_id: data.local_user_view.person.id,
-        post_id: data.inserted_post.id,
-        removed: false,
-        deleted: false,
-        published: data.inserted_comment_0.published,
-        ap_id: data.inserted_comment_0.ap_id.clone(),
-        updated: None,
-        local: true,
-        distinguished: false,
-        path: data.inserted_comment_0.clone().path,
-        language_id: LanguageId(37),
-      },
-      creator: Person {
-        id: data.local_user_view.person.id,
-        name: "timmy".into(),
-        display_name: None,
-        published: data.local_user_view.person.published,
-        avatar: None,
-        actor_id: data.local_user_view.person.actor_id.clone(),
-        local: true,
-        banned: false,
-        deleted: false,
-        bot_account: false,
-        bio: None,
-        banner: None,
-        updated: None,
-        inbox_url: data.local_user_view.person.inbox_url.clone(),
-        shared_inbox_url: None,
-        matrix_user_id: None,
-        ban_expires: None,
-        instance_id: data.inserted_instance.id,
-        private_key: data.local_user_view.person.private_key.clone(),
-        public_key: data.local_user_view.person.public_key.clone(),
-        last_refreshed_at: data.local_user_view.person.last_refreshed_at,
-      },
-      post: Post {
-        id: data.inserted_post.id,
-        name: data.inserted_post.name.clone(),
-        creator_id: data.local_user_view.person.id,
-        url: None,
-        body: None,
-        published: data.inserted_post.published,
-        updated: None,
-        community_id: data.inserted_community.id,
-        removed: false,
-        deleted: false,
-        locked: false,
-        nsfw: false,
-        embed_title: None,
-        embed_description: None,
-        embed_video_url: None,
-        thumbnail_url: None,
-        ap_id: data.inserted_post.ap_id.clone(),
-        local: true,
-        language_id: Default::default(),
-        featured_community: false,
-        featured_local: false,
-      },
-      community: Community {
-        id: data.inserted_community.id,
-        name: "test community 5".to_string(),
-        icon: None,
-        removed: false,
-        deleted: false,
-        nsfw: false,
-        actor_id: data.inserted_community.actor_id.clone(),
-        local: true,
-        title: "nada".to_owned(),
-        description: None,
-        updated: None,
-        banner: None,
-        hidden: false,
-        posting_restricted_to_mods: false,
-        published: data.inserted_community.published,
-        instance_id: data.inserted_instance.id,
-        private_key: data.inserted_community.private_key.clone(),
-        public_key: data.inserted_community.public_key.clone(),
-        last_refreshed_at: data.inserted_community.last_refreshed_at,
-        followers_url: data.inserted_community.followers_url.clone(),
-        inbox_url: data.inserted_community.inbox_url.clone(),
-        shared_inbox_url: data.inserted_community.shared_inbox_url.clone(),
-        moderators_url: data.inserted_community.moderators_url.clone(),
-        featured_url: data.inserted_community.featured_url.clone(),
-      },
-      counts: CommentAggregates {
-        id: agg.id,
-        comment_id: data.inserted_comment_0.id,
-        score: 1,
-        upvotes: 1,
-        downvotes: 0,
-        published: agg.published,
-        child_count: 5,
-        hot_rank: 1728,
-        controversy_rank: 0.0,
-      },
-    }
-  }
 }

--- a/crates/db_views/src/custom_emoji_view.rs
+++ b/crates/db_views/src/custom_emoji_view.rs
@@ -2,84 +2,86 @@ use crate::structs::CustomEmojiView;
 use diesel::{result::Error, ExpressionMethods, JoinOnDsl, NullableExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  newtypes::{CustomEmojiId, LocalSiteId},
-  schema::{custom_emoji, custom_emoji_keyword},
-  source::{custom_emoji::CustomEmoji, custom_emoji_keyword::CustomEmojiKeyword},
-  utils::{get_conn, DbPool},
+    newtypes::{CustomEmojiId, LocalSiteId},
+    schema::{custom_emoji, custom_emoji_keyword},
+    source::{custom_emoji::CustomEmoji, custom_emoji_keyword::CustomEmojiKeyword},
+    utils::{get_conn, DbPool},
 };
 use std::collections::HashMap;
 
 type CustomEmojiTuple = (CustomEmoji, Option<CustomEmojiKeyword>);
 
 impl CustomEmojiView {
-  pub async fn get(pool: &mut DbPool<'_>, emoji_id: CustomEmojiId) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let emojis = custom_emoji::table
-      .find(emoji_id)
-      .left_join(
-        custom_emoji_keyword::table.on(custom_emoji_keyword::custom_emoji_id.eq(custom_emoji::id)),
-      )
-      .select((
-        custom_emoji::all_columns,
-        custom_emoji_keyword::all_columns.nullable(), // (or all the columns if you want)
-      ))
-      .load::<CustomEmojiTuple>(conn)
-      .await?;
-    if let Some(emoji) = CustomEmojiView::from_tuple_to_vec(emojis)
-      .into_iter()
-      .next()
-    {
-      Ok(emoji)
-    } else {
-      Err(diesel::result::Error::NotFound)
-    }
-  }
-
-  pub async fn get_all(
-    pool: &mut DbPool<'_>,
-    for_local_site_id: LocalSiteId,
-  ) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let emojis = custom_emoji::table
-      .filter(custom_emoji::local_site_id.eq(for_local_site_id))
-      .left_join(
-        custom_emoji_keyword::table.on(custom_emoji_keyword::custom_emoji_id.eq(custom_emoji::id)),
-      )
-      .order(custom_emoji::category)
-      .then_order_by(custom_emoji::id)
-      .select((
-        custom_emoji::all_columns,
-        custom_emoji_keyword::all_columns.nullable(), // (or all the columns if you want)
-      ))
-      .load::<CustomEmojiTuple>(conn)
-      .await?;
-
-    Ok(CustomEmojiView::from_tuple_to_vec(emojis))
-  }
-
-  fn from_tuple_to_vec(items: Vec<CustomEmojiTuple>) -> Vec<Self> {
-    let mut result = Vec::new();
-    let mut hash: HashMap<CustomEmojiId, Vec<CustomEmojiKeyword>> = HashMap::new();
-    for item in &items {
-      let emoji_id: CustomEmojiId = item.0.id;
-      if let std::collections::hash_map::Entry::Vacant(e) = hash.entry(emoji_id) {
-        e.insert(Vec::new());
-        result.push(CustomEmojiView {
-          custom_emoji: item.0.clone(),
-          keywords: Vec::new(),
-        })
-      }
-      if let Some(item_keyword) = &item.1 {
-        if let Some(keywords) = hash.get_mut(&emoji_id) {
-          keywords.push(item_keyword.clone())
+    pub async fn get(pool: &mut DbPool<'_>, emoji_id: CustomEmojiId) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let emojis = custom_emoji::table
+            .find(emoji_id)
+            .left_join(
+                custom_emoji_keyword::table
+                    .on(custom_emoji_keyword::custom_emoji_id.eq(custom_emoji::id)),
+            )
+            .select((
+                custom_emoji::all_columns,
+                custom_emoji_keyword::all_columns.nullable(), // (or all the columns if you want)
+            ))
+            .load::<CustomEmojiTuple>(conn)
+            .await?;
+        if let Some(emoji) = CustomEmojiView::from_tuple_to_vec(emojis)
+            .into_iter()
+            .next()
+        {
+            Ok(emoji)
+        } else {
+            Err(diesel::result::Error::NotFound)
         }
-      }
     }
-    for emoji in &mut result {
-      if let Some(keywords) = hash.get_mut(&emoji.custom_emoji.id) {
-        emoji.keywords = keywords.clone();
-      }
+
+    pub async fn get_all(
+        pool: &mut DbPool<'_>,
+        for_local_site_id: LocalSiteId,
+    ) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let emojis = custom_emoji::table
+            .filter(custom_emoji::local_site_id.eq(for_local_site_id))
+            .left_join(
+                custom_emoji_keyword::table
+                    .on(custom_emoji_keyword::custom_emoji_id.eq(custom_emoji::id)),
+            )
+            .order(custom_emoji::category)
+            .then_order_by(custom_emoji::id)
+            .select((
+                custom_emoji::all_columns,
+                custom_emoji_keyword::all_columns.nullable(), // (or all the columns if you want)
+            ))
+            .load::<CustomEmojiTuple>(conn)
+            .await?;
+
+        Ok(CustomEmojiView::from_tuple_to_vec(emojis))
     }
-    result
-  }
+
+    fn from_tuple_to_vec(items: Vec<CustomEmojiTuple>) -> Vec<Self> {
+        let mut result = Vec::new();
+        let mut hash: HashMap<CustomEmojiId, Vec<CustomEmojiKeyword>> = HashMap::new();
+        for item in &items {
+            let emoji_id: CustomEmojiId = item.0.id;
+            if let std::collections::hash_map::Entry::Vacant(e) = hash.entry(emoji_id) {
+                e.insert(Vec::new());
+                result.push(CustomEmojiView {
+                    custom_emoji: item.0.clone(),
+                    keywords: Vec::new(),
+                })
+            }
+            if let Some(item_keyword) = &item.1 {
+                if let Some(keywords) = hash.get_mut(&emoji_id) {
+                    keywords.push(item_keyword.clone())
+                }
+            }
+        }
+        for emoji in &mut result {
+            if let Some(keywords) = hash.get_mut(&emoji.custom_emoji.id) {
+                emoji.keywords = keywords.clone();
+            }
+        }
+        result
+    }
 }

--- a/crates/db_views/src/local_user_view.rs
+++ b/crates/db_views/src/local_user_view.rs
@@ -3,115 +3,117 @@ use actix_web::{dev::Payload, FromRequest, HttpMessage, HttpRequest};
 use diesel::{result::Error, BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl};
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  newtypes::{LocalUserId, PersonId},
-  schema::{local_user, person, person_aggregates},
-  utils::{functions::lower, DbConn, DbPool, ListFn, Queries, ReadFn},
+    newtypes::{LocalUserId, PersonId},
+    schema::{local_user, person, person_aggregates},
+    utils::{functions::lower, DbConn, DbPool, ListFn, Queries, ReadFn},
 };
 use lemmy_utils::error::{LemmyError, LemmyErrorType};
 use std::future::{ready, Ready};
 
 enum ReadBy<'a> {
-  Id(LocalUserId),
-  Person(PersonId),
-  Name(&'a str),
-  NameOrEmail(&'a str),
-  Email(&'a str),
+    Id(LocalUserId),
+    Person(PersonId),
+    Name(&'a str),
+    NameOrEmail(&'a str),
+    Email(&'a str),
 }
 
 enum ListMode {
-  AdminsWithEmails,
+    AdminsWithEmails,
 }
 
 fn queries<'a>(
 ) -> Queries<impl ReadFn<'a, LocalUserView, ReadBy<'a>>, impl ListFn<'a, LocalUserView, ListMode>> {
-  let selection = (
-    local_user::all_columns,
-    person::all_columns,
-    person_aggregates::all_columns,
-  );
+    let selection = (
+        local_user::all_columns,
+        person::all_columns,
+        person_aggregates::all_columns,
+    );
 
-  let read = move |mut conn: DbConn<'a>, search: ReadBy<'a>| async move {
-    let mut query = local_user::table.into_boxed();
-    query = match search {
-      ReadBy::Id(local_user_id) => query.filter(local_user::id.eq(local_user_id)),
-      ReadBy::Email(from_email) => query.filter(local_user::email.eq(from_email)),
-      _ => query,
+    let read = move |mut conn: DbConn<'a>, search: ReadBy<'a>| async move {
+        let mut query = local_user::table.into_boxed();
+        query = match search {
+            ReadBy::Id(local_user_id) => query.filter(local_user::id.eq(local_user_id)),
+            ReadBy::Email(from_email) => query.filter(local_user::email.eq(from_email)),
+            _ => query,
+        };
+        let mut query = query.inner_join(person::table);
+        query = match search {
+            ReadBy::Person(person_id) => query.filter(person::id.eq(person_id)),
+            ReadBy::Name(name) => query.filter(lower(person::name).eq(name.to_lowercase())),
+            ReadBy::NameOrEmail(name_or_email) => query.filter(
+                lower(person::name)
+                    .eq(lower(name_or_email))
+                    .or(local_user::email.eq(name_or_email)),
+            ),
+            _ => query,
+        };
+        query
+            .inner_join(person_aggregates::table.on(person::id.eq(person_aggregates::person_id)))
+            .select(selection)
+            .first::<LocalUserView>(&mut conn)
+            .await
     };
-    let mut query = query.inner_join(person::table);
-    query = match search {
-      ReadBy::Person(person_id) => query.filter(person::id.eq(person_id)),
-      ReadBy::Name(name) => query.filter(lower(person::name).eq(name.to_lowercase())),
-      ReadBy::NameOrEmail(name_or_email) => query.filter(
-        lower(person::name)
-          .eq(lower(name_or_email))
-          .or(local_user::email.eq(name_or_email)),
-      ),
-      _ => query,
+
+    let list = move |mut conn: DbConn<'a>, mode: ListMode| async move {
+        match mode {
+            ListMode::AdminsWithEmails => {
+                local_user::table
+                    .filter(local_user::email.is_not_null())
+                    .filter(local_user::admin.eq(true))
+                    .inner_join(person::table)
+                    .inner_join(
+                        person_aggregates::table.on(person::id.eq(person_aggregates::person_id)),
+                    )
+                    .select(selection)
+                    .load::<LocalUserView>(&mut conn)
+                    .await
+            }
+        }
     };
-    query
-      .inner_join(person_aggregates::table.on(person::id.eq(person_aggregates::person_id)))
-      .select(selection)
-      .first::<LocalUserView>(&mut conn)
-      .await
-  };
 
-  let list = move |mut conn: DbConn<'a>, mode: ListMode| async move {
-    match mode {
-      ListMode::AdminsWithEmails => {
-        local_user::table
-          .filter(local_user::email.is_not_null())
-          .filter(local_user::admin.eq(true))
-          .inner_join(person::table)
-          .inner_join(person_aggregates::table.on(person::id.eq(person_aggregates::person_id)))
-          .select(selection)
-          .load::<LocalUserView>(&mut conn)
-          .await
-      }
-    }
-  };
-
-  Queries::new(read, list)
+    Queries::new(read, list)
 }
 
 impl LocalUserView {
-  pub async fn read(pool: &mut DbPool<'_>, local_user_id: LocalUserId) -> Result<Self, Error> {
-    queries().read(pool, ReadBy::Id(local_user_id)).await
-  }
+    pub async fn read(pool: &mut DbPool<'_>, local_user_id: LocalUserId) -> Result<Self, Error> {
+        queries().read(pool, ReadBy::Id(local_user_id)).await
+    }
 
-  pub async fn read_person(pool: &mut DbPool<'_>, person_id: PersonId) -> Result<Self, Error> {
-    queries().read(pool, ReadBy::Person(person_id)).await
-  }
+    pub async fn read_person(pool: &mut DbPool<'_>, person_id: PersonId) -> Result<Self, Error> {
+        queries().read(pool, ReadBy::Person(person_id)).await
+    }
 
-  pub async fn read_from_name(pool: &mut DbPool<'_>, name: &str) -> Result<Self, Error> {
-    queries().read(pool, ReadBy::Name(name)).await
-  }
+    pub async fn read_from_name(pool: &mut DbPool<'_>, name: &str) -> Result<Self, Error> {
+        queries().read(pool, ReadBy::Name(name)).await
+    }
 
-  pub async fn find_by_email_or_name(
-    pool: &mut DbPool<'_>,
-    name_or_email: &str,
-  ) -> Result<Self, Error> {
-    queries()
-      .read(pool, ReadBy::NameOrEmail(name_or_email))
-      .await
-  }
+    pub async fn find_by_email_or_name(
+        pool: &mut DbPool<'_>,
+        name_or_email: &str,
+    ) -> Result<Self, Error> {
+        queries()
+            .read(pool, ReadBy::NameOrEmail(name_or_email))
+            .await
+    }
 
-  pub async fn find_by_email(pool: &mut DbPool<'_>, from_email: &str) -> Result<Self, Error> {
-    queries().read(pool, ReadBy::Email(from_email)).await
-  }
+    pub async fn find_by_email(pool: &mut DbPool<'_>, from_email: &str) -> Result<Self, Error> {
+        queries().read(pool, ReadBy::Email(from_email)).await
+    }
 
-  pub async fn list_admins_with_emails(pool: &mut DbPool<'_>) -> Result<Vec<Self>, Error> {
-    queries().list(pool, ListMode::AdminsWithEmails).await
-  }
+    pub async fn list_admins_with_emails(pool: &mut DbPool<'_>) -> Result<Vec<Self>, Error> {
+        queries().list(pool, ListMode::AdminsWithEmails).await
+    }
 }
 
 impl FromRequest for LocalUserView {
-  type Error = LemmyError;
-  type Future = Ready<Result<Self, Self::Error>>;
+    type Error = LemmyError;
+    type Future = Ready<Result<Self, Self::Error>>;
 
-  fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
-    ready(match req.extensions().get::<LocalUserView>() {
-      Some(c) => Ok(c.clone()),
-      None => Err(LemmyErrorType::IncorrectLogin.into()),
-    })
-  }
+    fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
+        ready(match req.extensions().get::<LocalUserView>() {
+            Some(c) => Ok(c.clone()),
+            None => Err(LemmyErrorType::IncorrectLogin.into()),
+        })
+    }
 }

--- a/crates/db_views/src/post_report_view.rs
+++ b/crates/db_views/src/post_report_view.rs
@@ -1,401 +1,389 @@
 use crate::structs::{LocalUserView, PostReportView};
 use diesel::{
-  pg::Pg,
-  result::Error,
-  BoolExpressionMethods,
-  ExpressionMethods,
-  JoinOnDsl,
-  NullableExpressionMethods,
-  QueryDsl,
+    pg::Pg, result::Error, BoolExpressionMethods, ExpressionMethods, JoinOnDsl,
+    NullableExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  aliases,
-  newtypes::{CommunityId, PersonId, PostReportId},
-  schema::{
-    community,
-    community_moderator,
-    community_person_ban,
-    person,
-    post,
-    post_aggregates,
-    post_like,
-    post_report,
-  },
-  utils::{get_conn, limit_and_offset, DbConn, DbPool, ListFn, Queries, ReadFn},
+    aliases,
+    newtypes::{CommunityId, PersonId, PostReportId},
+    schema::{
+        community, community_moderator, community_person_ban, person, post, post_aggregates,
+        post_like, post_report,
+    },
+    utils::{get_conn, limit_and_offset, DbConn, DbPool, ListFn, Queries, ReadFn},
 };
 
 fn queries<'a>() -> Queries<
-  impl ReadFn<'a, PostReportView, (PostReportId, PersonId)>,
-  impl ListFn<'a, PostReportView, (PostReportQuery, &'a LocalUserView)>,
+    impl ReadFn<'a, PostReportView, (PostReportId, PersonId)>,
+    impl ListFn<'a, PostReportView, (PostReportQuery, &'a LocalUserView)>,
 > {
-  let all_joins = |query: post_report::BoxedQuery<'a, Pg>, my_person_id: PersonId| {
-    query
-      .inner_join(post::table)
-      .inner_join(community::table.on(post::community_id.eq(community::id)))
-      .inner_join(person::table.on(post_report::creator_id.eq(person::id)))
-      .inner_join(aliases::person1.on(post::creator_id.eq(aliases::person1.field(person::id))))
-      .left_join(
-        community_person_ban::table.on(
-          post::community_id
-            .eq(community_person_ban::community_id)
-            .and(community_person_ban::person_id.eq(post::creator_id)),
-        ),
-      )
-      .left_join(
-        post_like::table.on(
-          post::id
-            .eq(post_like::post_id)
-            .and(post_like::person_id.eq(my_person_id)),
-        ),
-      )
-      .inner_join(post_aggregates::table.on(post_report::post_id.eq(post_aggregates::post_id)))
-      .left_join(
-        aliases::person2
-          .on(post_report::resolver_id.eq(aliases::person2.field(person::id).nullable())),
-      )
-      .select((
-        post_report::all_columns,
-        post::all_columns,
-        community::all_columns,
-        person::all_columns,
-        aliases::person1.fields(person::all_columns),
-        community_person_ban::id.nullable().is_not_null(),
-        post_like::score.nullable(),
-        post_aggregates::all_columns,
-        aliases::person2.fields(person::all_columns.nullable()),
-      ))
-  };
+    let all_joins = |query: post_report::BoxedQuery<'a, Pg>, my_person_id: PersonId| {
+        query
+            .inner_join(post::table)
+            .inner_join(community::table.on(post::community_id.eq(community::id)))
+            .inner_join(person::table.on(post_report::creator_id.eq(person::id)))
+            .inner_join(
+                aliases::person1.on(post::creator_id.eq(aliases::person1.field(person::id))),
+            )
+            .left_join(
+                community_person_ban::table.on(post::community_id
+                    .eq(community_person_ban::community_id)
+                    .and(community_person_ban::person_id.eq(post::creator_id))),
+            )
+            .left_join(
+                post_like::table.on(post::id
+                    .eq(post_like::post_id)
+                    .and(post_like::person_id.eq(my_person_id))),
+            )
+            .inner_join(
+                post_aggregates::table.on(post_report::post_id.eq(post_aggregates::post_id)),
+            )
+            .left_join(
+                aliases::person2
+                    .on(post_report::resolver_id.eq(aliases::person2.field(person::id).nullable())),
+            )
+            .select((
+                post_report::all_columns,
+                post::all_columns,
+                community::all_columns,
+                person::all_columns,
+                aliases::person1.fields(person::all_columns),
+                community_person_ban::id.nullable().is_not_null(),
+                post_like::score.nullable(),
+                post_aggregates::all_columns,
+                aliases::person2.fields(person::all_columns.nullable()),
+            ))
+    };
 
-  let read = move |mut conn: DbConn<'a>, (report_id, my_person_id): (PostReportId, PersonId)| async move {
-    all_joins(
-      post_report::table.find(report_id).into_boxed(),
-      my_person_id,
-    )
-    .first::<PostReportView>(&mut conn)
-    .await
-  };
-
-  let list = move |mut conn: DbConn<'a>, (options, user): (PostReportQuery, &'a LocalUserView)| async move {
-    let mut query = all_joins(post_report::table.into_boxed(), user.person.id);
-
-    if let Some(community_id) = options.community_id {
-      query = query.filter(post::community_id.eq(community_id));
-    }
-
-    if options.unresolved_only {
-      query = query.filter(post_report::resolved.eq(false));
-    }
-
-    let (limit, offset) = limit_and_offset(options.page, options.limit)?;
-
-    query = query
-      .order_by(post_report::published.desc())
-      .limit(limit)
-      .offset(offset);
-
-    // If its not an admin, get only the ones you mod
-    if !user.local_user.admin {
-      query
-        .inner_join(
-          community_moderator::table.on(
-            community_moderator::community_id
-              .eq(post::community_id)
-              .and(community_moderator::person_id.eq(user.person.id)),
-          ),
+    let read = move |mut conn: DbConn<'a>, (report_id, my_person_id): (PostReportId, PersonId)| async move {
+        all_joins(
+            post_report::table.find(report_id).into_boxed(),
+            my_person_id,
         )
-        .load::<PostReportView>(&mut conn)
+        .first::<PostReportView>(&mut conn)
         .await
-    } else {
-      query.load::<PostReportView>(&mut conn).await
-    }
-  };
+    };
 
-  Queries::new(read, list)
+    let list = move |mut conn: DbConn<'a>,
+                     (options, user): (PostReportQuery, &'a LocalUserView)| async move {
+        let mut query = all_joins(post_report::table.into_boxed(), user.person.id);
+
+        if let Some(community_id) = options.community_id {
+            query = query.filter(post::community_id.eq(community_id));
+        }
+
+        if options.unresolved_only {
+            query = query.filter(post_report::resolved.eq(false));
+        }
+
+        let (limit, offset) = limit_and_offset(options.page, options.limit)?;
+
+        query = query
+            .order_by(post_report::published.desc())
+            .limit(limit)
+            .offset(offset);
+
+        // If its not an admin, get only the ones you mod
+        if !user.local_user.admin {
+            query
+                .inner_join(
+                    community_moderator::table.on(community_moderator::community_id
+                        .eq(post::community_id)
+                        .and(community_moderator::person_id.eq(user.person.id))),
+                )
+                .load::<PostReportView>(&mut conn)
+                .await
+        } else {
+            query.load::<PostReportView>(&mut conn).await
+        }
+    };
+
+    Queries::new(read, list)
 }
 
 impl PostReportView {
-  /// returns the PostReportView for the provided report_id
-  ///
-  /// * `report_id` - the report id to obtain
-  pub async fn read(
-    pool: &mut DbPool<'_>,
-    report_id: PostReportId,
-    my_person_id: PersonId,
-  ) -> Result<Self, Error> {
-    queries().read(pool, (report_id, my_person_id)).await
-  }
-
-  /// returns the current unresolved post report count for the communities you mod
-  pub async fn get_report_count(
-    pool: &mut DbPool<'_>,
-    my_person_id: PersonId,
-    admin: bool,
-    community_id: Option<CommunityId>,
-  ) -> Result<i64, Error> {
-    use diesel::dsl::count;
-    let conn = &mut get_conn(pool).await?;
-    let mut query = post_report::table
-      .inner_join(post::table)
-      .filter(post_report::resolved.eq(false))
-      .into_boxed();
-
-    if let Some(community_id) = community_id {
-      query = query.filter(post::community_id.eq(community_id))
+    /// returns the PostReportView for the provided report_id
+    ///
+    /// * `report_id` - the report id to obtain
+    pub async fn read(
+        pool: &mut DbPool<'_>,
+        report_id: PostReportId,
+        my_person_id: PersonId,
+    ) -> Result<Self, Error> {
+        queries().read(pool, (report_id, my_person_id)).await
     }
 
-    // If its not an admin, get only the ones you mod
-    if !admin {
-      query
-        .inner_join(
-          community_moderator::table.on(
-            community_moderator::community_id
-              .eq(post::community_id)
-              .and(community_moderator::person_id.eq(my_person_id)),
-          ),
-        )
-        .select(count(post_report::id))
-        .first::<i64>(conn)
-        .await
-    } else {
-      query
-        .select(count(post_report::id))
-        .first::<i64>(conn)
-        .await
+    /// returns the current unresolved post report count for the communities you mod
+    pub async fn get_report_count(
+        pool: &mut DbPool<'_>,
+        my_person_id: PersonId,
+        admin: bool,
+        community_id: Option<CommunityId>,
+    ) -> Result<i64, Error> {
+        use diesel::dsl::count;
+        let conn = &mut get_conn(pool).await?;
+        let mut query = post_report::table
+            .inner_join(post::table)
+            .filter(post_report::resolved.eq(false))
+            .into_boxed();
+
+        if let Some(community_id) = community_id {
+            query = query.filter(post::community_id.eq(community_id))
+        }
+
+        // If its not an admin, get only the ones you mod
+        if !admin {
+            query
+                .inner_join(
+                    community_moderator::table.on(community_moderator::community_id
+                        .eq(post::community_id)
+                        .and(community_moderator::person_id.eq(my_person_id))),
+                )
+                .select(count(post_report::id))
+                .first::<i64>(conn)
+                .await
+        } else {
+            query
+                .select(count(post_report::id))
+                .first::<i64>(conn)
+                .await
+        }
     }
-  }
 }
 
 #[derive(Default)]
 pub struct PostReportQuery {
-  pub community_id: Option<CommunityId>,
-  pub page: Option<i64>,
-  pub limit: Option<i64>,
-  pub unresolved_only: bool,
+    pub community_id: Option<CommunityId>,
+    pub page: Option<i64>,
+    pub limit: Option<i64>,
+    pub unresolved_only: bool,
 }
 
 impl PostReportQuery {
-  pub async fn list(
-    self,
-    pool: &mut DbPool<'_>,
-    user: &LocalUserView,
-  ) -> Result<Vec<PostReportView>, Error> {
-    queries().list(pool, (self, user)).await
-  }
+    pub async fn list(
+        self,
+        pool: &mut DbPool<'_>,
+        user: &LocalUserView,
+    ) -> Result<Vec<PostReportView>, Error> {
+        queries().list(pool, (self, user)).await
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::{
-    post_report_view::{PostReportQuery, PostReportView},
-    structs::LocalUserView,
-  };
-  use lemmy_db_schema::{
-    source::{
-      community::{Community, CommunityInsertForm, CommunityModerator, CommunityModeratorForm},
-      instance::Instance,
-      local_user::{LocalUser, LocalUserInsertForm},
-      moderator::{ModRemovePost, ModRemovePostForm},
-      person::{Person, PersonInsertForm},
-      post::{Post, PostInsertForm},
-      post_report::{PostReport, PostReportForm},
-    },
-    traits::{Crud, Joinable, Reportable},
-    utils::build_db_pool_for_tests,
-  };
-  use serial_test::serial;
-
-  #[tokio::test]
-  #[serial]
-  async fn test_crud() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-
-    let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
-      .await
-      .unwrap();
-
-    let new_person = PersonInsertForm::builder()
-      .name("timmy_prv".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_timmy = Person::create(pool, &new_person).await.unwrap();
-
-    let new_local_user = LocalUserInsertForm::builder()
-      .person_id(inserted_timmy.id)
-      .password_encrypted("123".to_string())
-      .build();
-    let timmy_local_user = LocalUser::create(pool, &new_local_user).await.unwrap();
-    let timmy_view = LocalUserView {
-      local_user: timmy_local_user,
-      person: inserted_timmy.clone(),
-      counts: Default::default(),
+    use crate::{
+        post_report_view::{PostReportQuery, PostReportView},
+        structs::LocalUserView,
     };
-
-    let new_person_2 = PersonInsertForm::builder()
-      .name("sara_prv".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_sara = Person::create(pool, &new_person_2).await.unwrap();
-
-    // Add a third person, since new ppl can only report something once.
-    let new_person_3 = PersonInsertForm::builder()
-      .name("jessica_prv".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_jessica = Person::create(pool, &new_person_3).await.unwrap();
-
-    let new_community = CommunityInsertForm::builder()
-      .name("test community prv".to_string())
-      .title("nada".to_owned())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_community = Community::create(pool, &new_community).await.unwrap();
-
-    // Make timmy a mod
-    let timmy_moderator_form = CommunityModeratorForm {
-      community_id: inserted_community.id,
-      person_id: inserted_timmy.id,
+    use lemmy_db_schema::{
+        source::{
+            community::{
+                Community, CommunityInsertForm, CommunityModerator, CommunityModeratorForm,
+            },
+            instance::Instance,
+            local_user::{LocalUser, LocalUserInsertForm},
+            moderator::{ModRemovePost, ModRemovePostForm},
+            person::{Person, PersonInsertForm},
+            post::{Post, PostInsertForm},
+            post_report::{PostReport, PostReportForm},
+        },
+        traits::{Crud, Joinable, Reportable},
+        utils::build_db_pool_for_tests,
     };
+    use serial_test::serial;
 
-    let _inserted_moderator = CommunityModerator::join(pool, &timmy_moderator_form)
-      .await
-      .unwrap();
+    #[tokio::test]
+    #[serial]
+    async fn test_crud() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
 
-    let new_post = PostInsertForm::builder()
-      .name("A test post crv".into())
-      .creator_id(inserted_timmy.id)
-      .community_id(inserted_community.id)
-      .build();
+        let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
+            .await
+            .unwrap();
 
-    let inserted_post = Post::create(pool, &new_post).await.unwrap();
+        let new_person = PersonInsertForm::builder()
+            .name("timmy_prv".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    // sara reports
-    let sara_report_form = PostReportForm {
-      creator_id: inserted_sara.id,
-      post_id: inserted_post.id,
-      original_post_name: "Orig post".into(),
-      original_post_url: None,
-      original_post_body: None,
-      reason: "from sara".into(),
-    };
+        let inserted_timmy = Person::create(pool, &new_person).await.unwrap();
 
-    PostReport::report(pool, &sara_report_form).await.unwrap();
+        let new_local_user = LocalUserInsertForm::builder()
+            .person_id(inserted_timmy.id)
+            .password_encrypted("123".to_string())
+            .build();
+        let timmy_local_user = LocalUser::create(pool, &new_local_user).await.unwrap();
+        let timmy_view = LocalUserView {
+            local_user: timmy_local_user,
+            person: inserted_timmy.clone(),
+            counts: Default::default(),
+        };
 
-    let new_post_2 = PostInsertForm::builder()
-      .name("A test post crv 2".into())
-      .creator_id(inserted_timmy.id)
-      .community_id(inserted_community.id)
-      .build();
+        let new_person_2 = PersonInsertForm::builder()
+            .name("sara_prv".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let inserted_post_2 = Post::create(pool, &new_post_2).await.unwrap();
+        let inserted_sara = Person::create(pool, &new_person_2).await.unwrap();
 
-    // jessica reports
-    let jessica_report_form = PostReportForm {
-      creator_id: inserted_jessica.id,
-      post_id: inserted_post_2.id,
-      original_post_name: "Orig post".into(),
-      original_post_url: None,
-      original_post_body: None,
-      reason: "from jessica".into(),
-    };
+        // Add a third person, since new ppl can only report something once.
+        let new_person_3 = PersonInsertForm::builder()
+            .name("jessica_prv".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    let inserted_jessica_report = PostReport::report(pool, &jessica_report_form)
-      .await
-      .unwrap();
+        let inserted_jessica = Person::create(pool, &new_person_3).await.unwrap();
 
-    let read_jessica_report_view =
-      PostReportView::read(pool, inserted_jessica_report.id, inserted_timmy.id)
+        let new_community = CommunityInsertForm::builder()
+            .name("test community prv".to_string())
+            .title("nada".to_owned())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
+
+        let inserted_community = Community::create(pool, &new_community).await.unwrap();
+
+        // Make timmy a mod
+        let timmy_moderator_form = CommunityModeratorForm {
+            community_id: inserted_community.id,
+            person_id: inserted_timmy.id,
+        };
+
+        let _inserted_moderator = CommunityModerator::join(pool, &timmy_moderator_form)
+            .await
+            .unwrap();
+
+        let new_post = PostInsertForm::builder()
+            .name("A test post crv".into())
+            .creator_id(inserted_timmy.id)
+            .community_id(inserted_community.id)
+            .build();
+
+        let inserted_post = Post::create(pool, &new_post).await.unwrap();
+
+        // sara reports
+        let sara_report_form = PostReportForm {
+            creator_id: inserted_sara.id,
+            post_id: inserted_post.id,
+            original_post_name: "Orig post".into(),
+            original_post_url: None,
+            original_post_body: None,
+            reason: "from sara".into(),
+        };
+
+        PostReport::report(pool, &sara_report_form).await.unwrap();
+
+        let new_post_2 = PostInsertForm::builder()
+            .name("A test post crv 2".into())
+            .creator_id(inserted_timmy.id)
+            .community_id(inserted_community.id)
+            .build();
+
+        let inserted_post_2 = Post::create(pool, &new_post_2).await.unwrap();
+
+        // jessica reports
+        let jessica_report_form = PostReportForm {
+            creator_id: inserted_jessica.id,
+            post_id: inserted_post_2.id,
+            original_post_name: "Orig post".into(),
+            original_post_url: None,
+            original_post_body: None,
+            reason: "from jessica".into(),
+        };
+
+        let inserted_jessica_report = PostReport::report(pool, &jessica_report_form)
+            .await
+            .unwrap();
+
+        let read_jessica_report_view =
+            PostReportView::read(pool, inserted_jessica_report.id, inserted_timmy.id)
+                .await
+                .unwrap();
+
+        assert_eq!(
+            read_jessica_report_view.post_report,
+            inserted_jessica_report
+        );
+        assert_eq!(read_jessica_report_view.post, inserted_post_2);
+        assert_eq!(read_jessica_report_view.community.id, inserted_community.id);
+        assert_eq!(read_jessica_report_view.creator.id, inserted_jessica.id);
+        assert_eq!(read_jessica_report_view.post_creator.id, inserted_timmy.id);
+        assert_eq!(read_jessica_report_view.my_vote, None);
+        assert_eq!(read_jessica_report_view.resolver, None);
+
+        // Do a batch read of timmys reports
+        let reports = PostReportQuery::default()
+            .list(pool, &timmy_view)
+            .await
+            .unwrap();
+
+        assert_eq!(reports[0].creator.id, inserted_jessica.id);
+        assert_eq!(reports[1].creator.id, inserted_sara.id);
+
+        // Make sure the counts are correct
+        let report_count = PostReportView::get_report_count(pool, inserted_timmy.id, false, None)
+            .await
+            .unwrap();
+        assert_eq!(2, report_count);
+
+        // Writing post removal to mod log should automatically resolve reports
+        let remove_form = ModRemovePostForm {
+            mod_person_id: inserted_timmy.id,
+            post_id: inserted_jessica_report.post_id,
+            reason: None,
+            removed: Some(true),
+        };
+        ModRemovePost::create(pool, &remove_form).await.unwrap();
+
+        let read_jessica_report_view_after_resolve =
+            PostReportView::read(pool, inserted_jessica_report.id, inserted_timmy.id)
+                .await
+                .unwrap();
+        assert!(read_jessica_report_view_after_resolve.post_report.resolved);
+        assert_eq!(
+            read_jessica_report_view_after_resolve
+                .post_report
+                .resolver_id,
+            Some(inserted_timmy.id)
+        );
+        assert_eq!(
+            read_jessica_report_view_after_resolve.resolver.unwrap().id,
+            inserted_timmy.id
+        );
+
+        // Do a batch read of timmys reports
+        // It should only show saras, which is unresolved
+        let reports_after_resolve = PostReportQuery {
+            unresolved_only: true,
+            ..Default::default()
+        }
+        .list(pool, &timmy_view)
         .await
         .unwrap();
+        assert_eq!(reports_after_resolve.len(), 1);
+        assert_eq!(reports_after_resolve[0].creator.id, inserted_sara.id);
 
-    assert_eq!(
-      read_jessica_report_view.post_report,
-      inserted_jessica_report
-    );
-    assert_eq!(read_jessica_report_view.post, inserted_post_2);
-    assert_eq!(read_jessica_report_view.community.id, inserted_community.id);
-    assert_eq!(read_jessica_report_view.creator.id, inserted_jessica.id);
-    assert_eq!(read_jessica_report_view.post_creator.id, inserted_timmy.id);
-    assert_eq!(read_jessica_report_view.my_vote, None);
-    assert_eq!(read_jessica_report_view.resolver, None);
+        // Make sure the counts are correct
+        let report_count_after_resolved =
+            PostReportView::get_report_count(pool, inserted_timmy.id, false, None)
+                .await
+                .unwrap();
+        assert_eq!(1, report_count_after_resolved);
 
-    // Do a batch read of timmys reports
-    let reports = PostReportQuery::default()
-      .list(pool, &timmy_view)
-      .await
-      .unwrap();
-
-    assert_eq!(reports[0].creator.id, inserted_jessica.id);
-    assert_eq!(reports[1].creator.id, inserted_sara.id);
-
-    // Make sure the counts are correct
-    let report_count = PostReportView::get_report_count(pool, inserted_timmy.id, false, None)
-      .await
-      .unwrap();
-    assert_eq!(2, report_count);
-
-    // Writing post removal to mod log should automatically resolve reports
-    let remove_form = ModRemovePostForm {
-      mod_person_id: inserted_timmy.id,
-      post_id: inserted_jessica_report.post_id,
-      reason: None,
-      removed: Some(true),
-    };
-    ModRemovePost::create(pool, &remove_form).await.unwrap();
-
-    let read_jessica_report_view_after_resolve =
-      PostReportView::read(pool, inserted_jessica_report.id, inserted_timmy.id)
-        .await
-        .unwrap();
-    assert!(read_jessica_report_view_after_resolve.post_report.resolved);
-    assert_eq!(
-      read_jessica_report_view_after_resolve
-        .post_report
-        .resolver_id,
-      Some(inserted_timmy.id)
-    );
-    assert_eq!(
-      read_jessica_report_view_after_resolve.resolver.unwrap().id,
-      inserted_timmy.id
-    );
-
-    // Do a batch read of timmys reports
-    // It should only show saras, which is unresolved
-    let reports_after_resolve = PostReportQuery {
-      unresolved_only: true,
-      ..Default::default()
+        Person::delete(pool, inserted_timmy.id).await.unwrap();
+        Person::delete(pool, inserted_sara.id).await.unwrap();
+        Person::delete(pool, inserted_jessica.id).await.unwrap();
+        Community::delete(pool, inserted_community.id)
+            .await
+            .unwrap();
+        Instance::delete(pool, inserted_instance.id).await.unwrap();
     }
-    .list(pool, &timmy_view)
-    .await
-    .unwrap();
-    assert_eq!(reports_after_resolve.len(), 1);
-    assert_eq!(reports_after_resolve[0].creator.id, inserted_sara.id);
-
-    // Make sure the counts are correct
-    let report_count_after_resolved =
-      PostReportView::get_report_count(pool, inserted_timmy.id, false, None)
-        .await
-        .unwrap();
-    assert_eq!(1, report_count_after_resolved);
-
-    Person::delete(pool, inserted_timmy.id).await.unwrap();
-    Person::delete(pool, inserted_sara.id).await.unwrap();
-    Person::delete(pool, inserted_jessica.id).await.unwrap();
-    Community::delete(pool, inserted_community.id)
-      .await
-      .unwrap();
-    Instance::delete(pool, inserted_instance.id).await.unwrap();
-  }
 }

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -1,1169 +1,1158 @@
 use crate::structs::{LocalUserView, PostView};
 use diesel::{
-  debug_query,
-  dsl::{exists, not, IntervalDsl},
-  pg::Pg,
-  result::Error,
-  sql_function,
-  sql_types::{self, Timestamptz},
-  BoolExpressionMethods,
-  BoxableExpression,
-  ExpressionMethods,
-  IntoSql,
-  NullableExpressionMethods,
-  PgTextExpressionMethods,
-  QueryDsl,
+    debug_query,
+    dsl::{exists, not, IntervalDsl},
+    pg::Pg,
+    result::Error,
+    sql_function,
+    sql_types::{self, Timestamptz},
+    BoolExpressionMethods, BoxableExpression, ExpressionMethods, IntoSql,
+    NullableExpressionMethods, PgTextExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  newtypes::{CommunityId, LocalUserId, PersonId, PostId},
-  schema::{
-    community,
-    community_block,
-    community_follower,
-    community_moderator,
-    community_person_ban,
-    local_user_language,
-    person,
-    person_block,
-    person_post_aggregates,
-    post,
-    post_aggregates,
-    post_like,
-    post_read,
-    post_saved,
-  },
-  utils::{fuzzy_search, limit_and_offset, DbConn, DbPool, ListFn, Queries, ReadFn},
-  ListingType,
-  SortType,
+    newtypes::{CommunityId, LocalUserId, PersonId, PostId},
+    schema::{
+        community, community_block, community_follower, community_moderator, community_person_ban,
+        local_user_language, person, person_block, person_post_aggregates, post, post_aggregates,
+        post_like, post_read, post_saved,
+    },
+    utils::{fuzzy_search, limit_and_offset, DbConn, DbPool, ListFn, Queries, ReadFn},
+    ListingType, SortType,
 };
 use tracing::debug;
 
 sql_function!(fn coalesce(x: sql_types::Nullable<sql_types::BigInt>, y: sql_types::BigInt) -> sql_types::BigInt);
 
 fn queries<'a>() -> Queries<
-  impl ReadFn<'a, PostView, (PostId, Option<PersonId>, bool)>,
-  impl ListFn<'a, PostView, PostQuery<'a>>,
+    impl ReadFn<'a, PostView, (PostId, Option<PersonId>, bool)>,
+    impl ListFn<'a, PostView, PostQuery<'a>>,
 > {
-  let is_creator_banned_from_community = exists(
-    community_person_ban::table.filter(
-      post_aggregates::community_id
-        .eq(community_person_ban::community_id)
-        .and(community_person_ban::person_id.eq(post_aggregates::creator_id)),
-    ),
-  );
-
-  let is_saved = |person_id| {
-    exists(
-      post_saved::table.filter(
-        post_aggregates::post_id
-          .eq(post_saved::post_id)
-          .and(post_saved::person_id.eq(person_id)),
-      ),
-    )
-  };
-
-  let is_read = |person_id| {
-    exists(
-      post_read::table.filter(
-        post_aggregates::post_id
-          .eq(post_read::post_id)
-          .and(post_read::person_id.eq(person_id)),
-      ),
-    )
-  };
-
-  let is_creator_blocked = |person_id| {
-    exists(
-      person_block::table.filter(
-        post_aggregates::creator_id
-          .eq(person_block::target_id)
-          .and(person_block::person_id.eq(person_id)),
-      ),
-    )
-  };
-
-  let score = |person_id| {
-    post_like::table
-      .filter(
-        post_aggregates::post_id
-          .eq(post_like::post_id)
-          .and(post_like::person_id.eq(person_id)),
-      )
-      .select(post_like::score.nullable())
-      .single_value()
-  };
-
-  let all_joins = move |query: post_aggregates::BoxedQuery<'a, Pg>,
-                        my_person_id: Option<PersonId>,
-                        saved_only: bool| {
-    let is_saved_selection: Box<dyn BoxableExpression<_, Pg, SqlType = sql_types::Bool>> =
-      if saved_only {
-        Box::new(true.into_sql::<sql_types::Bool>())
-      } else if let Some(person_id) = my_person_id {
-        Box::new(is_saved(person_id))
-      } else {
-        Box::new(false.into_sql::<sql_types::Bool>())
-      };
-
-    let is_read_selection: Box<dyn BoxableExpression<_, Pg, SqlType = sql_types::Bool>> =
-      if let Some(person_id) = my_person_id {
-        Box::new(is_read(person_id))
-      } else {
-        Box::new(false.into_sql::<sql_types::Bool>())
-      };
-
-    let is_creator_blocked_selection: Box<dyn BoxableExpression<_, Pg, SqlType = sql_types::Bool>> =
-      if let Some(person_id) = my_person_id {
-        Box::new(is_creator_blocked(person_id))
-      } else {
-        Box::new(false.into_sql::<sql_types::Bool>())
-      };
-
-    let subscribed_type_selection: Box<
-      dyn BoxableExpression<_, Pg, SqlType = sql_types::Nullable<sql_types::Bool>>,
-    > = if let Some(person_id) = my_person_id {
-      Box::new(
-        community_follower::table
-          .filter(
+    let is_creator_banned_from_community = exists(
+        community_person_ban::table.filter(
             post_aggregates::community_id
-              .eq(community_follower::community_id)
-              .and(community_follower::person_id.eq(person_id)),
-          )
-          .select(community_follower::pending.nullable())
-          .single_value(),
-      )
-    } else {
-      Box::new(None::<bool>.into_sql::<sql_types::Nullable<sql_types::Bool>>())
-    };
-
-    let score_selection: Box<
-      dyn BoxableExpression<_, Pg, SqlType = sql_types::Nullable<sql_types::SmallInt>>,
-    > = if let Some(person_id) = my_person_id {
-      Box::new(score(person_id))
-    } else {
-      Box::new(None::<i16>.into_sql::<sql_types::Nullable<sql_types::SmallInt>>())
-    };
-
-    let read_comments: Box<
-      dyn BoxableExpression<_, Pg, SqlType = sql_types::Nullable<sql_types::BigInt>>,
-    > = if let Some(person_id) = my_person_id {
-      Box::new(
-        person_post_aggregates::table
-          .filter(
-            post_aggregates::post_id
-              .eq(person_post_aggregates::post_id)
-              .and(person_post_aggregates::person_id.eq(person_id)),
-          )
-          .select(person_post_aggregates::read_comments.nullable())
-          .single_value(),
-      )
-    } else {
-      Box::new(None::<i64>.into_sql::<sql_types::Nullable<sql_types::BigInt>>())
-    };
-
-    query
-      .inner_join(person::table)
-      .inner_join(community::table)
-      .inner_join(post::table)
-      .select((
-        post::all_columns,
-        person::all_columns,
-        community::all_columns,
-        is_creator_banned_from_community,
-        post_aggregates::all_columns,
-        subscribed_type_selection,
-        is_saved_selection,
-        is_read_selection,
-        is_creator_blocked_selection,
-        score_selection,
-        coalesce(
-          post_aggregates::comments.nullable() - read_comments,
-          post_aggregates::comments,
+                .eq(community_person_ban::community_id)
+                .and(community_person_ban::person_id.eq(post_aggregates::creator_id)),
         ),
-      ))
-  };
-
-  let read =
-    move |mut conn: DbConn<'a>,
-          (post_id, my_person_id, is_mod_or_admin): (PostId, Option<PersonId>, bool)| async move {
-      // The left join below will return None in this case
-      let person_id_join = my_person_id.unwrap_or(PersonId(-1));
-
-      let mut query = all_joins(
-        post_aggregates::table
-          .filter(post_aggregates::post_id.eq(post_id))
-          .into_boxed(),
-        my_person_id,
-        false,
-      );
-
-      // Hide deleted and removed for non-admins or mods
-      if !is_mod_or_admin {
-        query = query
-          .filter(community::removed.eq(false))
-          .filter(post::removed.eq(false))
-          // users can see their own deleted posts
-          .filter(
-            community::deleted
-              .eq(false)
-              .or(post::creator_id.eq(person_id_join)),
-          )
-          .filter(
-            post::deleted
-              .eq(false)
-              .or(post::creator_id.eq(person_id_join)),
-          );
-      }
-
-      query.first::<PostView>(&mut conn).await
-    };
-
-  let list = move |mut conn: DbConn<'a>, options: PostQuery<'a>| async move {
-    let person_id = options.local_user.map(|l| l.person.id);
-    let local_user_id = options.local_user.map(|l| l.local_user.id);
-
-    // The left join below will return None in this case
-    let person_id_join = person_id.unwrap_or(PersonId(-1));
-    let local_user_id_join = local_user_id.unwrap_or(LocalUserId(-1));
-
-    let mut query = all_joins(
-      post_aggregates::table.into_boxed(),
-      person_id,
-      options.saved_only,
     );
 
-    let is_creator = options.creator_id == options.local_user.map(|l| l.person.id);
-    // only show deleted posts to creator
-    if is_creator {
-      query = query
-        .filter(community::deleted.eq(false))
-        .filter(post::deleted.eq(false));
-    }
-
-    let is_admin = options
-      .local_user
-      .map(|l| l.local_user.admin)
-      .unwrap_or(false);
-    // only show removed posts to admin when viewing user profile
-    if !(options.is_profile_view && is_admin) {
-      query = query
-        .filter(community::removed.eq(false))
-        .filter(post::removed.eq(false));
-    }
-
-    if options.community_id.is_none() {
-      query = query.then_order_by(post_aggregates::featured_local.desc());
-    } else if let Some(community_id) = options.community_id {
-      query = query
-        .filter(post_aggregates::community_id.eq(community_id))
-        .then_order_by(post_aggregates::featured_community.desc());
-    }
-
-    if let Some(creator_id) = options.creator_id {
-      query = query.filter(post_aggregates::creator_id.eq(creator_id));
-    }
-
-    if let (Some(listing_type), Some(person_id)) = (options.listing_type, person_id) {
-      let is_subscribed = exists(
-        community_follower::table.filter(
-          post_aggregates::community_id
-            .eq(community_follower::community_id)
-            .and(community_follower::person_id.eq(person_id)),
-        ),
-      );
-      match listing_type {
-        ListingType::Subscribed => query = query.filter(is_subscribed),
-        ListingType::Local => {
-          query = query
-            .filter(community::local.eq(true))
-            .filter(community::hidden.eq(false).or(is_subscribed));
-        }
-        ListingType::All => query = query.filter(community::hidden.eq(false).or(is_subscribed)),
-        ListingType::ModeratorView => {
-          query = query.filter(exists(
-            community_moderator::table.filter(
-              post::community_id
-                .eq(community_moderator::community_id)
-                .and(community_moderator::person_id.eq(person_id)),
+    let is_saved = |person_id| {
+        exists(
+            post_saved::table.filter(
+                post_aggregates::post_id
+                    .eq(post_saved::post_id)
+                    .and(post_saved::person_id.eq(person_id)),
             ),
-          ));
+        )
+    };
+
+    let is_read = |person_id| {
+        exists(
+            post_read::table.filter(
+                post_aggregates::post_id
+                    .eq(post_read::post_id)
+                    .and(post_read::person_id.eq(person_id)),
+            ),
+        )
+    };
+
+    let is_creator_blocked = |person_id| {
+        exists(
+            person_block::table.filter(
+                post_aggregates::creator_id
+                    .eq(person_block::target_id)
+                    .and(person_block::person_id.eq(person_id)),
+            ),
+        )
+    };
+
+    let score = |person_id| {
+        post_like::table
+            .filter(
+                post_aggregates::post_id
+                    .eq(post_like::post_id)
+                    .and(post_like::person_id.eq(person_id)),
+            )
+            .select(post_like::score.nullable())
+            .single_value()
+    };
+
+    let all_joins = move |query: post_aggregates::BoxedQuery<'a, Pg>,
+                          my_person_id: Option<PersonId>,
+                          saved_only: bool| {
+        let is_saved_selection: Box<dyn BoxableExpression<_, Pg, SqlType = sql_types::Bool>> =
+            if saved_only {
+                Box::new(true.into_sql::<sql_types::Bool>())
+            } else if let Some(person_id) = my_person_id {
+                Box::new(is_saved(person_id))
+            } else {
+                Box::new(false.into_sql::<sql_types::Bool>())
+            };
+
+        let is_read_selection: Box<dyn BoxableExpression<_, Pg, SqlType = sql_types::Bool>> =
+            if let Some(person_id) = my_person_id {
+                Box::new(is_read(person_id))
+            } else {
+                Box::new(false.into_sql::<sql_types::Bool>())
+            };
+
+        let is_creator_blocked_selection: Box<
+            dyn BoxableExpression<_, Pg, SqlType = sql_types::Bool>,
+        > = if let Some(person_id) = my_person_id {
+            Box::new(is_creator_blocked(person_id))
+        } else {
+            Box::new(false.into_sql::<sql_types::Bool>())
+        };
+
+        let subscribed_type_selection: Box<
+            dyn BoxableExpression<_, Pg, SqlType = sql_types::Nullable<sql_types::Bool>>,
+        > = if let Some(person_id) = my_person_id {
+            Box::new(
+                community_follower::table
+                    .filter(
+                        post_aggregates::community_id
+                            .eq(community_follower::community_id)
+                            .and(community_follower::person_id.eq(person_id)),
+                    )
+                    .select(community_follower::pending.nullable())
+                    .single_value(),
+            )
+        } else {
+            Box::new(None::<bool>.into_sql::<sql_types::Nullable<sql_types::Bool>>())
+        };
+
+        let score_selection: Box<
+            dyn BoxableExpression<_, Pg, SqlType = sql_types::Nullable<sql_types::SmallInt>>,
+        > = if let Some(person_id) = my_person_id {
+            Box::new(score(person_id))
+        } else {
+            Box::new(None::<i16>.into_sql::<sql_types::Nullable<sql_types::SmallInt>>())
+        };
+
+        let read_comments: Box<
+            dyn BoxableExpression<_, Pg, SqlType = sql_types::Nullable<sql_types::BigInt>>,
+        > = if let Some(person_id) = my_person_id {
+            Box::new(
+                person_post_aggregates::table
+                    .filter(
+                        post_aggregates::post_id
+                            .eq(person_post_aggregates::post_id)
+                            .and(person_post_aggregates::person_id.eq(person_id)),
+                    )
+                    .select(person_post_aggregates::read_comments.nullable())
+                    .single_value(),
+            )
+        } else {
+            Box::new(None::<i64>.into_sql::<sql_types::Nullable<sql_types::BigInt>>())
+        };
+
+        query
+            .inner_join(person::table)
+            .inner_join(community::table)
+            .inner_join(post::table)
+            .select((
+                post::all_columns,
+                person::all_columns,
+                community::all_columns,
+                is_creator_banned_from_community,
+                post_aggregates::all_columns,
+                subscribed_type_selection,
+                is_saved_selection,
+                is_read_selection,
+                is_creator_blocked_selection,
+                score_selection,
+                coalesce(
+                    post_aggregates::comments.nullable() - read_comments,
+                    post_aggregates::comments,
+                ),
+            ))
+    };
+
+    let read =
+        move |mut conn: DbConn<'a>,
+              (post_id, my_person_id, is_mod_or_admin): (PostId, Option<PersonId>, bool)| async move {
+            // The left join below will return None in this case
+            let person_id_join = my_person_id.unwrap_or(PersonId(-1));
+
+            let mut query = all_joins(
+                post_aggregates::table
+                    .filter(post_aggregates::post_id.eq(post_id))
+                    .into_boxed(),
+                my_person_id,
+                false,
+            );
+
+            // Hide deleted and removed for non-admins or mods
+            if !is_mod_or_admin {
+                query = query
+                    .filter(community::removed.eq(false))
+                    .filter(post::removed.eq(false))
+                    // users can see their own deleted posts
+                    .filter(
+                        community::deleted
+                            .eq(false)
+                            .or(post::creator_id.eq(person_id_join)),
+                    )
+                    .filter(
+                        post::deleted
+                            .eq(false)
+                            .or(post::creator_id.eq(person_id_join)),
+                    );
+            }
+
+            query.first::<PostView>(&mut conn).await
+        };
+
+    let list = move |mut conn: DbConn<'a>, options: PostQuery<'a>| async move {
+        let person_id = options.local_user.map(|l| l.person.id);
+        let local_user_id = options.local_user.map(|l| l.local_user.id);
+
+        // The left join below will return None in this case
+        let person_id_join = person_id.unwrap_or(PersonId(-1));
+        let local_user_id_join = local_user_id.unwrap_or(LocalUserId(-1));
+
+        let mut query = all_joins(
+            post_aggregates::table.into_boxed(),
+            person_id,
+            options.saved_only,
+        );
+
+        let is_creator = options.creator_id == options.local_user.map(|l| l.person.id);
+        // only show deleted posts to creator
+        if is_creator {
+            query = query
+                .filter(community::deleted.eq(false))
+                .filter(post::deleted.eq(false));
         }
-      }
-    }
 
-    if let Some(url_search) = options.url_search {
-      query = query.filter(post::url.eq(url_search));
-    }
+        let is_admin = options
+            .local_user
+            .map(|l| l.local_user.admin)
+            .unwrap_or(false);
+        // only show removed posts to admin when viewing user profile
+        if !(options.is_profile_view && is_admin) {
+            query = query
+                .filter(community::removed.eq(false))
+                .filter(post::removed.eq(false));
+        }
 
-    if let Some(search_term) = options.search_term {
-      let searcher = fuzzy_search(&search_term);
-      query = query.filter(
-        post::name
-          .ilike(searcher.clone())
-          .or(post::body.ilike(searcher)),
-      );
-    }
+        if options.community_id.is_none() {
+            query = query.then_order_by(post_aggregates::featured_local.desc());
+        } else if let Some(community_id) = options.community_id {
+            query = query
+                .filter(post_aggregates::community_id.eq(community_id))
+                .then_order_by(post_aggregates::featured_community.desc());
+        }
 
-    if !options
-      .local_user
-      .map(|l| l.local_user.show_nsfw)
-      .unwrap_or(false)
-    {
-      query = query
-        .filter(post::nsfw.eq(false))
-        .filter(community::nsfw.eq(false));
+        if let Some(creator_id) = options.creator_id {
+            query = query.filter(post_aggregates::creator_id.eq(creator_id));
+        }
+
+        if let (Some(listing_type), Some(person_id)) = (options.listing_type, person_id) {
+            let is_subscribed = exists(
+                community_follower::table.filter(
+                    post_aggregates::community_id
+                        .eq(community_follower::community_id)
+                        .and(community_follower::person_id.eq(person_id)),
+                ),
+            );
+            match listing_type {
+                ListingType::Subscribed => query = query.filter(is_subscribed),
+                ListingType::Local => {
+                    query = query
+                        .filter(community::local.eq(true))
+                        .filter(community::hidden.eq(false).or(is_subscribed));
+                }
+                ListingType::All => {
+                    query = query.filter(community::hidden.eq(false).or(is_subscribed))
+                }
+                ListingType::ModeratorView => {
+                    query = query.filter(exists(
+                        community_moderator::table.filter(
+                            post::community_id
+                                .eq(community_moderator::community_id)
+                                .and(community_moderator::person_id.eq(person_id)),
+                        ),
+                    ));
+                }
+            }
+        }
+
+        if let Some(url_search) = options.url_search {
+            query = query.filter(post::url.eq(url_search));
+        }
+
+        if let Some(search_term) = options.search_term {
+            let searcher = fuzzy_search(&search_term);
+            query = query.filter(
+                post::name
+                    .ilike(searcher.clone())
+                    .or(post::body.ilike(searcher)),
+            );
+        }
+
+        if !options
+            .local_user
+            .map(|l| l.local_user.show_nsfw)
+            .unwrap_or(false)
+        {
+            query = query
+                .filter(post::nsfw.eq(false))
+                .filter(community::nsfw.eq(false));
+        };
+
+        if !options
+            .local_user
+            .map(|l| l.local_user.show_bot_accounts)
+            .unwrap_or(true)
+        {
+            query = query.filter(person::bot_account.eq(false));
+        };
+
+        if let (true, Some(person_id)) = (options.saved_only, person_id) {
+            query = query.filter(is_saved(person_id));
+        }
+        // Only hide the read posts, if the saved_only is false. Otherwise ppl with the hide_read
+        // setting wont be able to see saved posts.
+        else if !options
+            .local_user
+            .map(|l| l.local_user.show_read_posts)
+            .unwrap_or(true)
+        {
+            // Do not hide read posts when it is a user profile view
+            if let (false, Some(person_id)) = (options.is_profile_view, person_id) {
+                query = query.filter(not(is_read(person_id)));
+            }
+        }
+
+        if let Some(person_id) = person_id {
+            if options.liked_only {
+                query = query.filter(score(person_id).eq(1));
+            } else if options.disliked_only {
+                query = query.filter(score(person_id).eq(-1));
+            }
+        };
+
+        // Dont filter blocks or missing languages for moderator view type
+        if let (Some(person_id), false) = (
+            person_id,
+            options.listing_type.unwrap_or_default() == ListingType::ModeratorView,
+        ) {
+            // Filter out the rows with missing languages
+            query = query.filter(exists(
+                local_user_language::table.filter(
+                    post::language_id
+                        .eq(local_user_language::language_id)
+                        .and(local_user_language::local_user_id.eq(local_user_id_join)),
+                ),
+            ));
+
+            // Don't show blocked communities or persons
+            query = query.filter(not(exists(
+                community_block::table.filter(
+                    post_aggregates::community_id
+                        .eq(community_block::community_id)
+                        .and(community_block::person_id.eq(person_id_join)),
+                ),
+            )));
+            query = query.filter(not(is_creator_blocked(person_id)));
+        }
+        let now = diesel::dsl::now.into_sql::<Timestamptz>();
+
+        query = match options.sort.unwrap_or(SortType::Hot) {
+            SortType::Active => query
+                .then_order_by(post_aggregates::hot_rank_active.desc())
+                .then_order_by(post_aggregates::published.desc()),
+            SortType::Hot => query
+                .then_order_by(post_aggregates::hot_rank.desc())
+                .then_order_by(post_aggregates::published.desc()),
+            SortType::Controversial => {
+                query.then_order_by(post_aggregates::controversy_rank.desc())
+            }
+            SortType::New => query.then_order_by(post_aggregates::published.desc()),
+            SortType::Old => query.then_order_by(post_aggregates::published.asc()),
+            SortType::NewComments => {
+                query.then_order_by(post_aggregates::newest_comment_time.desc())
+            }
+            SortType::MostComments => query
+                .then_order_by(post_aggregates::comments.desc())
+                .then_order_by(post_aggregates::published.desc()),
+            SortType::TopAll => query
+                .then_order_by(post_aggregates::score.desc())
+                .then_order_by(post_aggregates::published.desc()),
+            SortType::TopYear => query
+                .filter(post_aggregates::published.gt(now - 1.years()))
+                .then_order_by(post_aggregates::score.desc())
+                .then_order_by(post_aggregates::published.desc()),
+            SortType::TopMonth => query
+                .filter(post_aggregates::published.gt(now - 1.months()))
+                .then_order_by(post_aggregates::score.desc())
+                .then_order_by(post_aggregates::published.desc()),
+            SortType::TopWeek => query
+                .filter(post_aggregates::published.gt(now - 1.weeks()))
+                .then_order_by(post_aggregates::score.desc())
+                .then_order_by(post_aggregates::published.desc()),
+            SortType::TopDay => query
+                .filter(post_aggregates::published.gt(now - 1.days()))
+                .then_order_by(post_aggregates::score.desc())
+                .then_order_by(post_aggregates::published.desc()),
+            SortType::TopHour => query
+                .filter(post_aggregates::published.gt(now - 1.hours()))
+                .then_order_by(post_aggregates::score.desc())
+                .then_order_by(post_aggregates::published.desc()),
+            SortType::TopSixHour => query
+                .filter(post_aggregates::published.gt(now - 6.hours()))
+                .then_order_by(post_aggregates::score.desc())
+                .then_order_by(post_aggregates::published.desc()),
+            SortType::TopTwelveHour => query
+                .filter(post_aggregates::published.gt(now - 12.hours()))
+                .then_order_by(post_aggregates::score.desc())
+                .then_order_by(post_aggregates::published.desc()),
+            SortType::TopThreeMonths => query
+                .filter(post_aggregates::published.gt(now - 3.months()))
+                .then_order_by(post_aggregates::score.desc())
+                .then_order_by(post_aggregates::published.desc()),
+            SortType::TopSixMonths => query
+                .filter(post_aggregates::published.gt(now - 6.months()))
+                .then_order_by(post_aggregates::score.desc())
+                .then_order_by(post_aggregates::published.desc()),
+            SortType::TopNineMonths => query
+                .filter(post_aggregates::published.gt(now - 9.months()))
+                .then_order_by(post_aggregates::score.desc())
+                .then_order_by(post_aggregates::published.desc()),
+        };
+
+        let (limit, offset) = limit_and_offset(options.page, options.limit)?;
+
+        query = query.limit(limit).offset(offset);
+
+        debug!("Post View Query: {:?}", debug_query::<Pg, _>(&query));
+
+        query.load::<PostView>(&mut conn).await
     };
 
-    if !options
-      .local_user
-      .map(|l| l.local_user.show_bot_accounts)
-      .unwrap_or(true)
-    {
-      query = query.filter(person::bot_account.eq(false));
-    };
-
-    if let (true, Some(person_id)) = (options.saved_only, person_id) {
-      query = query.filter(is_saved(person_id));
-    }
-    // Only hide the read posts, if the saved_only is false. Otherwise ppl with the hide_read
-    // setting wont be able to see saved posts.
-    else if !options
-      .local_user
-      .map(|l| l.local_user.show_read_posts)
-      .unwrap_or(true)
-    {
-      // Do not hide read posts when it is a user profile view
-      if let (false, Some(person_id)) = (options.is_profile_view, person_id) {
-        query = query.filter(not(is_read(person_id)));
-      }
-    }
-
-    if let Some(person_id) = person_id {
-      if options.liked_only {
-        query = query.filter(score(person_id).eq(1));
-      } else if options.disliked_only {
-        query = query.filter(score(person_id).eq(-1));
-      }
-    };
-
-    // Dont filter blocks or missing languages for moderator view type
-    if let (Some(person_id), false) = (
-      person_id,
-      options.listing_type.unwrap_or_default() == ListingType::ModeratorView,
-    ) {
-      // Filter out the rows with missing languages
-      query = query.filter(exists(
-        local_user_language::table.filter(
-          post::language_id
-            .eq(local_user_language::language_id)
-            .and(local_user_language::local_user_id.eq(local_user_id_join)),
-        ),
-      ));
-
-      // Don't show blocked communities or persons
-      query = query.filter(not(exists(
-        community_block::table.filter(
-          post_aggregates::community_id
-            .eq(community_block::community_id)
-            .and(community_block::person_id.eq(person_id_join)),
-        ),
-      )));
-      query = query.filter(not(is_creator_blocked(person_id)));
-    }
-    let now = diesel::dsl::now.into_sql::<Timestamptz>();
-
-    query = match options.sort.unwrap_or(SortType::Hot) {
-      SortType::Active => query
-        .then_order_by(post_aggregates::hot_rank_active.desc())
-        .then_order_by(post_aggregates::published.desc()),
-      SortType::Hot => query
-        .then_order_by(post_aggregates::hot_rank.desc())
-        .then_order_by(post_aggregates::published.desc()),
-      SortType::Controversial => query.then_order_by(post_aggregates::controversy_rank.desc()),
-      SortType::New => query.then_order_by(post_aggregates::published.desc()),
-      SortType::Old => query.then_order_by(post_aggregates::published.asc()),
-      SortType::NewComments => query.then_order_by(post_aggregates::newest_comment_time.desc()),
-      SortType::MostComments => query
-        .then_order_by(post_aggregates::comments.desc())
-        .then_order_by(post_aggregates::published.desc()),
-      SortType::TopAll => query
-        .then_order_by(post_aggregates::score.desc())
-        .then_order_by(post_aggregates::published.desc()),
-      SortType::TopYear => query
-        .filter(post_aggregates::published.gt(now - 1.years()))
-        .then_order_by(post_aggregates::score.desc())
-        .then_order_by(post_aggregates::published.desc()),
-      SortType::TopMonth => query
-        .filter(post_aggregates::published.gt(now - 1.months()))
-        .then_order_by(post_aggregates::score.desc())
-        .then_order_by(post_aggregates::published.desc()),
-      SortType::TopWeek => query
-        .filter(post_aggregates::published.gt(now - 1.weeks()))
-        .then_order_by(post_aggregates::score.desc())
-        .then_order_by(post_aggregates::published.desc()),
-      SortType::TopDay => query
-        .filter(post_aggregates::published.gt(now - 1.days()))
-        .then_order_by(post_aggregates::score.desc())
-        .then_order_by(post_aggregates::published.desc()),
-      SortType::TopHour => query
-        .filter(post_aggregates::published.gt(now - 1.hours()))
-        .then_order_by(post_aggregates::score.desc())
-        .then_order_by(post_aggregates::published.desc()),
-      SortType::TopSixHour => query
-        .filter(post_aggregates::published.gt(now - 6.hours()))
-        .then_order_by(post_aggregates::score.desc())
-        .then_order_by(post_aggregates::published.desc()),
-      SortType::TopTwelveHour => query
-        .filter(post_aggregates::published.gt(now - 12.hours()))
-        .then_order_by(post_aggregates::score.desc())
-        .then_order_by(post_aggregates::published.desc()),
-      SortType::TopThreeMonths => query
-        .filter(post_aggregates::published.gt(now - 3.months()))
-        .then_order_by(post_aggregates::score.desc())
-        .then_order_by(post_aggregates::published.desc()),
-      SortType::TopSixMonths => query
-        .filter(post_aggregates::published.gt(now - 6.months()))
-        .then_order_by(post_aggregates::score.desc())
-        .then_order_by(post_aggregates::published.desc()),
-      SortType::TopNineMonths => query
-        .filter(post_aggregates::published.gt(now - 9.months()))
-        .then_order_by(post_aggregates::score.desc())
-        .then_order_by(post_aggregates::published.desc()),
-    };
-
-    let (limit, offset) = limit_and_offset(options.page, options.limit)?;
-
-    query = query.limit(limit).offset(offset);
-
-    debug!("Post View Query: {:?}", debug_query::<Pg, _>(&query));
-
-    query.load::<PostView>(&mut conn).await
-  };
-
-  Queries::new(read, list)
+    Queries::new(read, list)
 }
 
 impl PostView {
-  pub async fn read(
-    pool: &mut DbPool<'_>,
-    post_id: PostId,
-    my_person_id: Option<PersonId>,
-    is_mod_or_admin: bool,
-  ) -> Result<Self, Error> {
-    let mut res = queries()
-      .read(pool, (post_id, my_person_id, is_mod_or_admin))
-      .await?;
+    pub async fn read(
+        pool: &mut DbPool<'_>,
+        post_id: PostId,
+        my_person_id: Option<PersonId>,
+        is_mod_or_admin: bool,
+    ) -> Result<Self, Error> {
+        let mut res = queries()
+            .read(pool, (post_id, my_person_id, is_mod_or_admin))
+            .await?;
 
-    // If a person is given, then my_vote, if None, should be 0, not null
-    // Necessary to differentiate between other person's votes
-    if my_person_id.is_some() && res.my_vote.is_none() {
-      res.my_vote = Some(0)
-    };
+        // If a person is given, then my_vote, if None, should be 0, not null
+        // Necessary to differentiate between other person's votes
+        if my_person_id.is_some() && res.my_vote.is_none() {
+            res.my_vote = Some(0)
+        };
 
-    Ok(res)
-  }
+        Ok(res)
+    }
 }
 
 #[derive(Default)]
 pub struct PostQuery<'a> {
-  pub listing_type: Option<ListingType>,
-  pub sort: Option<SortType>,
-  pub creator_id: Option<PersonId>,
-  pub community_id: Option<CommunityId>,
-  pub local_user: Option<&'a LocalUserView>,
-  pub search_term: Option<String>,
-  pub url_search: Option<String>,
-  pub saved_only: bool,
-  pub liked_only: bool,
-  pub disliked_only: bool,
-  pub moderator_view: bool,
-  pub is_profile_view: bool,
-  pub page: Option<i64>,
-  pub limit: Option<i64>,
+    pub listing_type: Option<ListingType>,
+    pub sort: Option<SortType>,
+    pub creator_id: Option<PersonId>,
+    pub community_id: Option<CommunityId>,
+    pub local_user: Option<&'a LocalUserView>,
+    pub search_term: Option<String>,
+    pub url_search: Option<String>,
+    pub saved_only: bool,
+    pub liked_only: bool,
+    pub disliked_only: bool,
+    pub moderator_view: bool,
+    pub is_profile_view: bool,
+    pub page: Option<i64>,
+    pub limit: Option<i64>,
 }
 
 impl<'a> PostQuery<'a> {
-  pub async fn list(self, pool: &mut DbPool<'_>) -> Result<Vec<PostView>, Error> {
-    queries().list(pool, self).await
-  }
+    pub async fn list(self, pool: &mut DbPool<'_>) -> Result<Vec<PostView>, Error> {
+        queries().list(pool, self).await
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::{
-    post_view::{PostQuery, PostView},
-    structs::LocalUserView,
-  };
-  use lemmy_db_schema::{
-    aggregates::structs::PostAggregates,
-    impls::actor_language::UNDETERMINED_ID,
-    newtypes::LanguageId,
-    source::{
-      actor_language::LocalUserLanguage,
-      community::{Community, CommunityInsertForm},
-      community_block::{CommunityBlock, CommunityBlockForm},
-      instance::Instance,
-      language::Language,
-      local_user::{LocalUser, LocalUserInsertForm, LocalUserUpdateForm},
-      person::{Person, PersonInsertForm},
-      person_block::{PersonBlock, PersonBlockForm},
-      post::{Post, PostInsertForm, PostLike, PostLikeForm, PostUpdateForm},
-    },
-    traits::{Blockable, Crud, Likeable},
-    utils::{build_db_pool_for_tests, DbPool},
-    SortType,
-    SubscribedType,
-  };
-  use serial_test::serial;
-
-  struct Data {
-    inserted_instance: Instance,
-    local_user_view: LocalUserView,
-    inserted_blocked_person: Person,
-    inserted_bot: Person,
-    inserted_community: Community,
-    inserted_post: Post,
-  }
-
-  async fn init_data(pool: &mut DbPool<'_>) -> Data {
-    let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
-      .await
-      .unwrap();
-
-    let person_name = "tegan".to_string();
-
-    let new_person = PersonInsertForm::builder()
-      .name(person_name.clone())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_person = Person::create(pool, &new_person).await.unwrap();
-
-    let local_user_form = LocalUserInsertForm::builder()
-      .person_id(inserted_person.id)
-      .password_encrypted(String::new())
-      .build();
-    let inserted_local_user = LocalUser::create(pool, &local_user_form).await.unwrap();
-
-    let new_bot = PersonInsertForm::builder()
-      .name("mybot".to_string())
-      .bot_account(Some(true))
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_bot = Person::create(pool, &new_bot).await.unwrap();
-
-    let new_community = CommunityInsertForm::builder()
-      .name("test_community_3".to_string())
-      .title("nada".to_owned())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_community = Community::create(pool, &new_community).await.unwrap();
-
-    // Test a person block, make sure the post query doesn't include their post
-    let blocked_person = PersonInsertForm::builder()
-      .name(person_name)
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_blocked_person = Person::create(pool, &blocked_person).await.unwrap();
-
-    let post_from_blocked_person = PostInsertForm::builder()
-      .name("blocked_person_post".to_string())
-      .creator_id(inserted_blocked_person.id)
-      .community_id(inserted_community.id)
-      .language_id(Some(LanguageId(1)))
-      .build();
-
-    Post::create(pool, &post_from_blocked_person).await.unwrap();
-
-    // block that person
-    let person_block = PersonBlockForm {
-      person_id: inserted_person.id,
-      target_id: inserted_blocked_person.id,
+    use crate::{
+        post_view::{PostQuery, PostView},
+        structs::LocalUserView,
     };
-
-    PersonBlock::block(pool, &person_block).await.unwrap();
-
-    // A sample post
-    let new_post = PostInsertForm::builder()
-      .name("test post 3".to_string())
-      .creator_id(inserted_person.id)
-      .community_id(inserted_community.id)
-      .language_id(Some(LanguageId(47)))
-      .build();
-
-    let inserted_post = Post::create(pool, &new_post).await.unwrap();
-
-    let new_bot_post = PostInsertForm::builder()
-      .name("test bot post".to_string())
-      .creator_id(inserted_bot.id)
-      .community_id(inserted_community.id)
-      .build();
-
-    let _inserted_bot_post = Post::create(pool, &new_bot_post).await.unwrap();
-    let local_user_view = LocalUserView {
-      local_user: inserted_local_user,
-      person: inserted_person,
-      counts: Default::default(),
+    use lemmy_db_schema::{
+        aggregates::structs::PostAggregates,
+        impls::actor_language::UNDETERMINED_ID,
+        newtypes::LanguageId,
+        source::{
+            actor_language::LocalUserLanguage,
+            community::{Community, CommunityInsertForm},
+            community_block::{CommunityBlock, CommunityBlockForm},
+            instance::Instance,
+            language::Language,
+            local_user::{LocalUser, LocalUserInsertForm, LocalUserUpdateForm},
+            person::{Person, PersonInsertForm},
+            person_block::{PersonBlock, PersonBlockForm},
+            post::{Post, PostInsertForm, PostLike, PostLikeForm, PostUpdateForm},
+        },
+        traits::{Blockable, Crud, Likeable},
+        utils::{build_db_pool_for_tests, DbPool},
+        SortType, SubscribedType,
     };
+    use serial_test::serial;
 
-    Data {
-      inserted_instance,
-      local_user_view,
-      inserted_blocked_person,
-      inserted_bot,
-      inserted_community,
-      inserted_post,
+    struct Data {
+        inserted_instance: Instance,
+        local_user_view: LocalUserView,
+        inserted_blocked_person: Person,
+        inserted_bot: Person,
+        inserted_community: Community,
+        inserted_post: Post,
     }
-  }
 
-  #[tokio::test]
-  #[serial]
-  async fn post_listing_with_person() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-    let mut data = init_data(pool).await;
+    async fn init_data(pool: &mut DbPool<'_>) -> Data {
+        let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
+            .await
+            .unwrap();
 
-    let local_user_form = LocalUserUpdateForm {
-      show_bot_accounts: Some(false),
-      ..Default::default()
-    };
-    let inserted_local_user =
-      LocalUser::update(pool, data.local_user_view.local_user.id, &local_user_form)
-        .await
-        .unwrap();
-    data.local_user_view.local_user = inserted_local_user;
+        let person_name = "tegan".to_string();
 
-    let read_post_listing = PostQuery {
-      sort: (Some(SortType::New)),
-      community_id: (Some(data.inserted_community.id)),
-      local_user: (Some(&data.local_user_view)),
-      ..Default::default()
+        let new_person = PersonInsertForm::builder()
+            .name(person_name.clone())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
+
+        let inserted_person = Person::create(pool, &new_person).await.unwrap();
+
+        let local_user_form = LocalUserInsertForm::builder()
+            .person_id(inserted_person.id)
+            .password_encrypted(String::new())
+            .build();
+        let inserted_local_user = LocalUser::create(pool, &local_user_form).await.unwrap();
+
+        let new_bot = PersonInsertForm::builder()
+            .name("mybot".to_string())
+            .bot_account(Some(true))
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
+
+        let inserted_bot = Person::create(pool, &new_bot).await.unwrap();
+
+        let new_community = CommunityInsertForm::builder()
+            .name("test_community_3".to_string())
+            .title("nada".to_owned())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
+
+        let inserted_community = Community::create(pool, &new_community).await.unwrap();
+
+        // Test a person block, make sure the post query doesn't include their post
+        let blocked_person = PersonInsertForm::builder()
+            .name(person_name)
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
+
+        let inserted_blocked_person = Person::create(pool, &blocked_person).await.unwrap();
+
+        let post_from_blocked_person = PostInsertForm::builder()
+            .name("blocked_person_post".to_string())
+            .creator_id(inserted_blocked_person.id)
+            .community_id(inserted_community.id)
+            .language_id(Some(LanguageId(1)))
+            .build();
+
+        Post::create(pool, &post_from_blocked_person).await.unwrap();
+
+        // block that person
+        let person_block = PersonBlockForm {
+            person_id: inserted_person.id,
+            target_id: inserted_blocked_person.id,
+        };
+
+        PersonBlock::block(pool, &person_block).await.unwrap();
+
+        // A sample post
+        let new_post = PostInsertForm::builder()
+            .name("test post 3".to_string())
+            .creator_id(inserted_person.id)
+            .community_id(inserted_community.id)
+            .language_id(Some(LanguageId(47)))
+            .build();
+
+        let inserted_post = Post::create(pool, &new_post).await.unwrap();
+
+        let new_bot_post = PostInsertForm::builder()
+            .name("test bot post".to_string())
+            .creator_id(inserted_bot.id)
+            .community_id(inserted_community.id)
+            .build();
+
+        let _inserted_bot_post = Post::create(pool, &new_bot_post).await.unwrap();
+        let local_user_view = LocalUserView {
+            local_user: inserted_local_user,
+            person: inserted_person,
+            counts: Default::default(),
+        };
+
+        Data {
+            inserted_instance,
+            local_user_view,
+            inserted_blocked_person,
+            inserted_bot,
+            inserted_community,
+            inserted_post,
+        }
     }
-    .list(pool)
-    .await
-    .unwrap();
 
-    let post_listing_single_with_person = PostView::read(
-      pool,
-      data.inserted_post.id,
-      Some(data.local_user_view.person.id),
-      false,
-    )
-    .await
-    .unwrap();
+    #[tokio::test]
+    #[serial]
+    async fn post_listing_with_person() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
+        let mut data = init_data(pool).await;
 
-    let mut expected_post_listing_with_user = expected_post_view(&data, pool).await;
+        let local_user_form = LocalUserUpdateForm {
+            show_bot_accounts: Some(false),
+            ..Default::default()
+        };
+        let inserted_local_user =
+            LocalUser::update(pool, data.local_user_view.local_user.id, &local_user_form)
+                .await
+                .unwrap();
+        data.local_user_view.local_user = inserted_local_user;
 
-    // Should be only one person, IE the bot post, and blocked should be missing
-    assert_eq!(1, read_post_listing.len());
-
-    assert_eq!(expected_post_listing_with_user, read_post_listing[0]);
-    expected_post_listing_with_user.my_vote = Some(0);
-    assert_eq!(
-      expected_post_listing_with_user,
-      post_listing_single_with_person
-    );
-
-    let local_user_form = LocalUserUpdateForm {
-      show_bot_accounts: Some(true),
-      ..Default::default()
-    };
-    let inserted_local_user =
-      LocalUser::update(pool, data.local_user_view.local_user.id, &local_user_form)
-        .await
-        .unwrap();
-    data.local_user_view.local_user = inserted_local_user;
-
-    let post_listings_with_bots = PostQuery {
-      sort: (Some(SortType::New)),
-      community_id: (Some(data.inserted_community.id)),
-      local_user: (Some(&data.local_user_view)),
-      ..Default::default()
-    }
-    .list(pool)
-    .await
-    .unwrap();
-    // should include bot post which has "undetermined" language
-    assert_eq!(2, post_listings_with_bots.len());
-
-    cleanup(data, pool).await;
-  }
-
-  #[tokio::test]
-  #[serial]
-  async fn post_listing_no_person() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-    let data = init_data(pool).await;
-
-    let read_post_listing_multiple_no_person = PostQuery {
-      sort: (Some(SortType::New)),
-      community_id: (Some(data.inserted_community.id)),
-      ..Default::default()
-    }
-    .list(pool)
-    .await
-    .unwrap();
-
-    let read_post_listing_single_no_person =
-      PostView::read(pool, data.inserted_post.id, None, false)
+        let read_post_listing = PostQuery {
+            sort: (Some(SortType::New)),
+            community_id: (Some(data.inserted_community.id)),
+            local_user: (Some(&data.local_user_view)),
+            ..Default::default()
+        }
+        .list(pool)
         .await
         .unwrap();
 
-    let expected_post_listing_no_person = expected_post_view(&data, pool).await;
-
-    // Should be 2 posts, with the bot post, and the blocked
-    assert_eq!(3, read_post_listing_multiple_no_person.len());
-
-    assert_eq!(
-      expected_post_listing_no_person,
-      read_post_listing_multiple_no_person[1]
-    );
-    assert_eq!(
-      expected_post_listing_no_person,
-      read_post_listing_single_no_person
-    );
-
-    cleanup(data, pool).await;
-  }
-
-  #[tokio::test]
-  #[serial]
-  async fn post_listing_block_community() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-    let data = init_data(pool).await;
-
-    let community_block = CommunityBlockForm {
-      person_id: data.local_user_view.person.id,
-      community_id: data.inserted_community.id,
-    };
-    CommunityBlock::block(pool, &community_block).await.unwrap();
-
-    let read_post_listings_with_person_after_block = PostQuery {
-      sort: (Some(SortType::New)),
-      community_id: (Some(data.inserted_community.id)),
-      local_user: (Some(&data.local_user_view)),
-      ..Default::default()
-    }
-    .list(pool)
-    .await
-    .unwrap();
-    // Should be 0 posts after the community block
-    assert_eq!(0, read_post_listings_with_person_after_block.len());
-
-    CommunityBlock::unblock(pool, &community_block)
-      .await
-      .unwrap();
-    cleanup(data, pool).await;
-  }
-
-  #[tokio::test]
-  #[serial]
-  async fn post_listing_like() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-    let mut data = init_data(pool).await;
-
-    let post_like_form = PostLikeForm {
-      post_id: data.inserted_post.id,
-      person_id: data.local_user_view.person.id,
-      score: 1,
-    };
-
-    let inserted_post_like = PostLike::like(pool, &post_like_form).await.unwrap();
-
-    let expected_post_like = PostLike {
-      id: inserted_post_like.id,
-      post_id: data.inserted_post.id,
-      person_id: data.local_user_view.person.id,
-      published: inserted_post_like.published,
-      score: 1,
-    };
-    assert_eq!(expected_post_like, inserted_post_like);
-
-    let post_listing_single_with_person = PostView::read(
-      pool,
-      data.inserted_post.id,
-      Some(data.local_user_view.person.id),
-      false,
-    )
-    .await
-    .unwrap();
-
-    let mut expected_post_with_upvote = expected_post_view(&data, pool).await;
-    expected_post_with_upvote.my_vote = Some(1);
-    expected_post_with_upvote.counts.score = 1;
-    expected_post_with_upvote.counts.upvotes = 1;
-    assert_eq!(expected_post_with_upvote, post_listing_single_with_person);
-
-    let local_user_form = LocalUserUpdateForm {
-      show_bot_accounts: Some(false),
-      ..Default::default()
-    };
-    let inserted_local_user =
-      LocalUser::update(pool, data.local_user_view.local_user.id, &local_user_form)
+        let post_listing_single_with_person = PostView::read(
+            pool,
+            data.inserted_post.id,
+            Some(data.local_user_view.person.id),
+            false,
+        )
         .await
         .unwrap();
-    data.local_user_view.local_user = inserted_local_user;
 
-    let read_post_listing = PostQuery {
-      sort: (Some(SortType::New)),
-      community_id: (Some(data.inserted_community.id)),
-      local_user: (Some(&data.local_user_view)),
-      ..Default::default()
-    }
-    .list(pool)
-    .await
-    .unwrap();
-    assert_eq!(1, read_post_listing.len());
+        let mut expected_post_listing_with_user = expected_post_view(&data, pool).await;
 
-    assert_eq!(expected_post_with_upvote, read_post_listing[0]);
+        // Should be only one person, IE the bot post, and blocked should be missing
+        assert_eq!(1, read_post_listing.len());
 
-    let read_liked_post_listing = PostQuery {
-      community_id: (Some(data.inserted_community.id)),
-      local_user: (Some(&data.local_user_view)),
-      liked_only: (true),
-      ..Default::default()
-    }
-    .list(pool)
-    .await
-    .unwrap();
-    assert_eq!(read_post_listing, read_liked_post_listing);
+        assert_eq!(expected_post_listing_with_user, read_post_listing[0]);
+        expected_post_listing_with_user.my_vote = Some(0);
+        assert_eq!(
+            expected_post_listing_with_user,
+            post_listing_single_with_person
+        );
 
-    let read_disliked_post_listing = PostQuery {
-      community_id: (Some(data.inserted_community.id)),
-      local_user: (Some(&data.local_user_view)),
-      disliked_only: (true),
-      ..Default::default()
-    }
-    .list(pool)
-    .await
-    .unwrap();
-    assert!(read_disliked_post_listing.is_empty());
+        let local_user_form = LocalUserUpdateForm {
+            show_bot_accounts: Some(true),
+            ..Default::default()
+        };
+        let inserted_local_user =
+            LocalUser::update(pool, data.local_user_view.local_user.id, &local_user_form)
+                .await
+                .unwrap();
+        data.local_user_view.local_user = inserted_local_user;
 
-    let like_removed =
-      PostLike::remove(pool, data.local_user_view.person.id, data.inserted_post.id)
+        let post_listings_with_bots = PostQuery {
+            sort: (Some(SortType::New)),
+            community_id: (Some(data.inserted_community.id)),
+            local_user: (Some(&data.local_user_view)),
+            ..Default::default()
+        }
+        .list(pool)
         .await
         .unwrap();
-    assert_eq!(1, like_removed);
-    cleanup(data, pool).await;
-  }
+        // should include bot post which has "undetermined" language
+        assert_eq!(2, post_listings_with_bots.len());
 
-  #[tokio::test]
-  #[serial]
-  async fn post_listing_person_language() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-    let data = init_data(pool).await;
-
-    let spanish_id = Language::read_id_from_code(pool, Some("es"))
-      .await
-      .unwrap()
-      .unwrap();
-    let post_spanish = PostInsertForm::builder()
-      .name("asffgdsc".to_string())
-      .creator_id(data.local_user_view.person.id)
-      .community_id(data.inserted_community.id)
-      .language_id(Some(spanish_id))
-      .build();
-
-    Post::create(pool, &post_spanish).await.unwrap();
-
-    let post_listings_all = PostQuery {
-      sort: (Some(SortType::New)),
-      local_user: (Some(&data.local_user_view)),
-      ..Default::default()
+        cleanup(data, pool).await;
     }
-    .list(pool)
-    .await
-    .unwrap();
 
-    // no language filters specified, all posts should be returned
-    assert_eq!(3, post_listings_all.len());
+    #[tokio::test]
+    #[serial]
+    async fn post_listing_no_person() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
+        let data = init_data(pool).await;
 
-    let french_id = Language::read_id_from_code(pool, Some("fr"))
-      .await
-      .unwrap()
-      .unwrap();
-    LocalUserLanguage::update(pool, vec![french_id], data.local_user_view.local_user.id)
-      .await
-      .unwrap();
+        let read_post_listing_multiple_no_person = PostQuery {
+            sort: (Some(SortType::New)),
+            community_id: (Some(data.inserted_community.id)),
+            ..Default::default()
+        }
+        .list(pool)
+        .await
+        .unwrap();
 
-    let post_listing_french = PostQuery {
-      sort: (Some(SortType::New)),
-      local_user: (Some(&data.local_user_view)),
-      ..Default::default()
+        let read_post_listing_single_no_person =
+            PostView::read(pool, data.inserted_post.id, None, false)
+                .await
+                .unwrap();
+
+        let expected_post_listing_no_person = expected_post_view(&data, pool).await;
+
+        // Should be 2 posts, with the bot post, and the blocked
+        assert_eq!(3, read_post_listing_multiple_no_person.len());
+
+        assert_eq!(
+            expected_post_listing_no_person,
+            read_post_listing_multiple_no_person[1]
+        );
+        assert_eq!(
+            expected_post_listing_no_person,
+            read_post_listing_single_no_person
+        );
+
+        cleanup(data, pool).await;
     }
-    .list(pool)
-    .await
-    .unwrap();
 
-    // only one post in french and one undetermined should be returned
-    assert_eq!(2, post_listing_french.len());
-    assert!(post_listing_french
-      .iter()
-      .any(|p| p.post.language_id == french_id));
+    #[tokio::test]
+    #[serial]
+    async fn post_listing_block_community() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
+        let data = init_data(pool).await;
 
-    LocalUserLanguage::update(
-      pool,
-      vec![french_id, UNDETERMINED_ID],
-      data.local_user_view.local_user.id,
-    )
-    .await
-    .unwrap();
-    let post_listings_french_und = PostQuery {
-      sort: (Some(SortType::New)),
-      local_user: (Some(&data.local_user_view)),
-      ..Default::default()
+        let community_block = CommunityBlockForm {
+            person_id: data.local_user_view.person.id,
+            community_id: data.inserted_community.id,
+        };
+        CommunityBlock::block(pool, &community_block).await.unwrap();
+
+        let read_post_listings_with_person_after_block = PostQuery {
+            sort: (Some(SortType::New)),
+            community_id: (Some(data.inserted_community.id)),
+            local_user: (Some(&data.local_user_view)),
+            ..Default::default()
+        }
+        .list(pool)
+        .await
+        .unwrap();
+        // Should be 0 posts after the community block
+        assert_eq!(0, read_post_listings_with_person_after_block.len());
+
+        CommunityBlock::unblock(pool, &community_block)
+            .await
+            .unwrap();
+        cleanup(data, pool).await;
     }
-    .list(pool)
-    .await
-    .unwrap();
 
-    // french post and undetermined language post should be returned
-    assert_eq!(2, post_listings_french_und.len());
-    assert_eq!(
-      UNDETERMINED_ID,
-      post_listings_french_und[0].post.language_id
-    );
-    assert_eq!(french_id, post_listings_french_und[1].post.language_id);
+    #[tokio::test]
+    #[serial]
+    async fn post_listing_like() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
+        let mut data = init_data(pool).await;
 
-    cleanup(data, pool).await;
-  }
+        let post_like_form = PostLikeForm {
+            post_id: data.inserted_post.id,
+            person_id: data.local_user_view.person.id,
+            score: 1,
+        };
 
-  #[tokio::test]
-  #[serial]
-  async fn post_listings_removed() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-    let mut data = init_data(pool).await;
+        let inserted_post_like = PostLike::like(pool, &post_like_form).await.unwrap();
 
-    // Remove the post
-    Post::update(
-      pool,
-      data.inserted_post.id,
-      &PostUpdateForm {
-        removed: Some(true),
-        ..Default::default()
-      },
-    )
-    .await
-    .unwrap();
+        let expected_post_like = PostLike {
+            id: inserted_post_like.id,
+            post_id: data.inserted_post.id,
+            person_id: data.local_user_view.person.id,
+            published: inserted_post_like.published,
+            score: 1,
+        };
+        assert_eq!(expected_post_like, inserted_post_like);
 
-    // Make sure you don't see the removed post in the results
-    let post_listings_no_admin = PostQuery {
-      sort: Some(SortType::New),
-      local_user: Some(&data.local_user_view),
-      ..Default::default()
+        let post_listing_single_with_person = PostView::read(
+            pool,
+            data.inserted_post.id,
+            Some(data.local_user_view.person.id),
+            false,
+        )
+        .await
+        .unwrap();
+
+        let mut expected_post_with_upvote = expected_post_view(&data, pool).await;
+        expected_post_with_upvote.my_vote = Some(1);
+        expected_post_with_upvote.counts.score = 1;
+        expected_post_with_upvote.counts.upvotes = 1;
+        assert_eq!(expected_post_with_upvote, post_listing_single_with_person);
+
+        let local_user_form = LocalUserUpdateForm {
+            show_bot_accounts: Some(false),
+            ..Default::default()
+        };
+        let inserted_local_user =
+            LocalUser::update(pool, data.local_user_view.local_user.id, &local_user_form)
+                .await
+                .unwrap();
+        data.local_user_view.local_user = inserted_local_user;
+
+        let read_post_listing = PostQuery {
+            sort: (Some(SortType::New)),
+            community_id: (Some(data.inserted_community.id)),
+            local_user: (Some(&data.local_user_view)),
+            ..Default::default()
+        }
+        .list(pool)
+        .await
+        .unwrap();
+        assert_eq!(1, read_post_listing.len());
+
+        assert_eq!(expected_post_with_upvote, read_post_listing[0]);
+
+        let read_liked_post_listing = PostQuery {
+            community_id: (Some(data.inserted_community.id)),
+            local_user: (Some(&data.local_user_view)),
+            liked_only: (true),
+            ..Default::default()
+        }
+        .list(pool)
+        .await
+        .unwrap();
+        assert_eq!(read_post_listing, read_liked_post_listing);
+
+        let read_disliked_post_listing = PostQuery {
+            community_id: (Some(data.inserted_community.id)),
+            local_user: (Some(&data.local_user_view)),
+            disliked_only: (true),
+            ..Default::default()
+        }
+        .list(pool)
+        .await
+        .unwrap();
+        assert!(read_disliked_post_listing.is_empty());
+
+        let like_removed =
+            PostLike::remove(pool, data.local_user_view.person.id, data.inserted_post.id)
+                .await
+                .unwrap();
+        assert_eq!(1, like_removed);
+        cleanup(data, pool).await;
     }
-    .list(pool)
-    .await
-    .unwrap();
-    assert_eq!(1, post_listings_no_admin.len());
 
-    // Removed post is shown to admins on profile page
-    data.local_user_view.local_user.admin = true;
-    let post_listings_is_admin = PostQuery {
-      sort: Some(SortType::New),
-      local_user: Some(&data.local_user_view),
-      is_profile_view: true,
-      ..Default::default()
+    #[tokio::test]
+    #[serial]
+    async fn post_listing_person_language() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
+        let data = init_data(pool).await;
+
+        let spanish_id = Language::read_id_from_code(pool, Some("es"))
+            .await
+            .unwrap()
+            .unwrap();
+        let post_spanish = PostInsertForm::builder()
+            .name("asffgdsc".to_string())
+            .creator_id(data.local_user_view.person.id)
+            .community_id(data.inserted_community.id)
+            .language_id(Some(spanish_id))
+            .build();
+
+        Post::create(pool, &post_spanish).await.unwrap();
+
+        let post_listings_all = PostQuery {
+            sort: (Some(SortType::New)),
+            local_user: (Some(&data.local_user_view)),
+            ..Default::default()
+        }
+        .list(pool)
+        .await
+        .unwrap();
+
+        // no language filters specified, all posts should be returned
+        assert_eq!(3, post_listings_all.len());
+
+        let french_id = Language::read_id_from_code(pool, Some("fr"))
+            .await
+            .unwrap()
+            .unwrap();
+        LocalUserLanguage::update(pool, vec![french_id], data.local_user_view.local_user.id)
+            .await
+            .unwrap();
+
+        let post_listing_french = PostQuery {
+            sort: (Some(SortType::New)),
+            local_user: (Some(&data.local_user_view)),
+            ..Default::default()
+        }
+        .list(pool)
+        .await
+        .unwrap();
+
+        // only one post in french and one undetermined should be returned
+        assert_eq!(2, post_listing_french.len());
+        assert!(post_listing_french
+            .iter()
+            .any(|p| p.post.language_id == french_id));
+
+        LocalUserLanguage::update(
+            pool,
+            vec![french_id, UNDETERMINED_ID],
+            data.local_user_view.local_user.id,
+        )
+        .await
+        .unwrap();
+        let post_listings_french_und = PostQuery {
+            sort: (Some(SortType::New)),
+            local_user: (Some(&data.local_user_view)),
+            ..Default::default()
+        }
+        .list(pool)
+        .await
+        .unwrap();
+
+        // french post and undetermined language post should be returned
+        assert_eq!(2, post_listings_french_und.len());
+        assert_eq!(
+            UNDETERMINED_ID,
+            post_listings_french_und[0].post.language_id
+        );
+        assert_eq!(french_id, post_listings_french_und[1].post.language_id);
+
+        cleanup(data, pool).await;
     }
-    .list(pool)
-    .await
-    .unwrap();
-    assert_eq!(2, post_listings_is_admin.len());
 
-    cleanup(data, pool).await;
-  }
+    #[tokio::test]
+    #[serial]
+    async fn post_listings_removed() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
+        let mut data = init_data(pool).await;
 
-  #[tokio::test]
-  #[serial]
-  async fn post_listings_deleted() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-    let data = init_data(pool).await;
+        // Remove the post
+        Post::update(
+            pool,
+            data.inserted_post.id,
+            &PostUpdateForm {
+                removed: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
 
-    // Delete the post
-    Post::update(
-      pool,
-      data.inserted_post.id,
-      &PostUpdateForm {
-        deleted: Some(true),
-        ..Default::default()
-      },
-    )
-    .await
-    .unwrap();
+        // Make sure you don't see the removed post in the results
+        let post_listings_no_admin = PostQuery {
+            sort: Some(SortType::New),
+            local_user: Some(&data.local_user_view),
+            ..Default::default()
+        }
+        .list(pool)
+        .await
+        .unwrap();
+        assert_eq!(1, post_listings_no_admin.len());
 
-    // Make sure you don't see the deleted post in the results
-    let post_listings_no_creator = PostQuery {
-      sort: Some(SortType::New),
-      ..Default::default()
+        // Removed post is shown to admins on profile page
+        data.local_user_view.local_user.admin = true;
+        let post_listings_is_admin = PostQuery {
+            sort: Some(SortType::New),
+            local_user: Some(&data.local_user_view),
+            is_profile_view: true,
+            ..Default::default()
+        }
+        .list(pool)
+        .await
+        .unwrap();
+        assert_eq!(2, post_listings_is_admin.len());
+
+        cleanup(data, pool).await;
     }
-    .list(pool)
-    .await
-    .unwrap();
-    let not_contains_deleted = post_listings_no_creator
-      .iter()
-      .map(|p| p.post.id)
-      .all(|p| p != data.inserted_post.id);
-    assert!(not_contains_deleted);
 
-    // Deleted post is shown to creator
-    let post_listings_is_creator = PostQuery {
-      sort: Some(SortType::New),
-      local_user: Some(&data.local_user_view),
-      ..Default::default()
+    #[tokio::test]
+    #[serial]
+    async fn post_listings_deleted() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
+        let data = init_data(pool).await;
+
+        // Delete the post
+        Post::update(
+            pool,
+            data.inserted_post.id,
+            &PostUpdateForm {
+                deleted: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        // Make sure you don't see the deleted post in the results
+        let post_listings_no_creator = PostQuery {
+            sort: Some(SortType::New),
+            ..Default::default()
+        }
+        .list(pool)
+        .await
+        .unwrap();
+        let not_contains_deleted = post_listings_no_creator
+            .iter()
+            .map(|p| p.post.id)
+            .all(|p| p != data.inserted_post.id);
+        assert!(not_contains_deleted);
+
+        // Deleted post is shown to creator
+        let post_listings_is_creator = PostQuery {
+            sort: Some(SortType::New),
+            local_user: Some(&data.local_user_view),
+            ..Default::default()
+        }
+        .list(pool)
+        .await
+        .unwrap();
+        let contains_deleted = post_listings_is_creator
+            .iter()
+            .map(|p| p.post.id)
+            .any(|p| p == data.inserted_post.id);
+        assert!(contains_deleted);
+
+        cleanup(data, pool).await;
     }
-    .list(pool)
-    .await
-    .unwrap();
-    let contains_deleted = post_listings_is_creator
-      .iter()
-      .map(|p| p.post.id)
-      .any(|p| p == data.inserted_post.id);
-    assert!(contains_deleted);
 
-    cleanup(data, pool).await;
-  }
-
-  async fn cleanup(data: Data, pool: &mut DbPool<'_>) {
-    let num_deleted = Post::delete(pool, data.inserted_post.id).await.unwrap();
-    Community::delete(pool, data.inserted_community.id)
-      .await
-      .unwrap();
-    Person::delete(pool, data.local_user_view.person.id)
-      .await
-      .unwrap();
-    Person::delete(pool, data.inserted_bot.id).await.unwrap();
-    Person::delete(pool, data.inserted_blocked_person.id)
-      .await
-      .unwrap();
-    Instance::delete(pool, data.inserted_instance.id)
-      .await
-      .unwrap();
-    assert_eq!(1, num_deleted);
-  }
-
-  async fn expected_post_view(data: &Data, pool: &mut DbPool<'_>) -> PostView {
-    let (inserted_person, inserted_community, inserted_post) = (
-      &data.local_user_view.person,
-      &data.inserted_community,
-      &data.inserted_post,
-    );
-    let agg = PostAggregates::read(pool, inserted_post.id).await.unwrap();
-
-    PostView {
-      post: Post {
-        id: inserted_post.id,
-        name: inserted_post.name.clone(),
-        creator_id: inserted_person.id,
-        url: None,
-        body: None,
-        published: inserted_post.published,
-        updated: None,
-        community_id: inserted_community.id,
-        removed: false,
-        deleted: false,
-        locked: false,
-        nsfw: false,
-        embed_title: None,
-        embed_description: None,
-        embed_video_url: None,
-        thumbnail_url: None,
-        ap_id: inserted_post.ap_id.clone(),
-        local: true,
-        language_id: LanguageId(47),
-        featured_community: false,
-        featured_local: false,
-      },
-      my_vote: None,
-      unread_comments: 0,
-      creator: Person {
-        id: inserted_person.id,
-        name: inserted_person.name.clone(),
-        display_name: None,
-        published: inserted_person.published,
-        avatar: None,
-        actor_id: inserted_person.actor_id.clone(),
-        local: true,
-        bot_account: false,
-        banned: false,
-        deleted: false,
-        bio: None,
-        banner: None,
-        updated: None,
-        inbox_url: inserted_person.inbox_url.clone(),
-        shared_inbox_url: None,
-        matrix_user_id: None,
-        ban_expires: None,
-        instance_id: data.inserted_instance.id,
-        private_key: inserted_person.private_key.clone(),
-        public_key: inserted_person.public_key.clone(),
-        last_refreshed_at: inserted_person.last_refreshed_at,
-      },
-      creator_banned_from_community: false,
-      community: Community {
-        id: inserted_community.id,
-        name: inserted_community.name.clone(),
-        icon: None,
-        removed: false,
-        deleted: false,
-        nsfw: false,
-        actor_id: inserted_community.actor_id.clone(),
-        local: true,
-        title: "nada".to_owned(),
-        description: None,
-        updated: None,
-        banner: None,
-        hidden: false,
-        posting_restricted_to_mods: false,
-        published: inserted_community.published,
-        instance_id: data.inserted_instance.id,
-        private_key: inserted_community.private_key.clone(),
-        public_key: inserted_community.public_key.clone(),
-        last_refreshed_at: inserted_community.last_refreshed_at,
-        followers_url: inserted_community.followers_url.clone(),
-        inbox_url: inserted_community.inbox_url.clone(),
-        shared_inbox_url: inserted_community.shared_inbox_url.clone(),
-        moderators_url: inserted_community.moderators_url.clone(),
-        featured_url: inserted_community.featured_url.clone(),
-      },
-      counts: PostAggregates {
-        id: agg.id,
-        post_id: inserted_post.id,
-        comments: 0,
-        score: 0,
-        upvotes: 0,
-        downvotes: 0,
-        published: agg.published,
-        newest_comment_time_necro: inserted_post.published,
-        newest_comment_time: inserted_post.published,
-        featured_community: false,
-        featured_local: false,
-        hot_rank: 1728,
-        hot_rank_active: 1728,
-        controversy_rank: 0.0,
-        community_id: inserted_post.community_id,
-        creator_id: inserted_post.creator_id,
-      },
-      subscribed: SubscribedType::NotSubscribed,
-      read: false,
-      saved: false,
-      creator_blocked: false,
+    async fn cleanup(data: Data, pool: &mut DbPool<'_>) {
+        let num_deleted = Post::delete(pool, data.inserted_post.id).await.unwrap();
+        Community::delete(pool, data.inserted_community.id)
+            .await
+            .unwrap();
+        Person::delete(pool, data.local_user_view.person.id)
+            .await
+            .unwrap();
+        Person::delete(pool, data.inserted_bot.id).await.unwrap();
+        Person::delete(pool, data.inserted_blocked_person.id)
+            .await
+            .unwrap();
+        Instance::delete(pool, data.inserted_instance.id)
+            .await
+            .unwrap();
+        assert_eq!(1, num_deleted);
     }
-  }
+
+    async fn expected_post_view(data: &Data, pool: &mut DbPool<'_>) -> PostView {
+        let (inserted_person, inserted_community, inserted_post) = (
+            &data.local_user_view.person,
+            &data.inserted_community,
+            &data.inserted_post,
+        );
+        let agg = PostAggregates::read(pool, inserted_post.id).await.unwrap();
+
+        PostView {
+            post: Post {
+                id: inserted_post.id,
+                name: inserted_post.name.clone(),
+                creator_id: inserted_person.id,
+                url: None,
+                body: None,
+                published: inserted_post.published,
+                updated: None,
+                community_id: inserted_community.id,
+                removed: false,
+                deleted: false,
+                locked: false,
+                nsfw: false,
+                embed_title: None,
+                embed_description: None,
+                embed_video_url: None,
+                thumbnail_url: None,
+                ap_id: inserted_post.ap_id.clone(),
+                local: true,
+                language_id: LanguageId(47),
+                featured_community: false,
+                featured_local: false,
+            },
+            my_vote: None,
+            unread_comments: 0,
+            creator: Person {
+                id: inserted_person.id,
+                name: inserted_person.name.clone(),
+                display_name: None,
+                published: inserted_person.published,
+                avatar: None,
+                actor_id: inserted_person.actor_id.clone(),
+                local: true,
+                bot_account: false,
+                banned: false,
+                deleted: false,
+                bio: None,
+                banner: None,
+                updated: None,
+                inbox_url: inserted_person.inbox_url.clone(),
+                shared_inbox_url: None,
+                matrix_user_id: None,
+                ban_expires: None,
+                instance_id: data.inserted_instance.id,
+                private_key: inserted_person.private_key.clone(),
+                public_key: inserted_person.public_key.clone(),
+                last_refreshed_at: inserted_person.last_refreshed_at,
+            },
+            creator_banned_from_community: false,
+            community: Community {
+                id: inserted_community.id,
+                name: inserted_community.name.clone(),
+                icon: None,
+                removed: false,
+                deleted: false,
+                nsfw: false,
+                actor_id: inserted_community.actor_id.clone(),
+                local: true,
+                title: "nada".to_owned(),
+                description: None,
+                updated: None,
+                banner: None,
+                hidden: false,
+                posting_restricted_to_mods: false,
+                published: inserted_community.published,
+                instance_id: data.inserted_instance.id,
+                private_key: inserted_community.private_key.clone(),
+                public_key: inserted_community.public_key.clone(),
+                last_refreshed_at: inserted_community.last_refreshed_at,
+                followers_url: inserted_community.followers_url.clone(),
+                inbox_url: inserted_community.inbox_url.clone(),
+                shared_inbox_url: inserted_community.shared_inbox_url.clone(),
+                moderators_url: inserted_community.moderators_url.clone(),
+                featured_url: inserted_community.featured_url.clone(),
+            },
+            counts: PostAggregates {
+                id: agg.id,
+                post_id: inserted_post.id,
+                comments: 0,
+                score: 0,
+                upvotes: 0,
+                downvotes: 0,
+                published: agg.published,
+                newest_comment_time_necro: inserted_post.published,
+                newest_comment_time: inserted_post.published,
+                featured_community: false,
+                featured_local: false,
+                hot_rank: 1728,
+                hot_rank_active: 1728,
+                controversy_rank: 0.0,
+                community_id: inserted_post.community_id,
+                creator_id: inserted_post.creator_id,
+            },
+            subscribed: SubscribedType::NotSubscribed,
+            read: false,
+            saved: false,
+            creator_blocked: false,
+        }
+    }
 }

--- a/crates/db_views/src/private_message_report_view.rs
+++ b/crates/db_views/src/private_message_report_view.rs
@@ -1,209 +1,204 @@
 use crate::structs::PrivateMessageReportView;
 use diesel::{
-  pg::Pg,
-  result::Error,
-  ExpressionMethods,
-  JoinOnDsl,
-  NullableExpressionMethods,
-  QueryDsl,
+    pg::Pg, result::Error, ExpressionMethods, JoinOnDsl, NullableExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  aliases,
-  newtypes::PrivateMessageReportId,
-  schema::{person, private_message, private_message_report},
-  utils::{get_conn, limit_and_offset, DbConn, DbPool, ListFn, Queries, ReadFn},
+    aliases,
+    newtypes::PrivateMessageReportId,
+    schema::{person, private_message, private_message_report},
+    utils::{get_conn, limit_and_offset, DbConn, DbPool, ListFn, Queries, ReadFn},
 };
 
 fn queries<'a>() -> Queries<
-  impl ReadFn<'a, PrivateMessageReportView, PrivateMessageReportId>,
-  impl ListFn<'a, PrivateMessageReportView, PrivateMessageReportQuery>,
+    impl ReadFn<'a, PrivateMessageReportView, PrivateMessageReportId>,
+    impl ListFn<'a, PrivateMessageReportView, PrivateMessageReportQuery>,
 > {
-  let all_joins =
-    |query: private_message_report::BoxedQuery<'a, Pg>| {
-      query
-        .inner_join(private_message::table)
-        .inner_join(person::table.on(private_message::creator_id.eq(person::id)))
-        .inner_join(
-          aliases::person1
-            .on(private_message_report::creator_id.eq(aliases::person1.field(person::id))),
-        )
-        .left_join(aliases::person2.on(
-          private_message_report::resolver_id.eq(aliases::person2.field(person::id).nullable()),
-        ))
-        .select((
-          private_message_report::all_columns,
-          private_message::all_columns,
-          person::all_columns,
-          aliases::person1.fields(person::all_columns),
-          aliases::person2.fields(person::all_columns).nullable(),
-        ))
+    let all_joins = |query: private_message_report::BoxedQuery<'a, Pg>| {
+        query
+            .inner_join(private_message::table)
+            .inner_join(person::table.on(private_message::creator_id.eq(person::id)))
+            .inner_join(
+                aliases::person1
+                    .on(private_message_report::creator_id.eq(aliases::person1.field(person::id))),
+            )
+            .left_join(
+                aliases::person2.on(private_message_report::resolver_id
+                    .eq(aliases::person2.field(person::id).nullable())),
+            )
+            .select((
+                private_message_report::all_columns,
+                private_message::all_columns,
+                person::all_columns,
+                aliases::person1.fields(person::all_columns),
+                aliases::person2.fields(person::all_columns).nullable(),
+            ))
     };
 
-  let read = move |mut conn: DbConn<'a>, report_id: PrivateMessageReportId| async move {
-    all_joins(private_message_report::table.find(report_id).into_boxed())
-      .first::<PrivateMessageReportView>(&mut conn)
-      .await
-  };
+    let read = move |mut conn: DbConn<'a>, report_id: PrivateMessageReportId| async move {
+        all_joins(private_message_report::table.find(report_id).into_boxed())
+            .first::<PrivateMessageReportView>(&mut conn)
+            .await
+    };
 
-  let list = move |mut conn: DbConn<'a>, options: PrivateMessageReportQuery| async move {
-    let mut query = all_joins(private_message_report::table.into_boxed());
+    let list = move |mut conn: DbConn<'a>, options: PrivateMessageReportQuery| async move {
+        let mut query = all_joins(private_message_report::table.into_boxed());
 
-    if options.unresolved_only {
-      query = query.filter(private_message_report::resolved.eq(false));
-    }
+        if options.unresolved_only {
+            query = query.filter(private_message_report::resolved.eq(false));
+        }
 
-    let (limit, offset) = limit_and_offset(options.page, options.limit)?;
+        let (limit, offset) = limit_and_offset(options.page, options.limit)?;
 
-    query
-      .order_by(private_message::published.desc())
-      .limit(limit)
-      .offset(offset)
-      .load::<PrivateMessageReportView>(&mut conn)
-      .await
-  };
+        query
+            .order_by(private_message::published.desc())
+            .limit(limit)
+            .offset(offset)
+            .load::<PrivateMessageReportView>(&mut conn)
+            .await
+    };
 
-  Queries::new(read, list)
+    Queries::new(read, list)
 }
 
 impl PrivateMessageReportView {
-  /// returns the PrivateMessageReportView for the provided report_id
-  ///
-  /// * `report_id` - the report id to obtain
-  pub async fn read(
-    pool: &mut DbPool<'_>,
-    report_id: PrivateMessageReportId,
-  ) -> Result<Self, Error> {
-    queries().read(pool, report_id).await
-  }
+    /// returns the PrivateMessageReportView for the provided report_id
+    ///
+    /// * `report_id` - the report id to obtain
+    pub async fn read(
+        pool: &mut DbPool<'_>,
+        report_id: PrivateMessageReportId,
+    ) -> Result<Self, Error> {
+        queries().read(pool, report_id).await
+    }
 
-  /// Returns the current unresolved post report count for the communities you mod
-  pub async fn get_report_count(pool: &mut DbPool<'_>) -> Result<i64, Error> {
-    use diesel::dsl::count;
-    let conn = &mut get_conn(pool).await?;
+    /// Returns the current unresolved post report count for the communities you mod
+    pub async fn get_report_count(pool: &mut DbPool<'_>) -> Result<i64, Error> {
+        use diesel::dsl::count;
+        let conn = &mut get_conn(pool).await?;
 
-    private_message_report::table
-      .inner_join(private_message::table)
-      .filter(private_message_report::resolved.eq(false))
-      .into_boxed()
-      .select(count(private_message_report::id))
-      .first::<i64>(conn)
-      .await
-  }
+        private_message_report::table
+            .inner_join(private_message::table)
+            .filter(private_message_report::resolved.eq(false))
+            .into_boxed()
+            .select(count(private_message_report::id))
+            .first::<i64>(conn)
+            .await
+    }
 }
 
 #[derive(Default)]
 pub struct PrivateMessageReportQuery {
-  pub page: Option<i64>,
-  pub limit: Option<i64>,
-  pub unresolved_only: bool,
+    pub page: Option<i64>,
+    pub limit: Option<i64>,
+    pub unresolved_only: bool,
 }
 
 impl PrivateMessageReportQuery {
-  pub async fn list(self, pool: &mut DbPool<'_>) -> Result<Vec<PrivateMessageReportView>, Error> {
-    queries().list(pool, self).await
-  }
+    pub async fn list(self, pool: &mut DbPool<'_>) -> Result<Vec<PrivateMessageReportView>, Error> {
+        queries().list(pool, self).await
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::private_message_report_view::PrivateMessageReportQuery;
-  use lemmy_db_schema::{
-    source::{
-      instance::Instance,
-      person::{Person, PersonInsertForm},
-      private_message::{PrivateMessage, PrivateMessageInsertForm},
-      private_message_report::{PrivateMessageReport, PrivateMessageReportForm},
-    },
-    traits::{Crud, Reportable},
-    utils::build_db_pool_for_tests,
-  };
-  use serial_test::serial;
-
-  #[tokio::test]
-  #[serial]
-  async fn test_crud() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-
-    let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
-      .await
-      .unwrap();
-
-    let new_person_1 = PersonInsertForm::builder()
-      .name("timmy_mrv".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-    let inserted_timmy = Person::create(pool, &new_person_1).await.unwrap();
-
-    let new_person_2 = PersonInsertForm::builder()
-      .name("jessica_mrv".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-    let inserted_jessica = Person::create(pool, &new_person_2).await.unwrap();
-
-    // timmy sends private message to jessica
-    let pm_form = PrivateMessageInsertForm::builder()
-      .creator_id(inserted_timmy.id)
-      .recipient_id(inserted_jessica.id)
-      .content("something offensive".to_string())
-      .build();
-    let pm = PrivateMessage::create(pool, &pm_form).await.unwrap();
-
-    // jessica reports private message
-    let pm_report_form = PrivateMessageReportForm {
-      creator_id: inserted_jessica.id,
-      original_pm_text: pm.content.clone(),
-      private_message_id: pm.id,
-      reason: "its offensive".to_string(),
+    use crate::private_message_report_view::PrivateMessageReportQuery;
+    use lemmy_db_schema::{
+        source::{
+            instance::Instance,
+            person::{Person, PersonInsertForm},
+            private_message::{PrivateMessage, PrivateMessageInsertForm},
+            private_message_report::{PrivateMessageReport, PrivateMessageReportForm},
+        },
+        traits::{Crud, Reportable},
+        utils::build_db_pool_for_tests,
     };
-    let pm_report = PrivateMessageReport::report(pool, &pm_report_form)
-      .await
-      .unwrap();
+    use serial_test::serial;
 
-    let reports = PrivateMessageReportQuery::default()
-      .list(pool)
-      .await
-      .unwrap();
-    assert_eq!(1, reports.len());
-    assert!(!reports[0].private_message_report.resolved);
-    assert_eq!(inserted_timmy.name, reports[0].private_message_creator.name);
-    assert_eq!(inserted_jessica.name, reports[0].creator.name);
-    assert_eq!(pm_report.reason, reports[0].private_message_report.reason);
-    assert_eq!(pm.content, reports[0].private_message.content);
+    #[tokio::test]
+    #[serial]
+    async fn test_crud() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
 
-    let new_person_3 = PersonInsertForm::builder()
-      .name("admin_mrv".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-    let inserted_admin = Person::create(pool, &new_person_3).await.unwrap();
+        let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
+            .await
+            .unwrap();
 
-    // admin resolves the report (after taking appropriate action)
-    PrivateMessageReport::resolve(pool, pm_report.id, inserted_admin.id)
-      .await
-      .unwrap();
+        let new_person_1 = PersonInsertForm::builder()
+            .name("timmy_mrv".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
+        let inserted_timmy = Person::create(pool, &new_person_1).await.unwrap();
 
-    let reports = PrivateMessageReportQuery {
-      unresolved_only: (false),
-      ..Default::default()
+        let new_person_2 = PersonInsertForm::builder()
+            .name("jessica_mrv".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
+        let inserted_jessica = Person::create(pool, &new_person_2).await.unwrap();
+
+        // timmy sends private message to jessica
+        let pm_form = PrivateMessageInsertForm::builder()
+            .creator_id(inserted_timmy.id)
+            .recipient_id(inserted_jessica.id)
+            .content("something offensive".to_string())
+            .build();
+        let pm = PrivateMessage::create(pool, &pm_form).await.unwrap();
+
+        // jessica reports private message
+        let pm_report_form = PrivateMessageReportForm {
+            creator_id: inserted_jessica.id,
+            original_pm_text: pm.content.clone(),
+            private_message_id: pm.id,
+            reason: "its offensive".to_string(),
+        };
+        let pm_report = PrivateMessageReport::report(pool, &pm_report_form)
+            .await
+            .unwrap();
+
+        let reports = PrivateMessageReportQuery::default()
+            .list(pool)
+            .await
+            .unwrap();
+        assert_eq!(1, reports.len());
+        assert!(!reports[0].private_message_report.resolved);
+        assert_eq!(inserted_timmy.name, reports[0].private_message_creator.name);
+        assert_eq!(inserted_jessica.name, reports[0].creator.name);
+        assert_eq!(pm_report.reason, reports[0].private_message_report.reason);
+        assert_eq!(pm.content, reports[0].private_message.content);
+
+        let new_person_3 = PersonInsertForm::builder()
+            .name("admin_mrv".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
+        let inserted_admin = Person::create(pool, &new_person_3).await.unwrap();
+
+        // admin resolves the report (after taking appropriate action)
+        PrivateMessageReport::resolve(pool, pm_report.id, inserted_admin.id)
+            .await
+            .unwrap();
+
+        let reports = PrivateMessageReportQuery {
+            unresolved_only: (false),
+            ..Default::default()
+        }
+        .list(pool)
+        .await
+        .unwrap();
+        assert_eq!(1, reports.len());
+        assert!(reports[0].private_message_report.resolved);
+        assert!(reports[0].resolver.is_some());
+        assert_eq!(
+            inserted_admin.name,
+            reports[0].resolver.as_ref().unwrap().name
+        );
+
+        Instance::delete(pool, inserted_instance.id).await.unwrap();
     }
-    .list(pool)
-    .await
-    .unwrap();
-    assert_eq!(1, reports.len());
-    assert!(reports[0].private_message_report.resolved);
-    assert!(reports[0].resolver.is_some());
-    assert_eq!(
-      inserted_admin.name,
-      reports[0].resolver.as_ref().unwrap().name
-    );
-
-    Instance::delete(pool, inserted_instance.id).await.unwrap();
-  }
 }

--- a/crates/db_views/src/private_message_view.rs
+++ b/crates/db_views/src/private_message_view.rs
@@ -1,284 +1,284 @@
 use crate::structs::PrivateMessageView;
 use diesel::{
-  debug_query,
-  pg::Pg,
-  result::Error,
-  BoolExpressionMethods,
-  ExpressionMethods,
-  JoinOnDsl,
-  QueryDsl,
+    debug_query, pg::Pg, result::Error, BoolExpressionMethods, ExpressionMethods, JoinOnDsl,
+    QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  aliases,
-  newtypes::{PersonId, PrivateMessageId},
-  schema::{person, private_message},
-  utils::{get_conn, limit_and_offset, DbConn, DbPool, ListFn, Queries, ReadFn},
+    aliases,
+    newtypes::{PersonId, PrivateMessageId},
+    schema::{person, private_message},
+    utils::{get_conn, limit_and_offset, DbConn, DbPool, ListFn, Queries, ReadFn},
 };
 use tracing::debug;
 
 fn queries<'a>() -> Queries<
-  impl ReadFn<'a, PrivateMessageView, PrivateMessageId>,
-  impl ListFn<'a, PrivateMessageView, (PrivateMessageQuery, PersonId)>,
+    impl ReadFn<'a, PrivateMessageView, PrivateMessageId>,
+    impl ListFn<'a, PrivateMessageView, (PrivateMessageQuery, PersonId)>,
 > {
-  let all_joins = |query: private_message::BoxedQuery<'a, Pg>| {
-    query
-      .inner_join(person::table.on(private_message::creator_id.eq(person::id)))
-      .inner_join(
-        aliases::person1.on(private_message::recipient_id.eq(aliases::person1.field(person::id))),
-      )
-  };
+    let all_joins = |query: private_message::BoxedQuery<'a, Pg>| {
+        query
+            .inner_join(person::table.on(private_message::creator_id.eq(person::id)))
+            .inner_join(
+                aliases::person1
+                    .on(private_message::recipient_id.eq(aliases::person1.field(person::id))),
+            )
+    };
 
-  let selection = (
-    private_message::all_columns,
-    person::all_columns,
-    aliases::person1.fields(person::all_columns),
-  );
-
-  let read = move |mut conn: DbConn<'a>, private_message_id: PrivateMessageId| async move {
-    all_joins(private_message::table.find(private_message_id).into_boxed())
-      .order_by(private_message::published.desc())
-      .select(selection)
-      .first::<PrivateMessageView>(&mut conn)
-      .await
-  };
-
-  let list = move |mut conn: DbConn<'a>,
-                   (options, recipient_id): (PrivateMessageQuery, PersonId)| async move {
-    let mut query = all_joins(private_message::table.into_boxed()).select(selection);
-
-    // If its unread, I only want the ones to me
-    if options.unread_only {
-      query = query.filter(private_message::read.eq(false));
-      if let Some(i) = options.creator_id {
-        query = query.filter(private_message::creator_id.eq(i))
-      }
-      query = query.filter(private_message::recipient_id.eq(recipient_id));
-    }
-    // Otherwise, I want the ALL view to show both sent and received
-    else {
-      query = query.filter(
-        private_message::recipient_id
-          .eq(recipient_id)
-          .or(private_message::creator_id.eq(recipient_id)),
-      );
-      if let Some(i) = options.creator_id {
-        query = query.filter(
-          private_message::creator_id
-            .eq(i)
-            .or(private_message::recipient_id.eq(i)),
-        )
-      }
-    }
-
-    let (limit, offset) = limit_and_offset(options.page, options.limit)?;
-
-    query = query
-      .filter(private_message::deleted.eq(false))
-      .limit(limit)
-      .offset(offset)
-      .order_by(private_message::published.desc());
-
-    debug!(
-      "Private Message View Query: {:?}",
-      debug_query::<Pg, _>(&query)
+    let selection = (
+        private_message::all_columns,
+        person::all_columns,
+        aliases::person1.fields(person::all_columns),
     );
 
-    query.load::<PrivateMessageView>(&mut conn).await
-  };
+    let read = move |mut conn: DbConn<'a>, private_message_id: PrivateMessageId| async move {
+        all_joins(private_message::table.find(private_message_id).into_boxed())
+            .order_by(private_message::published.desc())
+            .select(selection)
+            .first::<PrivateMessageView>(&mut conn)
+            .await
+    };
 
-  Queries::new(read, list)
+    let list = move |mut conn: DbConn<'a>,
+                     (options, recipient_id): (PrivateMessageQuery, PersonId)| async move {
+        let mut query = all_joins(private_message::table.into_boxed()).select(selection);
+
+        // If its unread, I only want the ones to me
+        if options.unread_only {
+            query = query.filter(private_message::read.eq(false));
+            if let Some(i) = options.creator_id {
+                query = query.filter(private_message::creator_id.eq(i))
+            }
+            query = query.filter(private_message::recipient_id.eq(recipient_id));
+        }
+        // Otherwise, I want the ALL view to show both sent and received
+        else {
+            query = query.filter(
+                private_message::recipient_id
+                    .eq(recipient_id)
+                    .or(private_message::creator_id.eq(recipient_id)),
+            );
+            if let Some(i) = options.creator_id {
+                query = query.filter(
+                    private_message::creator_id
+                        .eq(i)
+                        .or(private_message::recipient_id.eq(i)),
+                )
+            }
+        }
+
+        let (limit, offset) = limit_and_offset(options.page, options.limit)?;
+
+        query = query
+            .filter(private_message::deleted.eq(false))
+            .limit(limit)
+            .offset(offset)
+            .order_by(private_message::published.desc());
+
+        debug!(
+            "Private Message View Query: {:?}",
+            debug_query::<Pg, _>(&query)
+        );
+
+        query.load::<PrivateMessageView>(&mut conn).await
+    };
+
+    Queries::new(read, list)
 }
 
 impl PrivateMessageView {
-  pub async fn read(
-    pool: &mut DbPool<'_>,
-    private_message_id: PrivateMessageId,
-  ) -> Result<Self, Error> {
-    queries().read(pool, private_message_id).await
-  }
+    pub async fn read(
+        pool: &mut DbPool<'_>,
+        private_message_id: PrivateMessageId,
+    ) -> Result<Self, Error> {
+        queries().read(pool, private_message_id).await
+    }
 
-  /// Gets the number of unread messages
-  pub async fn get_unread_messages(
-    pool: &mut DbPool<'_>,
-    my_person_id: PersonId,
-  ) -> Result<i64, Error> {
-    use diesel::dsl::count;
-    let conn = &mut get_conn(pool).await?;
-    private_message::table
-      .filter(private_message::read.eq(false))
-      .filter(private_message::recipient_id.eq(my_person_id))
-      .filter(private_message::deleted.eq(false))
-      .select(count(private_message::id))
-      .first::<i64>(conn)
-      .await
-  }
+    /// Gets the number of unread messages
+    pub async fn get_unread_messages(
+        pool: &mut DbPool<'_>,
+        my_person_id: PersonId,
+    ) -> Result<i64, Error> {
+        use diesel::dsl::count;
+        let conn = &mut get_conn(pool).await?;
+        private_message::table
+            .filter(private_message::read.eq(false))
+            .filter(private_message::recipient_id.eq(my_person_id))
+            .filter(private_message::deleted.eq(false))
+            .select(count(private_message::id))
+            .first::<i64>(conn)
+            .await
+    }
 }
 
 #[derive(Default)]
 pub struct PrivateMessageQuery {
-  pub unread_only: bool,
-  pub page: Option<i64>,
-  pub limit: Option<i64>,
-  pub creator_id: Option<PersonId>,
+    pub unread_only: bool,
+    pub page: Option<i64>,
+    pub limit: Option<i64>,
+    pub creator_id: Option<PersonId>,
 }
 
 impl PrivateMessageQuery {
-  pub async fn list(
-    self,
-    pool: &mut DbPool<'_>,
-    recipient_id: PersonId,
-  ) -> Result<Vec<PrivateMessageView>, Error> {
-    queries().list(pool, (self, recipient_id)).await
-  }
+    pub async fn list(
+        self,
+        pool: &mut DbPool<'_>,
+        recipient_id: PersonId,
+    ) -> Result<Vec<PrivateMessageView>, Error> {
+        queries().list(pool, (self, recipient_id)).await
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::private_message_view::PrivateMessageQuery;
-  use lemmy_db_schema::{
-    source::{
-      instance::Instance,
-      person::{Person, PersonInsertForm},
-      private_message::{PrivateMessage, PrivateMessageInsertForm},
-    },
-    traits::Crud,
-    utils::build_db_pool_for_tests,
-  };
-  use serial_test::serial;
+    use crate::private_message_view::PrivateMessageQuery;
+    use lemmy_db_schema::{
+        source::{
+            instance::Instance,
+            person::{Person, PersonInsertForm},
+            private_message::{PrivateMessage, PrivateMessageInsertForm},
+        },
+        traits::Crud,
+        utils::build_db_pool_for_tests,
+    };
+    use serial_test::serial;
 
-  #[tokio::test]
-  #[serial]
-  async fn test_crud() {
-    let message_content = String::new();
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
+    #[tokio::test]
+    #[serial]
+    async fn test_crud() {
+        let message_content = String::new();
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
 
-    let instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
-      .await
-      .unwrap();
+        let instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
+            .await
+            .unwrap();
 
-    let timmy_form = PersonInsertForm::builder()
-      .name("timmy_rav".into())
-      .public_key("pubkey".to_string())
-      .instance_id(instance.id)
-      .build();
+        let timmy_form = PersonInsertForm::builder()
+            .name("timmy_rav".into())
+            .public_key("pubkey".to_string())
+            .instance_id(instance.id)
+            .build();
 
-    let timmy = Person::create(pool, &timmy_form).await.unwrap();
+        let timmy = Person::create(pool, &timmy_form).await.unwrap();
 
-    let sara_form = PersonInsertForm::builder()
-      .name("sara_rav".into())
-      .public_key("pubkey".to_string())
-      .instance_id(instance.id)
-      .build();
+        let sara_form = PersonInsertForm::builder()
+            .name("sara_rav".into())
+            .public_key("pubkey".to_string())
+            .instance_id(instance.id)
+            .build();
 
-    let sara = Person::create(pool, &sara_form).await.unwrap();
+        let sara = Person::create(pool, &sara_form).await.unwrap();
 
-    let jess_form = PersonInsertForm::builder()
-      .name("jess_rav".into())
-      .public_key("pubkey".to_string())
-      .instance_id(instance.id)
-      .build();
+        let jess_form = PersonInsertForm::builder()
+            .name("jess_rav".into())
+            .public_key("pubkey".to_string())
+            .instance_id(instance.id)
+            .build();
 
-    let jess = Person::create(pool, &jess_form).await.unwrap();
+        let jess = Person::create(pool, &jess_form).await.unwrap();
 
-    let sara_timmy_message_form = PrivateMessageInsertForm::builder()
-      .creator_id(sara.id)
-      .recipient_id(timmy.id)
-      .content(message_content.clone())
-      .build();
-    let _inserted_sara_timmy_message_form = PrivateMessage::create(pool, &sara_timmy_message_form)
-      .await
-      .unwrap();
+        let sara_timmy_message_form = PrivateMessageInsertForm::builder()
+            .creator_id(sara.id)
+            .recipient_id(timmy.id)
+            .content(message_content.clone())
+            .build();
+        let _inserted_sara_timmy_message_form =
+            PrivateMessage::create(pool, &sara_timmy_message_form)
+                .await
+                .unwrap();
 
-    let sara_jess_message_form = PrivateMessageInsertForm::builder()
-      .creator_id(sara.id)
-      .recipient_id(jess.id)
-      .content(message_content.clone())
-      .build();
-    let _inserted_sara_jess_message_form = PrivateMessage::create(pool, &sara_jess_message_form)
-      .await
-      .unwrap();
+        let sara_jess_message_form = PrivateMessageInsertForm::builder()
+            .creator_id(sara.id)
+            .recipient_id(jess.id)
+            .content(message_content.clone())
+            .build();
+        let _inserted_sara_jess_message_form =
+            PrivateMessage::create(pool, &sara_jess_message_form)
+                .await
+                .unwrap();
 
-    let timmy_sara_message_form = PrivateMessageInsertForm::builder()
-      .creator_id(timmy.id)
-      .recipient_id(sara.id)
-      .content(message_content.clone())
-      .build();
-    let _inserted_timmy_sara_message_form = PrivateMessage::create(pool, &timmy_sara_message_form)
-      .await
-      .unwrap();
+        let timmy_sara_message_form = PrivateMessageInsertForm::builder()
+            .creator_id(timmy.id)
+            .recipient_id(sara.id)
+            .content(message_content.clone())
+            .build();
+        let _inserted_timmy_sara_message_form =
+            PrivateMessage::create(pool, &timmy_sara_message_form)
+                .await
+                .unwrap();
 
-    let jess_timmy_message_form = PrivateMessageInsertForm::builder()
-      .creator_id(jess.id)
-      .recipient_id(timmy.id)
-      .content(message_content.clone())
-      .build();
-    let _inserted_jess_timmy_message_form = PrivateMessage::create(pool, &jess_timmy_message_form)
-      .await
-      .unwrap();
+        let jess_timmy_message_form = PrivateMessageInsertForm::builder()
+            .creator_id(jess.id)
+            .recipient_id(timmy.id)
+            .content(message_content.clone())
+            .build();
+        let _inserted_jess_timmy_message_form =
+            PrivateMessage::create(pool, &jess_timmy_message_form)
+                .await
+                .unwrap();
 
-    let timmy_messages = PrivateMessageQuery {
-      unread_only: false,
-      creator_id: Option::None,
-      ..Default::default()
+        let timmy_messages = PrivateMessageQuery {
+            unread_only: false,
+            creator_id: Option::None,
+            ..Default::default()
+        }
+        .list(pool, timmy.id)
+        .await
+        .unwrap();
+
+        assert_eq!(timmy_messages.len(), 3);
+        assert_eq!(timmy_messages[0].creator.id, jess.id);
+        assert_eq!(timmy_messages[0].recipient.id, timmy.id);
+        assert_eq!(timmy_messages[1].creator.id, timmy.id);
+        assert_eq!(timmy_messages[1].recipient.id, sara.id);
+        assert_eq!(timmy_messages[2].creator.id, sara.id);
+        assert_eq!(timmy_messages[2].recipient.id, timmy.id);
+
+        let timmy_unread_messages = PrivateMessageQuery {
+            unread_only: true,
+            creator_id: Option::None,
+            ..Default::default()
+        }
+        .list(pool, timmy.id)
+        .await
+        .unwrap();
+
+        assert_eq!(timmy_unread_messages.len(), 2);
+        assert_eq!(timmy_unread_messages[0].creator.id, jess.id);
+        assert_eq!(timmy_unread_messages[0].recipient.id, timmy.id);
+        assert_eq!(timmy_unread_messages[1].creator.id, sara.id);
+        assert_eq!(timmy_unread_messages[1].recipient.id, timmy.id);
+
+        let timmy_sara_messages = PrivateMessageQuery {
+            unread_only: false,
+            creator_id: Some(sara.id),
+            ..Default::default()
+        }
+        .list(pool, timmy.id)
+        .await
+        .unwrap();
+
+        assert_eq!(timmy_sara_messages.len(), 2);
+        assert_eq!(timmy_sara_messages[0].creator.id, timmy.id);
+        assert_eq!(timmy_sara_messages[0].recipient.id, sara.id);
+        assert_eq!(timmy_sara_messages[1].creator.id, sara.id);
+        assert_eq!(timmy_sara_messages[1].recipient.id, timmy.id);
+
+        let timmy_sara_unread_messages = PrivateMessageQuery {
+            unread_only: true,
+            creator_id: Some(sara.id),
+            ..Default::default()
+        }
+        .list(pool, timmy.id)
+        .await
+        .unwrap();
+
+        assert_eq!(timmy_sara_unread_messages.len(), 1);
+        assert_eq!(timmy_sara_unread_messages[0].creator.id, sara.id);
+        assert_eq!(timmy_sara_unread_messages[0].recipient.id, timmy.id);
     }
-    .list(pool, timmy.id)
-    .await
-    .unwrap();
-
-    assert_eq!(timmy_messages.len(), 3);
-    assert_eq!(timmy_messages[0].creator.id, jess.id);
-    assert_eq!(timmy_messages[0].recipient.id, timmy.id);
-    assert_eq!(timmy_messages[1].creator.id, timmy.id);
-    assert_eq!(timmy_messages[1].recipient.id, sara.id);
-    assert_eq!(timmy_messages[2].creator.id, sara.id);
-    assert_eq!(timmy_messages[2].recipient.id, timmy.id);
-
-    let timmy_unread_messages = PrivateMessageQuery {
-      unread_only: true,
-      creator_id: Option::None,
-      ..Default::default()
-    }
-    .list(pool, timmy.id)
-    .await
-    .unwrap();
-
-    assert_eq!(timmy_unread_messages.len(), 2);
-    assert_eq!(timmy_unread_messages[0].creator.id, jess.id);
-    assert_eq!(timmy_unread_messages[0].recipient.id, timmy.id);
-    assert_eq!(timmy_unread_messages[1].creator.id, sara.id);
-    assert_eq!(timmy_unread_messages[1].recipient.id, timmy.id);
-
-    let timmy_sara_messages = PrivateMessageQuery {
-      unread_only: false,
-      creator_id: Some(sara.id),
-      ..Default::default()
-    }
-    .list(pool, timmy.id)
-    .await
-    .unwrap();
-
-    assert_eq!(timmy_sara_messages.len(), 2);
-    assert_eq!(timmy_sara_messages[0].creator.id, timmy.id);
-    assert_eq!(timmy_sara_messages[0].recipient.id, sara.id);
-    assert_eq!(timmy_sara_messages[1].creator.id, sara.id);
-    assert_eq!(timmy_sara_messages[1].recipient.id, timmy.id);
-
-    let timmy_sara_unread_messages = PrivateMessageQuery {
-      unread_only: true,
-      creator_id: Some(sara.id),
-      ..Default::default()
-    }
-    .list(pool, timmy.id)
-    .await
-    .unwrap();
-
-    assert_eq!(timmy_sara_unread_messages.len(), 1);
-    assert_eq!(timmy_sara_unread_messages[0].creator.id, sara.id);
-    assert_eq!(timmy_sara_unread_messages[0].recipient.id, timmy.id);
-  }
 }

--- a/crates/db_views/src/registration_application_view.rs
+++ b/crates/db_views/src/registration_application_view.rs
@@ -1,406 +1,402 @@
 use crate::structs::RegistrationApplicationView;
 use diesel::{
-  dsl::count,
-  pg::Pg,
-  result::Error,
-  ExpressionMethods,
-  JoinOnDsl,
-  NullableExpressionMethods,
-  QueryDsl,
+    dsl::count, pg::Pg, result::Error, ExpressionMethods, JoinOnDsl, NullableExpressionMethods,
+    QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  aliases,
-  schema::{local_user, person, registration_application},
-  utils::{get_conn, limit_and_offset, DbConn, DbPool, ListFn, Queries, ReadFn},
+    aliases,
+    schema::{local_user, person, registration_application},
+    utils::{get_conn, limit_and_offset, DbConn, DbPool, ListFn, Queries, ReadFn},
 };
 
 fn queries<'a>() -> Queries<
-  impl ReadFn<'a, RegistrationApplicationView, i32>,
-  impl ListFn<'a, RegistrationApplicationView, RegistrationApplicationQuery>,
+    impl ReadFn<'a, RegistrationApplicationView, i32>,
+    impl ListFn<'a, RegistrationApplicationView, RegistrationApplicationQuery>,
 > {
-  let all_joins = |query: registration_application::BoxedQuery<'a, Pg>| {
-    query
-      .inner_join(local_user::table.on(registration_application::local_user_id.eq(local_user::id)))
-      .inner_join(person::table.on(local_user::person_id.eq(person::id)))
-      .left_join(
-        aliases::person1
-          .on(registration_application::admin_id.eq(aliases::person1.field(person::id).nullable())),
-      )
-      .order_by(registration_application::published.desc())
-      .select((
-        registration_application::all_columns,
-        local_user::all_columns,
-        person::all_columns,
-        aliases::person1.fields(person::all_columns).nullable(),
-      ))
-  };
+    let all_joins = |query: registration_application::BoxedQuery<'a, Pg>| {
+        query
+            .inner_join(
+                local_user::table.on(registration_application::local_user_id.eq(local_user::id)),
+            )
+            .inner_join(person::table.on(local_user::person_id.eq(person::id)))
+            .left_join(
+                aliases::person1.on(registration_application::admin_id
+                    .eq(aliases::person1.field(person::id).nullable())),
+            )
+            .order_by(registration_application::published.desc())
+            .select((
+                registration_application::all_columns,
+                local_user::all_columns,
+                person::all_columns,
+                aliases::person1.fields(person::all_columns).nullable(),
+            ))
+    };
 
-  let read = move |mut conn: DbConn<'a>, registration_application_id: i32| async move {
-    all_joins(
-      registration_application::table
-        .find(registration_application_id)
-        .into_boxed(),
-    )
-    .first::<RegistrationApplicationView>(&mut conn)
-    .await
-  };
+    let read = move |mut conn: DbConn<'a>, registration_application_id: i32| async move {
+        all_joins(
+            registration_application::table
+                .find(registration_application_id)
+                .into_boxed(),
+        )
+        .first::<RegistrationApplicationView>(&mut conn)
+        .await
+    };
 
-  let list = move |mut conn: DbConn<'a>, options: RegistrationApplicationQuery| async move {
-    let mut query = all_joins(registration_application::table.into_boxed());
+    let list = move |mut conn: DbConn<'a>, options: RegistrationApplicationQuery| async move {
+        let mut query = all_joins(registration_application::table.into_boxed());
 
-    if options.unread_only {
-      query = query.filter(registration_application::admin_id.is_null())
-    }
+        if options.unread_only {
+            query = query.filter(registration_application::admin_id.is_null())
+        }
 
-    if options.verified_email_only {
-      query = query.filter(local_user::email_verified.eq(true))
-    }
+        if options.verified_email_only {
+            query = query.filter(local_user::email_verified.eq(true))
+        }
 
-    let (limit, offset) = limit_and_offset(options.page, options.limit)?;
+        let (limit, offset) = limit_and_offset(options.page, options.limit)?;
 
-    query = query
-      .limit(limit)
-      .offset(offset)
-      .order_by(registration_application::published.desc());
+        query = query
+            .limit(limit)
+            .offset(offset)
+            .order_by(registration_application::published.desc());
 
-    query.load::<RegistrationApplicationView>(&mut conn).await
-  };
+        query.load::<RegistrationApplicationView>(&mut conn).await
+    };
 
-  Queries::new(read, list)
+    Queries::new(read, list)
 }
 
 impl RegistrationApplicationView {
-  pub async fn read(
-    pool: &mut DbPool<'_>,
-    registration_application_id: i32,
-  ) -> Result<Self, Error> {
-    queries().read(pool, registration_application_id).await
-  }
-
-  /// Returns the current unread registration_application count
-  pub async fn get_unread_count(
-    pool: &mut DbPool<'_>,
-    verified_email_only: bool,
-  ) -> Result<i64, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let person_alias_1 = diesel::alias!(person as person1);
-
-    let mut query = registration_application::table
-      .inner_join(local_user::table.on(registration_application::local_user_id.eq(local_user::id)))
-      .inner_join(person::table.on(local_user::person_id.eq(person::id)))
-      .left_join(
-        person_alias_1
-          .on(registration_application::admin_id.eq(person_alias_1.field(person::id).nullable())),
-      )
-      .filter(registration_application::admin_id.is_null())
-      .into_boxed();
-
-    if verified_email_only {
-      query = query.filter(local_user::email_verified.eq(true))
+    pub async fn read(
+        pool: &mut DbPool<'_>,
+        registration_application_id: i32,
+    ) -> Result<Self, Error> {
+        queries().read(pool, registration_application_id).await
     }
 
-    query
-      .select(count(registration_application::id))
-      .first::<i64>(conn)
-      .await
-  }
+    /// Returns the current unread registration_application count
+    pub async fn get_unread_count(
+        pool: &mut DbPool<'_>,
+        verified_email_only: bool,
+    ) -> Result<i64, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let person_alias_1 = diesel::alias!(person as person1);
+
+        let mut query = registration_application::table
+            .inner_join(
+                local_user::table.on(registration_application::local_user_id.eq(local_user::id)),
+            )
+            .inner_join(person::table.on(local_user::person_id.eq(person::id)))
+            .left_join(person_alias_1.on(
+                registration_application::admin_id.eq(person_alias_1.field(person::id).nullable()),
+            ))
+            .filter(registration_application::admin_id.is_null())
+            .into_boxed();
+
+        if verified_email_only {
+            query = query.filter(local_user::email_verified.eq(true))
+        }
+
+        query
+            .select(count(registration_application::id))
+            .first::<i64>(conn)
+            .await
+    }
 }
 
 #[derive(Default)]
 pub struct RegistrationApplicationQuery {
-  pub unread_only: bool,
-  pub verified_email_only: bool,
-  pub page: Option<i64>,
-  pub limit: Option<i64>,
+    pub unread_only: bool,
+    pub verified_email_only: bool,
+    pub page: Option<i64>,
+    pub limit: Option<i64>,
 }
 
 impl RegistrationApplicationQuery {
-  pub async fn list(
-    self,
-    pool: &mut DbPool<'_>,
-  ) -> Result<Vec<RegistrationApplicationView>, Error> {
-    queries().list(pool, self).await
-  }
+    pub async fn list(
+        self,
+        pool: &mut DbPool<'_>,
+    ) -> Result<Vec<RegistrationApplicationView>, Error> {
+        queries().list(pool, self).await
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::registration_application_view::{
-    RegistrationApplicationQuery,
-    RegistrationApplicationView,
-  };
-  use lemmy_db_schema::{
-    source::{
-      instance::Instance,
-      local_user::{LocalUser, LocalUserInsertForm, LocalUserUpdateForm},
-      person::{Person, PersonInsertForm},
-      registration_application::{
-        RegistrationApplication,
-        RegistrationApplicationInsertForm,
-        RegistrationApplicationUpdateForm,
-      },
-    },
-    traits::Crud,
-    utils::build_db_pool_for_tests,
-  };
-  use serial_test::serial;
-
-  #[tokio::test]
-  #[serial]
-  async fn test_crud() {
-    let pool = &build_db_pool_for_tests().await;
-    let pool = &mut pool.into();
-
-    let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
-      .await
-      .unwrap();
-
-    let timmy_person_form = PersonInsertForm::builder()
-      .name("timmy_rav".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_timmy_person = Person::create(pool, &timmy_person_form).await.unwrap();
-
-    let timmy_local_user_form = LocalUserInsertForm::builder()
-      .person_id(inserted_timmy_person.id)
-      .password_encrypted("nada".to_string())
-      .admin(Some(true))
-      .build();
-
-    let _inserted_timmy_local_user = LocalUser::create(pool, &timmy_local_user_form)
-      .await
-      .unwrap();
-
-    let sara_person_form = PersonInsertForm::builder()
-      .name("sara_rav".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_sara_person = Person::create(pool, &sara_person_form).await.unwrap();
-
-    let sara_local_user_form = LocalUserInsertForm::builder()
-      .person_id(inserted_sara_person.id)
-      .password_encrypted("nada".to_string())
-      .build();
-
-    let inserted_sara_local_user = LocalUser::create(pool, &sara_local_user_form)
-      .await
-      .unwrap();
-
-    // Sara creates an application
-    let sara_app_form = RegistrationApplicationInsertForm {
-      local_user_id: inserted_sara_local_user.id,
-      answer: "LET ME IIIIINN".to_string(),
+    use crate::registration_application_view::{
+        RegistrationApplicationQuery, RegistrationApplicationView,
     };
-
-    let sara_app = RegistrationApplication::create(pool, &sara_app_form)
-      .await
-      .unwrap();
-
-    let read_sara_app_view = RegistrationApplicationView::read(pool, sara_app.id)
-      .await
-      .unwrap();
-
-    let jess_person_form = PersonInsertForm::builder()
-      .name("jess_rav".into())
-      .public_key("pubkey".to_string())
-      .instance_id(inserted_instance.id)
-      .build();
-
-    let inserted_jess_person = Person::create(pool, &jess_person_form).await.unwrap();
-
-    let jess_local_user_form = LocalUserInsertForm::builder()
-      .person_id(inserted_jess_person.id)
-      .password_encrypted("nada".to_string())
-      .build();
-
-    let inserted_jess_local_user = LocalUser::create(pool, &jess_local_user_form)
-      .await
-      .unwrap();
-
-    // Sara creates an application
-    let jess_app_form = RegistrationApplicationInsertForm {
-      local_user_id: inserted_jess_local_user.id,
-      answer: "LET ME IIIIINN".to_string(),
+    use lemmy_db_schema::{
+        source::{
+            instance::Instance,
+            local_user::{LocalUser, LocalUserInsertForm, LocalUserUpdateForm},
+            person::{Person, PersonInsertForm},
+            registration_application::{
+                RegistrationApplication, RegistrationApplicationInsertForm,
+                RegistrationApplicationUpdateForm,
+            },
+        },
+        traits::Crud,
+        utils::build_db_pool_for_tests,
     };
+    use serial_test::serial;
 
-    let jess_app = RegistrationApplication::create(pool, &jess_app_form)
-      .await
-      .unwrap();
+    #[tokio::test]
+    #[serial]
+    async fn test_crud() {
+        let pool = &build_db_pool_for_tests().await;
+        let pool = &mut pool.into();
 
-    let read_jess_app_view = RegistrationApplicationView::read(pool, jess_app.id)
-      .await
-      .unwrap();
+        let inserted_instance = Instance::read_or_create(pool, "my_domain.tld".to_string())
+            .await
+            .unwrap();
 
-    let mut expected_sara_app_view = RegistrationApplicationView {
-      registration_application: sara_app.clone(),
-      creator_local_user: LocalUser {
-        id: inserted_sara_local_user.id,
-        person_id: inserted_sara_local_user.person_id,
-        email: inserted_sara_local_user.email,
-        show_nsfw: inserted_sara_local_user.show_nsfw,
-        auto_expand: inserted_sara_local_user.auto_expand,
-        blur_nsfw: inserted_sara_local_user.blur_nsfw,
-        theme: inserted_sara_local_user.theme,
-        default_sort_type: inserted_sara_local_user.default_sort_type,
-        default_listing_type: inserted_sara_local_user.default_listing_type,
-        interface_language: inserted_sara_local_user.interface_language,
-        show_avatars: inserted_sara_local_user.show_avatars,
-        send_notifications_to_email: inserted_sara_local_user.send_notifications_to_email,
-        validator_time: inserted_sara_local_user.validator_time,
-        show_bot_accounts: inserted_sara_local_user.show_bot_accounts,
-        show_scores: inserted_sara_local_user.show_scores,
-        show_read_posts: inserted_sara_local_user.show_read_posts,
-        show_new_post_notifs: inserted_sara_local_user.show_new_post_notifs,
-        email_verified: inserted_sara_local_user.email_verified,
-        accepted_application: inserted_sara_local_user.accepted_application,
-        totp_2fa_secret: inserted_sara_local_user.totp_2fa_secret,
-        totp_2fa_url: inserted_sara_local_user.totp_2fa_url,
-        password_encrypted: inserted_sara_local_user.password_encrypted,
-        open_links_in_new_tab: inserted_sara_local_user.open_links_in_new_tab,
-        infinite_scroll_enabled: inserted_sara_local_user.infinite_scroll_enabled,
-        admin: false,
-        post_listing_mode: inserted_sara_local_user.post_listing_mode,
-      },
-      creator: Person {
-        id: inserted_sara_person.id,
-        name: inserted_sara_person.name.clone(),
-        display_name: None,
-        published: inserted_sara_person.published,
-        avatar: None,
-        actor_id: inserted_sara_person.actor_id.clone(),
-        local: true,
-        banned: false,
-        ban_expires: None,
-        deleted: false,
-        bot_account: false,
-        bio: None,
-        banner: None,
-        updated: None,
-        inbox_url: inserted_sara_person.inbox_url.clone(),
-        shared_inbox_url: None,
-        matrix_user_id: None,
-        instance_id: inserted_instance.id,
-        private_key: inserted_sara_person.private_key,
-        public_key: inserted_sara_person.public_key,
-        last_refreshed_at: inserted_sara_person.last_refreshed_at,
-      },
-      admin: None,
-    };
+        let timmy_person_form = PersonInsertForm::builder()
+            .name("timmy_rav".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
 
-    assert_eq!(read_sara_app_view, expected_sara_app_view);
+        let inserted_timmy_person = Person::create(pool, &timmy_person_form).await.unwrap();
 
-    // Do a batch read of the applications
-    let apps = RegistrationApplicationQuery {
-      unread_only: (true),
-      ..Default::default()
+        let timmy_local_user_form = LocalUserInsertForm::builder()
+            .person_id(inserted_timmy_person.id)
+            .password_encrypted("nada".to_string())
+            .admin(Some(true))
+            .build();
+
+        let _inserted_timmy_local_user = LocalUser::create(pool, &timmy_local_user_form)
+            .await
+            .unwrap();
+
+        let sara_person_form = PersonInsertForm::builder()
+            .name("sara_rav".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
+
+        let inserted_sara_person = Person::create(pool, &sara_person_form).await.unwrap();
+
+        let sara_local_user_form = LocalUserInsertForm::builder()
+            .person_id(inserted_sara_person.id)
+            .password_encrypted("nada".to_string())
+            .build();
+
+        let inserted_sara_local_user = LocalUser::create(pool, &sara_local_user_form)
+            .await
+            .unwrap();
+
+        // Sara creates an application
+        let sara_app_form = RegistrationApplicationInsertForm {
+            local_user_id: inserted_sara_local_user.id,
+            answer: "LET ME IIIIINN".to_string(),
+        };
+
+        let sara_app = RegistrationApplication::create(pool, &sara_app_form)
+            .await
+            .unwrap();
+
+        let read_sara_app_view = RegistrationApplicationView::read(pool, sara_app.id)
+            .await
+            .unwrap();
+
+        let jess_person_form = PersonInsertForm::builder()
+            .name("jess_rav".into())
+            .public_key("pubkey".to_string())
+            .instance_id(inserted_instance.id)
+            .build();
+
+        let inserted_jess_person = Person::create(pool, &jess_person_form).await.unwrap();
+
+        let jess_local_user_form = LocalUserInsertForm::builder()
+            .person_id(inserted_jess_person.id)
+            .password_encrypted("nada".to_string())
+            .build();
+
+        let inserted_jess_local_user = LocalUser::create(pool, &jess_local_user_form)
+            .await
+            .unwrap();
+
+        // Sara creates an application
+        let jess_app_form = RegistrationApplicationInsertForm {
+            local_user_id: inserted_jess_local_user.id,
+            answer: "LET ME IIIIINN".to_string(),
+        };
+
+        let jess_app = RegistrationApplication::create(pool, &jess_app_form)
+            .await
+            .unwrap();
+
+        let read_jess_app_view = RegistrationApplicationView::read(pool, jess_app.id)
+            .await
+            .unwrap();
+
+        let mut expected_sara_app_view = RegistrationApplicationView {
+            registration_application: sara_app.clone(),
+            creator_local_user: LocalUser {
+                id: inserted_sara_local_user.id,
+                person_id: inserted_sara_local_user.person_id,
+                email: inserted_sara_local_user.email,
+                show_nsfw: inserted_sara_local_user.show_nsfw,
+                auto_expand: inserted_sara_local_user.auto_expand,
+                blur_nsfw: inserted_sara_local_user.blur_nsfw,
+                theme: inserted_sara_local_user.theme,
+                default_sort_type: inserted_sara_local_user.default_sort_type,
+                default_listing_type: inserted_sara_local_user.default_listing_type,
+                interface_language: inserted_sara_local_user.interface_language,
+                show_avatars: inserted_sara_local_user.show_avatars,
+                send_notifications_to_email: inserted_sara_local_user.send_notifications_to_email,
+                validator_time: inserted_sara_local_user.validator_time,
+                show_bot_accounts: inserted_sara_local_user.show_bot_accounts,
+                show_scores: inserted_sara_local_user.show_scores,
+                show_read_posts: inserted_sara_local_user.show_read_posts,
+                show_new_post_notifs: inserted_sara_local_user.show_new_post_notifs,
+                email_verified: inserted_sara_local_user.email_verified,
+                accepted_application: inserted_sara_local_user.accepted_application,
+                totp_2fa_secret: inserted_sara_local_user.totp_2fa_secret,
+                totp_2fa_url: inserted_sara_local_user.totp_2fa_url,
+                password_encrypted: inserted_sara_local_user.password_encrypted,
+                open_links_in_new_tab: inserted_sara_local_user.open_links_in_new_tab,
+                infinite_scroll_enabled: inserted_sara_local_user.infinite_scroll_enabled,
+                admin: false,
+                post_listing_mode: inserted_sara_local_user.post_listing_mode,
+            },
+            creator: Person {
+                id: inserted_sara_person.id,
+                name: inserted_sara_person.name.clone(),
+                display_name: None,
+                published: inserted_sara_person.published,
+                avatar: None,
+                actor_id: inserted_sara_person.actor_id.clone(),
+                local: true,
+                banned: false,
+                ban_expires: None,
+                deleted: false,
+                bot_account: false,
+                bio: None,
+                banner: None,
+                updated: None,
+                inbox_url: inserted_sara_person.inbox_url.clone(),
+                shared_inbox_url: None,
+                matrix_user_id: None,
+                instance_id: inserted_instance.id,
+                private_key: inserted_sara_person.private_key,
+                public_key: inserted_sara_person.public_key,
+                last_refreshed_at: inserted_sara_person.last_refreshed_at,
+            },
+            admin: None,
+        };
+
+        assert_eq!(read_sara_app_view, expected_sara_app_view);
+
+        // Do a batch read of the applications
+        let apps = RegistrationApplicationQuery {
+            unread_only: (true),
+            ..Default::default()
+        }
+        .list(pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            apps,
+            [read_jess_app_view.clone(), expected_sara_app_view.clone()]
+        );
+
+        // Make sure the counts are correct
+        let unread_count = RegistrationApplicationView::get_unread_count(pool, false)
+            .await
+            .unwrap();
+        assert_eq!(unread_count, 2);
+
+        // Approve the application
+        let approve_form = RegistrationApplicationUpdateForm {
+            admin_id: Some(Some(inserted_timmy_person.id)),
+            deny_reason: None,
+        };
+
+        RegistrationApplication::update(pool, sara_app.id, &approve_form)
+            .await
+            .unwrap();
+
+        // Update the local_user row
+        let approve_local_user_form = LocalUserUpdateForm {
+            accepted_application: Some(true),
+            ..Default::default()
+        };
+
+        LocalUser::update(pool, inserted_sara_local_user.id, &approve_local_user_form)
+            .await
+            .unwrap();
+
+        let read_sara_app_view_after_approve = RegistrationApplicationView::read(pool, sara_app.id)
+            .await
+            .unwrap();
+
+        // Make sure the columns changed
+        expected_sara_app_view
+            .creator_local_user
+            .accepted_application = true;
+        expected_sara_app_view.registration_application.admin_id = Some(inserted_timmy_person.id);
+
+        expected_sara_app_view.admin = Some(Person {
+            id: inserted_timmy_person.id,
+            name: inserted_timmy_person.name.clone(),
+            display_name: None,
+            published: inserted_timmy_person.published,
+            avatar: None,
+            actor_id: inserted_timmy_person.actor_id.clone(),
+            local: true,
+            banned: false,
+            ban_expires: None,
+            deleted: false,
+            bot_account: false,
+            bio: None,
+            banner: None,
+            updated: None,
+            inbox_url: inserted_timmy_person.inbox_url.clone(),
+            shared_inbox_url: None,
+            matrix_user_id: None,
+            instance_id: inserted_instance.id,
+            private_key: inserted_timmy_person.private_key,
+            public_key: inserted_timmy_person.public_key,
+            last_refreshed_at: inserted_timmy_person.last_refreshed_at,
+        });
+        assert_eq!(read_sara_app_view_after_approve, expected_sara_app_view);
+
+        // Do a batch read of apps again
+        // It should show only jessicas which is unresolved
+        let apps_after_resolve = RegistrationApplicationQuery {
+            unread_only: (true),
+            ..Default::default()
+        }
+        .list(pool)
+        .await
+        .unwrap();
+        assert_eq!(apps_after_resolve, vec![read_jess_app_view]);
+
+        // Make sure the counts are correct
+        let unread_count_after_approve = RegistrationApplicationView::get_unread_count(pool, false)
+            .await
+            .unwrap();
+        assert_eq!(unread_count_after_approve, 1);
+
+        // Make sure the not undenied_only has all the apps
+        let all_apps = RegistrationApplicationQuery::default()
+            .list(pool)
+            .await
+            .unwrap();
+        assert_eq!(all_apps.len(), 2);
+
+        Person::delete(pool, inserted_timmy_person.id)
+            .await
+            .unwrap();
+        Person::delete(pool, inserted_sara_person.id).await.unwrap();
+        Person::delete(pool, inserted_jess_person.id).await.unwrap();
+        Instance::delete(pool, inserted_instance.id).await.unwrap();
     }
-    .list(pool)
-    .await
-    .unwrap();
-
-    assert_eq!(
-      apps,
-      [read_jess_app_view.clone(), expected_sara_app_view.clone()]
-    );
-
-    // Make sure the counts are correct
-    let unread_count = RegistrationApplicationView::get_unread_count(pool, false)
-      .await
-      .unwrap();
-    assert_eq!(unread_count, 2);
-
-    // Approve the application
-    let approve_form = RegistrationApplicationUpdateForm {
-      admin_id: Some(Some(inserted_timmy_person.id)),
-      deny_reason: None,
-    };
-
-    RegistrationApplication::update(pool, sara_app.id, &approve_form)
-      .await
-      .unwrap();
-
-    // Update the local_user row
-    let approve_local_user_form = LocalUserUpdateForm {
-      accepted_application: Some(true),
-      ..Default::default()
-    };
-
-    LocalUser::update(pool, inserted_sara_local_user.id, &approve_local_user_form)
-      .await
-      .unwrap();
-
-    let read_sara_app_view_after_approve = RegistrationApplicationView::read(pool, sara_app.id)
-      .await
-      .unwrap();
-
-    // Make sure the columns changed
-    expected_sara_app_view
-      .creator_local_user
-      .accepted_application = true;
-    expected_sara_app_view.registration_application.admin_id = Some(inserted_timmy_person.id);
-
-    expected_sara_app_view.admin = Some(Person {
-      id: inserted_timmy_person.id,
-      name: inserted_timmy_person.name.clone(),
-      display_name: None,
-      published: inserted_timmy_person.published,
-      avatar: None,
-      actor_id: inserted_timmy_person.actor_id.clone(),
-      local: true,
-      banned: false,
-      ban_expires: None,
-      deleted: false,
-      bot_account: false,
-      bio: None,
-      banner: None,
-      updated: None,
-      inbox_url: inserted_timmy_person.inbox_url.clone(),
-      shared_inbox_url: None,
-      matrix_user_id: None,
-      instance_id: inserted_instance.id,
-      private_key: inserted_timmy_person.private_key,
-      public_key: inserted_timmy_person.public_key,
-      last_refreshed_at: inserted_timmy_person.last_refreshed_at,
-    });
-    assert_eq!(read_sara_app_view_after_approve, expected_sara_app_view);
-
-    // Do a batch read of apps again
-    // It should show only jessicas which is unresolved
-    let apps_after_resolve = RegistrationApplicationQuery {
-      unread_only: (true),
-      ..Default::default()
-    }
-    .list(pool)
-    .await
-    .unwrap();
-    assert_eq!(apps_after_resolve, vec![read_jess_app_view]);
-
-    // Make sure the counts are correct
-    let unread_count_after_approve = RegistrationApplicationView::get_unread_count(pool, false)
-      .await
-      .unwrap();
-    assert_eq!(unread_count_after_approve, 1);
-
-    // Make sure the not undenied_only has all the apps
-    let all_apps = RegistrationApplicationQuery::default()
-      .list(pool)
-      .await
-      .unwrap();
-    assert_eq!(all_apps.len(), 2);
-
-    Person::delete(pool, inserted_timmy_person.id)
-      .await
-      .unwrap();
-    Person::delete(pool, inserted_sara_person.id).await.unwrap();
-    Person::delete(pool, inserted_jess_person.id).await.unwrap();
-    Instance::delete(pool, inserted_instance.id).await.unwrap();
-  }
 }

--- a/crates/db_views/src/site_view.rs
+++ b/crates/db_views/src/site_view.rs
@@ -2,29 +2,30 @@ use crate::structs::SiteView;
 use diesel::{result::Error, ExpressionMethods, JoinOnDsl, QueryDsl};
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  schema::{local_site, local_site_rate_limit, site, site_aggregates},
-  utils::{get_conn, DbPool},
+    schema::{local_site, local_site_rate_limit, site, site_aggregates},
+    utils::{get_conn, DbPool},
 };
 
 impl SiteView {
-  pub async fn read_local(pool: &mut DbPool<'_>) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let mut res = site::table
-      .inner_join(local_site::table)
-      .inner_join(
-        local_site_rate_limit::table.on(local_site::id.eq(local_site_rate_limit::local_site_id)),
-      )
-      .inner_join(site_aggregates::table)
-      .select((
-        site::all_columns,
-        local_site::all_columns,
-        local_site_rate_limit::all_columns,
-        site_aggregates::all_columns,
-      ))
-      .first::<SiteView>(conn)
-      .await?;
+    pub async fn read_local(pool: &mut DbPool<'_>) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let mut res = site::table
+            .inner_join(local_site::table)
+            .inner_join(
+                local_site_rate_limit::table
+                    .on(local_site::id.eq(local_site_rate_limit::local_site_id)),
+            )
+            .inner_join(site_aggregates::table)
+            .select((
+                site::all_columns,
+                local_site::all_columns,
+                local_site_rate_limit::all_columns,
+                site_aggregates::all_columns,
+            ))
+            .first::<SiteView>(conn)
+            .await?;
 
-    res.site.private_key = None;
-    Ok(res)
-  }
+        res.site.private_key = None;
+        Ok(res)
+    }
 }

--- a/crates/db_views/src/structs.rs
+++ b/crates/db_views/src/structs.rs
@@ -1,25 +1,16 @@
 #[cfg(feature = "full")]
 use diesel::Queryable;
 use lemmy_db_schema::{
-  aggregates::structs::{CommentAggregates, PersonAggregates, PostAggregates, SiteAggregates},
-  source::{
-    comment::Comment,
-    comment_report::CommentReport,
-    community::Community,
-    custom_emoji::CustomEmoji,
-    custom_emoji_keyword::CustomEmojiKeyword,
-    local_site::LocalSite,
-    local_site_rate_limit::LocalSiteRateLimit,
-    local_user::LocalUser,
-    person::Person,
-    post::Post,
-    post_report::PostReport,
-    private_message::PrivateMessage,
-    private_message_report::PrivateMessageReport,
-    registration_application::RegistrationApplication,
-    site::Site,
-  },
-  SubscribedType,
+    aggregates::structs::{CommentAggregates, PersonAggregates, PostAggregates, SiteAggregates},
+    source::{
+        comment::Comment, comment_report::CommentReport, community::Community,
+        custom_emoji::CustomEmoji, custom_emoji_keyword::CustomEmojiKeyword, local_site::LocalSite,
+        local_site_rate_limit::LocalSiteRateLimit, local_user::LocalUser, person::Person,
+        post::Post, post_report::PostReport, private_message::PrivateMessage,
+        private_message_report::PrivateMessageReport,
+        registration_application::RegistrationApplication, site::Site,
+    },
+    SubscribedType,
 };
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -32,16 +23,16 @@ use ts_rs::TS;
 #[cfg_attr(feature = "full", ts(export))]
 /// A comment report view.
 pub struct CommentReportView {
-  pub comment_report: CommentReport,
-  pub comment: Comment,
-  pub post: Post,
-  pub community: Community,
-  pub creator: Person,
-  pub comment_creator: Person,
-  pub counts: CommentAggregates,
-  pub creator_banned_from_community: bool,
-  pub my_vote: Option<i16>,
-  pub resolver: Option<Person>,
+    pub comment_report: CommentReport,
+    pub comment: Comment,
+    pub post: Post,
+    pub community: Community,
+    pub creator: Person,
+    pub comment_creator: Person,
+    pub counts: CommentAggregates,
+    pub creator_banned_from_community: bool,
+    pub my_vote: Option<i16>,
+    pub resolver: Option<Person>,
 }
 
 #[skip_serializing_none]
@@ -50,16 +41,16 @@ pub struct CommentReportView {
 #[cfg_attr(feature = "full", ts(export))]
 /// A comment view.
 pub struct CommentView {
-  pub comment: Comment,
-  pub creator: Person,
-  pub post: Post,
-  pub community: Community,
-  pub counts: CommentAggregates,
-  pub creator_banned_from_community: bool,
-  pub subscribed: SubscribedType,
-  pub saved: bool,
-  pub creator_blocked: bool,
-  pub my_vote: Option<i16>,
+    pub comment: Comment,
+    pub creator: Person,
+    pub post: Post,
+    pub community: Community,
+    pub counts: CommentAggregates,
+    pub creator_banned_from_community: bool,
+    pub subscribed: SubscribedType,
+    pub saved: bool,
+    pub creator_blocked: bool,
+    pub my_vote: Option<i16>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -67,9 +58,9 @@ pub struct CommentView {
 #[cfg_attr(feature = "full", ts(export))]
 /// A local user view.
 pub struct LocalUserView {
-  pub local_user: LocalUser,
-  pub person: Person,
-  pub counts: PersonAggregates,
+    pub local_user: LocalUser,
+    pub person: Person,
+    pub counts: PersonAggregates,
 }
 
 #[skip_serializing_none]
@@ -78,15 +69,15 @@ pub struct LocalUserView {
 #[cfg_attr(feature = "full", ts(export))]
 /// A post report view.
 pub struct PostReportView {
-  pub post_report: PostReport,
-  pub post: Post,
-  pub community: Community,
-  pub creator: Person,
-  pub post_creator: Person,
-  pub creator_banned_from_community: bool,
-  pub my_vote: Option<i16>,
-  pub counts: PostAggregates,
-  pub resolver: Option<Person>,
+    pub post_report: PostReport,
+    pub post: Post,
+    pub community: Community,
+    pub creator: Person,
+    pub post_creator: Person,
+    pub creator_banned_from_community: bool,
+    pub my_vote: Option<i16>,
+    pub counts: PostAggregates,
+    pub resolver: Option<Person>,
 }
 
 #[skip_serializing_none]
@@ -95,17 +86,17 @@ pub struct PostReportView {
 #[cfg_attr(feature = "full", ts(export))]
 /// A post view.
 pub struct PostView {
-  pub post: Post,
-  pub creator: Person,
-  pub community: Community,
-  pub creator_banned_from_community: bool,
-  pub counts: PostAggregates,
-  pub subscribed: SubscribedType,
-  pub saved: bool,
-  pub read: bool,
-  pub creator_blocked: bool,
-  pub my_vote: Option<i16>,
-  pub unread_comments: i64,
+    pub post: Post,
+    pub creator: Person,
+    pub community: Community,
+    pub creator_banned_from_community: bool,
+    pub counts: PostAggregates,
+    pub subscribed: SubscribedType,
+    pub saved: bool,
+    pub read: bool,
+    pub creator_blocked: bool,
+    pub my_vote: Option<i16>,
+    pub unread_comments: i64,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
@@ -113,9 +104,9 @@ pub struct PostView {
 #[cfg_attr(feature = "full", ts(export))]
 /// A private message view.
 pub struct PrivateMessageView {
-  pub private_message: PrivateMessage,
-  pub creator: Person,
-  pub recipient: Person,
+    pub private_message: PrivateMessage,
+    pub creator: Person,
+    pub recipient: Person,
 }
 
 #[skip_serializing_none]
@@ -124,11 +115,11 @@ pub struct PrivateMessageView {
 #[cfg_attr(feature = "full", ts(export))]
 /// A private message report view.
 pub struct PrivateMessageReportView {
-  pub private_message_report: PrivateMessageReport,
-  pub private_message: PrivateMessage,
-  pub private_message_creator: Person,
-  pub creator: Person,
-  pub resolver: Option<Person>,
+    pub private_message_report: PrivateMessageReport,
+    pub private_message: PrivateMessage,
+    pub private_message_creator: Person,
+    pub creator: Person,
+    pub resolver: Option<Person>,
 }
 
 #[skip_serializing_none]
@@ -137,10 +128,10 @@ pub struct PrivateMessageReportView {
 #[cfg_attr(feature = "full", ts(export))]
 /// A registration application view.
 pub struct RegistrationApplicationView {
-  pub registration_application: RegistrationApplication,
-  pub creator_local_user: LocalUser,
-  pub creator: Person,
-  pub admin: Option<Person>,
+    pub registration_application: RegistrationApplication,
+    pub creator_local_user: LocalUser,
+    pub creator: Person,
+    pub admin: Option<Person>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -148,10 +139,10 @@ pub struct RegistrationApplicationView {
 #[cfg_attr(feature = "full", ts(export))]
 /// A site view.
 pub struct SiteView {
-  pub site: Site,
-  pub local_site: LocalSite,
-  pub local_site_rate_limit: LocalSiteRateLimit,
-  pub counts: SiteAggregates,
+    pub site: Site,
+    pub local_site: LocalSite,
+    pub local_site_rate_limit: LocalSiteRateLimit,
+    pub counts: SiteAggregates,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -159,6 +150,6 @@ pub struct SiteView {
 #[cfg_attr(feature = "full", ts(export))]
 /// A custom emoji view.
 pub struct CustomEmojiView {
-  pub custom_emoji: CustomEmoji,
-  pub keywords: Vec<CustomEmojiKeyword>,
+    pub custom_emoji: CustomEmoji,
+    pub keywords: Vec<CustomEmojiKeyword>,
 }

--- a/crates/db_views_actor/src/comment_reply_view.rs
+++ b/crates/db_views_actor/src/comment_reply_view.rs
@@ -1,192 +1,170 @@
 use crate::structs::CommentReplyView;
 use diesel::{
-  pg::Pg,
-  result::Error,
-  BoolExpressionMethods,
-  ExpressionMethods,
-  JoinOnDsl,
-  NullableExpressionMethods,
-  QueryDsl,
+    pg::Pg, result::Error, BoolExpressionMethods, ExpressionMethods, JoinOnDsl,
+    NullableExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  aliases,
-  newtypes::{CommentReplyId, PersonId},
-  schema::{
-    comment,
-    comment_aggregates,
-    comment_like,
-    comment_reply,
-    comment_saved,
-    community,
-    community_follower,
-    community_person_ban,
-    person,
-    person_block,
-    post,
-  },
-  source::community::CommunityFollower,
-  utils::{get_conn, limit_and_offset, DbConn, DbPool, ListFn, Queries, ReadFn},
-  CommentSortType,
+    aliases,
+    newtypes::{CommentReplyId, PersonId},
+    schema::{
+        comment, comment_aggregates, comment_like, comment_reply, comment_saved, community,
+        community_follower, community_person_ban, person, person_block, post,
+    },
+    source::community::CommunityFollower,
+    utils::{get_conn, limit_and_offset, DbConn, DbPool, ListFn, Queries, ReadFn},
+    CommentSortType,
 };
 
 fn queries<'a>() -> Queries<
-  impl ReadFn<'a, CommentReplyView, (CommentReplyId, Option<PersonId>)>,
-  impl ListFn<'a, CommentReplyView, CommentReplyQuery>,
+    impl ReadFn<'a, CommentReplyView, (CommentReplyId, Option<PersonId>)>,
+    impl ListFn<'a, CommentReplyView, CommentReplyQuery>,
 > {
-  let all_joins = |query: comment_reply::BoxedQuery<'a, Pg>, my_person_id: Option<PersonId>| {
-    // The left join below will return None in this case
-    let person_id_join = my_person_id.unwrap_or(PersonId(-1));
+    let all_joins = |query: comment_reply::BoxedQuery<'a, Pg>, my_person_id: Option<PersonId>| {
+        // The left join below will return None in this case
+        let person_id_join = my_person_id.unwrap_or(PersonId(-1));
 
-    query
-      .inner_join(comment::table)
-      .inner_join(person::table.on(comment::creator_id.eq(person::id)))
-      .inner_join(post::table.on(comment::post_id.eq(post::id)))
-      .inner_join(community::table.on(post::community_id.eq(community::id)))
-      .inner_join(aliases::person1)
-      .inner_join(comment_aggregates::table.on(comment::id.eq(comment_aggregates::comment_id)))
-      .left_join(
-        community_person_ban::table.on(
-          community::id
-            .eq(community_person_ban::community_id)
-            .and(community_person_ban::person_id.eq(comment::creator_id)),
-        ),
-      )
-      .left_join(
-        community_follower::table.on(
-          post::community_id
-            .eq(community_follower::community_id)
-            .and(community_follower::person_id.eq(person_id_join)),
-        ),
-      )
-      .left_join(
-        comment_saved::table.on(
-          comment::id
-            .eq(comment_saved::comment_id)
-            .and(comment_saved::person_id.eq(person_id_join)),
-        ),
-      )
-      .left_join(
-        person_block::table.on(
-          comment::creator_id
-            .eq(person_block::target_id)
-            .and(person_block::person_id.eq(person_id_join)),
-        ),
-      )
-      .left_join(
-        comment_like::table.on(
-          comment::id
-            .eq(comment_like::comment_id)
-            .and(comment_like::person_id.eq(person_id_join)),
-        ),
-      )
-      .select((
-        comment_reply::all_columns,
-        comment::all_columns,
-        person::all_columns,
-        post::all_columns,
-        community::all_columns,
-        aliases::person1.fields(person::all_columns),
-        comment_aggregates::all_columns,
-        community_person_ban::id.nullable().is_not_null(),
-        CommunityFollower::select_subscribed_type(),
-        comment_saved::id.nullable().is_not_null(),
-        person_block::id.nullable().is_not_null(),
-        comment_like::score.nullable(),
-      ))
-  };
-
-  let read =
-    move |mut conn: DbConn<'a>,
-          (comment_reply_id, my_person_id): (CommentReplyId, Option<PersonId>)| async move {
-      all_joins(
-        comment_reply::table.find(comment_reply_id).into_boxed(),
-        my_person_id,
-      )
-      .first::<CommentReplyView>(&mut conn)
-      .await
+        query
+            .inner_join(comment::table)
+            .inner_join(person::table.on(comment::creator_id.eq(person::id)))
+            .inner_join(post::table.on(comment::post_id.eq(post::id)))
+            .inner_join(community::table.on(post::community_id.eq(community::id)))
+            .inner_join(aliases::person1)
+            .inner_join(
+                comment_aggregates::table.on(comment::id.eq(comment_aggregates::comment_id)),
+            )
+            .left_join(
+                community_person_ban::table.on(community::id
+                    .eq(community_person_ban::community_id)
+                    .and(community_person_ban::person_id.eq(comment::creator_id))),
+            )
+            .left_join(
+                community_follower::table.on(post::community_id
+                    .eq(community_follower::community_id)
+                    .and(community_follower::person_id.eq(person_id_join))),
+            )
+            .left_join(
+                comment_saved::table.on(comment::id
+                    .eq(comment_saved::comment_id)
+                    .and(comment_saved::person_id.eq(person_id_join))),
+            )
+            .left_join(
+                person_block::table.on(comment::creator_id
+                    .eq(person_block::target_id)
+                    .and(person_block::person_id.eq(person_id_join))),
+            )
+            .left_join(
+                comment_like::table.on(comment::id
+                    .eq(comment_like::comment_id)
+                    .and(comment_like::person_id.eq(person_id_join))),
+            )
+            .select((
+                comment_reply::all_columns,
+                comment::all_columns,
+                person::all_columns,
+                post::all_columns,
+                community::all_columns,
+                aliases::person1.fields(person::all_columns),
+                comment_aggregates::all_columns,
+                community_person_ban::id.nullable().is_not_null(),
+                CommunityFollower::select_subscribed_type(),
+                comment_saved::id.nullable().is_not_null(),
+                person_block::id.nullable().is_not_null(),
+                comment_like::score.nullable(),
+            ))
     };
 
-  let list = move |mut conn: DbConn<'a>, options: CommentReplyQuery| async move {
-    let mut query = all_joins(comment_reply::table.into_boxed(), options.my_person_id);
+    let read =
+        move |mut conn: DbConn<'a>,
+              (comment_reply_id, my_person_id): (CommentReplyId, Option<PersonId>)| async move {
+            all_joins(
+                comment_reply::table.find(comment_reply_id).into_boxed(),
+                my_person_id,
+            )
+            .first::<CommentReplyView>(&mut conn)
+            .await
+        };
 
-    if let Some(recipient_id) = options.recipient_id {
-      query = query.filter(comment_reply::recipient_id.eq(recipient_id));
-    }
+    let list = move |mut conn: DbConn<'a>, options: CommentReplyQuery| async move {
+        let mut query = all_joins(comment_reply::table.into_boxed(), options.my_person_id);
 
-    if options.unread_only {
-      query = query.filter(comment_reply::read.eq(false));
-    }
+        if let Some(recipient_id) = options.recipient_id {
+            query = query.filter(comment_reply::recipient_id.eq(recipient_id));
+        }
 
-    if !options.show_bot_accounts {
-      query = query.filter(person::bot_account.eq(false));
+        if options.unread_only {
+            query = query.filter(comment_reply::read.eq(false));
+        }
+
+        if !options.show_bot_accounts {
+            query = query.filter(person::bot_account.eq(false));
+        };
+
+        query = match options.sort.unwrap_or(CommentSortType::New) {
+            CommentSortType::Hot => query.then_order_by(comment_aggregates::hot_rank.desc()),
+            CommentSortType::Controversial => {
+                query.then_order_by(comment_aggregates::controversy_rank.desc())
+            }
+            CommentSortType::New => query.then_order_by(comment_reply::published.desc()),
+            CommentSortType::Old => query.then_order_by(comment_reply::published.asc()),
+            CommentSortType::Top => query.order_by(comment_aggregates::score.desc()),
+        };
+
+        let (limit, offset) = limit_and_offset(options.page, options.limit)?;
+
+        query
+            .limit(limit)
+            .offset(offset)
+            .load::<CommentReplyView>(&mut conn)
+            .await
     };
 
-    query = match options.sort.unwrap_or(CommentSortType::New) {
-      CommentSortType::Hot => query.then_order_by(comment_aggregates::hot_rank.desc()),
-      CommentSortType::Controversial => {
-        query.then_order_by(comment_aggregates::controversy_rank.desc())
-      }
-      CommentSortType::New => query.then_order_by(comment_reply::published.desc()),
-      CommentSortType::Old => query.then_order_by(comment_reply::published.asc()),
-      CommentSortType::Top => query.order_by(comment_aggregates::score.desc()),
-    };
-
-    let (limit, offset) = limit_and_offset(options.page, options.limit)?;
-
-    query
-      .limit(limit)
-      .offset(offset)
-      .load::<CommentReplyView>(&mut conn)
-      .await
-  };
-
-  Queries::new(read, list)
+    Queries::new(read, list)
 }
 
 impl CommentReplyView {
-  pub async fn read(
-    pool: &mut DbPool<'_>,
-    comment_reply_id: CommentReplyId,
-    my_person_id: Option<PersonId>,
-  ) -> Result<Self, Error> {
-    queries().read(pool, (comment_reply_id, my_person_id)).await
-  }
+    pub async fn read(
+        pool: &mut DbPool<'_>,
+        comment_reply_id: CommentReplyId,
+        my_person_id: Option<PersonId>,
+    ) -> Result<Self, Error> {
+        queries().read(pool, (comment_reply_id, my_person_id)).await
+    }
 
-  /// Gets the number of unread replies
-  pub async fn get_unread_replies(
-    pool: &mut DbPool<'_>,
-    my_person_id: PersonId,
-  ) -> Result<i64, Error> {
-    use diesel::dsl::count;
+    /// Gets the number of unread replies
+    pub async fn get_unread_replies(
+        pool: &mut DbPool<'_>,
+        my_person_id: PersonId,
+    ) -> Result<i64, Error> {
+        use diesel::dsl::count;
 
-    let conn = &mut get_conn(pool).await?;
+        let conn = &mut get_conn(pool).await?;
 
-    comment_reply::table
-      .inner_join(comment::table)
-      .filter(comment_reply::recipient_id.eq(my_person_id))
-      .filter(comment_reply::read.eq(false))
-      .filter(comment::deleted.eq(false))
-      .filter(comment::removed.eq(false))
-      .select(count(comment_reply::id))
-      .first::<i64>(conn)
-      .await
-  }
+        comment_reply::table
+            .inner_join(comment::table)
+            .filter(comment_reply::recipient_id.eq(my_person_id))
+            .filter(comment_reply::read.eq(false))
+            .filter(comment::deleted.eq(false))
+            .filter(comment::removed.eq(false))
+            .select(count(comment_reply::id))
+            .first::<i64>(conn)
+            .await
+    }
 }
 
 #[derive(Default)]
 pub struct CommentReplyQuery {
-  pub my_person_id: Option<PersonId>,
-  pub recipient_id: Option<PersonId>,
-  pub sort: Option<CommentSortType>,
-  pub unread_only: bool,
-  pub show_bot_accounts: bool,
-  pub page: Option<i64>,
-  pub limit: Option<i64>,
+    pub my_person_id: Option<PersonId>,
+    pub recipient_id: Option<PersonId>,
+    pub sort: Option<CommentSortType>,
+    pub unread_only: bool,
+    pub show_bot_accounts: bool,
+    pub page: Option<i64>,
+    pub limit: Option<i64>,
 }
 
 impl CommentReplyQuery {
-  pub async fn list(self, pool: &mut DbPool<'_>) -> Result<Vec<CommentReplyView>, Error> {
-    queries().list(pool, self).await
-  }
+    pub async fn list(self, pool: &mut DbPool<'_>) -> Result<Vec<CommentReplyView>, Error> {
+        queries().list(pool, self).await
+    }
 }

--- a/crates/db_views_actor/src/community_block_view.rs
+++ b/crates/db_views_actor/src/community_block_view.rs
@@ -2,23 +2,26 @@ use crate::structs::CommunityBlockView;
 use diesel::{result::Error, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  newtypes::PersonId,
-  schema::{community, community_block, person},
-  utils::{get_conn, DbPool},
+    newtypes::PersonId,
+    schema::{community, community_block, person},
+    utils::{get_conn, DbPool},
 };
 
 impl CommunityBlockView {
-  pub async fn for_person(pool: &mut DbPool<'_>, person_id: PersonId) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    community_block::table
-      .inner_join(person::table)
-      .inner_join(community::table)
-      .select((person::all_columns, community::all_columns))
-      .filter(community_block::person_id.eq(person_id))
-      .filter(community::deleted.eq(false))
-      .filter(community::removed.eq(false))
-      .order_by(community_block::published)
-      .load::<CommunityBlockView>(conn)
-      .await
-  }
+    pub async fn for_person(
+        pool: &mut DbPool<'_>,
+        person_id: PersonId,
+    ) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        community_block::table
+            .inner_join(person::table)
+            .inner_join(community::table)
+            .select((person::all_columns, community::all_columns))
+            .filter(community_block::person_id.eq(person_id))
+            .filter(community::deleted.eq(false))
+            .filter(community::removed.eq(false))
+            .order_by(community_block::published)
+            .load::<CommunityBlockView>(conn)
+            .await
+    }
 }

--- a/crates/db_views_actor/src/community_follower_view.rs
+++ b/crates/db_views_actor/src/community_follower_view.rs
@@ -1,62 +1,63 @@
 use crate::structs::CommunityFollowerView;
 use diesel::{
-  dsl::{count_star, not},
-  result::Error,
-  sql_function,
-  ExpressionMethods,
-  QueryDsl,
+    dsl::{count_star, not},
+    result::Error,
+    sql_function, ExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  newtypes::{CommunityId, DbUrl, PersonId},
-  schema::{community, community_follower, person},
-  utils::{get_conn, DbPool},
+    newtypes::{CommunityId, DbUrl, PersonId},
+    schema::{community, community_follower, person},
+    utils::{get_conn, DbPool},
 };
 
 sql_function!(fn coalesce(x: diesel::sql_types::Nullable<diesel::sql_types::Text>, y: diesel::sql_types::Text) -> diesel::sql_types::Text);
 
 impl CommunityFollowerView {
-  pub async fn get_community_follower_inboxes(
-    pool: &mut DbPool<'_>,
-    community_id: CommunityId,
-  ) -> Result<Vec<DbUrl>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let res = community_follower::table
-      .filter(community_follower::community_id.eq(community_id))
-      .filter(not(person::local))
-      .inner_join(person::table)
-      .select(coalesce(person::shared_inbox_url, person::inbox_url))
-      .distinct()
-      .load::<DbUrl>(conn)
-      .await?;
+    pub async fn get_community_follower_inboxes(
+        pool: &mut DbPool<'_>,
+        community_id: CommunityId,
+    ) -> Result<Vec<DbUrl>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let res = community_follower::table
+            .filter(community_follower::community_id.eq(community_id))
+            .filter(not(person::local))
+            .inner_join(person::table)
+            .select(coalesce(person::shared_inbox_url, person::inbox_url))
+            .distinct()
+            .load::<DbUrl>(conn)
+            .await?;
 
-    Ok(res)
-  }
-  pub async fn count_community_followers(
-    pool: &mut DbPool<'_>,
-    community_id: CommunityId,
-  ) -> Result<i64, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let res = community_follower::table
-      .filter(community_follower::community_id.eq(community_id))
-      .select(count_star())
-      .first::<i64>(conn)
-      .await?;
+        Ok(res)
+    }
+    pub async fn count_community_followers(
+        pool: &mut DbPool<'_>,
+        community_id: CommunityId,
+    ) -> Result<i64, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let res = community_follower::table
+            .filter(community_follower::community_id.eq(community_id))
+            .select(count_star())
+            .first::<i64>(conn)
+            .await?;
 
-    Ok(res)
-  }
+        Ok(res)
+    }
 
-  pub async fn for_person(pool: &mut DbPool<'_>, person_id: PersonId) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    community_follower::table
-      .inner_join(community::table)
-      .inner_join(person::table)
-      .select((community::all_columns, person::all_columns))
-      .filter(community_follower::person_id.eq(person_id))
-      .filter(community::deleted.eq(false))
-      .filter(community::removed.eq(false))
-      .order_by(community::title)
-      .load::<CommunityFollowerView>(conn)
-      .await
-  }
+    pub async fn for_person(
+        pool: &mut DbPool<'_>,
+        person_id: PersonId,
+    ) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        community_follower::table
+            .inner_join(community::table)
+            .inner_join(person::table)
+            .select((community::all_columns, person::all_columns))
+            .filter(community_follower::person_id.eq(person_id))
+            .filter(community::deleted.eq(false))
+            .filter(community::removed.eq(false))
+            .order_by(community::title)
+            .load::<CommunityFollowerView>(conn)
+            .await
+    }
 }

--- a/crates/db_views_actor/src/community_moderator_view.rs
+++ b/crates/db_views_actor/src/community_moderator_view.rs
@@ -2,75 +2,76 @@ use crate::structs::CommunityModeratorView;
 use diesel::{dsl::exists, result::Error, select, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  newtypes::{CommunityId, PersonId},
-  schema::{community, community_moderator, person},
-  utils::{get_conn, DbPool},
+    newtypes::{CommunityId, PersonId},
+    schema::{community, community_moderator, person},
+    utils::{get_conn, DbPool},
 };
 
 impl CommunityModeratorView {
-  pub async fn is_community_moderator(
-    pool: &mut DbPool<'_>,
-    find_community_id: CommunityId,
-    find_person_id: PersonId,
-  ) -> Result<bool, Error> {
-    use lemmy_db_schema::schema::community_moderator::dsl::{
-      community_id,
-      community_moderator,
-      person_id,
-    };
-    let conn = &mut get_conn(pool).await?;
-    select(exists(
-      community_moderator
-        .filter(community_id.eq(find_community_id))
-        .filter(person_id.eq(find_person_id)),
-    ))
-    .get_result::<bool>(conn)
-    .await
-  }
-  pub async fn for_community(
-    pool: &mut DbPool<'_>,
-    community_id: CommunityId,
-  ) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    community_moderator::table
-      .inner_join(community::table)
-      .inner_join(person::table)
-      .filter(community_moderator::community_id.eq(community_id))
-      .select((community::all_columns, person::all_columns))
-      .order_by(community_moderator::published)
-      .load::<CommunityModeratorView>(conn)
-      .await
-  }
+    pub async fn is_community_moderator(
+        pool: &mut DbPool<'_>,
+        find_community_id: CommunityId,
+        find_person_id: PersonId,
+    ) -> Result<bool, Error> {
+        use lemmy_db_schema::schema::community_moderator::dsl::{
+            community_id, community_moderator, person_id,
+        };
+        let conn = &mut get_conn(pool).await?;
+        select(exists(
+            community_moderator
+                .filter(community_id.eq(find_community_id))
+                .filter(person_id.eq(find_person_id)),
+        ))
+        .get_result::<bool>(conn)
+        .await
+    }
+    pub async fn for_community(
+        pool: &mut DbPool<'_>,
+        community_id: CommunityId,
+    ) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        community_moderator::table
+            .inner_join(community::table)
+            .inner_join(person::table)
+            .filter(community_moderator::community_id.eq(community_id))
+            .select((community::all_columns, person::all_columns))
+            .order_by(community_moderator::published)
+            .load::<CommunityModeratorView>(conn)
+            .await
+    }
 
-  pub async fn for_person(pool: &mut DbPool<'_>, person_id: PersonId) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    community_moderator::table
-      .inner_join(community::table)
-      .inner_join(person::table)
-      .filter(community_moderator::person_id.eq(person_id))
-      .filter(community::deleted.eq(false))
-      .filter(community::removed.eq(false))
-      .select((community::all_columns, person::all_columns))
-      .load::<CommunityModeratorView>(conn)
-      .await
-  }
+    pub async fn for_person(
+        pool: &mut DbPool<'_>,
+        person_id: PersonId,
+    ) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        community_moderator::table
+            .inner_join(community::table)
+            .inner_join(person::table)
+            .filter(community_moderator::person_id.eq(person_id))
+            .filter(community::deleted.eq(false))
+            .filter(community::removed.eq(false))
+            .select((community::all_columns, person::all_columns))
+            .load::<CommunityModeratorView>(conn)
+            .await
+    }
 
-  /// Finds all communities first mods / creators
-  /// Ideally this should be a group by, but diesel doesn't support it yet
-  pub async fn get_community_first_mods(pool: &mut DbPool<'_>) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    community_moderator::table
-      .inner_join(community::table)
-      .inner_join(person::table)
-      .select((community::all_columns, person::all_columns))
-      // A hacky workaround instead of group_bys
-      // https://stackoverflow.com/questions/24042359/how-to-join-only-one-row-in-joined-table-with-postgres
-      .distinct_on(community_moderator::community_id)
-      .order_by((
-        community_moderator::community_id,
-        community_moderator::person_id,
-      ))
-      .load::<CommunityModeratorView>(conn)
-      .await
-  }
+    /// Finds all communities first mods / creators
+    /// Ideally this should be a group by, but diesel doesn't support it yet
+    pub async fn get_community_first_mods(pool: &mut DbPool<'_>) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        community_moderator::table
+            .inner_join(community::table)
+            .inner_join(person::table)
+            .select((community::all_columns, person::all_columns))
+            // A hacky workaround instead of group_bys
+            // https://stackoverflow.com/questions/24042359/how-to-join-only-one-row-in-joined-table-with-postgres
+            .distinct_on(community_moderator::community_id)
+            .order_by((
+                community_moderator::community_id,
+                community_moderator::person_id,
+            ))
+            .load::<CommunityModeratorView>(conn)
+            .await
+    }
 }

--- a/crates/db_views_actor/src/community_person_ban_view.rs
+++ b/crates/db_views_actor/src/community_person_ban_view.rs
@@ -2,26 +2,26 @@ use crate::structs::CommunityPersonBanView;
 use diesel::{result::Error, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  newtypes::{CommunityId, PersonId},
-  schema::{community, community_person_ban, person},
-  utils::{get_conn, DbPool},
+    newtypes::{CommunityId, PersonId},
+    schema::{community, community_person_ban, person},
+    utils::{get_conn, DbPool},
 };
 
 impl CommunityPersonBanView {
-  pub async fn get(
-    pool: &mut DbPool<'_>,
-    from_person_id: PersonId,
-    from_community_id: CommunityId,
-  ) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
-    community_person_ban::table
-      .inner_join(community::table)
-      .inner_join(person::table)
-      .select((community::all_columns, person::all_columns))
-      .filter(community_person_ban::community_id.eq(from_community_id))
-      .filter(community_person_ban::person_id.eq(from_person_id))
-      .order_by(community_person_ban::published)
-      .first::<CommunityPersonBanView>(conn)
-      .await
-  }
+    pub async fn get(
+        pool: &mut DbPool<'_>,
+        from_person_id: PersonId,
+        from_community_id: CommunityId,
+    ) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        community_person_ban::table
+            .inner_join(community::table)
+            .inner_join(person::table)
+            .select((community::all_columns, person::all_columns))
+            .filter(community_person_ban::community_id.eq(from_community_id))
+            .filter(community_person_ban::person_id.eq(from_person_id))
+            .order_by(community_person_ban::published)
+            .first::<CommunityPersonBanView>(conn)
+            .await
+    }
 }

--- a/crates/db_views_actor/src/community_view.rs
+++ b/crates/db_views_actor/src/community_view.rs
@@ -1,199 +1,190 @@
 use crate::structs::{CommunityModeratorView, CommunityView, PersonView};
 use diesel::{
-  pg::Pg,
-  result::Error,
-  BoolExpressionMethods,
-  ExpressionMethods,
-  JoinOnDsl,
-  NullableExpressionMethods,
-  PgTextExpressionMethods,
-  QueryDsl,
+    pg::Pg, result::Error, BoolExpressionMethods, ExpressionMethods, JoinOnDsl,
+    NullableExpressionMethods, PgTextExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  newtypes::{CommunityId, PersonId},
-  schema::{community, community_aggregates, community_block, community_follower, local_user},
-  source::{community::CommunityFollower, local_user::LocalUser},
-  utils::{fuzzy_search, limit_and_offset, DbConn, DbPool, ListFn, Queries, ReadFn},
-  ListingType,
-  SortType,
+    newtypes::{CommunityId, PersonId},
+    schema::{community, community_aggregates, community_block, community_follower, local_user},
+    source::{community::CommunityFollower, local_user::LocalUser},
+    utils::{fuzzy_search, limit_and_offset, DbConn, DbPool, ListFn, Queries, ReadFn},
+    ListingType, SortType,
 };
 
 fn queries<'a>() -> Queries<
-  impl ReadFn<'a, CommunityView, (CommunityId, Option<PersonId>, bool)>,
-  impl ListFn<'a, CommunityView, CommunityQuery<'a>>,
+    impl ReadFn<'a, CommunityView, (CommunityId, Option<PersonId>, bool)>,
+    impl ListFn<'a, CommunityView, CommunityQuery<'a>>,
 > {
-  let all_joins = |query: community::BoxedQuery<'a, Pg>, my_person_id: Option<PersonId>| {
-    // The left join below will return None in this case
-    let person_id_join = my_person_id.unwrap_or(PersonId(-1));
+    let all_joins = |query: community::BoxedQuery<'a, Pg>, my_person_id: Option<PersonId>| {
+        // The left join below will return None in this case
+        let person_id_join = my_person_id.unwrap_or(PersonId(-1));
 
-    query
-      .inner_join(community_aggregates::table)
-      .left_join(
-        community_follower::table.on(
-          community::id
-            .eq(community_follower::community_id)
-            .and(community_follower::person_id.eq(person_id_join)),
-        ),
-      )
-      .left_join(
-        community_block::table.on(
-          community::id
-            .eq(community_block::community_id)
-            .and(community_block::person_id.eq(person_id_join)),
-        ),
-      )
-  };
-
-  let selection = (
-    community::all_columns,
-    CommunityFollower::select_subscribed_type(),
-    community_block::id.nullable().is_not_null(),
-    community_aggregates::all_columns,
-  );
-
-  let not_removed_or_deleted = community::removed
-    .eq(false)
-    .and(community::deleted.eq(false));
-
-  let read = move |mut conn: DbConn<'a>,
-                   (community_id, my_person_id, is_mod_or_admin): (
-    CommunityId,
-    Option<PersonId>,
-    bool,
-  )| async move {
-    let mut query = all_joins(
-      community::table.find(community_id).into_boxed(),
-      my_person_id,
-    )
-    .select(selection);
-
-    // Hide deleted and removed for non-admins or mods
-    if !is_mod_or_admin {
-      query = query.filter(not_removed_or_deleted);
-    }
-
-    query.first::<CommunityView>(&mut conn).await
-  };
-
-  let list = move |mut conn: DbConn<'a>, options: CommunityQuery<'a>| async move {
-    use SortType::*;
-
-    let my_person_id = options.local_user.map(|l| l.person_id);
-
-    // The left join below will return None in this case
-    let person_id_join = my_person_id.unwrap_or(PersonId(-1));
-
-    let mut query = all_joins(community::table.into_boxed(), my_person_id)
-      .left_join(local_user::table.on(local_user::person_id.eq(person_id_join)))
-      .select(selection);
-
-    if let Some(search_term) = options.search_term {
-      let searcher = fuzzy_search(&search_term);
-      query = query
-        .filter(community::name.ilike(searcher.clone()))
-        .or_filter(community::title.ilike(searcher))
-    }
-
-    // Hide deleted and removed for non-admins or mods
-    if !options.is_mod_or_admin {
-      query = query.filter(not_removed_or_deleted).filter(
-        community::hidden
-          .eq(false)
-          .or(community_follower::person_id.eq(person_id_join)),
-      );
-    }
-
-    match options.sort.unwrap_or(Hot) {
-      Hot | Active => query = query.order_by(community_aggregates::hot_rank.desc()),
-      NewComments | TopDay | TopTwelveHour | TopSixHour | TopHour => {
-        query = query.order_by(community_aggregates::users_active_day.desc())
-      }
-      New => query = query.order_by(community::published.desc()),
-      Old => query = query.order_by(community::published.asc()),
-      // Controversial is temporary until a CommentSortType is created
-      MostComments | Controversial => query = query.order_by(community_aggregates::comments.desc()),
-      TopAll | TopYear | TopNineMonths => {
-        query = query.order_by(community_aggregates::subscribers.desc())
-      }
-      TopSixMonths | TopThreeMonths => {
-        query = query.order_by(community_aggregates::users_active_half_year.desc())
-      }
-      TopMonth => query = query.order_by(community_aggregates::users_active_month.desc()),
-      TopWeek => query = query.order_by(community_aggregates::users_active_week.desc()),
+        query
+            .inner_join(community_aggregates::table)
+            .left_join(
+                community_follower::table.on(community::id
+                    .eq(community_follower::community_id)
+                    .and(community_follower::person_id.eq(person_id_join))),
+            )
+            .left_join(
+                community_block::table.on(community::id
+                    .eq(community_block::community_id)
+                    .and(community_block::person_id.eq(person_id_join))),
+            )
     };
 
-    if let Some(listing_type) = options.listing_type {
-      query = match listing_type {
-        ListingType::Subscribed => query.filter(community_follower::pending.is_not_null()), // TODO could be this: and(community_follower::person_id.eq(person_id_join)),
-        ListingType::Local => query.filter(community::local.eq(true)),
-        _ => query,
-      };
-    }
+    let selection = (
+        community::all_columns,
+        CommunityFollower::select_subscribed_type(),
+        community_block::id.nullable().is_not_null(),
+        community_aggregates::all_columns,
+    );
 
-    // Don't show blocked communities or nsfw communities if not enabled in profile
-    if options.local_user.is_some() {
-      query = query.filter(community_block::person_id.is_null());
-      query = query.filter(community::nsfw.eq(false).or(local_user::show_nsfw.eq(true)));
-    } else {
-      // No person in request, only show nsfw communities if show_nsfw is passed into request
-      if !options.show_nsfw {
-        query = query.filter(community::nsfw.eq(false));
-      }
-    }
+    let not_removed_or_deleted = community::removed
+        .eq(false)
+        .and(community::deleted.eq(false));
 
-    let (limit, offset) = limit_and_offset(options.page, options.limit)?;
-    query
-      .limit(limit)
-      .offset(offset)
-      .load::<CommunityView>(&mut conn)
-      .await
-  };
+    let read = move |mut conn: DbConn<'a>,
+                     (community_id, my_person_id, is_mod_or_admin): (
+        CommunityId,
+        Option<PersonId>,
+        bool,
+    )| async move {
+        let mut query = all_joins(
+            community::table.find(community_id).into_boxed(),
+            my_person_id,
+        )
+        .select(selection);
 
-  Queries::new(read, list)
+        // Hide deleted and removed for non-admins or mods
+        if !is_mod_or_admin {
+            query = query.filter(not_removed_or_deleted);
+        }
+
+        query.first::<CommunityView>(&mut conn).await
+    };
+
+    let list = move |mut conn: DbConn<'a>, options: CommunityQuery<'a>| async move {
+        use SortType::*;
+
+        let my_person_id = options.local_user.map(|l| l.person_id);
+
+        // The left join below will return None in this case
+        let person_id_join = my_person_id.unwrap_or(PersonId(-1));
+
+        let mut query = all_joins(community::table.into_boxed(), my_person_id)
+            .left_join(local_user::table.on(local_user::person_id.eq(person_id_join)))
+            .select(selection);
+
+        if let Some(search_term) = options.search_term {
+            let searcher = fuzzy_search(&search_term);
+            query = query
+                .filter(community::name.ilike(searcher.clone()))
+                .or_filter(community::title.ilike(searcher))
+        }
+
+        // Hide deleted and removed for non-admins or mods
+        if !options.is_mod_or_admin {
+            query = query.filter(not_removed_or_deleted).filter(
+                community::hidden
+                    .eq(false)
+                    .or(community_follower::person_id.eq(person_id_join)),
+            );
+        }
+
+        match options.sort.unwrap_or(Hot) {
+            Hot | Active => query = query.order_by(community_aggregates::hot_rank.desc()),
+            NewComments | TopDay | TopTwelveHour | TopSixHour | TopHour => {
+                query = query.order_by(community_aggregates::users_active_day.desc())
+            }
+            New => query = query.order_by(community::published.desc()),
+            Old => query = query.order_by(community::published.asc()),
+            // Controversial is temporary until a CommentSortType is created
+            MostComments | Controversial => {
+                query = query.order_by(community_aggregates::comments.desc())
+            }
+            TopAll | TopYear | TopNineMonths => {
+                query = query.order_by(community_aggregates::subscribers.desc())
+            }
+            TopSixMonths | TopThreeMonths => {
+                query = query.order_by(community_aggregates::users_active_half_year.desc())
+            }
+            TopMonth => query = query.order_by(community_aggregates::users_active_month.desc()),
+            TopWeek => query = query.order_by(community_aggregates::users_active_week.desc()),
+        };
+
+        if let Some(listing_type) = options.listing_type {
+            query = match listing_type {
+                ListingType::Subscribed => query.filter(community_follower::pending.is_not_null()), // TODO could be this: and(community_follower::person_id.eq(person_id_join)),
+                ListingType::Local => query.filter(community::local.eq(true)),
+                _ => query,
+            };
+        }
+
+        // Don't show blocked communities or nsfw communities if not enabled in profile
+        if options.local_user.is_some() {
+            query = query.filter(community_block::person_id.is_null());
+            query = query.filter(community::nsfw.eq(false).or(local_user::show_nsfw.eq(true)));
+        } else {
+            // No person in request, only show nsfw communities if show_nsfw is passed into request
+            if !options.show_nsfw {
+                query = query.filter(community::nsfw.eq(false));
+            }
+        }
+
+        let (limit, offset) = limit_and_offset(options.page, options.limit)?;
+        query
+            .limit(limit)
+            .offset(offset)
+            .load::<CommunityView>(&mut conn)
+            .await
+    };
+
+    Queries::new(read, list)
 }
 
 impl CommunityView {
-  pub async fn read(
-    pool: &mut DbPool<'_>,
-    community_id: CommunityId,
-    my_person_id: Option<PersonId>,
-    is_mod_or_admin: bool,
-  ) -> Result<Self, Error> {
-    queries()
-      .read(pool, (community_id, my_person_id, is_mod_or_admin))
-      .await
-  }
-
-  pub async fn is_mod_or_admin(
-    pool: &mut DbPool<'_>,
-    person_id: PersonId,
-    community_id: CommunityId,
-  ) -> Result<bool, Error> {
-    let is_mod =
-      CommunityModeratorView::is_community_moderator(pool, community_id, person_id).await?;
-    if is_mod {
-      return Ok(true);
+    pub async fn read(
+        pool: &mut DbPool<'_>,
+        community_id: CommunityId,
+        my_person_id: Option<PersonId>,
+        is_mod_or_admin: bool,
+    ) -> Result<Self, Error> {
+        queries()
+            .read(pool, (community_id, my_person_id, is_mod_or_admin))
+            .await
     }
 
-    PersonView::is_admin(pool, person_id).await
-  }
+    pub async fn is_mod_or_admin(
+        pool: &mut DbPool<'_>,
+        person_id: PersonId,
+        community_id: CommunityId,
+    ) -> Result<bool, Error> {
+        let is_mod =
+            CommunityModeratorView::is_community_moderator(pool, community_id, person_id).await?;
+        if is_mod {
+            return Ok(true);
+        }
+
+        PersonView::is_admin(pool, person_id).await
+    }
 }
 
 #[derive(Default)]
 pub struct CommunityQuery<'a> {
-  pub listing_type: Option<ListingType>,
-  pub sort: Option<SortType>,
-  pub local_user: Option<&'a LocalUser>,
-  pub search_term: Option<String>,
-  pub is_mod_or_admin: bool,
-  pub show_nsfw: bool,
-  pub page: Option<i64>,
-  pub limit: Option<i64>,
+    pub listing_type: Option<ListingType>,
+    pub sort: Option<SortType>,
+    pub local_user: Option<&'a LocalUser>,
+    pub search_term: Option<String>,
+    pub is_mod_or_admin: bool,
+    pub show_nsfw: bool,
+    pub page: Option<i64>,
+    pub limit: Option<i64>,
 }
 
 impl<'a> CommunityQuery<'a> {
-  pub async fn list(self, pool: &mut DbPool<'_>) -> Result<Vec<CommunityView>, Error> {
-    queries().list(pool, self).await
-  }
+    pub async fn list(self, pool: &mut DbPool<'_>) -> Result<Vec<CommunityView>, Error> {
+        queries().list(pool, self).await
+    }
 }

--- a/crates/db_views_actor/src/person_block_view.rs
+++ b/crates/db_views_actor/src/person_block_view.rs
@@ -2,29 +2,33 @@ use crate::structs::PersonBlockView;
 use diesel::{result::Error, ExpressionMethods, JoinOnDsl, QueryDsl};
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  newtypes::PersonId,
-  schema::{person, person_block},
-  utils::{get_conn, DbPool},
+    newtypes::PersonId,
+    schema::{person, person_block},
+    utils::{get_conn, DbPool},
 };
 
 impl PersonBlockView {
-  pub async fn for_person(pool: &mut DbPool<'_>, person_id: PersonId) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let target_person_alias = diesel::alias!(person as person1);
+    pub async fn for_person(
+        pool: &mut DbPool<'_>,
+        person_id: PersonId,
+    ) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let target_person_alias = diesel::alias!(person as person1);
 
-    person_block::table
-      .inner_join(person::table.on(person_block::person_id.eq(person::id)))
-      .inner_join(
-        target_person_alias.on(person_block::target_id.eq(target_person_alias.field(person::id))),
-      )
-      .select((
-        person::all_columns,
-        target_person_alias.fields(person::all_columns),
-      ))
-      .filter(person_block::person_id.eq(person_id))
-      .filter(target_person_alias.field(person::deleted).eq(false))
-      .order_by(person_block::published)
-      .load::<PersonBlockView>(conn)
-      .await
-  }
+        person_block::table
+            .inner_join(person::table.on(person_block::person_id.eq(person::id)))
+            .inner_join(
+                target_person_alias
+                    .on(person_block::target_id.eq(target_person_alias.field(person::id))),
+            )
+            .select((
+                person::all_columns,
+                target_person_alias.fields(person::all_columns),
+            ))
+            .filter(person_block::person_id.eq(person_id))
+            .filter(target_person_alias.field(person::deleted).eq(false))
+            .order_by(person_block::published)
+            .load::<PersonBlockView>(conn)
+            .await
+    }
 }

--- a/crates/db_views_actor/src/person_mention_view.rs
+++ b/crates/db_views_actor/src/person_mention_view.rs
@@ -1,209 +1,184 @@
 use crate::structs::PersonMentionView;
 use diesel::{
-  dsl::now,
-  pg::Pg,
-  result::Error,
-  BoolExpressionMethods,
-  ExpressionMethods,
-  JoinOnDsl,
-  NullableExpressionMethods,
-  QueryDsl,
+    dsl::now, pg::Pg, result::Error, BoolExpressionMethods, ExpressionMethods, JoinOnDsl,
+    NullableExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  aliases,
-  newtypes::{PersonId, PersonMentionId},
-  schema::{
-    comment,
-    comment_aggregates,
-    comment_like,
-    comment_saved,
-    community,
-    community_follower,
-    community_person_ban,
-    person,
-    person_block,
-    person_mention,
-    post,
-  },
-  source::community::CommunityFollower,
-  utils::{get_conn, limit_and_offset, DbConn, DbPool, ListFn, Queries, ReadFn},
-  CommentSortType,
+    aliases,
+    newtypes::{PersonId, PersonMentionId},
+    schema::{
+        comment, comment_aggregates, comment_like, comment_saved, community, community_follower,
+        community_person_ban, person, person_block, person_mention, post,
+    },
+    source::community::CommunityFollower,
+    utils::{get_conn, limit_and_offset, DbConn, DbPool, ListFn, Queries, ReadFn},
+    CommentSortType,
 };
 
 fn queries<'a>() -> Queries<
-  impl ReadFn<'a, PersonMentionView, (PersonMentionId, Option<PersonId>)>,
-  impl ListFn<'a, PersonMentionView, PersonMentionQuery>,
+    impl ReadFn<'a, PersonMentionView, (PersonMentionId, Option<PersonId>)>,
+    impl ListFn<'a, PersonMentionView, PersonMentionQuery>,
 > {
-  let all_joins = |query: person_mention::BoxedQuery<'a, Pg>, my_person_id: Option<PersonId>| {
-    // The left join below will return None in this case
-    let person_id_join = my_person_id.unwrap_or(PersonId(-1));
+    let all_joins = |query: person_mention::BoxedQuery<'a, Pg>, my_person_id: Option<PersonId>| {
+        // The left join below will return None in this case
+        let person_id_join = my_person_id.unwrap_or(PersonId(-1));
 
-    query
-      .inner_join(comment::table)
-      .inner_join(person::table.on(comment::creator_id.eq(person::id)))
-      .inner_join(post::table.on(comment::post_id.eq(post::id)))
-      .inner_join(community::table.on(post::community_id.eq(community::id)))
-      .inner_join(aliases::person1)
-      .inner_join(comment_aggregates::table.on(comment::id.eq(comment_aggregates::comment_id)))
-      .left_join(
-        community_follower::table.on(
-          post::community_id
-            .eq(community_follower::community_id)
-            .and(community_follower::person_id.eq(person_id_join)),
-        ),
-      )
-      .left_join(
-        comment_saved::table.on(
-          comment::id
-            .eq(comment_saved::comment_id)
-            .and(comment_saved::person_id.eq(person_id_join)),
-        ),
-      )
-      .left_join(
-        person_block::table.on(
-          comment::creator_id
-            .eq(person_block::target_id)
-            .and(person_block::person_id.eq(person_id_join)),
-        ),
-      )
-      .left_join(
-        comment_like::table.on(
-          comment::id
-            .eq(comment_like::comment_id)
-            .and(comment_like::person_id.eq(person_id_join)),
-        ),
-      )
-  };
-
-  let selection = (
-    person_mention::all_columns,
-    comment::all_columns,
-    person::all_columns,
-    post::all_columns,
-    community::all_columns,
-    aliases::person1.fields(person::all_columns),
-    comment_aggregates::all_columns,
-    community_person_ban::id.nullable().is_not_null(),
-    CommunityFollower::select_subscribed_type(),
-    comment_saved::id.nullable().is_not_null(),
-    person_block::id.nullable().is_not_null(),
-    comment_like::score.nullable(),
-  );
-
-  let read =
-    move |mut conn: DbConn<'a>,
-          (person_mention_id, my_person_id): (PersonMentionId, Option<PersonId>)| async move {
-      all_joins(
-        person_mention::table.find(person_mention_id).into_boxed(),
-        my_person_id,
-      )
-      .left_join(
-        community_person_ban::table.on(
-          community::id
-            .eq(community_person_ban::community_id)
-            .and(community_person_ban::person_id.eq(comment::creator_id)),
-        ),
-      )
-      .select(selection)
-      .first::<PersonMentionView>(&mut conn)
-      .await
+        query
+            .inner_join(comment::table)
+            .inner_join(person::table.on(comment::creator_id.eq(person::id)))
+            .inner_join(post::table.on(comment::post_id.eq(post::id)))
+            .inner_join(community::table.on(post::community_id.eq(community::id)))
+            .inner_join(aliases::person1)
+            .inner_join(
+                comment_aggregates::table.on(comment::id.eq(comment_aggregates::comment_id)),
+            )
+            .left_join(
+                community_follower::table.on(post::community_id
+                    .eq(community_follower::community_id)
+                    .and(community_follower::person_id.eq(person_id_join))),
+            )
+            .left_join(
+                comment_saved::table.on(comment::id
+                    .eq(comment_saved::comment_id)
+                    .and(comment_saved::person_id.eq(person_id_join))),
+            )
+            .left_join(
+                person_block::table.on(comment::creator_id
+                    .eq(person_block::target_id)
+                    .and(person_block::person_id.eq(person_id_join))),
+            )
+            .left_join(
+                comment_like::table.on(comment::id
+                    .eq(comment_like::comment_id)
+                    .and(comment_like::person_id.eq(person_id_join))),
+            )
     };
 
-  let list = move |mut conn: DbConn<'a>, options: PersonMentionQuery| async move {
-    let mut query = all_joins(person_mention::table.into_boxed(), options.my_person_id)
-      .left_join(
-        community_person_ban::table.on(
-          community::id
-            .eq(community_person_ban::community_id)
-            .and(community_person_ban::person_id.eq(comment::creator_id))
-            .and(
-              community_person_ban::expires
-                .is_null()
-                .or(community_person_ban::expires.gt(now)),
-            ),
-        ),
-      )
-      .select(selection);
+    let selection = (
+        person_mention::all_columns,
+        comment::all_columns,
+        person::all_columns,
+        post::all_columns,
+        community::all_columns,
+        aliases::person1.fields(person::all_columns),
+        comment_aggregates::all_columns,
+        community_person_ban::id.nullable().is_not_null(),
+        CommunityFollower::select_subscribed_type(),
+        comment_saved::id.nullable().is_not_null(),
+        person_block::id.nullable().is_not_null(),
+        comment_like::score.nullable(),
+    );
 
-    if let Some(recipient_id) = options.recipient_id {
-      query = query.filter(person_mention::recipient_id.eq(recipient_id));
-    }
+    let read =
+        move |mut conn: DbConn<'a>,
+              (person_mention_id, my_person_id): (PersonMentionId, Option<PersonId>)| async move {
+            all_joins(
+                person_mention::table.find(person_mention_id).into_boxed(),
+                my_person_id,
+            )
+            .left_join(
+                community_person_ban::table.on(community::id
+                    .eq(community_person_ban::community_id)
+                    .and(community_person_ban::person_id.eq(comment::creator_id))),
+            )
+            .select(selection)
+            .first::<PersonMentionView>(&mut conn)
+            .await
+        };
 
-    if options.unread_only {
-      query = query.filter(person_mention::read.eq(false));
-    }
+    let list = move |mut conn: DbConn<'a>, options: PersonMentionQuery| async move {
+        let mut query = all_joins(person_mention::table.into_boxed(), options.my_person_id)
+            .left_join(
+                community_person_ban::table.on(community::id
+                    .eq(community_person_ban::community_id)
+                    .and(community_person_ban::person_id.eq(comment::creator_id))
+                    .and(
+                        community_person_ban::expires
+                            .is_null()
+                            .or(community_person_ban::expires.gt(now)),
+                    )),
+            )
+            .select(selection);
 
-    if !options.show_bot_accounts {
-      query = query.filter(person::bot_account.eq(false));
+        if let Some(recipient_id) = options.recipient_id {
+            query = query.filter(person_mention::recipient_id.eq(recipient_id));
+        }
+
+        if options.unread_only {
+            query = query.filter(person_mention::read.eq(false));
+        }
+
+        if !options.show_bot_accounts {
+            query = query.filter(person::bot_account.eq(false));
+        };
+
+        query = match options.sort.unwrap_or(CommentSortType::Hot) {
+            CommentSortType::Hot => query.then_order_by(comment_aggregates::hot_rank.desc()),
+            CommentSortType::Controversial => {
+                query.then_order_by(comment_aggregates::controversy_rank.desc())
+            }
+            CommentSortType::New => query.then_order_by(comment::published.desc()),
+            CommentSortType::Old => query.then_order_by(comment::published.asc()),
+            CommentSortType::Top => query.order_by(comment_aggregates::score.desc()),
+        };
+
+        let (limit, offset) = limit_and_offset(options.page, options.limit)?;
+
+        query
+            .limit(limit)
+            .offset(offset)
+            .load::<PersonMentionView>(&mut conn)
+            .await
     };
 
-    query = match options.sort.unwrap_or(CommentSortType::Hot) {
-      CommentSortType::Hot => query.then_order_by(comment_aggregates::hot_rank.desc()),
-      CommentSortType::Controversial => {
-        query.then_order_by(comment_aggregates::controversy_rank.desc())
-      }
-      CommentSortType::New => query.then_order_by(comment::published.desc()),
-      CommentSortType::Old => query.then_order_by(comment::published.asc()),
-      CommentSortType::Top => query.order_by(comment_aggregates::score.desc()),
-    };
-
-    let (limit, offset) = limit_and_offset(options.page, options.limit)?;
-
-    query
-      .limit(limit)
-      .offset(offset)
-      .load::<PersonMentionView>(&mut conn)
-      .await
-  };
-
-  Queries::new(read, list)
+    Queries::new(read, list)
 }
 
 impl PersonMentionView {
-  pub async fn read(
-    pool: &mut DbPool<'_>,
-    person_mention_id: PersonMentionId,
-    my_person_id: Option<PersonId>,
-  ) -> Result<Self, Error> {
-    queries()
-      .read(pool, (person_mention_id, my_person_id))
-      .await
-  }
+    pub async fn read(
+        pool: &mut DbPool<'_>,
+        person_mention_id: PersonMentionId,
+        my_person_id: Option<PersonId>,
+    ) -> Result<Self, Error> {
+        queries()
+            .read(pool, (person_mention_id, my_person_id))
+            .await
+    }
 
-  /// Gets the number of unread mentions
-  pub async fn get_unread_mentions(
-    pool: &mut DbPool<'_>,
-    my_person_id: PersonId,
-  ) -> Result<i64, Error> {
-    use diesel::dsl::count;
-    let conn = &mut get_conn(pool).await?;
+    /// Gets the number of unread mentions
+    pub async fn get_unread_mentions(
+        pool: &mut DbPool<'_>,
+        my_person_id: PersonId,
+    ) -> Result<i64, Error> {
+        use diesel::dsl::count;
+        let conn = &mut get_conn(pool).await?;
 
-    person_mention::table
-      .inner_join(comment::table)
-      .filter(person_mention::recipient_id.eq(my_person_id))
-      .filter(person_mention::read.eq(false))
-      .filter(comment::deleted.eq(false))
-      .filter(comment::removed.eq(false))
-      .select(count(person_mention::id))
-      .first::<i64>(conn)
-      .await
-  }
+        person_mention::table
+            .inner_join(comment::table)
+            .filter(person_mention::recipient_id.eq(my_person_id))
+            .filter(person_mention::read.eq(false))
+            .filter(comment::deleted.eq(false))
+            .filter(comment::removed.eq(false))
+            .select(count(person_mention::id))
+            .first::<i64>(conn)
+            .await
+    }
 }
 
 #[derive(Default)]
 pub struct PersonMentionQuery {
-  pub my_person_id: Option<PersonId>,
-  pub recipient_id: Option<PersonId>,
-  pub sort: Option<CommentSortType>,
-  pub unread_only: bool,
-  pub show_bot_accounts: bool,
-  pub page: Option<i64>,
-  pub limit: Option<i64>,
+    pub my_person_id: Option<PersonId>,
+    pub recipient_id: Option<PersonId>,
+    pub sort: Option<CommentSortType>,
+    pub unread_only: bool,
+    pub show_bot_accounts: bool,
+    pub page: Option<i64>,
+    pub limit: Option<i64>,
 }
 
 impl PersonMentionQuery {
-  pub async fn list(self, pool: &mut DbPool<'_>) -> Result<Vec<PersonMentionView>, Error> {
-    queries().list(pool, self).await
-  }
+    pub async fn list(self, pool: &mut DbPool<'_>) -> Result<Vec<PersonMentionView>, Error> {
+        queries().list(pool, self).await
+    }
 }

--- a/crates/db_views_actor/src/person_view.rs
+++ b/crates/db_views_actor/src/person_view.rs
@@ -1,129 +1,134 @@
 use crate::structs::PersonView;
 use diesel::{
-  pg::Pg,
-  result::Error,
-  BoolExpressionMethods,
-  ExpressionMethods,
-  NullableExpressionMethods,
-  PgTextExpressionMethods,
-  QueryDsl,
+    pg::Pg, result::Error, BoolExpressionMethods, ExpressionMethods, NullableExpressionMethods,
+    PgTextExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  newtypes::PersonId,
-  schema,
-  schema::{local_user, person, person_aggregates},
-  utils::{fuzzy_search, get_conn, limit_and_offset, now, DbConn, DbPool, ListFn, Queries, ReadFn},
-  PersonSortType,
+    newtypes::PersonId,
+    schema,
+    schema::{local_user, person, person_aggregates},
+    utils::{
+        fuzzy_search, get_conn, limit_and_offset, now, DbConn, DbPool, ListFn, Queries, ReadFn,
+    },
+    PersonSortType,
 };
 
 enum ListMode {
-  Admins,
-  Banned,
-  Query(PersonQuery),
+    Admins,
+    Banned,
+    Query(PersonQuery),
 }
 
 fn queries<'a>(
 ) -> Queries<impl ReadFn<'a, PersonView, PersonId>, impl ListFn<'a, PersonView, ListMode>> {
-  let all_joins = |query: person::BoxedQuery<'a, Pg>| {
-    query
-      .inner_join(person_aggregates::table)
-      .left_join(local_user::table)
-      .select((person::all_columns, person_aggregates::all_columns))
-  };
+    let all_joins = |query: person::BoxedQuery<'a, Pg>| {
+        query
+            .inner_join(person_aggregates::table)
+            .left_join(local_user::table)
+            .select((person::all_columns, person_aggregates::all_columns))
+    };
 
-  let read = move |mut conn: DbConn<'a>, person_id: PersonId| async move {
-    all_joins(person::table.find(person_id).into_boxed())
-      .first::<PersonView>(&mut conn)
-      .await
-  };
+    let read = move |mut conn: DbConn<'a>, person_id: PersonId| async move {
+        all_joins(person::table.find(person_id).into_boxed())
+            .first::<PersonView>(&mut conn)
+            .await
+    };
 
-  let list = move |mut conn: DbConn<'a>, mode: ListMode| async move {
-    let mut query = all_joins(person::table.into_boxed());
-    match mode {
-      ListMode::Admins => {
-        query = query
-          .filter(local_user::admin.eq(true))
-          .filter(person::deleted.eq(false))
-          .order_by(person::published);
-      }
-      ListMode::Banned => {
-        query = query
-          .filter(
-            person::banned.eq(true).and(
-              person::ban_expires
-                .is_null()
-                .or(person::ban_expires.gt(now().nullable())),
-            ),
-          )
-          .filter(person::deleted.eq(false));
-      }
-      ListMode::Query(options) => {
-        if let Some(search_term) = options.search_term {
-          let searcher = fuzzy_search(&search_term);
-          query = query
-            .filter(person::name.ilike(searcher.clone()))
-            .or_filter(person::display_name.ilike(searcher));
+    let list = move |mut conn: DbConn<'a>, mode: ListMode| async move {
+        let mut query = all_joins(person::table.into_boxed());
+        match mode {
+            ListMode::Admins => {
+                query = query
+                    .filter(local_user::admin.eq(true))
+                    .filter(person::deleted.eq(false))
+                    .order_by(person::published);
+            }
+            ListMode::Banned => {
+                query = query
+                    .filter(
+                        person::banned.eq(true).and(
+                            person::ban_expires
+                                .is_null()
+                                .or(person::ban_expires.gt(now().nullable())),
+                        ),
+                    )
+                    .filter(person::deleted.eq(false));
+            }
+            ListMode::Query(options) => {
+                if let Some(search_term) = options.search_term {
+                    let searcher = fuzzy_search(&search_term);
+                    query = query
+                        .filter(person::name.ilike(searcher.clone()))
+                        .or_filter(person::display_name.ilike(searcher));
+                }
+
+                query = match options.sort.unwrap_or(PersonSortType::CommentScore) {
+                    PersonSortType::New => query.order_by(person::published.desc()),
+                    PersonSortType::Old => query.order_by(person::published.asc()),
+                    PersonSortType::MostComments => {
+                        query.order_by(person_aggregates::comment_count.desc())
+                    }
+                    PersonSortType::CommentScore => {
+                        query.order_by(person_aggregates::comment_score.desc())
+                    }
+                    PersonSortType::PostScore => {
+                        query.order_by(person_aggregates::post_score.desc())
+                    }
+                    PersonSortType::PostCount => {
+                        query.order_by(person_aggregates::post_count.desc())
+                    }
+                };
+
+                let (limit, offset) = limit_and_offset(options.page, options.limit)?;
+                query = query.limit(limit).offset(offset);
+            }
         }
+        query.load::<PersonView>(&mut conn).await
+    };
 
-        query = match options.sort.unwrap_or(PersonSortType::CommentScore) {
-          PersonSortType::New => query.order_by(person::published.desc()),
-          PersonSortType::Old => query.order_by(person::published.asc()),
-          PersonSortType::MostComments => query.order_by(person_aggregates::comment_count.desc()),
-          PersonSortType::CommentScore => query.order_by(person_aggregates::comment_score.desc()),
-          PersonSortType::PostScore => query.order_by(person_aggregates::post_score.desc()),
-          PersonSortType::PostCount => query.order_by(person_aggregates::post_count.desc()),
-        };
-
-        let (limit, offset) = limit_and_offset(options.page, options.limit)?;
-        query = query.limit(limit).offset(offset);
-      }
-    }
-    query.load::<PersonView>(&mut conn).await
-  };
-
-  Queries::new(read, list)
+    Queries::new(read, list)
 }
 
 impl PersonView {
-  pub async fn read(pool: &mut DbPool<'_>, person_id: PersonId) -> Result<Self, Error> {
-    queries().read(pool, person_id).await
-  }
+    pub async fn read(pool: &mut DbPool<'_>, person_id: PersonId) -> Result<Self, Error> {
+        queries().read(pool, person_id).await
+    }
 
-  pub async fn is_admin(pool: &mut DbPool<'_>, person_id: PersonId) -> Result<bool, Error> {
-    use schema::{
-      local_user::dsl::admin,
-      person::dsl::{id, person},
-    };
-    let conn = &mut get_conn(pool).await?;
-    let is_admin = person
-      .inner_join(local_user::table)
-      .filter(id.eq(person_id))
-      .select(admin)
-      .first::<bool>(conn)
-      .await?;
-    Ok(is_admin)
-  }
+    pub async fn is_admin(pool: &mut DbPool<'_>, person_id: PersonId) -> Result<bool, Error> {
+        use schema::{
+            local_user::dsl::admin,
+            person::dsl::{id, person},
+        };
+        let conn = &mut get_conn(pool).await?;
+        let is_admin = person
+            .inner_join(local_user::table)
+            .filter(id.eq(person_id))
+            .select(admin)
+            .first::<bool>(conn)
+            .await?;
+        Ok(is_admin)
+    }
 
-  pub async fn admins(pool: &mut DbPool<'_>) -> Result<Vec<Self>, Error> {
-    queries().list(pool, ListMode::Admins).await
-  }
+    pub async fn admins(pool: &mut DbPool<'_>) -> Result<Vec<Self>, Error> {
+        queries().list(pool, ListMode::Admins).await
+    }
 
-  pub async fn banned(pool: &mut DbPool<'_>) -> Result<Vec<Self>, Error> {
-    queries().list(pool, ListMode::Banned).await
-  }
+    pub async fn banned(pool: &mut DbPool<'_>) -> Result<Vec<Self>, Error> {
+        queries().list(pool, ListMode::Banned).await
+    }
 }
 
 #[derive(Default)]
 pub struct PersonQuery {
-  pub sort: Option<PersonSortType>,
-  pub search_term: Option<String>,
-  pub page: Option<i64>,
-  pub limit: Option<i64>,
+    pub sort: Option<PersonSortType>,
+    pub search_term: Option<String>,
+    pub page: Option<i64>,
+    pub limit: Option<i64>,
 }
 
 impl PersonQuery {
-  pub async fn list(self, pool: &mut DbPool<'_>) -> Result<Vec<PersonView>, Error> {
-    queries().list(pool, ListMode::Query(self)).await
-  }
+    pub async fn list(self, pool: &mut DbPool<'_>) -> Result<Vec<PersonView>, Error> {
+        queries().list(pool, ListMode::Query(self)).await
+    }
 }

--- a/crates/db_views_actor/src/structs.rs
+++ b/crates/db_views_actor/src/structs.rs
@@ -1,16 +1,12 @@
 #[cfg(feature = "full")]
 use diesel::Queryable;
 use lemmy_db_schema::{
-  aggregates::structs::{CommentAggregates, CommunityAggregates, PersonAggregates},
-  source::{
-    comment::Comment,
-    comment_reply::CommentReply,
-    community::Community,
-    person::Person,
-    person_mention::PersonMention,
-    post::Post,
-  },
-  SubscribedType,
+    aggregates::structs::{CommentAggregates, CommunityAggregates, PersonAggregates},
+    source::{
+        comment::Comment, comment_reply::CommentReply, community::Community, person::Person,
+        person_mention::PersonMention, post::Post,
+    },
+    SubscribedType,
 };
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -22,8 +18,8 @@ use ts_rs::TS;
 #[cfg_attr(feature = "full", ts(export))]
 /// A community block.
 pub struct CommunityBlockView {
-  pub person: Person,
-  pub community: Community,
+    pub person: Person,
+    pub community: Community,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -31,8 +27,8 @@ pub struct CommunityBlockView {
 #[cfg_attr(feature = "full", ts(export))]
 /// A community follower.
 pub struct CommunityFollowerView {
-  pub community: Community,
-  pub follower: Person,
+    pub community: Community,
+    pub follower: Person,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -40,16 +36,16 @@ pub struct CommunityFollowerView {
 #[cfg_attr(feature = "full", ts(export))]
 /// A community moderator.
 pub struct CommunityModeratorView {
-  pub community: Community,
-  pub moderator: Person,
+    pub community: Community,
+    pub moderator: Person,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "full", derive(Queryable))]
 /// A community person ban.
 pub struct CommunityPersonBanView {
-  pub community: Community,
-  pub person: Person,
+    pub community: Community,
+    pub person: Person,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -57,10 +53,10 @@ pub struct CommunityPersonBanView {
 #[cfg_attr(feature = "full", ts(export))]
 /// A community view.
 pub struct CommunityView {
-  pub community: Community,
-  pub subscribed: SubscribedType,
-  pub blocked: bool,
-  pub counts: CommunityAggregates,
+    pub community: Community,
+    pub subscribed: SubscribedType,
+    pub blocked: bool,
+    pub counts: CommunityAggregates,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -68,8 +64,8 @@ pub struct CommunityView {
 #[cfg_attr(feature = "full", ts(export))]
 /// A person block.
 pub struct PersonBlockView {
-  pub person: Person,
-  pub target: Person,
+    pub person: Person,
+    pub target: Person,
 }
 
 #[skip_serializing_none]
@@ -78,18 +74,18 @@ pub struct PersonBlockView {
 #[cfg_attr(feature = "full", ts(export))]
 /// A person mention view.
 pub struct PersonMentionView {
-  pub person_mention: PersonMention,
-  pub comment: Comment,
-  pub creator: Person,
-  pub post: Post,
-  pub community: Community,
-  pub recipient: Person,
-  pub counts: CommentAggregates,
-  pub creator_banned_from_community: bool,
-  pub subscribed: SubscribedType,
-  pub saved: bool,
-  pub creator_blocked: bool,
-  pub my_vote: Option<i16>,
+    pub person_mention: PersonMention,
+    pub comment: Comment,
+    pub creator: Person,
+    pub post: Post,
+    pub community: Community,
+    pub recipient: Person,
+    pub counts: CommentAggregates,
+    pub creator_banned_from_community: bool,
+    pub subscribed: SubscribedType,
+    pub saved: bool,
+    pub creator_blocked: bool,
+    pub my_vote: Option<i16>,
 }
 
 #[skip_serializing_none]
@@ -98,18 +94,18 @@ pub struct PersonMentionView {
 #[cfg_attr(feature = "full", ts(export))]
 /// A comment reply view.
 pub struct CommentReplyView {
-  pub comment_reply: CommentReply,
-  pub comment: Comment,
-  pub creator: Person,
-  pub post: Post,
-  pub community: Community,
-  pub recipient: Person,
-  pub counts: CommentAggregates,
-  pub creator_banned_from_community: bool, // Left Join to CommunityPersonBan
-  pub subscribed: SubscribedType,          // Left join to CommunityFollower
-  pub saved: bool,                         // Left join to CommentSaved
-  pub creator_blocked: bool,               // Left join to PersonBlock
-  pub my_vote: Option<i16>,                // Left join to CommentLike
+    pub comment_reply: CommentReply,
+    pub comment: Comment,
+    pub creator: Person,
+    pub post: Post,
+    pub community: Community,
+    pub recipient: Person,
+    pub counts: CommentAggregates,
+    pub creator_banned_from_community: bool, // Left Join to CommunityPersonBan
+    pub subscribed: SubscribedType,          // Left join to CommunityFollower
+    pub saved: bool,                         // Left join to CommentSaved
+    pub creator_blocked: bool,               // Left join to PersonBlock
+    pub my_vote: Option<i16>,                // Left join to CommentLike
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -117,6 +113,6 @@ pub struct CommentReplyView {
 #[cfg_attr(feature = "full", ts(export))]
 /// A person view.
 pub struct PersonView {
-  pub person: Person,
-  pub counts: PersonAggregates,
+    pub person: Person,
+    pub counts: PersonAggregates,
 }

--- a/crates/db_views_moderator/src/admin_purge_comment_view.rs
+++ b/crates/db_views_moderator/src/admin_purge_comment_view.rs
@@ -1,52 +1,47 @@
 use crate::structs::{AdminPurgeCommentView, ModlogListParams};
 use diesel::{
-  result::Error,
-  BoolExpressionMethods,
-  ExpressionMethods,
-  IntoSql,
-  JoinOnDsl,
-  NullableExpressionMethods,
-  QueryDsl,
+    result::Error, BoolExpressionMethods, ExpressionMethods, IntoSql, JoinOnDsl,
+    NullableExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  newtypes::PersonId,
-  schema::{admin_purge_comment, person, post},
-  utils::{get_conn, limit_and_offset, DbPool},
+    newtypes::PersonId,
+    schema::{admin_purge_comment, person, post},
+    utils::{get_conn, limit_and_offset, DbPool},
 };
 
 impl AdminPurgeCommentView {
-  pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
-    let show_mod_names = !params.hide_modlog_names;
-    let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
+    pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
+        let show_mod_names = !params.hide_modlog_names;
+        let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
 
-    let admin_names_join = admin_purge_comment::admin_person_id
-      .eq(person::id)
-      .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
+        let admin_names_join = admin_purge_comment::admin_person_id
+            .eq(person::id)
+            .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
 
-    let mut query = admin_purge_comment::table
-      .left_join(person::table.on(admin_names_join))
-      .inner_join(post::table)
-      .select((
-        admin_purge_comment::all_columns,
-        person::all_columns.nullable(),
-        post::all_columns,
-      ))
-      .into_boxed();
+        let mut query = admin_purge_comment::table
+            .left_join(person::table.on(admin_names_join))
+            .inner_join(post::table)
+            .select((
+                admin_purge_comment::all_columns,
+                person::all_columns.nullable(),
+                post::all_columns,
+            ))
+            .into_boxed();
 
-    if let Some(admin_person_id) = params.mod_person_id {
-      query = query.filter(admin_purge_comment::admin_person_id.eq(admin_person_id));
-    };
+        if let Some(admin_person_id) = params.mod_person_id {
+            query = query.filter(admin_purge_comment::admin_person_id.eq(admin_person_id));
+        };
 
-    let (limit, offset) = limit_and_offset(params.page, params.limit)?;
+        let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
-    query
-      .limit(limit)
-      .offset(offset)
-      .order_by(admin_purge_comment::when_.desc())
-      .load::<AdminPurgeCommentView>(conn)
-      .await
-  }
+        query
+            .limit(limit)
+            .offset(offset)
+            .order_by(admin_purge_comment::when_.desc())
+            .load::<AdminPurgeCommentView>(conn)
+            .await
+    }
 }

--- a/crates/db_views_moderator/src/admin_purge_community_view.rs
+++ b/crates/db_views_moderator/src/admin_purge_community_view.rs
@@ -1,50 +1,45 @@
 use crate::structs::{AdminPurgeCommunityView, ModlogListParams};
 use diesel::{
-  result::Error,
-  BoolExpressionMethods,
-  ExpressionMethods,
-  IntoSql,
-  JoinOnDsl,
-  NullableExpressionMethods,
-  QueryDsl,
+    result::Error, BoolExpressionMethods, ExpressionMethods, IntoSql, JoinOnDsl,
+    NullableExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  newtypes::PersonId,
-  schema::{admin_purge_community, person},
-  utils::{get_conn, limit_and_offset, DbPool},
+    newtypes::PersonId,
+    schema::{admin_purge_community, person},
+    utils::{get_conn, limit_and_offset, DbPool},
 };
 
 impl AdminPurgeCommunityView {
-  pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
-    let show_mod_names = !params.hide_modlog_names;
-    let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
+    pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
+        let show_mod_names = !params.hide_modlog_names;
+        let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
 
-    let admin_names_join = admin_purge_community::admin_person_id
-      .eq(person::id)
-      .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
+        let admin_names_join = admin_purge_community::admin_person_id
+            .eq(person::id)
+            .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
 
-    let mut query = admin_purge_community::table
-      .left_join(person::table.on(admin_names_join))
-      .select((
-        admin_purge_community::all_columns,
-        person::all_columns.nullable(),
-      ))
-      .into_boxed();
+        let mut query = admin_purge_community::table
+            .left_join(person::table.on(admin_names_join))
+            .select((
+                admin_purge_community::all_columns,
+                person::all_columns.nullable(),
+            ))
+            .into_boxed();
 
-    if let Some(admin_person_id) = params.mod_person_id {
-      query = query.filter(admin_purge_community::admin_person_id.eq(admin_person_id));
-    };
+        if let Some(admin_person_id) = params.mod_person_id {
+            query = query.filter(admin_purge_community::admin_person_id.eq(admin_person_id));
+        };
 
-    let (limit, offset) = limit_and_offset(params.page, params.limit)?;
+        let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
-    query
-      .limit(limit)
-      .offset(offset)
-      .order_by(admin_purge_community::when_.desc())
-      .load::<AdminPurgeCommunityView>(conn)
-      .await
-  }
+        query
+            .limit(limit)
+            .offset(offset)
+            .order_by(admin_purge_community::when_.desc())
+            .load::<AdminPurgeCommunityView>(conn)
+            .await
+    }
 }

--- a/crates/db_views_moderator/src/admin_purge_person_view.rs
+++ b/crates/db_views_moderator/src/admin_purge_person_view.rs
@@ -1,50 +1,45 @@
 use crate::structs::{AdminPurgePersonView, ModlogListParams};
 use diesel::{
-  result::Error,
-  BoolExpressionMethods,
-  ExpressionMethods,
-  IntoSql,
-  JoinOnDsl,
-  NullableExpressionMethods,
-  QueryDsl,
+    result::Error, BoolExpressionMethods, ExpressionMethods, IntoSql, JoinOnDsl,
+    NullableExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  newtypes::PersonId,
-  schema::{admin_purge_person, person},
-  utils::{get_conn, limit_and_offset, DbPool},
+    newtypes::PersonId,
+    schema::{admin_purge_person, person},
+    utils::{get_conn, limit_and_offset, DbPool},
 };
 
 impl AdminPurgePersonView {
-  pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
+    pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
 
-    let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
-    let show_mod_names = !params.hide_modlog_names;
-    let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
+        let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
+        let show_mod_names = !params.hide_modlog_names;
+        let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
 
-    let admin_names_join = admin_purge_person::admin_person_id
-      .eq(person::id)
-      .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
-    let mut query = admin_purge_person::table
-      .left_join(person::table.on(admin_names_join))
-      .select((
-        admin_purge_person::all_columns,
-        person::all_columns.nullable(),
-      ))
-      .into_boxed();
+        let admin_names_join = admin_purge_person::admin_person_id
+            .eq(person::id)
+            .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
+        let mut query = admin_purge_person::table
+            .left_join(person::table.on(admin_names_join))
+            .select((
+                admin_purge_person::all_columns,
+                person::all_columns.nullable(),
+            ))
+            .into_boxed();
 
-    if let Some(admin_person_id) = params.mod_person_id {
-      query = query.filter(admin_purge_person::admin_person_id.eq(admin_person_id));
-    };
+        if let Some(admin_person_id) = params.mod_person_id {
+            query = query.filter(admin_purge_person::admin_person_id.eq(admin_person_id));
+        };
 
-    let (limit, offset) = limit_and_offset(params.page, params.limit)?;
+        let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
-    query
-      .limit(limit)
-      .offset(offset)
-      .order_by(admin_purge_person::when_.desc())
-      .load::<AdminPurgePersonView>(conn)
-      .await
-  }
+        query
+            .limit(limit)
+            .offset(offset)
+            .order_by(admin_purge_person::when_.desc())
+            .load::<AdminPurgePersonView>(conn)
+            .await
+    }
 }

--- a/crates/db_views_moderator/src/admin_purge_post_view.rs
+++ b/crates/db_views_moderator/src/admin_purge_post_view.rs
@@ -1,52 +1,47 @@
 use crate::structs::{AdminPurgePostView, ModlogListParams};
 use diesel::{
-  result::Error,
-  BoolExpressionMethods,
-  ExpressionMethods,
-  IntoSql,
-  JoinOnDsl,
-  NullableExpressionMethods,
-  QueryDsl,
+    result::Error, BoolExpressionMethods, ExpressionMethods, IntoSql, JoinOnDsl,
+    NullableExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  newtypes::PersonId,
-  schema::{admin_purge_post, community, person},
-  utils::{get_conn, limit_and_offset, DbPool},
+    newtypes::PersonId,
+    schema::{admin_purge_post, community, person},
+    utils::{get_conn, limit_and_offset, DbPool},
 };
 
 impl AdminPurgePostView {
-  pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
+    pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
 
-    let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
-    let show_mod_names = !params.hide_modlog_names;
-    let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
+        let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
+        let show_mod_names = !params.hide_modlog_names;
+        let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
 
-    let admin_names_join = admin_purge_post::admin_person_id
-      .eq(person::id)
-      .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
-    let mut query = admin_purge_post::table
-      .left_join(person::table.on(admin_names_join))
-      .inner_join(community::table)
-      .select((
-        admin_purge_post::all_columns,
-        person::all_columns.nullable(),
-        community::all_columns,
-      ))
-      .into_boxed();
+        let admin_names_join = admin_purge_post::admin_person_id
+            .eq(person::id)
+            .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
+        let mut query = admin_purge_post::table
+            .left_join(person::table.on(admin_names_join))
+            .inner_join(community::table)
+            .select((
+                admin_purge_post::all_columns,
+                person::all_columns.nullable(),
+                community::all_columns,
+            ))
+            .into_boxed();
 
-    if let Some(admin_person_id) = params.mod_person_id {
-      query = query.filter(admin_purge_post::admin_person_id.eq(admin_person_id));
-    };
+        if let Some(admin_person_id) = params.mod_person_id {
+            query = query.filter(admin_purge_post::admin_person_id.eq(admin_person_id));
+        };
 
-    let (limit, offset) = limit_and_offset(params.page, params.limit)?;
+        let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
-    query
-      .limit(limit)
-      .offset(offset)
-      .order_by(admin_purge_post::when_.desc())
-      .load::<AdminPurgePostView>(conn)
-      .await
-  }
+        query
+            .limit(limit)
+            .offset(offset)
+            .order_by(admin_purge_post::when_.desc())
+            .load::<AdminPurgePostView>(conn)
+            .await
+    }
 }

--- a/crates/db_views_moderator/src/mod_add_community_view.rs
+++ b/crates/db_views_moderator/src/mod_add_community_view.rs
@@ -1,64 +1,60 @@
 use crate::structs::{ModAddCommunityView, ModlogListParams};
 use diesel::{
-  result::Error,
-  BoolExpressionMethods,
-  ExpressionMethods,
-  IntoSql,
-  JoinOnDsl,
-  NullableExpressionMethods,
-  QueryDsl,
+    result::Error, BoolExpressionMethods, ExpressionMethods, IntoSql, JoinOnDsl,
+    NullableExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  newtypes::PersonId,
-  schema::{community, mod_add_community, person},
-  utils::{get_conn, limit_and_offset, DbPool},
+    newtypes::PersonId,
+    schema::{community, mod_add_community, person},
+    utils::{get_conn, limit_and_offset, DbPool},
 };
 
 impl ModAddCommunityView {
-  pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let person_alias_1 = diesel::alias!(person as person1);
-    let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
-    let show_mod_names = !params.hide_modlog_names;
-    let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
+    pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let person_alias_1 = diesel::alias!(person as person1);
+        let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
+        let show_mod_names = !params.hide_modlog_names;
+        let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
 
-    let admin_names_join = mod_add_community::mod_person_id
-      .eq(person::id)
-      .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
-    let mut query = mod_add_community::table
-      .left_join(person::table.on(admin_names_join))
-      .inner_join(community::table)
-      .inner_join(
-        person_alias_1.on(mod_add_community::other_person_id.eq(person_alias_1.field(person::id))),
-      )
-      .select((
-        mod_add_community::all_columns,
-        person::all_columns.nullable(),
-        community::all_columns,
-        person_alias_1.fields(person::all_columns),
-      ))
-      .into_boxed();
+        let admin_names_join = mod_add_community::mod_person_id
+            .eq(person::id)
+            .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
+        let mut query = mod_add_community::table
+            .left_join(person::table.on(admin_names_join))
+            .inner_join(community::table)
+            .inner_join(
+                person_alias_1
+                    .on(mod_add_community::other_person_id.eq(person_alias_1.field(person::id))),
+            )
+            .select((
+                mod_add_community::all_columns,
+                person::all_columns.nullable(),
+                community::all_columns,
+                person_alias_1.fields(person::all_columns),
+            ))
+            .into_boxed();
 
-    if let Some(mod_person_id) = params.mod_person_id {
-      query = query.filter(mod_add_community::mod_person_id.eq(mod_person_id));
-    };
+        if let Some(mod_person_id) = params.mod_person_id {
+            query = query.filter(mod_add_community::mod_person_id.eq(mod_person_id));
+        };
 
-    if let Some(community_id) = params.community_id {
-      query = query.filter(mod_add_community::community_id.eq(community_id));
-    };
+        if let Some(community_id) = params.community_id {
+            query = query.filter(mod_add_community::community_id.eq(community_id));
+        };
 
-    if let Some(other_person_id) = params.other_person_id {
-      query = query.filter(person_alias_1.field(person::id).eq(other_person_id));
-    };
+        if let Some(other_person_id) = params.other_person_id {
+            query = query.filter(person_alias_1.field(person::id).eq(other_person_id));
+        };
 
-    let (limit, offset) = limit_and_offset(params.page, params.limit)?;
+        let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
-    query
-      .limit(limit)
-      .offset(offset)
-      .order_by(mod_add_community::when_.desc())
-      .load::<ModAddCommunityView>(conn)
-      .await
-  }
+        query
+            .limit(limit)
+            .offset(offset)
+            .order_by(mod_add_community::when_.desc())
+            .load::<ModAddCommunityView>(conn)
+            .await
+    }
 }

--- a/crates/db_views_moderator/src/mod_add_view.rs
+++ b/crates/db_views_moderator/src/mod_add_view.rs
@@ -1,56 +1,53 @@
 use crate::structs::{ModAddView, ModlogListParams};
 use diesel::{
-  result::Error,
-  BoolExpressionMethods,
-  ExpressionMethods,
-  IntoSql,
-  JoinOnDsl,
-  NullableExpressionMethods,
-  QueryDsl,
+    result::Error, BoolExpressionMethods, ExpressionMethods, IntoSql, JoinOnDsl,
+    NullableExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  newtypes::PersonId,
-  schema::{mod_add, person},
-  utils::{get_conn, limit_and_offset, DbPool},
+    newtypes::PersonId,
+    schema::{mod_add, person},
+    utils::{get_conn, limit_and_offset, DbPool},
 };
 
 impl ModAddView {
-  pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let person_alias_1 = diesel::alias!(person as person1);
-    let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
-    let show_mod_names = !params.hide_modlog_names;
-    let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
+    pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let person_alias_1 = diesel::alias!(person as person1);
+        let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
+        let show_mod_names = !params.hide_modlog_names;
+        let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
 
-    let admin_names_join = mod_add::mod_person_id
-      .eq(person::id)
-      .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
-    let mut query = mod_add::table
-      .left_join(person::table.on(admin_names_join))
-      .inner_join(person_alias_1.on(mod_add::other_person_id.eq(person_alias_1.field(person::id))))
-      .select((
-        mod_add::all_columns,
-        person::all_columns.nullable(),
-        person_alias_1.fields(person::all_columns),
-      ))
-      .into_boxed();
+        let admin_names_join = mod_add::mod_person_id
+            .eq(person::id)
+            .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
+        let mut query = mod_add::table
+            .left_join(person::table.on(admin_names_join))
+            .inner_join(
+                person_alias_1.on(mod_add::other_person_id.eq(person_alias_1.field(person::id))),
+            )
+            .select((
+                mod_add::all_columns,
+                person::all_columns.nullable(),
+                person_alias_1.fields(person::all_columns),
+            ))
+            .into_boxed();
 
-    if let Some(mod_person_id) = params.mod_person_id {
-      query = query.filter(mod_add::mod_person_id.eq(mod_person_id));
-    };
+        if let Some(mod_person_id) = params.mod_person_id {
+            query = query.filter(mod_add::mod_person_id.eq(mod_person_id));
+        };
 
-    if let Some(other_person_id) = params.other_person_id {
-      query = query.filter(person_alias_1.field(person::id).eq(other_person_id));
-    };
+        if let Some(other_person_id) = params.other_person_id {
+            query = query.filter(person_alias_1.field(person::id).eq(other_person_id));
+        };
 
-    let (limit, offset) = limit_and_offset(params.page, params.limit)?;
+        let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
-    query
-      .limit(limit)
-      .offset(offset)
-      .order_by(mod_add::when_.desc())
-      .load::<ModAddView>(conn)
-      .await
-  }
+        query
+            .limit(limit)
+            .offset(offset)
+            .order_by(mod_add::when_.desc())
+            .load::<ModAddView>(conn)
+            .await
+    }
 }

--- a/crates/db_views_moderator/src/mod_ban_from_community_view.rs
+++ b/crates/db_views_moderator/src/mod_ban_from_community_view.rs
@@ -1,66 +1,61 @@
 use crate::structs::{ModBanFromCommunityView, ModlogListParams};
 use diesel::{
-  result::Error,
-  BoolExpressionMethods,
-  ExpressionMethods,
-  IntoSql,
-  JoinOnDsl,
-  NullableExpressionMethods,
-  QueryDsl,
+    result::Error, BoolExpressionMethods, ExpressionMethods, IntoSql, JoinOnDsl,
+    NullableExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  newtypes::PersonId,
-  schema::{community, mod_ban_from_community, person},
-  utils::{get_conn, limit_and_offset, DbPool},
+    newtypes::PersonId,
+    schema::{community, mod_ban_from_community, person},
+    utils::{get_conn, limit_and_offset, DbPool},
 };
 
 impl ModBanFromCommunityView {
-  pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
+    pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
 
-    let person_alias_1 = diesel::alias!(person as person1);
-    let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
-    let show_mod_names = !params.hide_modlog_names;
-    let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
+        let person_alias_1 = diesel::alias!(person as person1);
+        let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
+        let show_mod_names = !params.hide_modlog_names;
+        let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
 
-    let admin_names_join = mod_ban_from_community::mod_person_id
-      .eq(person::id)
-      .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
-    let mut query = mod_ban_from_community::table
-      .left_join(person::table.on(admin_names_join))
-      .inner_join(community::table)
-      .inner_join(
-        person_alias_1
-          .on(mod_ban_from_community::other_person_id.eq(person_alias_1.field(person::id))),
-      )
-      .select((
-        mod_ban_from_community::all_columns,
-        person::all_columns.nullable(),
-        community::all_columns,
-        person_alias_1.fields(person::all_columns),
-      ))
-      .into_boxed();
+        let admin_names_join = mod_ban_from_community::mod_person_id
+            .eq(person::id)
+            .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
+        let mut query =
+            mod_ban_from_community::table
+                .left_join(person::table.on(admin_names_join))
+                .inner_join(community::table)
+                .inner_join(person_alias_1.on(
+                    mod_ban_from_community::other_person_id.eq(person_alias_1.field(person::id)),
+                ))
+                .select((
+                    mod_ban_from_community::all_columns,
+                    person::all_columns.nullable(),
+                    community::all_columns,
+                    person_alias_1.fields(person::all_columns),
+                ))
+                .into_boxed();
 
-    if let Some(mod_person_id) = params.mod_person_id {
-      query = query.filter(mod_ban_from_community::mod_person_id.eq(mod_person_id));
-    };
+        if let Some(mod_person_id) = params.mod_person_id {
+            query = query.filter(mod_ban_from_community::mod_person_id.eq(mod_person_id));
+        };
 
-    if let Some(community_id) = params.community_id {
-      query = query.filter(mod_ban_from_community::community_id.eq(community_id));
-    };
+        if let Some(community_id) = params.community_id {
+            query = query.filter(mod_ban_from_community::community_id.eq(community_id));
+        };
 
-    if let Some(other_person_id) = params.other_person_id {
-      query = query.filter(mod_ban_from_community::other_person_id.eq(other_person_id));
-    };
+        if let Some(other_person_id) = params.other_person_id {
+            query = query.filter(mod_ban_from_community::other_person_id.eq(other_person_id));
+        };
 
-    let (limit, offset) = limit_and_offset(params.page, params.limit)?;
+        let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
-    query
-      .limit(limit)
-      .offset(offset)
-      .order_by(mod_ban_from_community::when_.desc())
-      .load::<ModBanFromCommunityView>(conn)
-      .await
-  }
+        query
+            .limit(limit)
+            .offset(offset)
+            .order_by(mod_ban_from_community::when_.desc())
+            .load::<ModBanFromCommunityView>(conn)
+            .await
+    }
 }

--- a/crates/db_views_moderator/src/mod_ban_view.rs
+++ b/crates/db_views_moderator/src/mod_ban_view.rs
@@ -1,56 +1,53 @@
 use crate::structs::{ModBanView, ModlogListParams};
 use diesel::{
-  result::Error,
-  BoolExpressionMethods,
-  ExpressionMethods,
-  IntoSql,
-  JoinOnDsl,
-  NullableExpressionMethods,
-  QueryDsl,
+    result::Error, BoolExpressionMethods, ExpressionMethods, IntoSql, JoinOnDsl,
+    NullableExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  newtypes::PersonId,
-  schema::{mod_ban, person},
-  utils::{get_conn, limit_and_offset, DbPool},
+    newtypes::PersonId,
+    schema::{mod_ban, person},
+    utils::{get_conn, limit_and_offset, DbPool},
 };
 
 impl ModBanView {
-  pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let person_alias_1 = diesel::alias!(person as person1);
-    let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
-    let show_mod_names = !params.hide_modlog_names;
-    let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
+    pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let person_alias_1 = diesel::alias!(person as person1);
+        let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
+        let show_mod_names = !params.hide_modlog_names;
+        let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
 
-    let admin_names_join = mod_ban::mod_person_id
-      .eq(person::id)
-      .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
-    let mut query = mod_ban::table
-      .left_join(person::table.on(admin_names_join))
-      .inner_join(person_alias_1.on(mod_ban::other_person_id.eq(person_alias_1.field(person::id))))
-      .select((
-        mod_ban::all_columns,
-        person::all_columns.nullable(),
-        person_alias_1.fields(person::all_columns),
-      ))
-      .into_boxed();
+        let admin_names_join = mod_ban::mod_person_id
+            .eq(person::id)
+            .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
+        let mut query = mod_ban::table
+            .left_join(person::table.on(admin_names_join))
+            .inner_join(
+                person_alias_1.on(mod_ban::other_person_id.eq(person_alias_1.field(person::id))),
+            )
+            .select((
+                mod_ban::all_columns,
+                person::all_columns.nullable(),
+                person_alias_1.fields(person::all_columns),
+            ))
+            .into_boxed();
 
-    if let Some(mod_person_id) = params.mod_person_id {
-      query = query.filter(mod_ban::mod_person_id.eq(mod_person_id));
-    };
+        if let Some(mod_person_id) = params.mod_person_id {
+            query = query.filter(mod_ban::mod_person_id.eq(mod_person_id));
+        };
 
-    if let Some(other_person_id) = params.other_person_id {
-      query = query.filter(person_alias_1.field(person::id).eq(other_person_id));
-    };
+        if let Some(other_person_id) = params.other_person_id {
+            query = query.filter(person_alias_1.field(person::id).eq(other_person_id));
+        };
 
-    let (limit, offset) = limit_and_offset(params.page, params.limit)?;
+        let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
-    query
-      .limit(limit)
-      .offset(offset)
-      .order_by(mod_ban::when_.desc())
-      .load::<ModBanView>(conn)
-      .await
-  }
+        query
+            .limit(limit)
+            .offset(offset)
+            .order_by(mod_ban::when_.desc())
+            .load::<ModBanView>(conn)
+            .await
+    }
 }

--- a/crates/db_views_moderator/src/mod_feature_post_view.rs
+++ b/crates/db_views_moderator/src/mod_feature_post_view.rs
@@ -1,63 +1,58 @@
 use crate::structs::{ModFeaturePostView, ModlogListParams};
 use diesel::{
-  result::Error,
-  BoolExpressionMethods,
-  ExpressionMethods,
-  IntoSql,
-  JoinOnDsl,
-  NullableExpressionMethods,
-  QueryDsl,
+    result::Error, BoolExpressionMethods, ExpressionMethods, IntoSql, JoinOnDsl,
+    NullableExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  newtypes::PersonId,
-  schema::{community, mod_feature_post, person, post},
-  utils::{get_conn, limit_and_offset, DbPool},
+    newtypes::PersonId,
+    schema::{community, mod_feature_post, person, post},
+    utils::{get_conn, limit_and_offset, DbPool},
 };
 
 impl ModFeaturePostView {
-  pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let person_alias_1 = diesel::alias!(person as person1);
-    let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
-    let show_mod_names = !params.hide_modlog_names;
-    let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
+    pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let person_alias_1 = diesel::alias!(person as person1);
+        let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
+        let show_mod_names = !params.hide_modlog_names;
+        let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
 
-    let admin_names_join = mod_feature_post::mod_person_id
-      .eq(person::id)
-      .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
-    let mut query = mod_feature_post::table
-      .left_join(person::table.on(admin_names_join))
-      .inner_join(post::table)
-      .inner_join(person_alias_1.on(post::creator_id.eq(person_alias_1.field(person::id))))
-      .inner_join(community::table.on(post::community_id.eq(community::id)))
-      .select((
-        mod_feature_post::all_columns,
-        person::all_columns.nullable(),
-        post::all_columns,
-        community::all_columns,
-      ))
-      .into_boxed();
+        let admin_names_join = mod_feature_post::mod_person_id
+            .eq(person::id)
+            .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
+        let mut query = mod_feature_post::table
+            .left_join(person::table.on(admin_names_join))
+            .inner_join(post::table)
+            .inner_join(person_alias_1.on(post::creator_id.eq(person_alias_1.field(person::id))))
+            .inner_join(community::table.on(post::community_id.eq(community::id)))
+            .select((
+                mod_feature_post::all_columns,
+                person::all_columns.nullable(),
+                post::all_columns,
+                community::all_columns,
+            ))
+            .into_boxed();
 
-    if let Some(community_id) = params.community_id {
-      query = query.filter(post::community_id.eq(community_id));
-    };
+        if let Some(community_id) = params.community_id {
+            query = query.filter(post::community_id.eq(community_id));
+        };
 
-    if let Some(mod_person_id) = params.mod_person_id {
-      query = query.filter(mod_feature_post::mod_person_id.eq(mod_person_id));
-    };
+        if let Some(mod_person_id) = params.mod_person_id {
+            query = query.filter(mod_feature_post::mod_person_id.eq(mod_person_id));
+        };
 
-    if let Some(other_person_id) = params.other_person_id {
-      query = query.filter(person_alias_1.field(person::id).eq(other_person_id));
-    };
+        if let Some(other_person_id) = params.other_person_id {
+            query = query.filter(person_alias_1.field(person::id).eq(other_person_id));
+        };
 
-    let (limit, offset) = limit_and_offset(params.page, params.limit)?;
+        let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
-    query
-      .limit(limit)
-      .offset(offset)
-      .order_by(mod_feature_post::when_.desc())
-      .load::<ModFeaturePostView>(conn)
-      .await
-  }
+        query
+            .limit(limit)
+            .offset(offset)
+            .order_by(mod_feature_post::when_.desc())
+            .load::<ModFeaturePostView>(conn)
+            .await
+    }
 }

--- a/crates/db_views_moderator/src/mod_hide_community_view.rs
+++ b/crates/db_views_moderator/src/mod_hide_community_view.rs
@@ -1,57 +1,52 @@
 use crate::structs::{ModHideCommunityView, ModlogListParams};
 use diesel::{
-  result::Error,
-  BoolExpressionMethods,
-  ExpressionMethods,
-  IntoSql,
-  JoinOnDsl,
-  NullableExpressionMethods,
-  QueryDsl,
+    result::Error, BoolExpressionMethods, ExpressionMethods, IntoSql, JoinOnDsl,
+    NullableExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  newtypes::PersonId,
-  schema::{community, mod_hide_community, person},
-  utils::{get_conn, limit_and_offset, DbPool},
+    newtypes::PersonId,
+    schema::{community, mod_hide_community, person},
+    utils::{get_conn, limit_and_offset, DbPool},
 };
 
 impl ModHideCommunityView {
-  // Pass in mod_id as admin_id because only admins can do this action
-  pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
+    // Pass in mod_id as admin_id because only admins can do this action
+    pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
 
-    let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
-    let show_mod_names = !params.hide_modlog_names;
-    let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
+        let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
+        let show_mod_names = !params.hide_modlog_names;
+        let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
 
-    let admin_names_join = mod_hide_community::mod_person_id
-      .eq(person::id)
-      .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
-    let mut query = mod_hide_community::table
-      .left_join(person::table.on(admin_names_join))
-      .inner_join(community::table.on(mod_hide_community::community_id.eq(community::id)))
-      .select((
-        mod_hide_community::all_columns,
-        person::all_columns.nullable(),
-        community::all_columns,
-      ))
-      .into_boxed();
+        let admin_names_join = mod_hide_community::mod_person_id
+            .eq(person::id)
+            .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
+        let mut query = mod_hide_community::table
+            .left_join(person::table.on(admin_names_join))
+            .inner_join(community::table.on(mod_hide_community::community_id.eq(community::id)))
+            .select((
+                mod_hide_community::all_columns,
+                person::all_columns.nullable(),
+                community::all_columns,
+            ))
+            .into_boxed();
 
-    if let Some(community_id) = params.community_id {
-      query = query.filter(mod_hide_community::community_id.eq(community_id));
-    };
+        if let Some(community_id) = params.community_id {
+            query = query.filter(mod_hide_community::community_id.eq(community_id));
+        };
 
-    if let Some(admin_id) = params.mod_person_id {
-      query = query.filter(mod_hide_community::mod_person_id.eq(admin_id));
-    };
+        if let Some(admin_id) = params.mod_person_id {
+            query = query.filter(mod_hide_community::mod_person_id.eq(admin_id));
+        };
 
-    let (limit, offset) = limit_and_offset(params.page, params.limit)?;
+        let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
-    query
-      .limit(limit)
-      .offset(offset)
-      .order_by(mod_hide_community::when_.desc())
-      .load::<ModHideCommunityView>(conn)
-      .await
-  }
+        query
+            .limit(limit)
+            .offset(offset)
+            .order_by(mod_hide_community::when_.desc())
+            .load::<ModHideCommunityView>(conn)
+            .await
+    }
 }

--- a/crates/db_views_moderator/src/mod_lock_post_view.rs
+++ b/crates/db_views_moderator/src/mod_lock_post_view.rs
@@ -1,64 +1,59 @@
 use crate::structs::{ModLockPostView, ModlogListParams};
 use diesel::{
-  result::Error,
-  BoolExpressionMethods,
-  ExpressionMethods,
-  IntoSql,
-  JoinOnDsl,
-  NullableExpressionMethods,
-  QueryDsl,
+    result::Error, BoolExpressionMethods, ExpressionMethods, IntoSql, JoinOnDsl,
+    NullableExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  newtypes::PersonId,
-  schema::{community, mod_lock_post, person, post},
-  utils::{get_conn, limit_and_offset, DbPool},
+    newtypes::PersonId,
+    schema::{community, mod_lock_post, person, post},
+    utils::{get_conn, limit_and_offset, DbPool},
 };
 
 impl ModLockPostView {
-  pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
+    pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
 
-    let person_alias_1 = diesel::alias!(person as person1);
-    let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
-    let show_mod_names = !params.hide_modlog_names;
-    let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
+        let person_alias_1 = diesel::alias!(person as person1);
+        let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
+        let show_mod_names = !params.hide_modlog_names;
+        let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
 
-    let admin_names_join = mod_lock_post::mod_person_id
-      .eq(person::id)
-      .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
-    let mut query = mod_lock_post::table
-      .left_join(person::table.on(admin_names_join))
-      .inner_join(post::table)
-      .inner_join(community::table.on(post::community_id.eq(community::id)))
-      .inner_join(person_alias_1.on(post::creator_id.eq(person_alias_1.field(person::id))))
-      .select((
-        mod_lock_post::all_columns,
-        person::all_columns.nullable(),
-        post::all_columns,
-        community::all_columns,
-      ))
-      .into_boxed();
+        let admin_names_join = mod_lock_post::mod_person_id
+            .eq(person::id)
+            .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
+        let mut query = mod_lock_post::table
+            .left_join(person::table.on(admin_names_join))
+            .inner_join(post::table)
+            .inner_join(community::table.on(post::community_id.eq(community::id)))
+            .inner_join(person_alias_1.on(post::creator_id.eq(person_alias_1.field(person::id))))
+            .select((
+                mod_lock_post::all_columns,
+                person::all_columns.nullable(),
+                post::all_columns,
+                community::all_columns,
+            ))
+            .into_boxed();
 
-    if let Some(community_id) = params.community_id {
-      query = query.filter(post::community_id.eq(community_id));
-    };
+        if let Some(community_id) = params.community_id {
+            query = query.filter(post::community_id.eq(community_id));
+        };
 
-    if let Some(mod_person_id) = params.mod_person_id {
-      query = query.filter(mod_lock_post::mod_person_id.eq(mod_person_id));
-    };
+        if let Some(mod_person_id) = params.mod_person_id {
+            query = query.filter(mod_lock_post::mod_person_id.eq(mod_person_id));
+        };
 
-    if let Some(other_person_id) = params.other_person_id {
-      query = query.filter(person_alias_1.field(person::id).eq(other_person_id));
-    };
+        if let Some(other_person_id) = params.other_person_id {
+            query = query.filter(person_alias_1.field(person::id).eq(other_person_id));
+        };
 
-    let (limit, offset) = limit_and_offset(params.page, params.limit)?;
+        let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
-    query
-      .limit(limit)
-      .offset(offset)
-      .order_by(mod_lock_post::when_.desc())
-      .load::<ModLockPostView>(conn)
-      .await
-  }
+        query
+            .limit(limit)
+            .offset(offset)
+            .order_by(mod_lock_post::when_.desc())
+            .load::<ModLockPostView>(conn)
+            .await
+    }
 }

--- a/crates/db_views_moderator/src/mod_remove_comment_view.rs
+++ b/crates/db_views_moderator/src/mod_remove_comment_view.rs
@@ -1,66 +1,61 @@
 use crate::structs::{ModRemoveCommentView, ModlogListParams};
 use diesel::{
-  result::Error,
-  BoolExpressionMethods,
-  ExpressionMethods,
-  IntoSql,
-  JoinOnDsl,
-  NullableExpressionMethods,
-  QueryDsl,
+    result::Error, BoolExpressionMethods, ExpressionMethods, IntoSql, JoinOnDsl,
+    NullableExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  newtypes::PersonId,
-  schema::{comment, community, mod_remove_comment, person, post},
-  utils::{get_conn, limit_and_offset, DbPool},
+    newtypes::PersonId,
+    schema::{comment, community, mod_remove_comment, person, post},
+    utils::{get_conn, limit_and_offset, DbPool},
 };
 
 impl ModRemoveCommentView {
-  pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let person_alias_1 = diesel::alias!(lemmy_db_schema::schema::person as person1);
-    let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
-    let show_mod_names = !params.hide_modlog_names;
-    let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
+    pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let person_alias_1 = diesel::alias!(lemmy_db_schema::schema::person as person1);
+        let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
+        let show_mod_names = !params.hide_modlog_names;
+        let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
 
-    let admin_names_join = mod_remove_comment::mod_person_id
-      .eq(person::id)
-      .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
-    let mut query = mod_remove_comment::table
-      .left_join(person::table.on(admin_names_join))
-      .inner_join(comment::table)
-      .inner_join(person_alias_1.on(comment::creator_id.eq(person_alias_1.field(person::id))))
-      .inner_join(post::table.on(comment::post_id.eq(post::id)))
-      .inner_join(community::table.on(post::community_id.eq(community::id)))
-      .select((
-        mod_remove_comment::all_columns,
-        person::all_columns.nullable(),
-        comment::all_columns,
-        person_alias_1.fields(person::all_columns),
-        post::all_columns,
-        community::all_columns,
-      ))
-      .into_boxed();
+        let admin_names_join = mod_remove_comment::mod_person_id
+            .eq(person::id)
+            .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
+        let mut query = mod_remove_comment::table
+            .left_join(person::table.on(admin_names_join))
+            .inner_join(comment::table)
+            .inner_join(person_alias_1.on(comment::creator_id.eq(person_alias_1.field(person::id))))
+            .inner_join(post::table.on(comment::post_id.eq(post::id)))
+            .inner_join(community::table.on(post::community_id.eq(community::id)))
+            .select((
+                mod_remove_comment::all_columns,
+                person::all_columns.nullable(),
+                comment::all_columns,
+                person_alias_1.fields(person::all_columns),
+                post::all_columns,
+                community::all_columns,
+            ))
+            .into_boxed();
 
-    if let Some(community_id) = params.community_id {
-      query = query.filter(post::community_id.eq(community_id));
-    };
+        if let Some(community_id) = params.community_id {
+            query = query.filter(post::community_id.eq(community_id));
+        };
 
-    if let Some(mod_person_id) = params.mod_person_id {
-      query = query.filter(mod_remove_comment::mod_person_id.eq(mod_person_id));
-    };
+        if let Some(mod_person_id) = params.mod_person_id {
+            query = query.filter(mod_remove_comment::mod_person_id.eq(mod_person_id));
+        };
 
-    if let Some(other_person_id) = params.other_person_id {
-      query = query.filter(person_alias_1.field(person::id).eq(other_person_id));
-    };
+        if let Some(other_person_id) = params.other_person_id {
+            query = query.filter(person_alias_1.field(person::id).eq(other_person_id));
+        };
 
-    let (limit, offset) = limit_and_offset(params.page, params.limit)?;
+        let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
-    query
-      .limit(limit)
-      .offset(offset)
-      .order_by(mod_remove_comment::when_.desc())
-      .load::<ModRemoveCommentView>(conn)
-      .await
-  }
+        query
+            .limit(limit)
+            .offset(offset)
+            .order_by(mod_remove_comment::when_.desc())
+            .load::<ModRemoveCommentView>(conn)
+            .await
+    }
 }

--- a/crates/db_views_moderator/src/mod_remove_community_view.rs
+++ b/crates/db_views_moderator/src/mod_remove_community_view.rs
@@ -1,51 +1,46 @@
 use crate::structs::{ModRemoveCommunityView, ModlogListParams};
 use diesel::{
-  result::Error,
-  BoolExpressionMethods,
-  ExpressionMethods,
-  IntoSql,
-  JoinOnDsl,
-  NullableExpressionMethods,
-  QueryDsl,
+    result::Error, BoolExpressionMethods, ExpressionMethods, IntoSql, JoinOnDsl,
+    NullableExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  newtypes::PersonId,
-  schema::{community, mod_remove_community, person},
-  utils::{get_conn, limit_and_offset, DbPool},
+    newtypes::PersonId,
+    schema::{community, mod_remove_community, person},
+    utils::{get_conn, limit_and_offset, DbPool},
 };
 
 impl ModRemoveCommunityView {
-  pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
-    let show_mod_names = !params.hide_modlog_names;
-    let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
+    pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
+        let show_mod_names = !params.hide_modlog_names;
+        let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
 
-    let admin_names_join = mod_remove_community::mod_person_id
-      .eq(person::id)
-      .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
-    let mut query = mod_remove_community::table
-      .left_join(person::table.on(admin_names_join))
-      .inner_join(community::table)
-      .select((
-        mod_remove_community::all_columns,
-        person::all_columns.nullable(),
-        community::all_columns,
-      ))
-      .into_boxed();
+        let admin_names_join = mod_remove_community::mod_person_id
+            .eq(person::id)
+            .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
+        let mut query = mod_remove_community::table
+            .left_join(person::table.on(admin_names_join))
+            .inner_join(community::table)
+            .select((
+                mod_remove_community::all_columns,
+                person::all_columns.nullable(),
+                community::all_columns,
+            ))
+            .into_boxed();
 
-    if let Some(mod_person_id) = params.mod_person_id {
-      query = query.filter(mod_remove_community::mod_person_id.eq(mod_person_id));
-    };
+        if let Some(mod_person_id) = params.mod_person_id {
+            query = query.filter(mod_remove_community::mod_person_id.eq(mod_person_id));
+        };
 
-    let (limit, offset) = limit_and_offset(params.page, params.limit)?;
+        let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
-    query
-      .limit(limit)
-      .offset(offset)
-      .order_by(mod_remove_community::when_.desc())
-      .load::<ModRemoveCommunityView>(conn)
-      .await
-  }
+        query
+            .limit(limit)
+            .offset(offset)
+            .order_by(mod_remove_community::when_.desc())
+            .load::<ModRemoveCommunityView>(conn)
+            .await
+    }
 }

--- a/crates/db_views_moderator/src/mod_remove_post_view.rs
+++ b/crates/db_views_moderator/src/mod_remove_post_view.rs
@@ -1,64 +1,59 @@
 use crate::structs::{ModRemovePostView, ModlogListParams};
 use diesel::{
-  result::Error,
-  BoolExpressionMethods,
-  ExpressionMethods,
-  IntoSql,
-  JoinOnDsl,
-  NullableExpressionMethods,
-  QueryDsl,
+    result::Error, BoolExpressionMethods, ExpressionMethods, IntoSql, JoinOnDsl,
+    NullableExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  newtypes::PersonId,
-  schema::{community, mod_remove_post, person, post},
-  utils::{get_conn, limit_and_offset, DbPool},
+    newtypes::PersonId,
+    schema::{community, mod_remove_post, person, post},
+    utils::{get_conn, limit_and_offset, DbPool},
 };
 
 impl ModRemovePostView {
-  pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
+    pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
 
-    let person_alias_1 = diesel::alias!(person as person1);
-    let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
-    let show_mod_names = !params.hide_modlog_names;
-    let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
+        let person_alias_1 = diesel::alias!(person as person1);
+        let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
+        let show_mod_names = !params.hide_modlog_names;
+        let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
 
-    let admin_names_join = mod_remove_post::mod_person_id
-      .eq(person::id)
-      .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
-    let mut query = mod_remove_post::table
-      .left_join(person::table.on(admin_names_join))
-      .inner_join(post::table)
-      .inner_join(community::table.on(post::community_id.eq(community::id)))
-      .inner_join(person_alias_1.on(post::creator_id.eq(person_alias_1.field(person::id))))
-      .select((
-        mod_remove_post::all_columns,
-        person::all_columns.nullable(),
-        post::all_columns,
-        community::all_columns,
-      ))
-      .into_boxed();
+        let admin_names_join = mod_remove_post::mod_person_id
+            .eq(person::id)
+            .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
+        let mut query = mod_remove_post::table
+            .left_join(person::table.on(admin_names_join))
+            .inner_join(post::table)
+            .inner_join(community::table.on(post::community_id.eq(community::id)))
+            .inner_join(person_alias_1.on(post::creator_id.eq(person_alias_1.field(person::id))))
+            .select((
+                mod_remove_post::all_columns,
+                person::all_columns.nullable(),
+                post::all_columns,
+                community::all_columns,
+            ))
+            .into_boxed();
 
-    if let Some(community_id) = params.community_id {
-      query = query.filter(post::community_id.eq(community_id));
-    };
+        if let Some(community_id) = params.community_id {
+            query = query.filter(post::community_id.eq(community_id));
+        };
 
-    if let Some(mod_person_id) = params.mod_person_id {
-      query = query.filter(mod_remove_post::mod_person_id.eq(mod_person_id));
-    };
+        if let Some(mod_person_id) = params.mod_person_id {
+            query = query.filter(mod_remove_post::mod_person_id.eq(mod_person_id));
+        };
 
-    if let Some(other_person_id) = params.other_person_id {
-      query = query.filter(person_alias_1.field(person::id).eq(other_person_id));
-    };
+        if let Some(other_person_id) = params.other_person_id {
+            query = query.filter(person_alias_1.field(person::id).eq(other_person_id));
+        };
 
-    let (limit, offset) = limit_and_offset(params.page, params.limit)?;
+        let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
-    query
-      .limit(limit)
-      .offset(offset)
-      .order_by(mod_remove_post::when_.desc())
-      .load::<ModRemovePostView>(conn)
-      .await
-  }
+        query
+            .limit(limit)
+            .offset(offset)
+            .order_by(mod_remove_post::when_.desc())
+            .load::<ModRemovePostView>(conn)
+            .await
+    }
 }

--- a/crates/db_views_moderator/src/mod_transfer_community_view.rs
+++ b/crates/db_views_moderator/src/mod_transfer_community_view.rs
@@ -1,66 +1,61 @@
 use crate::structs::{ModTransferCommunityView, ModlogListParams};
 use diesel::{
-  result::Error,
-  BoolExpressionMethods,
-  ExpressionMethods,
-  IntoSql,
-  JoinOnDsl,
-  NullableExpressionMethods,
-  QueryDsl,
+    result::Error, BoolExpressionMethods, ExpressionMethods, IntoSql, JoinOnDsl,
+    NullableExpressionMethods, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
-  newtypes::PersonId,
-  schema::{community, mod_transfer_community, person},
-  utils::{get_conn, limit_and_offset, DbPool},
+    newtypes::PersonId,
+    schema::{community, mod_transfer_community, person},
+    utils::{get_conn, limit_and_offset, DbPool},
 };
 
 impl ModTransferCommunityView {
-  pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
+    pub async fn list(pool: &mut DbPool<'_>, params: ModlogListParams) -> Result<Vec<Self>, Error> {
+        let conn = &mut get_conn(pool).await?;
 
-    let person_alias_1 = diesel::alias!(person as person1);
-    let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
-    let show_mod_names = !params.hide_modlog_names;
-    let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
+        let person_alias_1 = diesel::alias!(person as person1);
+        let admin_person_id_join = params.mod_person_id.unwrap_or(PersonId(-1));
+        let show_mod_names = !params.hide_modlog_names;
+        let show_mod_names_expr = show_mod_names.as_sql::<diesel::sql_types::Bool>();
 
-    let admin_names_join = mod_transfer_community::mod_person_id
-      .eq(person::id)
-      .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
-    let mut query = mod_transfer_community::table
-      .left_join(person::table.on(admin_names_join))
-      .inner_join(community::table)
-      .inner_join(
-        person_alias_1
-          .on(mod_transfer_community::other_person_id.eq(person_alias_1.field(person::id))),
-      )
-      .select((
-        mod_transfer_community::all_columns,
-        person::all_columns.nullable(),
-        community::all_columns,
-        person_alias_1.fields(person::all_columns),
-      ))
-      .into_boxed();
+        let admin_names_join = mod_transfer_community::mod_person_id
+            .eq(person::id)
+            .and(show_mod_names_expr.or(person::id.eq(admin_person_id_join)));
+        let mut query =
+            mod_transfer_community::table
+                .left_join(person::table.on(admin_names_join))
+                .inner_join(community::table)
+                .inner_join(person_alias_1.on(
+                    mod_transfer_community::other_person_id.eq(person_alias_1.field(person::id)),
+                ))
+                .select((
+                    mod_transfer_community::all_columns,
+                    person::all_columns.nullable(),
+                    community::all_columns,
+                    person_alias_1.fields(person::all_columns),
+                ))
+                .into_boxed();
 
-    if let Some(mod_person_id) = params.mod_person_id {
-      query = query.filter(mod_transfer_community::mod_person_id.eq(mod_person_id));
-    };
+        if let Some(mod_person_id) = params.mod_person_id {
+            query = query.filter(mod_transfer_community::mod_person_id.eq(mod_person_id));
+        };
 
-    if let Some(community_id) = params.community_id {
-      query = query.filter(mod_transfer_community::community_id.eq(community_id));
-    };
+        if let Some(community_id) = params.community_id {
+            query = query.filter(mod_transfer_community::community_id.eq(community_id));
+        };
 
-    if let Some(other_person_id) = params.other_person_id {
-      query = query.filter(person_alias_1.field(person::id).eq(other_person_id));
-    };
+        if let Some(other_person_id) = params.other_person_id {
+            query = query.filter(person_alias_1.field(person::id).eq(other_person_id));
+        };
 
-    let (limit, offset) = limit_and_offset(params.page, params.limit)?;
+        let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
-    query
-      .limit(limit)
-      .offset(offset)
-      .order_by(mod_transfer_community::when_.desc())
-      .load::<ModTransferCommunityView>(conn)
-      .await
-  }
+        query
+            .limit(limit)
+            .offset(offset)
+            .order_by(mod_transfer_community::when_.desc())
+            .load::<ModTransferCommunityView>(conn)
+            .await
+    }
 }

--- a/crates/db_views_moderator/src/structs.rs
+++ b/crates/db_views_moderator/src/structs.rs
@@ -1,30 +1,18 @@
 #[cfg(feature = "full")]
 use diesel::Queryable;
 use lemmy_db_schema::{
-  newtypes::{CommunityId, PersonId},
-  source::{
-    comment::Comment,
-    community::Community,
-    moderator::{
-      AdminPurgeComment,
-      AdminPurgeCommunity,
-      AdminPurgePerson,
-      AdminPurgePost,
-      ModAdd,
-      ModAddCommunity,
-      ModBan,
-      ModBanFromCommunity,
-      ModFeaturePost,
-      ModHideCommunity,
-      ModLockPost,
-      ModRemoveComment,
-      ModRemoveCommunity,
-      ModRemovePost,
-      ModTransferCommunity,
+    newtypes::{CommunityId, PersonId},
+    source::{
+        comment::Comment,
+        community::Community,
+        moderator::{
+            AdminPurgeComment, AdminPurgeCommunity, AdminPurgePerson, AdminPurgePost, ModAdd,
+            ModAddCommunity, ModBan, ModBanFromCommunity, ModFeaturePost, ModHideCommunity,
+            ModLockPost, ModRemoveComment, ModRemoveCommunity, ModRemovePost, ModTransferCommunity,
+        },
+        person::Person,
+        post::Post,
     },
-    person::Person,
-    post::Post,
-  },
 };
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -37,10 +25,10 @@ use ts_rs::TS;
 #[cfg_attr(feature = "full", ts(export))]
 /// When someone is added as a community moderator.
 pub struct ModAddCommunityView {
-  pub mod_add_community: ModAddCommunity,
-  pub moderator: Option<Person>,
-  pub community: Community,
-  pub modded_person: Person,
+    pub mod_add_community: ModAddCommunity,
+    pub moderator: Option<Person>,
+    pub community: Community,
+    pub modded_person: Person,
 }
 
 #[skip_serializing_none]
@@ -49,9 +37,9 @@ pub struct ModAddCommunityView {
 #[cfg_attr(feature = "full", ts(export))]
 /// When someone is added as a site moderator.
 pub struct ModAddView {
-  pub mod_add: ModAdd,
-  pub moderator: Option<Person>,
-  pub modded_person: Person,
+    pub mod_add: ModAdd,
+    pub moderator: Option<Person>,
+    pub modded_person: Person,
 }
 
 #[skip_serializing_none]
@@ -60,10 +48,10 @@ pub struct ModAddView {
 #[cfg_attr(feature = "full", ts(export))]
 /// When someone is banned from a community.
 pub struct ModBanFromCommunityView {
-  pub mod_ban_from_community: ModBanFromCommunity,
-  pub moderator: Option<Person>,
-  pub community: Community,
-  pub banned_person: Person,
+    pub mod_ban_from_community: ModBanFromCommunity,
+    pub moderator: Option<Person>,
+    pub community: Community,
+    pub banned_person: Person,
 }
 
 #[skip_serializing_none]
@@ -72,9 +60,9 @@ pub struct ModBanFromCommunityView {
 #[cfg_attr(feature = "full", ts(export))]
 /// When someone is banned from the site.
 pub struct ModBanView {
-  pub mod_ban: ModBan,
-  pub moderator: Option<Person>,
-  pub banned_person: Person,
+    pub mod_ban: ModBan,
+    pub moderator: Option<Person>,
+    pub banned_person: Person,
 }
 
 #[skip_serializing_none]
@@ -83,9 +71,9 @@ pub struct ModBanView {
 #[cfg_attr(feature = "full", ts(export))]
 /// When a community is hidden from public view.
 pub struct ModHideCommunityView {
-  pub mod_hide_community: ModHideCommunity,
-  pub admin: Option<Person>,
-  pub community: Community,
+    pub mod_hide_community: ModHideCommunity,
+    pub admin: Option<Person>,
+    pub community: Community,
 }
 
 #[skip_serializing_none]
@@ -94,10 +82,10 @@ pub struct ModHideCommunityView {
 #[cfg_attr(feature = "full", ts(export))]
 /// When a moderator locks a post (prevents new comments being made).
 pub struct ModLockPostView {
-  pub mod_lock_post: ModLockPost,
-  pub moderator: Option<Person>,
-  pub post: Post,
-  pub community: Community,
+    pub mod_lock_post: ModLockPost,
+    pub moderator: Option<Person>,
+    pub post: Post,
+    pub community: Community,
 }
 
 #[skip_serializing_none]
@@ -106,12 +94,12 @@ pub struct ModLockPostView {
 #[cfg_attr(feature = "full", ts(export))]
 /// When a moderator removes a comment.
 pub struct ModRemoveCommentView {
-  pub mod_remove_comment: ModRemoveComment,
-  pub moderator: Option<Person>,
-  pub comment: Comment,
-  pub commenter: Person,
-  pub post: Post,
-  pub community: Community,
+    pub mod_remove_comment: ModRemoveComment,
+    pub moderator: Option<Person>,
+    pub comment: Comment,
+    pub commenter: Person,
+    pub post: Post,
+    pub community: Community,
 }
 
 #[skip_serializing_none]
@@ -120,9 +108,9 @@ pub struct ModRemoveCommentView {
 #[cfg_attr(feature = "full", ts(export))]
 /// When a moderator removes a community.
 pub struct ModRemoveCommunityView {
-  pub mod_remove_community: ModRemoveCommunity,
-  pub moderator: Option<Person>,
-  pub community: Community,
+    pub mod_remove_community: ModRemoveCommunity,
+    pub moderator: Option<Person>,
+    pub community: Community,
 }
 
 #[skip_serializing_none]
@@ -131,10 +119,10 @@ pub struct ModRemoveCommunityView {
 #[cfg_attr(feature = "full", ts(export))]
 /// When a moderator removes a post.
 pub struct ModRemovePostView {
-  pub mod_remove_post: ModRemovePost,
-  pub moderator: Option<Person>,
-  pub post: Post,
-  pub community: Community,
+    pub mod_remove_post: ModRemovePost,
+    pub moderator: Option<Person>,
+    pub post: Post,
+    pub community: Community,
 }
 
 #[skip_serializing_none]
@@ -143,10 +131,10 @@ pub struct ModRemovePostView {
 #[cfg_attr(feature = "full", ts(export))]
 /// When a moderator features a post on a community (pins it to the top).
 pub struct ModFeaturePostView {
-  pub mod_feature_post: ModFeaturePost,
-  pub moderator: Option<Person>,
-  pub post: Post,
-  pub community: Community,
+    pub mod_feature_post: ModFeaturePost,
+    pub moderator: Option<Person>,
+    pub post: Post,
+    pub community: Community,
 }
 
 #[skip_serializing_none]
@@ -155,10 +143,10 @@ pub struct ModFeaturePostView {
 #[cfg_attr(feature = "full", ts(export))]
 /// When a moderator transfers a community to a new owner.
 pub struct ModTransferCommunityView {
-  pub mod_transfer_community: ModTransferCommunity,
-  pub moderator: Option<Person>,
-  pub community: Community,
-  pub modded_person: Person,
+    pub mod_transfer_community: ModTransferCommunity,
+    pub moderator: Option<Person>,
+    pub community: Community,
+    pub modded_person: Person,
 }
 
 #[skip_serializing_none]
@@ -167,9 +155,9 @@ pub struct ModTransferCommunityView {
 #[cfg_attr(feature = "full", ts(export))]
 /// When an admin purges a comment.
 pub struct AdminPurgeCommentView {
-  pub admin_purge_comment: AdminPurgeComment,
-  pub admin: Option<Person>,
-  pub post: Post,
+    pub admin_purge_comment: AdminPurgeComment,
+    pub admin: Option<Person>,
+    pub post: Post,
 }
 
 #[skip_serializing_none]
@@ -178,8 +166,8 @@ pub struct AdminPurgeCommentView {
 #[cfg_attr(feature = "full", ts(export))]
 /// When an admin purges a community.
 pub struct AdminPurgeCommunityView {
-  pub admin_purge_community: AdminPurgeCommunity,
-  pub admin: Option<Person>,
+    pub admin_purge_community: AdminPurgeCommunity,
+    pub admin: Option<Person>,
 }
 
 #[skip_serializing_none]
@@ -188,8 +176,8 @@ pub struct AdminPurgeCommunityView {
 #[cfg_attr(feature = "full", ts(export))]
 /// When an admin purges a person.
 pub struct AdminPurgePersonView {
-  pub admin_purge_person: AdminPurgePerson,
-  pub admin: Option<Person>,
+    pub admin_purge_person: AdminPurgePerson,
+    pub admin: Option<Person>,
 }
 
 #[skip_serializing_none]
@@ -198,9 +186,9 @@ pub struct AdminPurgePersonView {
 #[cfg_attr(feature = "full", ts(export))]
 /// When an admin purges a post.
 pub struct AdminPurgePostView {
-  pub admin_purge_post: AdminPurgePost,
-  pub admin: Option<Person>,
-  pub community: Community,
+    pub admin_purge_post: AdminPurgePost,
+    pub admin: Option<Person>,
+    pub community: Community,
 }
 
 #[skip_serializing_none]
@@ -209,10 +197,10 @@ pub struct AdminPurgePostView {
 #[cfg_attr(feature = "full", ts(export))]
 /// Querying / filtering the modlog.
 pub struct ModlogListParams {
-  pub community_id: Option<CommunityId>,
-  pub mod_person_id: Option<PersonId>,
-  pub other_person_id: Option<PersonId>,
-  pub page: Option<i64>,
-  pub limit: Option<i64>,
-  pub hide_modlog_names: bool,
+    pub community_id: Option<CommunityId>,
+    pub mod_person_id: Option<PersonId>,
+    pub other_person_id: Option<PersonId>,
+    pub page: Option<i64>,
+    pub limit: Option<i64>,
+    pub hide_modlog_names: bool,
 }

--- a/crates/routes/src/feeds.rs
+++ b/crates/routes/src/feeds.rs
@@ -3,36 +3,28 @@ use anyhow::anyhow;
 use chrono::{DateTime, Utc};
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::{
-  newtypes::LocalUserId,
-  source::{community::Community, local_user::LocalUser, person::Person},
-  traits::{ApubActor, Crud},
-  utils::DbPool,
-  CommentSortType,
-  ListingType,
-  SortType,
+    newtypes::LocalUserId,
+    source::{community::Community, local_user::LocalUser, person::Person},
+    traits::{ApubActor, Crud},
+    utils::DbPool,
+    CommentSortType, ListingType, SortType,
 };
 use lemmy_db_views::{
-  post_view::PostQuery,
-  structs::{LocalUserView, PostView, SiteView},
+    post_view::PostQuery,
+    structs::{LocalUserView, PostView, SiteView},
 };
 use lemmy_db_views_actor::{
-  comment_reply_view::CommentReplyQuery,
-  person_mention_view::PersonMentionQuery,
-  structs::{CommentReplyView, PersonMentionView},
+    comment_reply_view::CommentReplyQuery,
+    person_mention_view::PersonMentionQuery,
+    structs::{CommentReplyView, PersonMentionView},
 };
 use lemmy_utils::{
-  cache_header::cache_1hour,
-  claims::Claims,
-  error::LemmyError,
-  utils::markdown::markdown_to_html,
+    cache_header::cache_1hour, claims::Claims, error::LemmyError, utils::markdown::markdown_to_html,
 };
 use once_cell::sync::Lazy;
 use rss::{
-  extension::dublincore::DublinCoreExtensionBuilder,
-  ChannelBuilder,
-  GuidBuilder,
-  Item,
-  ItemBuilder,
+    extension::dublincore::DublinCoreExtensionBuilder, ChannelBuilder, GuidBuilder, Item,
+    ItemBuilder,
 };
 use serde::Deserialize;
 use std::{collections::BTreeMap, str::FromStr};
@@ -41,467 +33,459 @@ const RSS_FETCH_LIMIT: i64 = 20;
 
 #[derive(Deserialize)]
 struct Params {
-  sort: Option<String>,
-  limit: Option<i64>,
-  page: Option<i64>,
+    sort: Option<String>,
+    limit: Option<i64>,
+    page: Option<i64>,
 }
 
 impl Params {
-  fn sort_type(&self) -> Result<SortType, Error> {
-    let sort_query = self
-      .sort
-      .clone()
-      .unwrap_or_else(|| SortType::Hot.to_string());
-    SortType::from_str(&sort_query).map_err(ErrorBadRequest)
-  }
-  fn get_limit(&self) -> i64 {
-    self.limit.unwrap_or(RSS_FETCH_LIMIT)
-  }
-  fn get_page(&self) -> i64 {
-    self.page.unwrap_or(1)
-  }
+    fn sort_type(&self) -> Result<SortType, Error> {
+        let sort_query = self
+            .sort
+            .clone()
+            .unwrap_or_else(|| SortType::Hot.to_string());
+        SortType::from_str(&sort_query).map_err(ErrorBadRequest)
+    }
+    fn get_limit(&self) -> i64 {
+        self.limit.unwrap_or(RSS_FETCH_LIMIT)
+    }
+    fn get_page(&self) -> i64 {
+        self.page.unwrap_or(1)
+    }
 }
 
 enum RequestType {
-  Community,
-  User,
-  Front,
-  Inbox,
+    Community,
+    User,
+    Front,
+    Inbox,
 }
 
 pub fn config(cfg: &mut web::ServiceConfig) {
-  cfg.service(
-    web::scope("/feeds")
-      .route("/{type}/{name}.xml", web::get().to(get_feed))
-      .route("/all.xml", web::get().to(get_all_feed).wrap(cache_1hour()))
-      .route(
-        "/local.xml",
-        web::get().to(get_local_feed).wrap(cache_1hour()),
-      ),
-  );
+    cfg.service(
+        web::scope("/feeds")
+            .route("/{type}/{name}.xml", web::get().to(get_feed))
+            .route("/all.xml", web::get().to(get_all_feed).wrap(cache_1hour()))
+            .route(
+                "/local.xml",
+                web::get().to(get_local_feed).wrap(cache_1hour()),
+            ),
+    );
 }
 
 static RSS_NAMESPACE: Lazy<BTreeMap<String, String>> = Lazy::new(|| {
-  let mut h = BTreeMap::new();
-  h.insert(
-    "dc".to_string(),
-    rss::extension::dublincore::NAMESPACE.to_string(),
-  );
-  h
+    let mut h = BTreeMap::new();
+    h.insert(
+        "dc".to_string(),
+        rss::extension::dublincore::NAMESPACE.to_string(),
+    );
+    h
 });
 
 #[tracing::instrument(skip_all)]
 async fn get_all_feed(
-  info: web::Query<Params>,
-  context: web::Data<LemmyContext>,
+    info: web::Query<Params>,
+    context: web::Data<LemmyContext>,
 ) -> Result<HttpResponse, Error> {
-  Ok(
-    get_feed_data(
-      &context,
-      ListingType::All,
-      info.sort_type()?,
-      info.get_limit(),
-      info.get_page(),
+    Ok(get_feed_data(
+        &context,
+        ListingType::All,
+        info.sort_type()?,
+        info.get_limit(),
+        info.get_page(),
     )
-    .await?,
-  )
+    .await?)
 }
 
 #[tracing::instrument(skip_all)]
 async fn get_local_feed(
-  info: web::Query<Params>,
-  context: web::Data<LemmyContext>,
+    info: web::Query<Params>,
+    context: web::Data<LemmyContext>,
 ) -> Result<HttpResponse, Error> {
-  Ok(
-    get_feed_data(
-      &context,
-      ListingType::Local,
-      info.sort_type()?,
-      info.get_limit(),
-      info.get_page(),
+    Ok(get_feed_data(
+        &context,
+        ListingType::Local,
+        info.sort_type()?,
+        info.get_limit(),
+        info.get_page(),
     )
-    .await?,
-  )
+    .await?)
 }
 
 #[tracing::instrument(skip_all)]
 async fn get_feed_data(
-  context: &LemmyContext,
-  listing_type: ListingType,
-  sort_type: SortType,
-  limit: i64,
-  page: i64,
+    context: &LemmyContext,
+    listing_type: ListingType,
+    sort_type: SortType,
+    limit: i64,
+    page: i64,
 ) -> Result<HttpResponse, LemmyError> {
-  let site_view = SiteView::read_local(&mut context.pool()).await?;
+    let site_view = SiteView::read_local(&mut context.pool()).await?;
 
-  let posts = PostQuery {
-    listing_type: (Some(listing_type)),
-    sort: (Some(sort_type)),
-    limit: (Some(limit)),
-    page: (Some(page)),
-    ..Default::default()
-  }
-  .list(&mut context.pool())
-  .await?;
+    let posts = PostQuery {
+        listing_type: (Some(listing_type)),
+        sort: (Some(sort_type)),
+        limit: (Some(limit)),
+        page: (Some(page)),
+        ..Default::default()
+    }
+    .list(&mut context.pool())
+    .await?;
 
-  let items = create_post_items(posts, &context.settings().get_protocol_and_hostname())?;
+    let items = create_post_items(posts, &context.settings().get_protocol_and_hostname())?;
 
-  let mut channel_builder = ChannelBuilder::default();
-  channel_builder
-    .namespaces(RSS_NAMESPACE.clone())
-    .title(&format!("{} - {}", site_view.site.name, listing_type))
-    .link(context.settings().get_protocol_and_hostname())
-    .items(items);
+    let mut channel_builder = ChannelBuilder::default();
+    channel_builder
+        .namespaces(RSS_NAMESPACE.clone())
+        .title(&format!("{} - {}", site_view.site.name, listing_type))
+        .link(context.settings().get_protocol_and_hostname())
+        .items(items);
 
-  if let Some(site_desc) = site_view.site.description {
-    channel_builder.description(&site_desc);
-  }
+    if let Some(site_desc) = site_view.site.description {
+        channel_builder.description(&site_desc);
+    }
 
-  let rss = channel_builder.build().to_string();
-  Ok(
-    HttpResponse::Ok()
-      .content_type("application/rss+xml")
-      .body(rss),
-  )
+    let rss = channel_builder.build().to_string();
+    Ok(HttpResponse::Ok()
+        .content_type("application/rss+xml")
+        .body(rss))
 }
 
 #[tracing::instrument(skip_all)]
 async fn get_feed(
-  req: HttpRequest,
-  info: web::Query<Params>,
-  context: web::Data<LemmyContext>,
+    req: HttpRequest,
+    info: web::Query<Params>,
+    context: web::Data<LemmyContext>,
 ) -> Result<HttpResponse, Error> {
-  let req_type: String = req.match_info().get("type").unwrap_or("none").parse()?;
-  let param: String = req.match_info().get("name").unwrap_or("none").parse()?;
+    let req_type: String = req.match_info().get("type").unwrap_or("none").parse()?;
+    let param: String = req.match_info().get("name").unwrap_or("none").parse()?;
 
-  let request_type = match req_type.as_str() {
-    "u" => RequestType::User,
-    "c" => RequestType::Community,
-    "front" => RequestType::Front,
-    "inbox" => RequestType::Inbox,
-    _ => return Err(ErrorBadRequest(LemmyError::from(anyhow!("wrong_type")))),
-  };
+    let request_type = match req_type.as_str() {
+        "u" => RequestType::User,
+        "c" => RequestType::Community,
+        "front" => RequestType::Front,
+        "inbox" => RequestType::Inbox,
+        _ => return Err(ErrorBadRequest(LemmyError::from(anyhow!("wrong_type")))),
+    };
 
-  let jwt_secret = context.secret().jwt_secret.clone();
-  let protocol_and_hostname = context.settings().get_protocol_and_hostname();
+    let jwt_secret = context.secret().jwt_secret.clone();
+    let protocol_and_hostname = context.settings().get_protocol_and_hostname();
 
-  let builder = match request_type {
-    RequestType::User => {
-      get_feed_user(
-        &mut context.pool(),
-        &info.sort_type()?,
-        &info.get_limit(),
-        &info.get_page(),
-        &param,
-        &protocol_and_hostname,
-      )
-      .await
+    let builder = match request_type {
+        RequestType::User => {
+            get_feed_user(
+                &mut context.pool(),
+                &info.sort_type()?,
+                &info.get_limit(),
+                &info.get_page(),
+                &param,
+                &protocol_and_hostname,
+            )
+            .await
+        }
+        RequestType::Community => {
+            get_feed_community(
+                &mut context.pool(),
+                &info.sort_type()?,
+                &info.get_limit(),
+                &info.get_page(),
+                &param,
+                &protocol_and_hostname,
+            )
+            .await
+        }
+        RequestType::Front => {
+            get_feed_front(
+                &mut context.pool(),
+                &jwt_secret,
+                &info.sort_type()?,
+                &info.get_limit(),
+                &info.get_page(),
+                &param,
+                &protocol_and_hostname,
+            )
+            .await
+        }
+        RequestType::Inbox => {
+            get_feed_inbox(
+                &mut context.pool(),
+                &jwt_secret,
+                &param,
+                &protocol_and_hostname,
+            )
+            .await
+        }
     }
-    RequestType::Community => {
-      get_feed_community(
-        &mut context.pool(),
-        &info.sort_type()?,
-        &info.get_limit(),
-        &info.get_page(),
-        &param,
-        &protocol_and_hostname,
-      )
-      .await
-    }
-    RequestType::Front => {
-      get_feed_front(
-        &mut context.pool(),
-        &jwt_secret,
-        &info.sort_type()?,
-        &info.get_limit(),
-        &info.get_page(),
-        &param,
-        &protocol_and_hostname,
-      )
-      .await
-    }
-    RequestType::Inbox => {
-      get_feed_inbox(
-        &mut context.pool(),
-        &jwt_secret,
-        &param,
-        &protocol_and_hostname,
-      )
-      .await
-    }
-  }
-  .map_err(ErrorBadRequest)?;
+    .map_err(ErrorBadRequest)?;
 
-  let rss = builder.build().to_string();
+    let rss = builder.build().to_string();
 
-  Ok(
-    HttpResponse::Ok()
-      .content_type("application/rss+xml")
-      .body(rss),
-  )
+    Ok(HttpResponse::Ok()
+        .content_type("application/rss+xml")
+        .body(rss))
 }
 
 #[tracing::instrument(skip_all)]
 async fn get_feed_user(
-  pool: &mut DbPool<'_>,
-  sort_type: &SortType,
-  limit: &i64,
-  page: &i64,
-  user_name: &str,
-  protocol_and_hostname: &str,
+    pool: &mut DbPool<'_>,
+    sort_type: &SortType,
+    limit: &i64,
+    page: &i64,
+    user_name: &str,
+    protocol_and_hostname: &str,
 ) -> Result<ChannelBuilder, LemmyError> {
-  let site_view = SiteView::read_local(pool).await?;
-  let person = Person::read_from_name(pool, user_name, false).await?;
+    let site_view = SiteView::read_local(pool).await?;
+    let person = Person::read_from_name(pool, user_name, false).await?;
 
-  let posts = PostQuery {
-    listing_type: (Some(ListingType::All)),
-    sort: (Some(*sort_type)),
-    creator_id: (Some(person.id)),
-    limit: (Some(*limit)),
-    page: (Some(*page)),
-    ..Default::default()
-  }
-  .list(pool)
-  .await?;
+    let posts = PostQuery {
+        listing_type: (Some(ListingType::All)),
+        sort: (Some(*sort_type)),
+        creator_id: (Some(person.id)),
+        limit: (Some(*limit)),
+        page: (Some(*page)),
+        ..Default::default()
+    }
+    .list(pool)
+    .await?;
 
-  let items = create_post_items(posts, protocol_and_hostname)?;
+    let items = create_post_items(posts, protocol_and_hostname)?;
 
-  let mut channel_builder = ChannelBuilder::default();
-  channel_builder
-    .namespaces(RSS_NAMESPACE.clone())
-    .title(&format!("{} - {}", site_view.site.name, person.name))
-    .link(person.actor_id.to_string())
-    .items(items);
+    let mut channel_builder = ChannelBuilder::default();
+    channel_builder
+        .namespaces(RSS_NAMESPACE.clone())
+        .title(&format!("{} - {}", site_view.site.name, person.name))
+        .link(person.actor_id.to_string())
+        .items(items);
 
-  Ok(channel_builder)
+    Ok(channel_builder)
 }
 
 #[tracing::instrument(skip_all)]
 async fn get_feed_community(
-  pool: &mut DbPool<'_>,
-  sort_type: &SortType,
-  limit: &i64,
-  page: &i64,
-  community_name: &str,
-  protocol_and_hostname: &str,
+    pool: &mut DbPool<'_>,
+    sort_type: &SortType,
+    limit: &i64,
+    page: &i64,
+    community_name: &str,
+    protocol_and_hostname: &str,
 ) -> Result<ChannelBuilder, LemmyError> {
-  let site_view = SiteView::read_local(pool).await?;
-  let community = Community::read_from_name(pool, community_name, false).await?;
+    let site_view = SiteView::read_local(pool).await?;
+    let community = Community::read_from_name(pool, community_name, false).await?;
 
-  let posts = PostQuery {
-    sort: (Some(*sort_type)),
-    community_id: (Some(community.id)),
-    limit: (Some(*limit)),
-    page: (Some(*page)),
-    ..Default::default()
-  }
-  .list(pool)
-  .await?;
+    let posts = PostQuery {
+        sort: (Some(*sort_type)),
+        community_id: (Some(community.id)),
+        limit: (Some(*limit)),
+        page: (Some(*page)),
+        ..Default::default()
+    }
+    .list(pool)
+    .await?;
 
-  let items = create_post_items(posts, protocol_and_hostname)?;
+    let items = create_post_items(posts, protocol_and_hostname)?;
 
-  let mut channel_builder = ChannelBuilder::default();
-  channel_builder
-    .namespaces(RSS_NAMESPACE.clone())
-    .title(&format!("{} - {}", site_view.site.name, community.name))
-    .link(community.actor_id.to_string())
-    .items(items);
+    let mut channel_builder = ChannelBuilder::default();
+    channel_builder
+        .namespaces(RSS_NAMESPACE.clone())
+        .title(&format!("{} - {}", site_view.site.name, community.name))
+        .link(community.actor_id.to_string())
+        .items(items);
 
-  if let Some(community_desc) = community.description {
-    channel_builder.description(&community_desc);
-  }
+    if let Some(community_desc) = community.description {
+        channel_builder.description(&community_desc);
+    }
 
-  Ok(channel_builder)
+    Ok(channel_builder)
 }
 
 #[tracing::instrument(skip_all)]
 async fn get_feed_front(
-  pool: &mut DbPool<'_>,
-  jwt_secret: &str,
-  sort_type: &SortType,
-  limit: &i64,
-  page: &i64,
-  jwt: &str,
-  protocol_and_hostname: &str,
+    pool: &mut DbPool<'_>,
+    jwt_secret: &str,
+    sort_type: &SortType,
+    limit: &i64,
+    page: &i64,
+    jwt: &str,
+    protocol_and_hostname: &str,
 ) -> Result<ChannelBuilder, LemmyError> {
-  let site_view = SiteView::read_local(pool).await?;
-  let local_user_id = LocalUserId(Claims::decode(jwt, jwt_secret)?.claims.sub);
-  let local_user = LocalUserView::read(pool, local_user_id).await?;
+    let site_view = SiteView::read_local(pool).await?;
+    let local_user_id = LocalUserId(Claims::decode(jwt, jwt_secret)?.claims.sub);
+    let local_user = LocalUserView::read(pool, local_user_id).await?;
 
-  let posts = PostQuery {
-    listing_type: (Some(ListingType::Subscribed)),
-    local_user: (Some(&local_user)),
-    sort: (Some(*sort_type)),
-    limit: (Some(*limit)),
-    page: (Some(*page)),
-    ..Default::default()
-  }
-  .list(pool)
-  .await?;
+    let posts = PostQuery {
+        listing_type: (Some(ListingType::Subscribed)),
+        local_user: (Some(&local_user)),
+        sort: (Some(*sort_type)),
+        limit: (Some(*limit)),
+        page: (Some(*page)),
+        ..Default::default()
+    }
+    .list(pool)
+    .await?;
 
-  let items = create_post_items(posts, protocol_and_hostname)?;
+    let items = create_post_items(posts, protocol_and_hostname)?;
 
-  let mut channel_builder = ChannelBuilder::default();
-  channel_builder
-    .namespaces(RSS_NAMESPACE.clone())
-    .title(&format!("{} - Subscribed", site_view.site.name))
-    .link(protocol_and_hostname)
-    .items(items);
+    let mut channel_builder = ChannelBuilder::default();
+    channel_builder
+        .namespaces(RSS_NAMESPACE.clone())
+        .title(&format!("{} - Subscribed", site_view.site.name))
+        .link(protocol_and_hostname)
+        .items(items);
 
-  if let Some(site_desc) = site_view.site.description {
-    channel_builder.description(&site_desc);
-  }
+    if let Some(site_desc) = site_view.site.description {
+        channel_builder.description(&site_desc);
+    }
 
-  Ok(channel_builder)
+    Ok(channel_builder)
 }
 
 #[tracing::instrument(skip_all)]
 async fn get_feed_inbox(
-  pool: &mut DbPool<'_>,
-  jwt_secret: &str,
-  jwt: &str,
-  protocol_and_hostname: &str,
+    pool: &mut DbPool<'_>,
+    jwt_secret: &str,
+    jwt: &str,
+    protocol_and_hostname: &str,
 ) -> Result<ChannelBuilder, LemmyError> {
-  let site_view = SiteView::read_local(pool).await?;
-  let local_user_id = LocalUserId(Claims::decode(jwt, jwt_secret)?.claims.sub);
-  let local_user = LocalUser::read(pool, local_user_id).await?;
-  let person_id = local_user.person_id;
-  let show_bot_accounts = local_user.show_bot_accounts;
+    let site_view = SiteView::read_local(pool).await?;
+    let local_user_id = LocalUserId(Claims::decode(jwt, jwt_secret)?.claims.sub);
+    let local_user = LocalUser::read(pool, local_user_id).await?;
+    let person_id = local_user.person_id;
+    let show_bot_accounts = local_user.show_bot_accounts;
 
-  let sort = CommentSortType::New;
+    let sort = CommentSortType::New;
 
-  let replies = CommentReplyQuery {
-    recipient_id: (Some(person_id)),
-    my_person_id: (Some(person_id)),
-    show_bot_accounts: (show_bot_accounts),
-    sort: (Some(sort)),
-    limit: (Some(RSS_FETCH_LIMIT)),
-    ..Default::default()
-  }
-  .list(pool)
-  .await?;
+    let replies = CommentReplyQuery {
+        recipient_id: (Some(person_id)),
+        my_person_id: (Some(person_id)),
+        show_bot_accounts: (show_bot_accounts),
+        sort: (Some(sort)),
+        limit: (Some(RSS_FETCH_LIMIT)),
+        ..Default::default()
+    }
+    .list(pool)
+    .await?;
 
-  let mentions = PersonMentionQuery {
-    recipient_id: (Some(person_id)),
-    my_person_id: (Some(person_id)),
-    show_bot_accounts: (show_bot_accounts),
-    sort: (Some(sort)),
-    limit: (Some(RSS_FETCH_LIMIT)),
-    ..Default::default()
-  }
-  .list(pool)
-  .await?;
+    let mentions = PersonMentionQuery {
+        recipient_id: (Some(person_id)),
+        my_person_id: (Some(person_id)),
+        show_bot_accounts: (show_bot_accounts),
+        sort: (Some(sort)),
+        limit: (Some(RSS_FETCH_LIMIT)),
+        ..Default::default()
+    }
+    .list(pool)
+    .await?;
 
-  let items = create_reply_and_mention_items(replies, mentions, protocol_and_hostname)?;
+    let items = create_reply_and_mention_items(replies, mentions, protocol_and_hostname)?;
 
-  let mut channel_builder = ChannelBuilder::default();
-  channel_builder
-    .namespaces(RSS_NAMESPACE.clone())
-    .title(&format!("{} - Inbox", site_view.site.name))
-    .link(format!("{protocol_and_hostname}/inbox",))
-    .items(items);
+    let mut channel_builder = ChannelBuilder::default();
+    channel_builder
+        .namespaces(RSS_NAMESPACE.clone())
+        .title(&format!("{} - Inbox", site_view.site.name))
+        .link(format!("{protocol_and_hostname}/inbox",))
+        .items(items);
 
-  if let Some(site_desc) = site_view.site.description {
-    channel_builder.description(&site_desc);
-  }
+    if let Some(site_desc) = site_view.site.description {
+        channel_builder.description(&site_desc);
+    }
 
-  Ok(channel_builder)
+    Ok(channel_builder)
 }
 
 #[tracing::instrument(skip_all)]
 fn create_reply_and_mention_items(
-  replies: Vec<CommentReplyView>,
-  mentions: Vec<PersonMentionView>,
-  protocol_and_hostname: &str,
+    replies: Vec<CommentReplyView>,
+    mentions: Vec<PersonMentionView>,
+    protocol_and_hostname: &str,
 ) -> Result<Vec<Item>, LemmyError> {
-  let mut reply_items: Vec<Item> = replies
-    .iter()
-    .map(|r| {
-      let reply_url = format!("{}/comment/{}", protocol_and_hostname, r.comment.id);
-      build_item(
-        &r.creator.name,
-        &r.comment.published,
-        &reply_url,
-        &r.comment.content,
-        protocol_and_hostname,
-      )
-    })
-    .collect::<Result<Vec<Item>, LemmyError>>()?;
+    let mut reply_items: Vec<Item> = replies
+        .iter()
+        .map(|r| {
+            let reply_url = format!("{}/comment/{}", protocol_and_hostname, r.comment.id);
+            build_item(
+                &r.creator.name,
+                &r.comment.published,
+                &reply_url,
+                &r.comment.content,
+                protocol_and_hostname,
+            )
+        })
+        .collect::<Result<Vec<Item>, LemmyError>>()?;
 
-  let mut mention_items: Vec<Item> = mentions
-    .iter()
-    .map(|m| {
-      let mention_url = format!("{}/comment/{}", protocol_and_hostname, m.comment.id);
-      build_item(
-        &m.creator.name,
-        &m.comment.published,
-        &mention_url,
-        &m.comment.content,
-        protocol_and_hostname,
-      )
-    })
-    .collect::<Result<Vec<Item>, LemmyError>>()?;
+    let mut mention_items: Vec<Item> = mentions
+        .iter()
+        .map(|m| {
+            let mention_url = format!("{}/comment/{}", protocol_and_hostname, m.comment.id);
+            build_item(
+                &m.creator.name,
+                &m.comment.published,
+                &mention_url,
+                &m.comment.content,
+                protocol_and_hostname,
+            )
+        })
+        .collect::<Result<Vec<Item>, LemmyError>>()?;
 
-  reply_items.append(&mut mention_items);
-  Ok(reply_items)
+    reply_items.append(&mut mention_items);
+    Ok(reply_items)
 }
 
 #[tracing::instrument(skip_all)]
 fn build_item(
-  creator_name: &str,
-  published: &DateTime<Utc>,
-  url: &str,
-  content: &str,
-  protocol_and_hostname: &str,
+    creator_name: &str,
+    published: &DateTime<Utc>,
+    url: &str,
+    content: &str,
+    protocol_and_hostname: &str,
 ) -> Result<Item, LemmyError> {
-  let mut i = ItemBuilder::default();
-  i.title(format!("Reply from {creator_name}"));
-  let author_url = format!("{protocol_and_hostname}/u/{creator_name}");
-  i.author(format!(
-    "/u/{creator_name} <a href=\"{author_url}\">(link)</a>"
-  ));
-  let dt = published;
-  i.pub_date(dt.to_rfc2822());
-  i.comments(url.to_owned());
-  let guid = GuidBuilder::default().permalink(true).value(url).build();
-  i.guid(guid);
-  i.link(url.to_owned());
-  // TODO add images
-  let html = markdown_to_html(content);
-  i.description(html);
-  Ok(i.build())
+    let mut i = ItemBuilder::default();
+    i.title(format!("Reply from {creator_name}"));
+    let author_url = format!("{protocol_and_hostname}/u/{creator_name}");
+    i.author(format!(
+        "/u/{creator_name} <a href=\"{author_url}\">(link)</a>"
+    ));
+    let dt = published;
+    i.pub_date(dt.to_rfc2822());
+    i.comments(url.to_owned());
+    let guid = GuidBuilder::default().permalink(true).value(url).build();
+    i.guid(guid);
+    i.link(url.to_owned());
+    // TODO add images
+    let html = markdown_to_html(content);
+    i.description(html);
+    Ok(i.build())
 }
 
 #[tracing::instrument(skip_all)]
 fn create_post_items(
-  posts: Vec<PostView>,
-  protocol_and_hostname: &str,
+    posts: Vec<PostView>,
+    protocol_and_hostname: &str,
 ) -> Result<Vec<Item>, LemmyError> {
-  let mut items: Vec<Item> = Vec::new();
+    let mut items: Vec<Item> = Vec::new();
 
-  for p in posts {
-    let mut i = ItemBuilder::default();
-    let mut dc_extension = DublinCoreExtensionBuilder::default();
+    for p in posts {
+        let mut i = ItemBuilder::default();
+        let mut dc_extension = DublinCoreExtensionBuilder::default();
 
-    i.title(p.post.name);
+        i.title(p.post.name);
 
-    dc_extension.creators(vec![p.creator.actor_id.to_string()]);
+        dc_extension.creators(vec![p.creator.actor_id.to_string()]);
 
-    let dt = p.post.published;
-    i.pub_date(dt.to_rfc2822());
+        let dt = p.post.published;
+        i.pub_date(dt.to_rfc2822());
 
-    let post_url = format!("{}/post/{}", protocol_and_hostname, p.post.id);
-    i.comments(post_url.clone());
-    let guid = GuidBuilder::default()
-      .permalink(true)
-      .value(&post_url)
-      .build();
-    i.guid(guid);
+        let post_url = format!("{}/post/{}", protocol_and_hostname, p.post.id);
+        i.comments(post_url.clone());
+        let guid = GuidBuilder::default()
+            .permalink(true)
+            .value(&post_url)
+            .build();
+        i.guid(guid);
 
-    let community_url = format!("{}/c/{}", protocol_and_hostname, p.community.name);
+        let community_url = format!("{}/c/{}", protocol_and_hostname, p.community.name);
 
-    // TODO add images
-    let mut description = format!("submitted by <a href=\"{}\">{}</a> to <a href=\"{}\">{}</a><br>{} points | <a href=\"{}\">{} comments</a>",
+        // TODO add images
+        let mut description = format!("submitted by <a href=\"{}\">{}</a> to <a href=\"{}\">{}</a><br>{} points | <a href=\"{}\">{} comments</a>",
     p.creator.actor_id,
     p.creator.name,
     community_url,
@@ -510,25 +494,25 @@ fn create_post_items(
     post_url,
     p.counts.comments);
 
-    // If its a url post, add it to the description
-    if let Some(url) = p.post.url {
-      let link_html = format!("<br><a href=\"{url}\">{url}</a>");
-      description.push_str(&link_html);
-      i.link(url.to_string());
-    } else {
-      i.link(post_url.clone());
+        // If its a url post, add it to the description
+        if let Some(url) = p.post.url {
+            let link_html = format!("<br><a href=\"{url}\">{url}</a>");
+            description.push_str(&link_html);
+            i.link(url.to_string());
+        } else {
+            i.link(post_url.clone());
+        }
+
+        if let Some(body) = p.post.body {
+            let html = markdown_to_html(&body);
+            description.push_str(&html);
+        }
+
+        i.description(description);
+
+        i.dublin_core_ext(dc_extension.build());
+        items.push(i.build());
     }
 
-    if let Some(body) = p.post.body {
-      let html = markdown_to_html(&body);
-      description.push_str(&html);
-    }
-
-    i.description(description);
-
-    i.dublin_core_ext(dc_extension.build());
-    items.push(i.build());
-  }
-
-  Ok(items)
+    Ok(items)
 }

--- a/crates/routes/src/images.rs
+++ b/crates/routes/src/images.rs
@@ -1,14 +1,11 @@
 use actix_web::{
-  body::BodyStream,
-  error,
-  http::{
-    header::{HeaderName, ACCEPT_ENCODING, HOST},
-    StatusCode,
-  },
-  web,
-  Error,
-  HttpRequest,
-  HttpResponse,
+    body::BodyStream,
+    error,
+    http::{
+        header::{HeaderName, ACCEPT_ENCODING, HOST},
+        StatusCode,
+    },
+    web, Error, HttpRequest, HttpResponse,
 };
 use futures::stream::{Stream, StreamExt};
 use lemmy_api_common::{context::LemmyContext, utils::local_user_view_from_jwt};
@@ -19,243 +16,244 @@ use reqwest_middleware::{ClientWithMiddleware, RequestBuilder};
 use serde::{Deserialize, Serialize};
 
 pub fn config(
-  cfg: &mut web::ServiceConfig,
-  client: ClientWithMiddleware,
-  rate_limit: &RateLimitCell,
+    cfg: &mut web::ServiceConfig,
+    client: ClientWithMiddleware,
+    rate_limit: &RateLimitCell,
 ) {
-  cfg
-    .app_data(web::Data::new(client))
-    .service(
-      web::resource("/pictrs/image")
-        .wrap(rate_limit.image())
-        .route(web::post().to(upload)),
-    )
-    // This has optional query params: /image/{filename}?format=jpg&thumbnail=256
-    .service(web::resource("/pictrs/image/{filename}").route(web::get().to(full_res)))
-    .service(web::resource("/pictrs/image/delete/{token}/{filename}").route(web::get().to(delete)));
+    cfg.app_data(web::Data::new(client))
+        .service(
+            web::resource("/pictrs/image")
+                .wrap(rate_limit.image())
+                .route(web::post().to(upload)),
+        )
+        // This has optional query params: /image/{filename}?format=jpg&thumbnail=256
+        .service(web::resource("/pictrs/image/{filename}").route(web::get().to(full_res)))
+        .service(
+            web::resource("/pictrs/image/delete/{token}/{filename}").route(web::get().to(delete)),
+        );
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Image {
-  file: String,
-  delete_token: String,
+    file: String,
+    delete_token: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Images {
-  msg: String,
-  files: Option<Vec<Image>>,
+    msg: String,
+    files: Option<Vec<Image>>,
 }
 
 #[derive(Deserialize)]
 struct PictrsParams {
-  format: Option<String>,
-  thumbnail: Option<i32>,
+    format: Option<String>,
+    thumbnail: Option<i32>,
 }
 
 #[derive(Deserialize)]
 enum PictrsPurgeParams {
-  #[serde(rename = "file")]
-  File(String),
-  #[serde(rename = "alias")]
-  Alias(String),
+    #[serde(rename = "file")]
+    File(String),
+    #[serde(rename = "alias")]
+    Alias(String),
 }
 
 fn adapt_request(
-  request: &HttpRequest,
-  client: &ClientWithMiddleware,
-  url: String,
+    request: &HttpRequest,
+    client: &ClientWithMiddleware,
+    url: String,
 ) -> RequestBuilder {
-  // remove accept-encoding header so that pictrs doesnt compress the response
-  const INVALID_HEADERS: &[HeaderName] = &[ACCEPT_ENCODING, HOST];
+    // remove accept-encoding header so that pictrs doesnt compress the response
+    const INVALID_HEADERS: &[HeaderName] = &[ACCEPT_ENCODING, HOST];
 
-  let client_request = client
-    .request(request.method().clone(), url)
-    .timeout(REQWEST_TIMEOUT);
+    let client_request = client
+        .request(request.method().clone(), url)
+        .timeout(REQWEST_TIMEOUT);
 
-  request
-    .headers()
-    .iter()
-    .fold(client_request, |client_req, (key, value)| {
-      if INVALID_HEADERS.contains(key) {
-        client_req
-      } else {
-        client_req.header(key, value)
-      }
-    })
+    request
+        .headers()
+        .iter()
+        .fold(client_request, |client_req, (key, value)| {
+            if INVALID_HEADERS.contains(key) {
+                client_req
+            } else {
+                client_req.header(key, value)
+            }
+        })
 }
 
 async fn upload(
-  req: HttpRequest,
-  body: web::Payload,
-  client: web::Data<ClientWithMiddleware>,
-  context: web::Data<LemmyContext>,
+    req: HttpRequest,
+    body: web::Payload,
+    client: web::Data<ClientWithMiddleware>,
+    context: web::Data<LemmyContext>,
 ) -> Result<HttpResponse, Error> {
-  // TODO: check rate limit here
-  let jwt = req.cookie("jwt").ok_or(error::ErrorUnauthorized(
-    "No auth header for picture upload",
-  ))?;
+    // TODO: check rate limit here
+    let jwt = req.cookie("jwt").ok_or(error::ErrorUnauthorized(
+        "No auth header for picture upload",
+    ))?;
 
-  if Claims::decode(jwt.value(), &context.secret().jwt_secret).is_err() {
-    return Ok(HttpResponse::Unauthorized().finish());
-  };
+    if Claims::decode(jwt.value(), &context.secret().jwt_secret).is_err() {
+        return Ok(HttpResponse::Unauthorized().finish());
+    };
 
-  let pictrs_config = context.settings().pictrs_config()?;
-  let image_url = format!("{}image", pictrs_config.url);
+    let pictrs_config = context.settings().pictrs_config()?;
+    let image_url = format!("{}image", pictrs_config.url);
 
-  let mut client_req = adapt_request(&req, &client, image_url);
+    let mut client_req = adapt_request(&req, &client, image_url);
 
-  if let Some(addr) = req.head().peer_addr {
-    client_req = client_req.header("X-Forwarded-For", addr.to_string())
-  };
+    if let Some(addr) = req.head().peer_addr {
+        client_req = client_req.header("X-Forwarded-For", addr.to_string())
+    };
 
-  let res = client_req
-    .body(Body::wrap_stream(make_send(body)))
-    .send()
-    .await
-    .map_err(error::ErrorBadRequest)?;
+    let res = client_req
+        .body(Body::wrap_stream(make_send(body)))
+        .send()
+        .await
+        .map_err(error::ErrorBadRequest)?;
 
-  let status = res.status();
-  let images = res.json::<Images>().await.map_err(error::ErrorBadRequest)?;
+    let status = res.status();
+    let images = res.json::<Images>().await.map_err(error::ErrorBadRequest)?;
 
-  Ok(HttpResponse::build(status).json(images))
+    Ok(HttpResponse::build(status).json(images))
 }
 
 async fn full_res(
-  filename: web::Path<String>,
-  web::Query(params): web::Query<PictrsParams>,
-  req: HttpRequest,
-  client: web::Data<ClientWithMiddleware>,
-  context: web::Data<LemmyContext>,
+    filename: web::Path<String>,
+    web::Query(params): web::Query<PictrsParams>,
+    req: HttpRequest,
+    client: web::Data<ClientWithMiddleware>,
+    context: web::Data<LemmyContext>,
 ) -> Result<HttpResponse, Error> {
-  // block access to images if instance is private and unauthorized, public
-  let local_site = LocalSite::read(&mut context.pool())
-    .await
-    .map_err(error::ErrorBadRequest)?;
-  if local_site.private_instance {
-    let jwt = req.cookie("jwt").ok_or(error::ErrorUnauthorized(
-      "No auth header for picture access",
-    ))?;
-    if local_user_view_from_jwt(jwt.value(), &context)
-      .await
-      .is_err()
-    {
-      return Ok(HttpResponse::Unauthorized().finish());
-    };
-  }
-  let name = &filename.into_inner();
-
-  // If there are no query params, the URL is original
-  let pictrs_config = context.settings().pictrs_config()?;
-  let url = if params.format.is_none() && params.thumbnail.is_none() {
-    format!("{}image/original/{}", pictrs_config.url, name,)
-  } else {
-    // Take file type from name, or jpg if nothing is given
-    let format = params
-      .format
-      .unwrap_or_else(|| name.split('.').last().unwrap_or("jpg").to_string());
-
-    let mut url = format!("{}image/process.{}?src={}", pictrs_config.url, format, name,);
-
-    if let Some(size) = params.thumbnail {
-      url = format!("{url}&thumbnail={size}",);
+    // block access to images if instance is private and unauthorized, public
+    let local_site = LocalSite::read(&mut context.pool())
+        .await
+        .map_err(error::ErrorBadRequest)?;
+    if local_site.private_instance {
+        let jwt = req.cookie("jwt").ok_or(error::ErrorUnauthorized(
+            "No auth header for picture access",
+        ))?;
+        if local_user_view_from_jwt(jwt.value(), &context)
+            .await
+            .is_err()
+        {
+            return Ok(HttpResponse::Unauthorized().finish());
+        };
     }
-    url
-  };
+    let name = &filename.into_inner();
 
-  image(url, req, client).await
+    // If there are no query params, the URL is original
+    let pictrs_config = context.settings().pictrs_config()?;
+    let url = if params.format.is_none() && params.thumbnail.is_none() {
+        format!("{}image/original/{}", pictrs_config.url, name,)
+    } else {
+        // Take file type from name, or jpg if nothing is given
+        let format = params
+            .format
+            .unwrap_or_else(|| name.split('.').last().unwrap_or("jpg").to_string());
+
+        let mut url = format!("{}image/process.{}?src={}", pictrs_config.url, format, name,);
+
+        if let Some(size) = params.thumbnail {
+            url = format!("{url}&thumbnail={size}",);
+        }
+        url
+    };
+
+    image(url, req, client).await
 }
 
 async fn image(
-  url: String,
-  req: HttpRequest,
-  client: web::Data<ClientWithMiddleware>,
+    url: String,
+    req: HttpRequest,
+    client: web::Data<ClientWithMiddleware>,
 ) -> Result<HttpResponse, Error> {
-  let mut client_req = adapt_request(&req, &client, url);
+    let mut client_req = adapt_request(&req, &client, url);
 
-  if let Some(addr) = req.head().peer_addr {
-    client_req = client_req.header("X-Forwarded-For", addr.to_string());
-  }
+    if let Some(addr) = req.head().peer_addr {
+        client_req = client_req.header("X-Forwarded-For", addr.to_string());
+    }
 
-  if let Some(addr) = req.head().peer_addr {
-    client_req = client_req.header("X-Forwarded-For", addr.to_string());
-  }
+    if let Some(addr) = req.head().peer_addr {
+        client_req = client_req.header("X-Forwarded-For", addr.to_string());
+    }
 
-  let res = client_req.send().await.map_err(error::ErrorBadRequest)?;
+    let res = client_req.send().await.map_err(error::ErrorBadRequest)?;
 
-  if res.status() == StatusCode::NOT_FOUND {
-    return Ok(HttpResponse::NotFound().finish());
-  }
+    if res.status() == StatusCode::NOT_FOUND {
+        return Ok(HttpResponse::NotFound().finish());
+    }
 
-  let mut client_res = HttpResponse::build(res.status());
+    let mut client_res = HttpResponse::build(res.status());
 
-  for (name, value) in res.headers().iter().filter(|(h, _)| *h != "connection") {
-    client_res.insert_header((name.clone(), value.clone()));
-  }
+    for (name, value) in res.headers().iter().filter(|(h, _)| *h != "connection") {
+        client_res.insert_header((name.clone(), value.clone()));
+    }
 
-  Ok(client_res.body(BodyStream::new(res.bytes_stream())))
+    Ok(client_res.body(BodyStream::new(res.bytes_stream())))
 }
 
 async fn delete(
-  components: web::Path<(String, String)>,
-  req: HttpRequest,
-  client: web::Data<ClientWithMiddleware>,
-  context: web::Data<LemmyContext>,
+    components: web::Path<(String, String)>,
+    req: HttpRequest,
+    client: web::Data<ClientWithMiddleware>,
+    context: web::Data<LemmyContext>,
 ) -> Result<HttpResponse, Error> {
-  let (token, file) = components.into_inner();
+    let (token, file) = components.into_inner();
 
-  let pictrs_config = context.settings().pictrs_config()?;
-  let url = format!("{}image/delete/{}/{}", pictrs_config.url, &token, &file);
+    let pictrs_config = context.settings().pictrs_config()?;
+    let url = format!("{}image/delete/{}/{}", pictrs_config.url, &token, &file);
 
-  let mut client_req = adapt_request(&req, &client, url);
+    let mut client_req = adapt_request(&req, &client, url);
 
-  if let Some(addr) = req.head().peer_addr {
-    client_req = client_req.header("X-Forwarded-For", addr.to_string());
-  }
+    if let Some(addr) = req.head().peer_addr {
+        client_req = client_req.header("X-Forwarded-For", addr.to_string());
+    }
 
-  let res = client_req.send().await.map_err(error::ErrorBadRequest)?;
+    let res = client_req.send().await.map_err(error::ErrorBadRequest)?;
 
-  Ok(HttpResponse::build(res.status()).body(BodyStream::new(res.bytes_stream())))
+    Ok(HttpResponse::build(res.status()).body(BodyStream::new(res.bytes_stream())))
 }
 
 fn make_send<S>(mut stream: S) -> impl Stream<Item = S::Item> + Send + Unpin + 'static
 where
-  S: Stream + Unpin + 'static,
-  S::Item: Send,
+    S: Stream + Unpin + 'static,
+    S::Item: Send,
 {
-  // NOTE: the 8 here is arbitrary
-  let (tx, rx) = tokio::sync::mpsc::channel(8);
+    // NOTE: the 8 here is arbitrary
+    let (tx, rx) = tokio::sync::mpsc::channel(8);
 
-  // NOTE: spawning stream into a new task can potentially hit this bug:
-  // - https://github.com/actix/actix-web/issues/1679
-  //
-  // Since 4.0.0-beta.2 this issue is incredibly less frequent. I have not personally reproduced it.
-  // That said, it is still technically possible to encounter.
-  actix_web::rt::spawn(async move {
-    while let Some(res) = stream.next().await {
-      if tx.send(res).await.is_err() {
-        break;
-      }
-    }
-  });
+    // NOTE: spawning stream into a new task can potentially hit this bug:
+    // - https://github.com/actix/actix-web/issues/1679
+    //
+    // Since 4.0.0-beta.2 this issue is incredibly less frequent. I have not personally reproduced it.
+    // That said, it is still technically possible to encounter.
+    actix_web::rt::spawn(async move {
+        while let Some(res) = stream.next().await {
+            if tx.send(res).await.is_err() {
+                break;
+            }
+        }
+    });
 
-  SendStream { rx }
+    SendStream { rx }
 }
 
 struct SendStream<T> {
-  rx: tokio::sync::mpsc::Receiver<T>,
+    rx: tokio::sync::mpsc::Receiver<T>,
 }
 
 impl<T> Stream for SendStream<T>
 where
-  T: Send,
+    T: Send,
 {
-  type Item = T;
+    type Item = T;
 
-  fn poll_next(
-    mut self: std::pin::Pin<&mut Self>,
-    cx: &mut std::task::Context<'_>,
-  ) -> std::task::Poll<Option<Self::Item>> {
-    std::pin::Pin::new(&mut self.rx).poll_recv(cx)
-  }
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        std::pin::Pin::new(&mut self.rx).poll_recv(cx)
+    }
 }

--- a/crates/routes/src/nodeinfo.rs
+++ b/crates/routes/src/nodeinfo.rs
@@ -4,115 +4,115 @@ use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::RegistrationMode;
 use lemmy_db_views::structs::SiteView;
 use lemmy_utils::{
-  cache_header::{cache_1hour, cache_3days},
-  error::LemmyError,
-  version,
+    cache_header::{cache_1hour, cache_3days},
+    error::LemmyError,
+    version,
 };
 use serde::{Deserialize, Serialize};
 use url::Url;
 
 pub fn config(cfg: &mut web::ServiceConfig) {
-  cfg
-    .route(
-      "/nodeinfo/2.0.json",
-      web::get().to(node_info).wrap(cache_1hour()),
+    cfg.route(
+        "/nodeinfo/2.0.json",
+        web::get().to(node_info).wrap(cache_1hour()),
     )
     .route(
-      "/.well-known/nodeinfo",
-      web::get().to(node_info_well_known).wrap(cache_3days()),
+        "/.well-known/nodeinfo",
+        web::get().to(node_info_well_known).wrap(cache_3days()),
     );
 }
 
 async fn node_info_well_known(
-  context: web::Data<LemmyContext>,
+    context: web::Data<LemmyContext>,
 ) -> Result<HttpResponse, LemmyError> {
-  let node_info = NodeInfoWellKnown {
-    links: vec![NodeInfoWellKnownLinks {
-      rel: Url::parse("http://nodeinfo.diaspora.software/ns/schema/2.0")?,
-      href: Url::parse(&format!(
-        "{}/nodeinfo/2.0.json",
-        &context.settings().get_protocol_and_hostname(),
-      ))?,
-    }],
-  };
-  Ok(HttpResponse::Ok().json(node_info))
+    let node_info = NodeInfoWellKnown {
+        links: vec![NodeInfoWellKnownLinks {
+            rel: Url::parse("http://nodeinfo.diaspora.software/ns/schema/2.0")?,
+            href: Url::parse(&format!(
+                "{}/nodeinfo/2.0.json",
+                &context.settings().get_protocol_and_hostname(),
+            ))?,
+        }],
+    };
+    Ok(HttpResponse::Ok().json(node_info))
 }
 
 async fn node_info(context: web::Data<LemmyContext>) -> Result<HttpResponse, Error> {
-  let site_view = SiteView::read_local(&mut context.pool())
-    .await
-    .map_err(|_| ErrorBadRequest(LemmyError::from(anyhow!("not_found"))))?;
+    let site_view = SiteView::read_local(&mut context.pool())
+        .await
+        .map_err(|_| ErrorBadRequest(LemmyError::from(anyhow!("not_found"))))?;
 
-  let protocols = if site_view.local_site.federation_enabled {
-    Some(vec!["activitypub".to_string()])
-  } else {
-    None
-  };
-  // Since there are 3 registration options,
-  // we need to set open_registrations as true if RegistrationMode is not Closed.
-  let open_registrations = Some(site_view.local_site.registration_mode != RegistrationMode::Closed);
-  let json = NodeInfo {
-    version: Some("2.0".to_string()),
-    software: Some(NodeInfoSoftware {
-      name: Some("lemmy".to_string()),
-      version: Some(version::VERSION.to_string()),
-    }),
-    protocols,
-    usage: Some(NodeInfoUsage {
-      users: Some(NodeInfoUsers {
-        total: Some(site_view.counts.users),
-        active_halfyear: Some(site_view.counts.users_active_half_year),
-        active_month: Some(site_view.counts.users_active_month),
-      }),
-      local_posts: Some(site_view.counts.posts),
-      local_comments: Some(site_view.counts.comments),
-    }),
-    open_registrations,
-  };
+    let protocols = if site_view.local_site.federation_enabled {
+        Some(vec!["activitypub".to_string()])
+    } else {
+        None
+    };
+    // Since there are 3 registration options,
+    // we need to set open_registrations as true if RegistrationMode is not Closed.
+    let open_registrations =
+        Some(site_view.local_site.registration_mode != RegistrationMode::Closed);
+    let json = NodeInfo {
+        version: Some("2.0".to_string()),
+        software: Some(NodeInfoSoftware {
+            name: Some("lemmy".to_string()),
+            version: Some(version::VERSION.to_string()),
+        }),
+        protocols,
+        usage: Some(NodeInfoUsage {
+            users: Some(NodeInfoUsers {
+                total: Some(site_view.counts.users),
+                active_halfyear: Some(site_view.counts.users_active_half_year),
+                active_month: Some(site_view.counts.users_active_month),
+            }),
+            local_posts: Some(site_view.counts.posts),
+            local_comments: Some(site_view.counts.comments),
+        }),
+        open_registrations,
+    };
 
-  Ok(HttpResponse::Ok().json(json))
+    Ok(HttpResponse::Ok().json(json))
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 struct NodeInfoWellKnown {
-  pub links: Vec<NodeInfoWellKnownLinks>,
+    pub links: Vec<NodeInfoWellKnownLinks>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 struct NodeInfoWellKnownLinks {
-  pub rel: Url,
-  pub href: Url,
+    pub rel: Url,
+    pub href: Url,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase", default)]
 pub struct NodeInfo {
-  pub version: Option<String>,
-  pub software: Option<NodeInfoSoftware>,
-  pub protocols: Option<Vec<String>>,
-  pub usage: Option<NodeInfoUsage>,
-  pub open_registrations: Option<bool>,
+    pub version: Option<String>,
+    pub software: Option<NodeInfoSoftware>,
+    pub protocols: Option<Vec<String>>,
+    pub usage: Option<NodeInfoUsage>,
+    pub open_registrations: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default)]
 #[serde(default)]
 pub struct NodeInfoSoftware {
-  pub name: Option<String>,
-  pub version: Option<String>,
+    pub name: Option<String>,
+    pub version: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase", default)]
 pub struct NodeInfoUsage {
-  pub users: Option<NodeInfoUsers>,
-  pub local_posts: Option<i64>,
-  pub local_comments: Option<i64>,
+    pub users: Option<NodeInfoUsers>,
+    pub local_posts: Option<i64>,
+    pub local_comments: Option<i64>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase", default)]
 pub struct NodeInfoUsers {
-  pub total: Option<i64>,
-  pub active_halfyear: Option<i64>,
-  pub active_month: Option<i64>,
+    pub total: Option<i64>,
+    pub active_halfyear: Option<i64>,
+    pub active_month: Option<i64>,
 }

--- a/crates/utils/build.rs
+++ b/crates/utils/build.rs
@@ -1,11 +1,11 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-  rosetta_build::config()
-    .source("en", "translations/email/en.json")
-    .source("fi", "translations/email/fi.json")
-    .source("ko", "translations/email/ko.json")
-    .source("pt", "translations/email/pt.json")
-    .fallback("en")
-    .generate()?;
+    rosetta_build::config()
+        .source("en", "translations/email/en.json")
+        .source("fi", "translations/email/fi.json")
+        .source("ko", "translations/email/ko.json")
+        .source("pt", "translations/email/pt.json")
+        .fallback("en")
+        .generate()?;
 
-  Ok(())
+    Ok(())
 }

--- a/crates/utils/src/apub.rs
+++ b/crates/utils/src/apub.rs
@@ -2,25 +2,25 @@ use openssl::{pkey::PKey, rsa::Rsa};
 use std::io::{Error, ErrorKind};
 
 pub struct Keypair {
-  pub private_key: String,
-  pub public_key: String,
+    pub private_key: String,
+    pub public_key: String,
 }
 
 /// Generate the asymmetric keypair for ActivityPub HTTP signatures.
 pub fn generate_actor_keypair() -> Result<Keypair, Error> {
-  let rsa = Rsa::generate(2048)?;
-  let pkey = PKey::from_rsa(rsa)?;
-  let public_key = pkey.public_key_to_pem()?;
-  let private_key = pkey.private_key_to_pem_pkcs8()?;
-  let key_to_string = |key| match String::from_utf8(key) {
-    Ok(s) => Ok(s),
-    Err(e) => Err(Error::new(
-      ErrorKind::Other,
-      format!("Failed converting key to string: {e}"),
-    )),
-  };
-  Ok(Keypair {
-    private_key: key_to_string(private_key)?,
-    public_key: key_to_string(public_key)?,
-  })
+    let rsa = Rsa::generate(2048)?;
+    let pkey = PKey::from_rsa(rsa)?;
+    let public_key = pkey.public_key_to_pem()?;
+    let private_key = pkey.private_key_to_pem_pkcs8()?;
+    let key_to_string = |key| match String::from_utf8(key) {
+        Ok(s) => Ok(s),
+        Err(e) => Err(Error::new(
+            ErrorKind::Other,
+            format!("Failed converting key to string: {e}"),
+        )),
+    };
+    Ok(Keypair {
+        private_key: key_to_string(private_key)?,
+        public_key: key_to_string(public_key)?,
+    })
 }

--- a/crates/utils/src/cache_header.rs
+++ b/crates/utils/src/cache_header.rs
@@ -8,15 +8,15 @@ use actix_web::middleware::DefaultHeaders;
 ///
 /// Mastodon & other activitypub server defaults to 3d
 pub fn cache_header(seconds: usize) -> DefaultHeaders {
-  DefaultHeaders::new().add(("Cache-Control", format!("public, max-age={seconds}")))
+    DefaultHeaders::new().add(("Cache-Control", format!("public, max-age={seconds}")))
 }
 
 /// Set a 1 hour cache time
 pub fn cache_1hour() -> DefaultHeaders {
-  cache_header(3600)
+    cache_header(3600)
 }
 
 /// Set a 3 day cache time
 pub fn cache_3days() -> DefaultHeaders {
-  cache_header(259200)
+    cache_header(259200)
 }

--- a/crates/utils/src/claims.rs
+++ b/crates/utils/src/claims.rs
@@ -6,30 +6,30 @@ type Jwt = String;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {
-  /// local_user_id, standard claim by RFC 7519.
-  pub sub: i32,
-  pub iss: String,
-  /// Time when this token was issued as UNIX-timestamp in seconds
-  pub iat: i64,
+    /// local_user_id, standard claim by RFC 7519.
+    pub sub: i32,
+    pub iss: String,
+    /// Time when this token was issued as UNIX-timestamp in seconds
+    pub iat: i64,
 }
 
 impl Claims {
-  pub fn decode(jwt: &str, jwt_secret: &str) -> Result<TokenData<Claims>, LemmyError> {
-    let mut validation = Validation::default();
-    validation.validate_exp = false;
-    validation.required_spec_claims.remove("exp");
-    let key = DecodingKey::from_secret(jwt_secret.as_ref());
-    Ok(decode::<Claims>(jwt, &key, &validation)?)
-  }
+    pub fn decode(jwt: &str, jwt_secret: &str) -> Result<TokenData<Claims>, LemmyError> {
+        let mut validation = Validation::default();
+        validation.validate_exp = false;
+        validation.required_spec_claims.remove("exp");
+        let key = DecodingKey::from_secret(jwt_secret.as_ref());
+        Ok(decode::<Claims>(jwt, &key, &validation)?)
+    }
 
-  pub fn jwt(local_user_id: i32, jwt_secret: &str, hostname: &str) -> Result<Jwt, LemmyError> {
-    let my_claims = Claims {
-      sub: local_user_id,
-      iss: hostname.to_string(),
-      iat: Utc::now().timestamp(),
-    };
+    pub fn jwt(local_user_id: i32, jwt_secret: &str, hostname: &str) -> Result<Jwt, LemmyError> {
+        let my_claims = Claims {
+            sub: local_user_id,
+            iss: hostname.to_string(),
+            iat: Utc::now().timestamp(),
+        };
 
-    let key = EncodingKey::from_secret(jwt_secret.as_ref());
-    Ok(encode(&Header::default(), &my_claims, &key)?)
-  }
+        let key = EncodingKey::from_secret(jwt_secret.as_ref());
+        Ok(encode(&Header::default(), &my_claims, &key)?)
+    }
 }

--- a/crates/utils/src/email.rs
+++ b/crates/utils/src/email.rs
@@ -1,94 +1,92 @@
 use crate::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
-  settings::structs::Settings,
+    error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+    settings::structs::Settings,
 };
 use html2text;
 use lettre::{
-  message::{Mailbox, MultiPart},
-  transport::smtp::{authentication::Credentials, extension::ClientId},
-  Address,
-  AsyncTransport,
-  Message,
+    message::{Mailbox, MultiPart},
+    transport::smtp::{authentication::Credentials, extension::ClientId},
+    Address, AsyncTransport, Message,
 };
 use std::str::FromStr;
 use uuid::Uuid;
 
 pub mod translations {
-  rosetta_i18n::include_translations!();
+    rosetta_i18n::include_translations!();
 }
 
 type AsyncSmtpTransport = lettre::AsyncSmtpTransport<lettre::Tokio1Executor>;
 
 pub async fn send_email(
-  subject: &str,
-  to_email: &str,
-  to_username: &str,
-  html: &str,
-  settings: &Settings,
+    subject: &str,
+    to_email: &str,
+    to_username: &str,
+    html: &str,
+    settings: &Settings,
 ) -> Result<(), LemmyError> {
-  let email_config = settings.email.clone().ok_or(LemmyErrorType::NoEmailSetup)?;
-  let domain = settings.hostname.clone();
+    let email_config = settings.email.clone().ok_or(LemmyErrorType::NoEmailSetup)?;
+    let domain = settings.hostname.clone();
 
-  let (smtp_server, smtp_port) = {
-    let email_and_port = email_config.smtp_server.split(':').collect::<Vec<&str>>();
-    let email = *email_and_port
-      .first()
-      .ok_or(LemmyErrorType::MissingAnEmail)?;
-    let port = email_and_port
-      .get(1)
-      .ok_or(LemmyErrorType::EmailSmtpServerNeedsAPort)?
-      .parse::<u16>()?;
+    let (smtp_server, smtp_port) = {
+        let email_and_port = email_config.smtp_server.split(':').collect::<Vec<&str>>();
+        let email = *email_and_port
+            .first()
+            .ok_or(LemmyErrorType::MissingAnEmail)?;
+        let port = email_and_port
+            .get(1)
+            .ok_or(LemmyErrorType::EmailSmtpServerNeedsAPort)?
+            .parse::<u16>()?;
 
-    (email, port)
-  };
+        (email, port)
+    };
 
-  // use usize::MAX as the line wrap length, since lettre handles the wrapping for us
-  let plain_text = html2text::from_read(html.as_bytes(), usize::MAX);
+    // use usize::MAX as the line wrap length, since lettre handles the wrapping for us
+    let plain_text = html2text::from_read(html.as_bytes(), usize::MAX);
 
-  let email = Message::builder()
-    .from(
-      email_config
-        .smtp_from_address
-        .parse()
-        .expect("email from address isn't valid"),
-    )
-    .to(Mailbox::new(
-      Some(to_username.to_string()),
-      Address::from_str(to_email).expect("email to address isn't valid"),
-    ))
-    .message_id(Some(format!("<{}@{}>", Uuid::new_v4(), settings.hostname)))
-    .subject(subject)
-    .multipart(MultiPart::alternative_plain_html(
-      plain_text,
-      html.to_string(),
-    ))
-    .expect("email built incorrectly");
+    let email = Message::builder()
+        .from(
+            email_config
+                .smtp_from_address
+                .parse()
+                .expect("email from address isn't valid"),
+        )
+        .to(Mailbox::new(
+            Some(to_username.to_string()),
+            Address::from_str(to_email).expect("email to address isn't valid"),
+        ))
+        .message_id(Some(format!("<{}@{}>", Uuid::new_v4(), settings.hostname)))
+        .subject(subject)
+        .multipart(MultiPart::alternative_plain_html(
+            plain_text,
+            html.to_string(),
+        ))
+        .expect("email built incorrectly");
 
-  // don't worry about 'dangeous'. it's just that leaving it at the default configuration
-  // is bad.
+    // don't worry about 'dangeous'. it's just that leaving it at the default configuration
+    // is bad.
 
-  // Set the TLS
-  let mut builder = match email_config.tls_type.as_str() {
-    "starttls" => AsyncSmtpTransport::starttls_relay(smtp_server)?.port(smtp_port),
-    "tls" => AsyncSmtpTransport::relay(smtp_server)?.port(smtp_port),
-    _ => AsyncSmtpTransport::builder_dangerous(smtp_server).port(smtp_port),
-  };
+    // Set the TLS
+    let mut builder = match email_config.tls_type.as_str() {
+        "starttls" => AsyncSmtpTransport::starttls_relay(smtp_server)?.port(smtp_port),
+        "tls" => AsyncSmtpTransport::relay(smtp_server)?.port(smtp_port),
+        _ => AsyncSmtpTransport::builder_dangerous(smtp_server).port(smtp_port),
+    };
 
-  // Set the creds if they exist
-  let smtp_password = std::env::var("LEMMY_SMTP_PASSWORD")
-    .ok()
-    .or(email_config.smtp_password);
+    // Set the creds if they exist
+    let smtp_password = std::env::var("LEMMY_SMTP_PASSWORD")
+        .ok()
+        .or(email_config.smtp_password);
 
-  if let (Some(username), Some(password)) = (email_config.smtp_login, smtp_password) {
-    builder = builder.credentials(Credentials::new(username, password));
-  }
+    if let (Some(username), Some(password)) = (email_config.smtp_login, smtp_password) {
+        builder = builder.credentials(Credentials::new(username, password));
+    }
 
-  let mailer = builder.hello_name(ClientId::Domain(domain)).build();
+    let mailer = builder.hello_name(ClientId::Domain(domain)).build();
 
-  mailer
-    .send(email)
-    .await
-    .with_lemmy_type(LemmyErrorType::EmailSendFailed)?;
+    mailer
+        .send(email)
+        .await
+        .with_lemmy_type(LemmyErrorType::EmailSendFailed)?;
 
-  Ok(())
+    Ok(())
 }

--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::{
-  fmt,
-  fmt::{Debug, Display},
+    fmt,
+    fmt::{Debug, Display},
 };
 use tracing_error::SpanTrace;
 #[cfg(feature = "full")]
@@ -10,58 +10,58 @@ use ts_rs::TS;
 pub type LemmyResult<T> = Result<T, LemmyError>;
 
 pub struct LemmyError {
-  pub error_type: LemmyErrorType,
-  pub inner: anyhow::Error,
-  pub context: SpanTrace,
+    pub error_type: LemmyErrorType,
+    pub inner: anyhow::Error,
+    pub context: SpanTrace,
 }
 
 impl<T> From<T> for LemmyError
 where
-  T: Into<anyhow::Error>,
+    T: Into<anyhow::Error>,
 {
-  fn from(t: T) -> Self {
-    let cause = t.into();
-    LemmyError {
-      error_type: LemmyErrorType::Unknown(format!("{}", &cause)),
-      inner: cause,
-      context: SpanTrace::capture(),
+    fn from(t: T) -> Self {
+        let cause = t.into();
+        LemmyError {
+            error_type: LemmyErrorType::Unknown(format!("{}", &cause)),
+            inner: cause,
+            context: SpanTrace::capture(),
+        }
     }
-  }
 }
 
 impl Debug for LemmyError {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    f.debug_struct("LemmyError")
-      .field("message", &self.error_type)
-      .field("inner", &self.inner)
-      .field("context", &self.context)
-      .finish()
-  }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LemmyError")
+            .field("message", &self.error_type)
+            .field("inner", &self.inner)
+            .field("context", &self.context)
+            .finish()
+    }
 }
 
 impl Display for LemmyError {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    write!(f, "{}: ", &self.error_type)?;
-    // print anyhow including trace
-    // https://docs.rs/anyhow/latest/anyhow/struct.Error.html#display-representations
-    // this will print the anyhow trace (only if it exists)
-    // and if RUST_BACKTRACE=1, also a full backtrace
-    writeln!(f, "{:?}", self.inner)?;
-    fmt::Display::fmt(&self.context, f)
-  }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}: ", &self.error_type)?;
+        // print anyhow including trace
+        // https://docs.rs/anyhow/latest/anyhow/struct.Error.html#display-representations
+        // this will print the anyhow trace (only if it exists)
+        // and if RUST_BACKTRACE=1, also a full backtrace
+        writeln!(f, "{:?}", self.inner)?;
+        fmt::Display::fmt(&self.context, f)
+    }
 }
 
 impl actix_web::error::ResponseError for LemmyError {
-  fn status_code(&self) -> http::StatusCode {
-    match self.inner.downcast_ref::<diesel::result::Error>() {
-      Some(diesel::result::Error::NotFound) => http::StatusCode::NOT_FOUND,
-      _ => http::StatusCode::BAD_REQUEST,
+    fn status_code(&self) -> http::StatusCode {
+        match self.inner.downcast_ref::<diesel::result::Error>() {
+            Some(diesel::result::Error::NotFound) => http::StatusCode::NOT_FOUND,
+            _ => http::StatusCode::BAD_REQUEST,
+        }
     }
-  }
 
-  fn error_response(&self) -> actix_web::HttpResponse {
-    actix_web::HttpResponse::build(self.status_code()).json(&self.error_type)
-  }
+    fn error_response(&self) -> actix_web::HttpResponse {
+        actix_web::HttpResponse::build(self.status_code()).json(&self.error_type)
+    }
 }
 
 #[derive(Display, Debug, Serialize, Deserialize, Clone, PartialEq, EnumIter)]
@@ -70,228 +70,228 @@ impl actix_web::error::ResponseError for LemmyError {
 #[serde(tag = "error", content = "message", rename_all = "snake_case")]
 // TODO: order these based on the crate they belong to (utils, federation, db, api)
 pub enum LemmyErrorType {
-  ReportReasonRequired,
-  ReportTooLong,
-  NotAModerator,
-  NotAnAdmin,
-  CantBlockYourself,
-  CantBlockAdmin,
-  CouldntUpdateUser,
-  PasswordsDoNotMatch,
-  EmailNotVerified,
-  EmailRequired,
-  CouldntUpdateComment,
-  CouldntUpdatePrivateMessage,
-  CannotLeaveAdmin,
-  NoLinesInHtml,
-  SiteMetadataPageIsNotDoctypeHtml,
-  PictrsResponseError(String),
-  PictrsPurgeResponseError(String),
-  PictrsCachingDisabled,
-  ImageUrlMissingPathSegments,
-  ImageUrlMissingLastPathSegment,
-  PictrsApiKeyNotProvided,
-  NoContentTypeHeader,
-  NotAnImageType,
-  NotAModOrAdmin,
-  NoAdmins,
-  NotTopAdmin,
-  NotTopMod,
-  NotLoggedIn,
-  SiteBan,
-  Deleted,
-  BannedFromCommunity,
-  CouldntFindCommunity,
-  CouldntFindPerson,
-  PersonIsBlocked,
-  DownvotesAreDisabled,
-  InstanceIsPrivate,
-  InvalidPassword,
-  SiteDescriptionLengthOverflow,
-  HoneypotFailed,
-  RegistrationApplicationIsPending,
-  CantEnablePrivateInstanceAndFederationTogether,
-  Locked,
-  CouldntCreateComment,
-  MaxCommentDepthReached,
-  NoCommentEditAllowed,
-  OnlyAdminsCanCreateCommunities,
-  CommunityAlreadyExists,
-  LanguageNotAllowed,
-  OnlyModsCanPostInCommunity,
-  CouldntUpdatePost,
-  NoPostEditAllowed,
-  CouldntFindPost,
-  EditPrivateMessageNotAllowed,
-  SiteAlreadyExists,
-  ApplicationQuestionRequired,
-  InvalidDefaultPostListingType,
-  RegistrationClosed,
-  RegistrationApplicationAnswerRequired,
-  EmailAlreadyExists,
-  FederationForbiddenByStrictAllowList,
-  PersonIsBannedFromCommunity,
-  ObjectIsNotPublic,
-  InvalidCommunity,
-  CannotCreatePostOrCommentInDeletedOrRemovedCommunity,
-  CannotReceivePage,
-  NewPostCannotBeLocked,
-  OnlyLocalAdminCanRemoveCommunity,
-  OnlyLocalAdminCanRestoreCommunity,
-  NoIdGiven,
-  IncorrectLogin,
-  InvalidQuery,
-  ObjectNotLocal,
-  PostIsLocked,
-  PersonIsBannedFromSite(String),
-  InvalidVoteValue,
-  PageDoesNotSpecifyCreator,
-  PageDoesNotSpecifyGroup,
-  NoCommunityFoundInCc,
-  NoEmailSetup,
-  EmailSmtpServerNeedsAPort,
-  MissingAnEmail,
-  RateLimitError,
-  InvalidName,
-  InvalidDisplayName,
-  InvalidMatrixId,
-  InvalidPostTitle,
-  InvalidBodyField,
-  BioLengthOverflow,
-  MissingTotpToken,
-  IncorrectTotpToken,
-  CouldntParseTotpSecret,
-  CouldntLikeComment,
-  CouldntSaveComment,
-  CouldntCreateReport,
-  CouldntResolveReport,
-  CommunityModeratorAlreadyExists,
-  CommunityUserAlreadyBanned,
-  CommunityBlockAlreadyExists,
-  CommunityFollowerAlreadyExists,
-  CouldntUpdateCommunityHiddenStatus,
-  PersonBlockAlreadyExists,
-  UserAlreadyExists,
-  TokenNotFound,
-  CouldntLikePost,
-  CouldntSavePost,
-  CouldntMarkPostAsRead,
-  CouldntUpdateCommunity,
-  CouldntUpdateReplies,
-  CouldntUpdatePersonMentions,
-  PostTitleTooLong,
-  CouldntCreatePost,
-  CouldntCreatePrivateMessage,
-  CouldntUpdatePrivate,
-  SystemErrLogin,
-  CouldntSetAllRegistrationsAccepted,
-  CouldntSetAllEmailVerified,
-  Banned,
-  CouldntGetComments,
-  CouldntGetPosts,
-  InvalidUrl,
-  EmailSendFailed,
-  Slurs,
-  CouldntGenerateTotp,
-  CouldntFindObject,
-  RegistrationDenied(String),
-  FederationDisabled,
-  DomainBlocked(String),
-  DomainNotInAllowList(String),
-  FederationDisabledByStrictAllowList,
-  SiteNameRequired,
-  SiteNameLengthOverflow,
-  PermissiveRegex,
-  InvalidRegex,
-  CaptchaIncorrect,
-  PasswordResetLimitReached,
-  CouldntCreateAudioCaptcha,
-  InvalidUrlScheme,
-  CouldntSendWebmention,
-  ContradictingFilters,
-  AuthCookieInsecure,
-  Unknown(String),
+    ReportReasonRequired,
+    ReportTooLong,
+    NotAModerator,
+    NotAnAdmin,
+    CantBlockYourself,
+    CantBlockAdmin,
+    CouldntUpdateUser,
+    PasswordsDoNotMatch,
+    EmailNotVerified,
+    EmailRequired,
+    CouldntUpdateComment,
+    CouldntUpdatePrivateMessage,
+    CannotLeaveAdmin,
+    NoLinesInHtml,
+    SiteMetadataPageIsNotDoctypeHtml,
+    PictrsResponseError(String),
+    PictrsPurgeResponseError(String),
+    PictrsCachingDisabled,
+    ImageUrlMissingPathSegments,
+    ImageUrlMissingLastPathSegment,
+    PictrsApiKeyNotProvided,
+    NoContentTypeHeader,
+    NotAnImageType,
+    NotAModOrAdmin,
+    NoAdmins,
+    NotTopAdmin,
+    NotTopMod,
+    NotLoggedIn,
+    SiteBan,
+    Deleted,
+    BannedFromCommunity,
+    CouldntFindCommunity,
+    CouldntFindPerson,
+    PersonIsBlocked,
+    DownvotesAreDisabled,
+    InstanceIsPrivate,
+    InvalidPassword,
+    SiteDescriptionLengthOverflow,
+    HoneypotFailed,
+    RegistrationApplicationIsPending,
+    CantEnablePrivateInstanceAndFederationTogether,
+    Locked,
+    CouldntCreateComment,
+    MaxCommentDepthReached,
+    NoCommentEditAllowed,
+    OnlyAdminsCanCreateCommunities,
+    CommunityAlreadyExists,
+    LanguageNotAllowed,
+    OnlyModsCanPostInCommunity,
+    CouldntUpdatePost,
+    NoPostEditAllowed,
+    CouldntFindPost,
+    EditPrivateMessageNotAllowed,
+    SiteAlreadyExists,
+    ApplicationQuestionRequired,
+    InvalidDefaultPostListingType,
+    RegistrationClosed,
+    RegistrationApplicationAnswerRequired,
+    EmailAlreadyExists,
+    FederationForbiddenByStrictAllowList,
+    PersonIsBannedFromCommunity,
+    ObjectIsNotPublic,
+    InvalidCommunity,
+    CannotCreatePostOrCommentInDeletedOrRemovedCommunity,
+    CannotReceivePage,
+    NewPostCannotBeLocked,
+    OnlyLocalAdminCanRemoveCommunity,
+    OnlyLocalAdminCanRestoreCommunity,
+    NoIdGiven,
+    IncorrectLogin,
+    InvalidQuery,
+    ObjectNotLocal,
+    PostIsLocked,
+    PersonIsBannedFromSite(String),
+    InvalidVoteValue,
+    PageDoesNotSpecifyCreator,
+    PageDoesNotSpecifyGroup,
+    NoCommunityFoundInCc,
+    NoEmailSetup,
+    EmailSmtpServerNeedsAPort,
+    MissingAnEmail,
+    RateLimitError,
+    InvalidName,
+    InvalidDisplayName,
+    InvalidMatrixId,
+    InvalidPostTitle,
+    InvalidBodyField,
+    BioLengthOverflow,
+    MissingTotpToken,
+    IncorrectTotpToken,
+    CouldntParseTotpSecret,
+    CouldntLikeComment,
+    CouldntSaveComment,
+    CouldntCreateReport,
+    CouldntResolveReport,
+    CommunityModeratorAlreadyExists,
+    CommunityUserAlreadyBanned,
+    CommunityBlockAlreadyExists,
+    CommunityFollowerAlreadyExists,
+    CouldntUpdateCommunityHiddenStatus,
+    PersonBlockAlreadyExists,
+    UserAlreadyExists,
+    TokenNotFound,
+    CouldntLikePost,
+    CouldntSavePost,
+    CouldntMarkPostAsRead,
+    CouldntUpdateCommunity,
+    CouldntUpdateReplies,
+    CouldntUpdatePersonMentions,
+    PostTitleTooLong,
+    CouldntCreatePost,
+    CouldntCreatePrivateMessage,
+    CouldntUpdatePrivate,
+    SystemErrLogin,
+    CouldntSetAllRegistrationsAccepted,
+    CouldntSetAllEmailVerified,
+    Banned,
+    CouldntGetComments,
+    CouldntGetPosts,
+    InvalidUrl,
+    EmailSendFailed,
+    Slurs,
+    CouldntGenerateTotp,
+    CouldntFindObject,
+    RegistrationDenied(String),
+    FederationDisabled,
+    DomainBlocked(String),
+    DomainNotInAllowList(String),
+    FederationDisabledByStrictAllowList,
+    SiteNameRequired,
+    SiteNameLengthOverflow,
+    PermissiveRegex,
+    InvalidRegex,
+    CaptchaIncorrect,
+    PasswordResetLimitReached,
+    CouldntCreateAudioCaptcha,
+    InvalidUrlScheme,
+    CouldntSendWebmention,
+    ContradictingFilters,
+    AuthCookieInsecure,
+    Unknown(String),
 }
 
 impl From<LemmyErrorType> for LemmyError {
-  fn from(error_type: LemmyErrorType) -> Self {
-    let inner = anyhow::anyhow!("{}", error_type);
-    LemmyError {
-      error_type,
-      inner,
-      context: SpanTrace::capture(),
+    fn from(error_type: LemmyErrorType) -> Self {
+        let inner = anyhow::anyhow!("{}", error_type);
+        LemmyError {
+            error_type,
+            inner,
+            context: SpanTrace::capture(),
+        }
     }
-  }
 }
 
 pub trait LemmyErrorExt<T, E: Into<anyhow::Error>> {
-  fn with_lemmy_type(self, error_type: LemmyErrorType) -> Result<T, LemmyError>;
+    fn with_lemmy_type(self, error_type: LemmyErrorType) -> Result<T, LemmyError>;
 }
 
 impl<T, E: Into<anyhow::Error>> LemmyErrorExt<T, E> for Result<T, E> {
-  fn with_lemmy_type(self, error_type: LemmyErrorType) -> Result<T, LemmyError> {
-    self.map_err(|error| LemmyError {
-      error_type,
-      inner: error.into(),
-      context: SpanTrace::capture(),
-    })
-  }
+    fn with_lemmy_type(self, error_type: LemmyErrorType) -> Result<T, LemmyError> {
+        self.map_err(|error| LemmyError {
+            error_type,
+            inner: error.into(),
+            context: SpanTrace::capture(),
+        })
+    }
 }
 pub trait LemmyErrorExt2<T> {
-  fn with_lemmy_type(self, error_type: LemmyErrorType) -> Result<T, LemmyError>;
+    fn with_lemmy_type(self, error_type: LemmyErrorType) -> Result<T, LemmyError>;
 }
 
 impl<T> LemmyErrorExt2<T> for Result<T, LemmyError> {
-  fn with_lemmy_type(self, error_type: LemmyErrorType) -> Result<T, LemmyError> {
-    self.map_err(|mut e| {
-      e.error_type = error_type;
-      e
-    })
-  }
+    fn with_lemmy_type(self, error_type: LemmyErrorType) -> Result<T, LemmyError> {
+        self.map_err(|mut e| {
+            e.error_type = error_type;
+            e
+        })
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
-  use super::*;
-  use actix_web::{body::MessageBody, ResponseError};
-  use std::fs::read_to_string;
-  use strum::IntoEnumIterator;
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
+    use super::*;
+    use actix_web::{body::MessageBody, ResponseError};
+    use std::fs::read_to_string;
+    use strum::IntoEnumIterator;
 
-  #[test]
-  fn deserializes_no_message() {
-    let err = LemmyError::from(LemmyErrorType::Banned).error_response();
-    let json = String::from_utf8(err.into_body().try_into_bytes().unwrap().to_vec()).unwrap();
-    assert_eq!(&json, "{\"error\":\"banned\"}")
-  }
-
-  #[test]
-  fn deserializes_with_message() {
-    let reg_denied = LemmyErrorType::RegistrationDenied(String::from("reason"));
-    let err = LemmyError::from(reg_denied).error_response();
-    let json = String::from_utf8(err.into_body().try_into_bytes().unwrap().to_vec()).unwrap();
-    assert_eq!(
-      &json,
-      "{\"error\":\"registration_denied\",\"message\":\"reason\"}"
-    )
-  }
-
-  /// Check if errors match translations. Disabled because many are not translated at all.
-  #[test]
-  #[ignore]
-  fn test_translations_match() {
-    #[derive(Deserialize)]
-    struct Err {
-      error: String,
+    #[test]
+    fn deserializes_no_message() {
+        let err = LemmyError::from(LemmyErrorType::Banned).error_response();
+        let json = String::from_utf8(err.into_body().try_into_bytes().unwrap().to_vec()).unwrap();
+        assert_eq!(&json, "{\"error\":\"banned\"}")
     }
 
-    let translations = read_to_string("translations/translations/en.json").unwrap();
-    LemmyErrorType::iter().for_each(|e| {
-      let msg = serde_json::to_string(&e).unwrap();
-      let msg: Err = serde_json::from_str(&msg).unwrap();
-      let msg = msg.error;
-      assert!(translations.contains(&format!("\"{msg}\"")), "{msg}");
-    });
-  }
+    #[test]
+    fn deserializes_with_message() {
+        let reg_denied = LemmyErrorType::RegistrationDenied(String::from("reason"));
+        let err = LemmyError::from(reg_denied).error_response();
+        let json = String::from_utf8(err.into_body().try_into_bytes().unwrap().to_vec()).unwrap();
+        assert_eq!(
+            &json,
+            "{\"error\":\"registration_denied\",\"message\":\"reason\"}"
+        )
+    }
+
+    /// Check if errors match translations. Disabled because many are not translated at all.
+    #[test]
+    #[ignore]
+    fn test_translations_match() {
+        #[derive(Deserialize)]
+        struct Err {
+            error: String,
+        }
+
+        let translations = read_to_string("translations/translations/en.json").unwrap();
+        LemmyErrorType::iter().for_each(|e| {
+            let msg = serde_json::to_string(&e).unwrap();
+            let msg: Err = serde_json::from_str(&msg).unwrap();
+            let msg = msg.error;
+            assert!(translations.contains(&format!("\"{msg}\"")), "{msg}");
+        });
+    }
 }

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -28,14 +28,14 @@ pub const REQWEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[macro_export]
 macro_rules! location_info {
-  () => {
-    format!(
-      "None value at {}:{}, column {}",
-      file!(),
-      line!(),
-      column!()
-    )
-  };
+    () => {
+        format!(
+            "None value at {}:{}, column {}",
+            file!(),
+            line!(),
+            column!()
+        )
+    };
 }
 
 /// if true, all federation should happen synchronously. useful for debugging and testing.
@@ -43,21 +43,21 @@ macro_rules! location_info {
 /// override to true by setting env LEMMY_SYNCHRONOUS_FEDERATION=1
 /// override to false by setting env LEMMY_SYNCHRONOUS_FEDERATION=""
 pub static SYNCHRONOUS_FEDERATION: Lazy<bool> = Lazy::new(|| {
-  std::env::var("LEMMY_SYNCHRONOUS_FEDERATION")
-    .map(|s| !s.is_empty())
-    .unwrap_or(cfg!(debug_assertions))
+    std::env::var("LEMMY_SYNCHRONOUS_FEDERATION")
+        .map(|s| !s.is_empty())
+        .unwrap_or(cfg!(debug_assertions))
 });
 
 /// tokio::spawn, but accepts a future that may fail and also
 /// * logs errors
 /// * attaches the spawned task to the tracing span of the caller for better logging
 pub fn spawn_try_task(task: impl Future<Output = Result<(), LemmyError>> + Send + 'static) {
-  tokio::spawn(
-    async {
-      if let Err(e) = task.await {
-        tracing::warn!("error in spawn: {e}");
-      }
-    }
-    .in_current_span(), // this makes sure the inner tracing gets the same context as where spawn was called
-  );
+    tokio::spawn(
+        async {
+            if let Err(e) = task.await {
+                tracing::warn!("error in spawn: {e}");
+            }
+        }
+        .in_current_span(), // this makes sure the inner tracing gets the same context as where spawn was called
+    );
 }

--- a/crates/utils/src/main.rs
+++ b/crates/utils/src/main.rs
@@ -1,16 +1,16 @@
 use doku::json::{AutoComments, CommentsStyle, Formatting, ObjectsStyle};
 use lemmy_utils::settings::structs::Settings;
 fn main() {
-  let fmt = Formatting {
-    auto_comments: AutoComments::none(),
-    comments_style: CommentsStyle {
-      separator: "#".to_owned(),
-    },
-    objects_style: ObjectsStyle {
-      surround_keys_with_quotes: false,
-      use_comma_as_separator: false,
-    },
-    ..Default::default()
-  };
-  println!("{}", doku::to_json_fmt_val(&fmt, &Settings::default()));
+    let fmt = Formatting {
+        auto_comments: AutoComments::none(),
+        comments_style: CommentsStyle {
+            separator: "#".to_owned(),
+        },
+        objects_style: ObjectsStyle {
+            surround_keys_with_quotes: false,
+            use_comma_as_separator: false,
+        },
+        ..Default::default()
+    };
+    println!("{}", doku::to_json_fmt_val(&fmt, &Settings::default()));
 }

--- a/crates/utils/src/rate_limit/mod.rs
+++ b/crates/utils/src/rate_limit/mod.rs
@@ -5,14 +5,14 @@ use futures::future::{ok, Ready};
 use rate_limiter::{InstantSecs, RateLimitStorage, RateLimitType};
 use serde::{Deserialize, Serialize};
 use std::{
-  future::Future,
-  net::{IpAddr, Ipv4Addr, SocketAddr},
-  pin::Pin,
-  rc::Rc,
-  str::FromStr,
-  sync::{Arc, Mutex},
-  task::{Context, Poll},
-  time::Duration,
+    future::Future,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    pin::Pin,
+    rc::Rc,
+    str::FromStr,
+    sync::{Arc, Mutex},
+    task::{Context, Poll},
+    time::Duration,
 };
 use tokio::sync::{mpsc, mpsc::Sender, OnceCell};
 use typed_builder::TypedBuilder;
@@ -21,274 +21,274 @@ pub mod rate_limiter;
 
 #[derive(Debug, Deserialize, Serialize, Clone, TypedBuilder)]
 pub struct RateLimitConfig {
-  #[builder(default = 180)]
-  /// Maximum number of messages created in interval
-  pub message: i32,
-  #[builder(default = 60)]
-  /// Interval length for message limit, in seconds
-  pub message_per_second: i32,
-  #[builder(default = 6)]
-  /// Maximum number of posts created in interval
-  pub post: i32,
-  #[builder(default = 300)]
-  /// Interval length for post limit, in seconds
-  pub post_per_second: i32,
-  #[builder(default = 3)]
-  /// Maximum number of registrations in interval
-  pub register: i32,
-  #[builder(default = 3600)]
-  /// Interval length for registration limit, in seconds
-  pub register_per_second: i32,
-  #[builder(default = 6)]
-  /// Maximum number of image uploads in interval
-  pub image: i32,
-  #[builder(default = 3600)]
-  /// Interval length for image uploads, in seconds
-  pub image_per_second: i32,
-  #[builder(default = 6)]
-  /// Maximum number of comments created in interval
-  pub comment: i32,
-  #[builder(default = 600)]
-  /// Interval length for comment limit, in seconds
-  pub comment_per_second: i32,
-  #[builder(default = 60)]
-  /// Maximum number of searches created in interval
-  pub search: i32,
-  #[builder(default = 600)]
-  /// Interval length for search limit, in seconds
-  pub search_per_second: i32,
+    #[builder(default = 180)]
+    /// Maximum number of messages created in interval
+    pub message: i32,
+    #[builder(default = 60)]
+    /// Interval length for message limit, in seconds
+    pub message_per_second: i32,
+    #[builder(default = 6)]
+    /// Maximum number of posts created in interval
+    pub post: i32,
+    #[builder(default = 300)]
+    /// Interval length for post limit, in seconds
+    pub post_per_second: i32,
+    #[builder(default = 3)]
+    /// Maximum number of registrations in interval
+    pub register: i32,
+    #[builder(default = 3600)]
+    /// Interval length for registration limit, in seconds
+    pub register_per_second: i32,
+    #[builder(default = 6)]
+    /// Maximum number of image uploads in interval
+    pub image: i32,
+    #[builder(default = 3600)]
+    /// Interval length for image uploads, in seconds
+    pub image_per_second: i32,
+    #[builder(default = 6)]
+    /// Maximum number of comments created in interval
+    pub comment: i32,
+    #[builder(default = 600)]
+    /// Interval length for comment limit, in seconds
+    pub comment_per_second: i32,
+    #[builder(default = 60)]
+    /// Maximum number of searches created in interval
+    pub search: i32,
+    #[builder(default = 600)]
+    /// Interval length for search limit, in seconds
+    pub search_per_second: i32,
 }
 
 #[derive(Debug, Clone)]
 struct RateLimit {
-  pub rate_limiter: RateLimitStorage,
-  pub rate_limit_config: RateLimitConfig,
+    pub rate_limiter: RateLimitStorage,
+    pub rate_limit_config: RateLimitConfig,
 }
 
 #[derive(Debug, Clone)]
 pub struct RateLimitedGuard {
-  rate_limit: Arc<Mutex<RateLimit>>,
-  type_: RateLimitType,
+    rate_limit: Arc<Mutex<RateLimit>>,
+    type_: RateLimitType,
 }
 
 /// Single instance of rate limit config and buckets, which is shared across all threads.
 #[derive(Clone)]
 pub struct RateLimitCell {
-  tx: Sender<RateLimitConfig>,
-  rate_limit: Arc<Mutex<RateLimit>>,
+    tx: Sender<RateLimitConfig>,
+    rate_limit: Arc<Mutex<RateLimit>>,
 }
 
 impl RateLimitCell {
-  /// Initialize cell if it wasnt initialized yet. Otherwise returns the existing cell.
-  pub async fn new(rate_limit_config: RateLimitConfig) -> &'static Self {
-    static LOCAL_INSTANCE: OnceCell<RateLimitCell> = OnceCell::const_new();
-    LOCAL_INSTANCE
-      .get_or_init(|| async {
-        let (tx, mut rx) = mpsc::channel::<RateLimitConfig>(4);
-        let rate_limit = Arc::new(Mutex::new(RateLimit {
-          rate_limiter: Default::default(),
-          rate_limit_config,
-        }));
-        let rate_limit2 = rate_limit.clone();
-        tokio::spawn(async move {
-          while let Some(r) = rx.recv().await {
-            rate_limit2
-              .lock()
-              .expect("Failed to lock rate limit mutex for updating")
-              .rate_limit_config = r;
-          }
-        });
-        RateLimitCell { tx, rate_limit }
-      })
-      .await
-  }
-
-  /// Call this when the config was updated, to update all in-memory cells.
-  pub async fn send(&self, config: RateLimitConfig) -> Result<(), LemmyError> {
-    self.tx.send(config).await?;
-    Ok(())
-  }
-
-  /// Remove buckets older than the given duration
-  pub fn remove_older_than(&self, mut duration: Duration) {
-    let mut guard = self
-      .rate_limit
-      .lock()
-      .expect("Failed to lock rate limit mutex for reading");
-    let rate_limit = &guard.rate_limit_config;
-
-    // If any rate limit interval is greater than `duration`, then the largest interval is used instead. This preserves buckets that would not pass the rate limit check.
-    let max_interval_secs = enum_map! {
-      RateLimitType::Message => rate_limit.message_per_second,
-      RateLimitType::Post => rate_limit.post_per_second,
-      RateLimitType::Register => rate_limit.register_per_second,
-      RateLimitType::Image => rate_limit.image_per_second,
-      RateLimitType::Comment => rate_limit.comment_per_second,
-      RateLimitType::Search => rate_limit.search_per_second,
+    /// Initialize cell if it wasnt initialized yet. Otherwise returns the existing cell.
+    pub async fn new(rate_limit_config: RateLimitConfig) -> &'static Self {
+        static LOCAL_INSTANCE: OnceCell<RateLimitCell> = OnceCell::const_new();
+        LOCAL_INSTANCE
+            .get_or_init(|| async {
+                let (tx, mut rx) = mpsc::channel::<RateLimitConfig>(4);
+                let rate_limit = Arc::new(Mutex::new(RateLimit {
+                    rate_limiter: Default::default(),
+                    rate_limit_config,
+                }));
+                let rate_limit2 = rate_limit.clone();
+                tokio::spawn(async move {
+                    while let Some(r) = rx.recv().await {
+                        rate_limit2
+                            .lock()
+                            .expect("Failed to lock rate limit mutex for updating")
+                            .rate_limit_config = r;
+                    }
+                });
+                RateLimitCell { tx, rate_limit }
+            })
+            .await
     }
-    .into_values()
-    .max()
-    .and_then(|max| u64::try_from(max).ok())
-    .unwrap_or(0);
 
-    duration = std::cmp::max(duration, Duration::from_secs(max_interval_secs));
-
-    guard
-      .rate_limiter
-      .remove_older_than(duration, InstantSecs::now())
-  }
-
-  pub fn message(&self) -> RateLimitedGuard {
-    self.kind(RateLimitType::Message)
-  }
-
-  pub fn post(&self) -> RateLimitedGuard {
-    self.kind(RateLimitType::Post)
-  }
-
-  pub fn register(&self) -> RateLimitedGuard {
-    self.kind(RateLimitType::Register)
-  }
-
-  pub fn image(&self) -> RateLimitedGuard {
-    self.kind(RateLimitType::Image)
-  }
-
-  pub fn comment(&self) -> RateLimitedGuard {
-    self.kind(RateLimitType::Comment)
-  }
-
-  pub fn search(&self) -> RateLimitedGuard {
-    self.kind(RateLimitType::Search)
-  }
-
-  fn kind(&self, type_: RateLimitType) -> RateLimitedGuard {
-    RateLimitedGuard {
-      rate_limit: self.rate_limit.clone(),
-      type_,
+    /// Call this when the config was updated, to update all in-memory cells.
+    pub async fn send(&self, config: RateLimitConfig) -> Result<(), LemmyError> {
+        self.tx.send(config).await?;
+        Ok(())
     }
-  }
+
+    /// Remove buckets older than the given duration
+    pub fn remove_older_than(&self, mut duration: Duration) {
+        let mut guard = self
+            .rate_limit
+            .lock()
+            .expect("Failed to lock rate limit mutex for reading");
+        let rate_limit = &guard.rate_limit_config;
+
+        // If any rate limit interval is greater than `duration`, then the largest interval is used instead. This preserves buckets that would not pass the rate limit check.
+        let max_interval_secs = enum_map! {
+          RateLimitType::Message => rate_limit.message_per_second,
+          RateLimitType::Post => rate_limit.post_per_second,
+          RateLimitType::Register => rate_limit.register_per_second,
+          RateLimitType::Image => rate_limit.image_per_second,
+          RateLimitType::Comment => rate_limit.comment_per_second,
+          RateLimitType::Search => rate_limit.search_per_second,
+        }
+        .into_values()
+        .max()
+        .and_then(|max| u64::try_from(max).ok())
+        .unwrap_or(0);
+
+        duration = std::cmp::max(duration, Duration::from_secs(max_interval_secs));
+
+        guard
+            .rate_limiter
+            .remove_older_than(duration, InstantSecs::now())
+    }
+
+    pub fn message(&self) -> RateLimitedGuard {
+        self.kind(RateLimitType::Message)
+    }
+
+    pub fn post(&self) -> RateLimitedGuard {
+        self.kind(RateLimitType::Post)
+    }
+
+    pub fn register(&self) -> RateLimitedGuard {
+        self.kind(RateLimitType::Register)
+    }
+
+    pub fn image(&self) -> RateLimitedGuard {
+        self.kind(RateLimitType::Image)
+    }
+
+    pub fn comment(&self) -> RateLimitedGuard {
+        self.kind(RateLimitType::Comment)
+    }
+
+    pub fn search(&self) -> RateLimitedGuard {
+        self.kind(RateLimitType::Search)
+    }
+
+    fn kind(&self, type_: RateLimitType) -> RateLimitedGuard {
+        RateLimitedGuard {
+            rate_limit: self.rate_limit.clone(),
+            type_,
+        }
+    }
 }
 
 pub struct RateLimitedMiddleware<S> {
-  rate_limited: RateLimitedGuard,
-  service: Rc<S>,
+    rate_limited: RateLimitedGuard,
+    service: Rc<S>,
 }
 
 impl RateLimitedGuard {
-  /// Returns true if the request passed the rate limit, false if it failed and should be rejected.
-  pub fn check(self, ip_addr: IpAddr) -> bool {
-    // Does not need to be blocking because the RwLock in settings never held across await points,
-    // and the operation here locks only long enough to clone
-    let mut guard = self
-      .rate_limit
-      .lock()
-      .expect("Failed to lock rate limit mutex for reading");
-    let rate_limit = &guard.rate_limit_config;
+    /// Returns true if the request passed the rate limit, false if it failed and should be rejected.
+    pub fn check(self, ip_addr: IpAddr) -> bool {
+        // Does not need to be blocking because the RwLock in settings never held across await points,
+        // and the operation here locks only long enough to clone
+        let mut guard = self
+            .rate_limit
+            .lock()
+            .expect("Failed to lock rate limit mutex for reading");
+        let rate_limit = &guard.rate_limit_config;
 
-    let (kind, interval) = match self.type_ {
-      RateLimitType::Message => (rate_limit.message, rate_limit.message_per_second),
-      RateLimitType::Post => (rate_limit.post, rate_limit.post_per_second),
-      RateLimitType::Register => (rate_limit.register, rate_limit.register_per_second),
-      RateLimitType::Image => (rate_limit.image, rate_limit.image_per_second),
-      RateLimitType::Comment => (rate_limit.comment, rate_limit.comment_per_second),
-      RateLimitType::Search => (rate_limit.search, rate_limit.search_per_second),
-    };
-    let limiter = &mut guard.rate_limiter;
+        let (kind, interval) = match self.type_ {
+            RateLimitType::Message => (rate_limit.message, rate_limit.message_per_second),
+            RateLimitType::Post => (rate_limit.post, rate_limit.post_per_second),
+            RateLimitType::Register => (rate_limit.register, rate_limit.register_per_second),
+            RateLimitType::Image => (rate_limit.image, rate_limit.image_per_second),
+            RateLimitType::Comment => (rate_limit.comment, rate_limit.comment_per_second),
+            RateLimitType::Search => (rate_limit.search, rate_limit.search_per_second),
+        };
+        let limiter = &mut guard.rate_limiter;
 
-    limiter.check_rate_limit_full(self.type_, ip_addr, kind, interval, InstantSecs::now())
-  }
+        limiter.check_rate_limit_full(self.type_, ip_addr, kind, interval, InstantSecs::now())
+    }
 }
 
 impl<S> Transform<S, ServiceRequest> for RateLimitedGuard
 where
-  S: Service<ServiceRequest, Response = ServiceResponse, Error = actix_web::Error> + 'static,
-  S::Future: 'static,
+    S: Service<ServiceRequest, Response = ServiceResponse, Error = actix_web::Error> + 'static,
+    S::Future: 'static,
 {
-  type Response = S::Response;
-  type Error = actix_web::Error;
-  type InitError = ();
-  type Transform = RateLimitedMiddleware<S>;
-  type Future = Ready<Result<Self::Transform, Self::InitError>>;
+    type Response = S::Response;
+    type Error = actix_web::Error;
+    type InitError = ();
+    type Transform = RateLimitedMiddleware<S>;
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
 
-  fn new_transform(&self, service: S) -> Self::Future {
-    ok(RateLimitedMiddleware {
-      rate_limited: self.clone(),
-      service: Rc::new(service),
-    })
-  }
+    fn new_transform(&self, service: S) -> Self::Future {
+        ok(RateLimitedMiddleware {
+            rate_limited: self.clone(),
+            service: Rc::new(service),
+        })
+    }
 }
 
 type FutResult<T, E> = dyn Future<Output = Result<T, E>>;
 
 impl<S> Service<ServiceRequest> for RateLimitedMiddleware<S>
 where
-  S: Service<ServiceRequest, Response = ServiceResponse, Error = actix_web::Error> + 'static,
-  S::Future: 'static,
+    S: Service<ServiceRequest, Response = ServiceResponse, Error = actix_web::Error> + 'static,
+    S::Future: 'static,
 {
-  type Response = S::Response;
-  type Error = actix_web::Error;
-  type Future = Pin<Box<FutResult<Self::Response, Self::Error>>>;
+    type Response = S::Response;
+    type Error = actix_web::Error;
+    type Future = Pin<Box<FutResult<Self::Response, Self::Error>>>;
 
-  fn poll_ready(&self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-    self.service.poll_ready(cx)
-  }
+    fn poll_ready(&self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.service.poll_ready(cx)
+    }
 
-  fn call(&self, req: ServiceRequest) -> Self::Future {
-    let ip_addr = get_ip(&req.connection_info());
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        let ip_addr = get_ip(&req.connection_info());
 
-    let rate_limited = self.rate_limited.clone();
-    let service = self.service.clone();
+        let rate_limited = self.rate_limited.clone();
+        let service = self.service.clone();
 
-    Box::pin(async move {
-      if rate_limited.check(ip_addr) {
-        service.call(req).await
-      } else {
-        let (http_req, _) = req.into_parts();
-        Ok(ServiceResponse::from_err(
-          LemmyError::from(LemmyErrorType::RateLimitError),
-          http_req,
-        ))
-      }
-    })
-  }
+        Box::pin(async move {
+            if rate_limited.check(ip_addr) {
+                service.call(req).await
+            } else {
+                let (http_req, _) = req.into_parts();
+                Ok(ServiceResponse::from_err(
+                    LemmyError::from(LemmyErrorType::RateLimitError),
+                    http_req,
+                ))
+            }
+        })
+    }
 }
 
 fn get_ip(conn_info: &ConnectionInfo) -> IpAddr {
-  conn_info
-    .realip_remote_addr()
-    .and_then(parse_ip)
-    .unwrap_or(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))
+    conn_info
+        .realip_remote_addr()
+        .and_then(parse_ip)
+        .unwrap_or(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))
 }
 
 fn parse_ip(addr: &str) -> Option<IpAddr> {
-  if let Some(s) = addr.strip_suffix(']') {
-    IpAddr::from_str(s.get(1..)?).ok()
-  } else if let Ok(ip) = IpAddr::from_str(addr) {
-    Some(ip)
-  } else if let Ok(socket) = SocketAddr::from_str(addr) {
-    Some(socket.ip())
-  } else {
-    None
-  }
+    if let Some(s) = addr.strip_suffix(']') {
+        IpAddr::from_str(s.get(1..)?).ok()
+    } else if let Ok(ip) = IpAddr::from_str(addr) {
+        Some(ip)
+    } else if let Ok(socket) = SocketAddr::from_str(addr) {
+        Some(socket.ip())
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  #[test]
-  fn test_parse_ip() {
-    let ip_addrs = [
-      "1.2.3.4",
-      "1.2.3.4:8000",
-      "2001:db8::",
-      "[2001:db8::]",
-      "[2001:db8::]:8000",
-    ];
-    for addr in ip_addrs {
-      assert!(super::parse_ip(addr).is_some(), "failed to parse {addr}");
+    #[test]
+    fn test_parse_ip() {
+        let ip_addrs = [
+            "1.2.3.4",
+            "1.2.3.4:8000",
+            "2001:db8::",
+            "[2001:db8::]",
+            "[2001:db8::]:8000",
+        ];
+        for addr in ip_addrs {
+            assert!(super::parse_ip(addr).is_some(), "failed to parse {addr}");
+        }
     }
-  }
 }

--- a/crates/utils/src/rate_limit/rate_limiter.rs
+++ b/crates/utils/src/rate_limit/rate_limiter.rs
@@ -1,10 +1,10 @@
 use enum_map::{enum_map, EnumMap};
 use once_cell::sync::Lazy;
 use std::{
-  collections::HashMap,
-  hash::Hash,
-  net::{IpAddr, Ipv4Addr, Ipv6Addr},
-  time::{Duration, Instant},
+    collections::HashMap,
+    hash::Hash,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    time::{Duration, Instant},
 };
 use tracing::debug;
 
@@ -16,316 +16,319 @@ static START_TIME: Lazy<Instant> = Lazy::new(Instant::now);
 /// store nanoseconds
 #[derive(PartialEq, Debug, Clone, Copy)]
 pub struct InstantSecs {
-  secs: u32,
+    secs: u32,
 }
 
 impl InstantSecs {
-  pub fn now() -> Self {
-    InstantSecs {
-      secs: u32::try_from(START_TIME.elapsed().as_secs())
-        .expect("server has been running for over 136 years"),
+    pub fn now() -> Self {
+        InstantSecs {
+            secs: u32::try_from(START_TIME.elapsed().as_secs())
+                .expect("server has been running for over 136 years"),
+        }
     }
-  }
 
-  fn secs_since(self, earlier: Self) -> u32 {
-    self.secs.saturating_sub(earlier.secs)
-  }
+    fn secs_since(self, earlier: Self) -> u32 {
+        self.secs.saturating_sub(earlier.secs)
+    }
 
-  fn to_instant(self) -> Instant {
-    *START_TIME + Duration::from_secs(self.secs.into())
-  }
+    fn to_instant(self) -> Instant {
+        *START_TIME + Duration::from_secs(self.secs.into())
+    }
 }
 
 #[derive(PartialEq, Debug, Clone)]
 struct RateLimitBucket {
-  last_checked: InstantSecs,
-  /// This field stores the amount of tokens that were present at `last_checked`.
-  /// The amount of tokens steadily increases until it reaches the bucket's capacity.
-  /// Performing the rate-limited action consumes 1 token.
-  tokens: f32,
+    last_checked: InstantSecs,
+    /// This field stores the amount of tokens that were present at `last_checked`.
+    /// The amount of tokens steadily increases until it reaches the bucket's capacity.
+    /// Performing the rate-limited action consumes 1 token.
+    tokens: f32,
 }
 
 #[derive(Debug, enum_map::Enum, Copy, Clone, AsRefStr)]
 pub(crate) enum RateLimitType {
-  Message,
-  Register,
-  Post,
-  Image,
-  Comment,
-  Search,
+    Message,
+    Register,
+    Post,
+    Image,
+    Comment,
+    Search,
 }
 
 type Map<K, C> = HashMap<K, RateLimitedGroup<C>>;
 
 #[derive(PartialEq, Debug, Clone)]
 struct RateLimitedGroup<C> {
-  total: EnumMap<RateLimitType, RateLimitBucket>,
-  children: C,
+    total: EnumMap<RateLimitType, RateLimitBucket>,
+    children: C,
 }
 
 impl<C: Default> RateLimitedGroup<C> {
-  fn new(now: InstantSecs) -> Self {
-    RateLimitedGroup {
-      total: enum_map! {
-        _ => RateLimitBucket {
-          last_checked: now,
-          tokens: UNINITIALIZED_TOKEN_AMOUNT,
-        },
-      },
-      children: Default::default(),
-    }
-  }
-
-  fn check_total(
-    &mut self,
-    type_: RateLimitType,
-    now: InstantSecs,
-    capacity: i32,
-    secs_to_refill: i32,
-  ) -> bool {
-    let capacity = capacity as f32;
-    let secs_to_refill = secs_to_refill as f32;
-
-    #[allow(clippy::indexing_slicing)] // `EnumMap` has no `get` funciton
-    let bucket = &mut self.total[type_];
-
-    if bucket.tokens == UNINITIALIZED_TOKEN_AMOUNT {
-      bucket.tokens = capacity;
+    fn new(now: InstantSecs) -> Self {
+        RateLimitedGroup {
+            total: enum_map! {
+              _ => RateLimitBucket {
+                last_checked: now,
+                tokens: UNINITIALIZED_TOKEN_AMOUNT,
+              },
+            },
+            children: Default::default(),
+        }
     }
 
-    let secs_since_last_checked = now.secs_since(bucket.last_checked) as f32;
-    bucket.last_checked = now;
+    fn check_total(
+        &mut self,
+        type_: RateLimitType,
+        now: InstantSecs,
+        capacity: i32,
+        secs_to_refill: i32,
+    ) -> bool {
+        let capacity = capacity as f32;
+        let secs_to_refill = secs_to_refill as f32;
 
-    // For `secs_since_last_checked` seconds, increase `bucket.tokens`
-    // by `capacity` every `secs_to_refill` seconds
-    bucket.tokens += {
-      let tokens_per_sec = capacity / secs_to_refill;
-      secs_since_last_checked * tokens_per_sec
-    };
+        #[allow(clippy::indexing_slicing)] // `EnumMap` has no `get` funciton
+        let bucket = &mut self.total[type_];
 
-    // Prevent `bucket.tokens` from exceeding `capacity`
-    if bucket.tokens > capacity {
-      bucket.tokens = capacity;
+        if bucket.tokens == UNINITIALIZED_TOKEN_AMOUNT {
+            bucket.tokens = capacity;
+        }
+
+        let secs_since_last_checked = now.secs_since(bucket.last_checked) as f32;
+        bucket.last_checked = now;
+
+        // For `secs_since_last_checked` seconds, increase `bucket.tokens`
+        // by `capacity` every `secs_to_refill` seconds
+        bucket.tokens += {
+            let tokens_per_sec = capacity / secs_to_refill;
+            secs_since_last_checked * tokens_per_sec
+        };
+
+        // Prevent `bucket.tokens` from exceeding `capacity`
+        if bucket.tokens > capacity {
+            bucket.tokens = capacity;
+        }
+
+        if bucket.tokens < 1.0 {
+            // Not enough tokens yet
+            debug!(
+                "Rate limited type: {}, time_passed: {}, allowance: {}",
+                type_.as_ref(),
+                secs_since_last_checked,
+                bucket.tokens
+            );
+            false
+        } else {
+            // Consume 1 token
+            bucket.tokens -= 1.0;
+            true
+        }
     }
-
-    if bucket.tokens < 1.0 {
-      // Not enough tokens yet
-      debug!(
-        "Rate limited type: {}, time_passed: {}, allowance: {}",
-        type_.as_ref(),
-        secs_since_last_checked,
-        bucket.tokens
-      );
-      false
-    } else {
-      // Consume 1 token
-      bucket.tokens -= 1.0;
-      true
-    }
-  }
 }
 
 /// Rate limiting based on rate type and IP addr
 #[derive(PartialEq, Debug, Clone, Default)]
 pub struct RateLimitStorage {
-  /// One bucket per individual IPv4 address
-  ipv4_buckets: Map<Ipv4Addr, ()>,
-  /// Seperate buckets for 48, 56, and 64 bit prefixes of IPv6 addresses
-  ipv6_buckets: Map<[u8; 6], Map<u8, Map<u8, ()>>>,
+    /// One bucket per individual IPv4 address
+    ipv4_buckets: Map<Ipv4Addr, ()>,
+    /// Seperate buckets for 48, 56, and 64 bit prefixes of IPv6 addresses
+    ipv6_buckets: Map<[u8; 6], Map<u8, Map<u8, ()>>>,
 }
 
 impl RateLimitStorage {
-  /// Rate limiting Algorithm described here: https://stackoverflow.com/a/668327/1655478
-  ///
-  /// Returns true if the request passed the rate limit, false if it failed and should be rejected.
-  pub(super) fn check_rate_limit_full(
-    &mut self,
-    type_: RateLimitType,
-    ip: IpAddr,
-    capacity: i32,
-    secs_to_refill: i32,
-    now: InstantSecs,
-  ) -> bool {
-    let mut result = true;
+    /// Rate limiting Algorithm described here: https://stackoverflow.com/a/668327/1655478
+    ///
+    /// Returns true if the request passed the rate limit, false if it failed and should be rejected.
+    pub(super) fn check_rate_limit_full(
+        &mut self,
+        type_: RateLimitType,
+        ip: IpAddr,
+        capacity: i32,
+        secs_to_refill: i32,
+        now: InstantSecs,
+    ) -> bool {
+        let mut result = true;
 
-    match ip {
-      IpAddr::V4(ipv4) => {
-        // Only used by one address.
-        let group = self
-          .ipv4_buckets
-          .entry(ipv4)
-          .or_insert(RateLimitedGroup::new(now));
+        match ip {
+            IpAddr::V4(ipv4) => {
+                // Only used by one address.
+                let group = self
+                    .ipv4_buckets
+                    .entry(ipv4)
+                    .or_insert(RateLimitedGroup::new(now));
 
-        result &= group.check_total(type_, now, capacity, secs_to_refill);
-      }
+                result &= group.check_total(type_, now, capacity, secs_to_refill);
+            }
 
-      IpAddr::V6(ipv6) => {
-        let (key_48, key_56, key_64) = split_ipv6(ipv6);
+            IpAddr::V6(ipv6) => {
+                let (key_48, key_56, key_64) = split_ipv6(ipv6);
 
-        // Contains all addresses with the same first 48 bits. These addresses might be part of the same network.
-        let group_48 = self
-          .ipv6_buckets
-          .entry(key_48)
-          .or_insert(RateLimitedGroup::new(now));
-        result &= group_48.check_total(type_, now, capacity.saturating_mul(16), secs_to_refill);
+                // Contains all addresses with the same first 48 bits. These addresses might be part of the same network.
+                let group_48 = self
+                    .ipv6_buckets
+                    .entry(key_48)
+                    .or_insert(RateLimitedGroup::new(now));
+                result &=
+                    group_48.check_total(type_, now, capacity.saturating_mul(16), secs_to_refill);
 
-        // Contains all addresses with the same first 56 bits. These addresses might be part of the same network.
-        let group_56 = group_48
-          .children
-          .entry(key_56)
-          .or_insert(RateLimitedGroup::new(now));
-        result &= group_56.check_total(type_, now, capacity.saturating_mul(4), secs_to_refill);
+                // Contains all addresses with the same first 56 bits. These addresses might be part of the same network.
+                let group_56 = group_48
+                    .children
+                    .entry(key_56)
+                    .or_insert(RateLimitedGroup::new(now));
+                result &=
+                    group_56.check_total(type_, now, capacity.saturating_mul(4), secs_to_refill);
 
-        // A group with no children. It is shared by all addresses with the same first 64 bits. These addresses are always part of the same network.
-        let group_64 = group_56
-          .children
-          .entry(key_64)
-          .or_insert(RateLimitedGroup::new(now));
+                // A group with no children. It is shared by all addresses with the same first 64 bits. These addresses are always part of the same network.
+                let group_64 = group_56
+                    .children
+                    .entry(key_64)
+                    .or_insert(RateLimitedGroup::new(now));
 
-        result &= group_64.check_total(type_, now, capacity, secs_to_refill);
-      }
-    };
+                result &= group_64.check_total(type_, now, capacity, secs_to_refill);
+            }
+        };
 
-    if !result {
-      debug!("Rate limited IP: {ip}");
+        if !result {
+            debug!("Rate limited IP: {ip}");
+        }
+
+        result
     }
 
-    result
-  }
-
-  /// Remove buckets older than the given duration
-  pub(super) fn remove_older_than(&mut self, duration: Duration, now: InstantSecs) {
-    // Only retain buckets that were last used after `instant`
-    let Some(instant) = now.to_instant().checked_sub(duration) else {
+    /// Remove buckets older than the given duration
+    pub(super) fn remove_older_than(&mut self, duration: Duration, now: InstantSecs) {
+        // Only retain buckets that were last used after `instant`
+        let Some(instant) = now.to_instant().checked_sub(duration) else {
       return;
     };
 
-    let is_recently_used = |group: &RateLimitedGroup<_>| {
-      group
-        .total
-        .values()
-        .all(|bucket| bucket.last_checked.to_instant() > instant)
-    };
+        let is_recently_used = |group: &RateLimitedGroup<_>| {
+            group
+                .total
+                .values()
+                .all(|bucket| bucket.last_checked.to_instant() > instant)
+        };
 
-    retain_and_shrink(&mut self.ipv4_buckets, |_, group| is_recently_used(group));
+        retain_and_shrink(&mut self.ipv4_buckets, |_, group| is_recently_used(group));
 
-    retain_and_shrink(&mut self.ipv6_buckets, |_, group_48| {
-      retain_and_shrink(&mut group_48.children, |_, group_56| {
-        retain_and_shrink(&mut group_56.children, |_, group_64| {
-          is_recently_used(group_64)
-        });
-        !group_56.children.is_empty()
-      });
-      !group_48.children.is_empty()
-    })
-  }
+        retain_and_shrink(&mut self.ipv6_buckets, |_, group_48| {
+            retain_and_shrink(&mut group_48.children, |_, group_56| {
+                retain_and_shrink(&mut group_56.children, |_, group_64| {
+                    is_recently_used(group_64)
+                });
+                !group_56.children.is_empty()
+            });
+            !group_48.children.is_empty()
+        })
+    }
 }
 
 fn retain_and_shrink<K, V, F>(map: &mut HashMap<K, V>, f: F)
 where
-  K: Eq + Hash,
-  F: FnMut(&K, &mut V) -> bool,
+    K: Eq + Hash,
+    F: FnMut(&K, &mut V) -> bool,
 {
-  map.retain(f);
-  map.shrink_to_fit();
+    map.retain(f);
+    map.shrink_to_fit();
 }
 
 fn split_ipv6(ip: Ipv6Addr) -> ([u8; 6], u8, u8) {
-  let [a0, a1, a2, a3, a4, a5, b, c, ..] = ip.octets();
-  ([a0, a1, a2, a3, a4, a5], b, c)
+    let [a0, a1, a2, a3, a4, a5, b, c, ..] = ip.octets();
+    ([a0, a1, a2, a3, a4, a5], b, c)
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  #[test]
-  fn test_split_ipv6() {
-    let ip = std::net::Ipv6Addr::new(
-      0x0011, 0x2233, 0x4455, 0x6677, 0x8899, 0xAABB, 0xCCDD, 0xEEFF,
-    );
-    assert_eq!(
-      super::split_ipv6(ip),
-      ([0x00, 0x11, 0x22, 0x33, 0x44, 0x55], 0x66, 0x77)
-    );
-  }
-
-  #[test]
-  fn test_rate_limiter() {
-    let mut rate_limiter = super::RateLimitStorage::default();
-    let mut now = super::InstantSecs::now();
-
-    let ips = [
-      "123.123.123.123",
-      "1:2:3::",
-      "1:2:3:0400::",
-      "1:2:3:0405::",
-      "1:2:3:0405:6::",
-    ];
-    for ip in ips {
-      let ip = ip.parse().unwrap();
-      let message_passed =
-        rate_limiter.check_rate_limit_full(super::RateLimitType::Message, ip, 2, 1, now);
-      let post_passed =
-        rate_limiter.check_rate_limit_full(super::RateLimitType::Post, ip, 3, 1, now);
-      assert!(message_passed);
-      assert!(post_passed);
+    #[test]
+    fn test_split_ipv6() {
+        let ip = std::net::Ipv6Addr::new(
+            0x0011, 0x2233, 0x4455, 0x6677, 0x8899, 0xAABB, 0xCCDD, 0xEEFF,
+        );
+        assert_eq!(
+            super::split_ipv6(ip),
+            ([0x00, 0x11, 0x22, 0x33, 0x44, 0x55], 0x66, 0x77)
+        );
     }
 
-    #[allow(clippy::indexing_slicing)]
-    let expected_buckets = |factor: f32, tokens_consumed: f32| {
-      let mut buckets = super::RateLimitedGroup::<()>::new(now).total;
-      buckets[super::RateLimitType::Message] = super::RateLimitBucket {
-        last_checked: now,
-        tokens: (2.0 * factor) - tokens_consumed,
-      };
-      buckets[super::RateLimitType::Post] = super::RateLimitBucket {
-        last_checked: now,
-        tokens: (3.0 * factor) - tokens_consumed,
-      };
-      buckets
-    };
+    #[test]
+    fn test_rate_limiter() {
+        let mut rate_limiter = super::RateLimitStorage::default();
+        let mut now = super::InstantSecs::now();
 
-    let bottom_group = |tokens_consumed| super::RateLimitedGroup {
-      total: expected_buckets(1.0, tokens_consumed),
-      children: (),
-    };
+        let ips = [
+            "123.123.123.123",
+            "1:2:3::",
+            "1:2:3:0400::",
+            "1:2:3:0405::",
+            "1:2:3:0405:6::",
+        ];
+        for ip in ips {
+            let ip = ip.parse().unwrap();
+            let message_passed =
+                rate_limiter.check_rate_limit_full(super::RateLimitType::Message, ip, 2, 1, now);
+            let post_passed =
+                rate_limiter.check_rate_limit_full(super::RateLimitType::Post, ip, 3, 1, now);
+            assert!(message_passed);
+            assert!(post_passed);
+        }
 
-    assert_eq!(
-      rate_limiter,
-      super::RateLimitStorage {
-        ipv4_buckets: [([123, 123, 123, 123].into(), bottom_group(1.0)),].into(),
-        ipv6_buckets: [(
-          [0, 1, 0, 2, 0, 3],
-          super::RateLimitedGroup {
-            total: expected_buckets(16.0, 4.0),
-            children: [
-              (
-                0,
-                super::RateLimitedGroup {
-                  total: expected_buckets(4.0, 1.0),
-                  children: [(0, bottom_group(1.0)),].into(),
-                }
-              ),
-              (
-                4,
-                super::RateLimitedGroup {
-                  total: expected_buckets(4.0, 3.0),
-                  children: [(0, bottom_group(1.0)), (5, bottom_group(2.0)),].into(),
-                }
-              ),
-            ]
-            .into(),
-          }
-        ),]
-        .into(),
-      }
-    );
+        #[allow(clippy::indexing_slicing)]
+        let expected_buckets = |factor: f32, tokens_consumed: f32| {
+            let mut buckets = super::RateLimitedGroup::<()>::new(now).total;
+            buckets[super::RateLimitType::Message] = super::RateLimitBucket {
+                last_checked: now,
+                tokens: (2.0 * factor) - tokens_consumed,
+            };
+            buckets[super::RateLimitType::Post] = super::RateLimitBucket {
+                last_checked: now,
+                tokens: (3.0 * factor) - tokens_consumed,
+            };
+            buckets
+        };
 
-    now.secs += 2;
-    rate_limiter.remove_older_than(std::time::Duration::from_secs(1), now);
-    assert!(rate_limiter.ipv4_buckets.is_empty());
-    assert!(rate_limiter.ipv6_buckets.is_empty());
-  }
+        let bottom_group = |tokens_consumed| super::RateLimitedGroup {
+            total: expected_buckets(1.0, tokens_consumed),
+            children: (),
+        };
+
+        assert_eq!(
+            rate_limiter,
+            super::RateLimitStorage {
+                ipv4_buckets: [([123, 123, 123, 123].into(), bottom_group(1.0)),].into(),
+                ipv6_buckets: [(
+                    [0, 1, 0, 2, 0, 3],
+                    super::RateLimitedGroup {
+                        total: expected_buckets(16.0, 4.0),
+                        children: [
+                            (
+                                0,
+                                super::RateLimitedGroup {
+                                    total: expected_buckets(4.0, 1.0),
+                                    children: [(0, bottom_group(1.0)),].into(),
+                                }
+                            ),
+                            (
+                                4,
+                                super::RateLimitedGroup {
+                                    total: expected_buckets(4.0, 3.0),
+                                    children: [(0, bottom_group(1.0)), (5, bottom_group(2.0)),]
+                                        .into(),
+                                }
+                            ),
+                        ]
+                        .into(),
+                    }
+                ),]
+                .into(),
+            }
+        );
+
+        now.secs += 2;
+        rate_limiter.remove_older_than(std::time::Duration::from_secs(1), now);
+        assert!(rate_limiter.ipv4_buckets.is_empty());
+        assert!(rate_limiter.ipv6_buckets.is_empty());
+    }
 }

--- a/crates/utils/src/request.rs
+++ b/crates/utils/src/request.rs
@@ -3,35 +3,35 @@ use std::future::Future;
 #[tracing::instrument(skip_all)]
 pub async fn retry<F, Fut, T>(f: F) -> Result<T, reqwest_middleware::Error>
 where
-  F: Fn() -> Fut,
-  Fut: Future<Output = Result<T, reqwest_middleware::Error>>,
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<T, reqwest_middleware::Error>>,
 {
-  retry_custom(|| async { Ok((f)().await) }).await
+    retry_custom(|| async { Ok((f)().await) }).await
 }
 
 #[tracing::instrument(skip_all)]
 async fn retry_custom<F, Fut, T>(f: F) -> Result<T, reqwest_middleware::Error>
 where
-  F: Fn() -> Fut,
-  Fut: Future<Output = Result<Result<T, reqwest_middleware::Error>, reqwest_middleware::Error>>,
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<Result<T, reqwest_middleware::Error>, reqwest_middleware::Error>>,
 {
-  let mut response: Option<Result<T, reqwest_middleware::Error>> = None;
+    let mut response: Option<Result<T, reqwest_middleware::Error>> = None;
 
-  for _ in 0u8..3 {
-    match (f)().await? {
-      Ok(t) => return Ok(t),
-      Err(reqwest_middleware::Error::Reqwest(e)) => {
-        if e.is_timeout() {
-          response = Some(Err(reqwest_middleware::Error::Reqwest(e)));
-          continue;
+    for _ in 0u8..3 {
+        match (f)().await? {
+            Ok(t) => return Ok(t),
+            Err(reqwest_middleware::Error::Reqwest(e)) => {
+                if e.is_timeout() {
+                    response = Some(Err(reqwest_middleware::Error::Reqwest(e)));
+                    continue;
+                }
+                return Err(reqwest_middleware::Error::Reqwest(e));
+            }
+            Err(otherwise) => {
+                return Err(otherwise);
+            }
         }
-        return Err(reqwest_middleware::Error::Reqwest(e));
-      }
-      Err(otherwise) => {
-        return Err(otherwise);
-      }
     }
-  }
 
-  response.expect("retry http request")
+    response.expect("retry http request")
 }

--- a/crates/utils/src/response.rs
+++ b/crates/utils/src/response.rs
@@ -1,127 +1,118 @@
 use crate::error::{LemmyError, LemmyErrorType};
 use actix_web::{
-  dev::ServiceResponse,
-  http::header,
-  middleware::ErrorHandlerResponse,
-  HttpResponse,
+    dev::ServiceResponse, http::header, middleware::ErrorHandlerResponse, HttpResponse,
 };
 
 pub fn jsonify_plain_text_errors<BODY>(
-  res: ServiceResponse<BODY>,
+    res: ServiceResponse<BODY>,
 ) -> actix_web::Result<ErrorHandlerResponse<BODY>> {
-  let maybe_error = res.response().error();
+    let maybe_error = res.response().error();
 
-  // This function is only expected to be called for errors, so if there is no error, return
-  if maybe_error.is_none() {
-    return Ok(ErrorHandlerResponse::Response(res.map_into_left_body()));
-  }
-  // We're assuming that any LemmyError is already in JSON format, so we don't need to do anything
-  if maybe_error
-    .expect("http responses with 400-599 statuses should have an error object")
-    .as_error::<LemmyError>()
-    .is_some()
-  {
-    return Ok(ErrorHandlerResponse::Response(res.map_into_left_body()));
-  }
+    // This function is only expected to be called for errors, so if there is no error, return
+    if maybe_error.is_none() {
+        return Ok(ErrorHandlerResponse::Response(res.map_into_left_body()));
+    }
+    // We're assuming that any LemmyError is already in JSON format, so we don't need to do anything
+    if maybe_error
+        .expect("http responses with 400-599 statuses should have an error object")
+        .as_error::<LemmyError>()
+        .is_some()
+    {
+        return Ok(ErrorHandlerResponse::Response(res.map_into_left_body()));
+    }
 
-  let (req, res) = res.into_parts();
-  let error = res
-    .error()
-    .expect("expected an error object in the response");
-  let response = HttpResponse::build(res.status())
-    .append_header(header::ContentType::json())
-    .json(LemmyErrorType::Unknown(error.to_string()));
+    let (req, res) = res.into_parts();
+    let error = res
+        .error()
+        .expect("expected an error object in the response");
+    let response = HttpResponse::build(res.status())
+        .append_header(header::ContentType::json())
+        .json(LemmyErrorType::Unknown(error.to_string()));
 
-  let service_response = ServiceResponse::new(req, response);
-  Ok(ErrorHandlerResponse::Response(
-    service_response.map_into_right_body(),
-  ))
+    let service_response = ServiceResponse::new(req, response);
+    Ok(ErrorHandlerResponse::Response(
+        service_response.map_into_right_body(),
+    ))
 }
 
 #[cfg(test)]
 mod tests {
-  use super::*;
-  use crate::error::{LemmyError, LemmyErrorType};
-  use actix_web::{
-    error::ErrorInternalServerError,
-    middleware::ErrorHandlers,
-    test,
-    web,
-    App,
-    Error,
-    Handler,
-    Responder,
-  };
-  use http::StatusCode;
+    use super::*;
+    use crate::error::{LemmyError, LemmyErrorType};
+    use actix_web::{
+        error::ErrorInternalServerError, middleware::ErrorHandlers, test, web, App, Error, Handler,
+        Responder,
+    };
+    use http::StatusCode;
 
-  #[actix_web::test]
-  async fn test_non_error_responses_are_not_modified() {
-    async fn ok_service() -> actix_web::Result<String, Error> {
-      Ok("Oll Korrect".to_string())
+    #[actix_web::test]
+    async fn test_non_error_responses_are_not_modified() {
+        async fn ok_service() -> actix_web::Result<String, Error> {
+            Ok("Oll Korrect".to_string())
+        }
+
+        check_for_jsonification(ok_service, StatusCode::OK, "Oll Korrect").await;
     }
 
-    check_for_jsonification(ok_service, StatusCode::OK, "Oll Korrect").await;
-  }
+    #[actix_web::test]
+    async fn test_lemmy_errors_are_not_modified() {
+        async fn lemmy_error_service() -> actix_web::Result<String, LemmyError> {
+            Err(LemmyError::from(LemmyErrorType::EmailAlreadyExists))
+        }
 
-  #[actix_web::test]
-  async fn test_lemmy_errors_are_not_modified() {
-    async fn lemmy_error_service() -> actix_web::Result<String, LemmyError> {
-      Err(LemmyError::from(LemmyErrorType::EmailAlreadyExists))
+        check_for_jsonification(
+            lemmy_error_service,
+            StatusCode::BAD_REQUEST,
+            "{\"error\":\"email_already_exists\"}",
+        )
+        .await;
     }
 
-    check_for_jsonification(
-      lemmy_error_service,
-      StatusCode::BAD_REQUEST,
-      "{\"error\":\"email_already_exists\"}",
-    )
-    .await;
-  }
+    #[actix_web::test]
+    async fn test_generic_errors_are_jsonified_as_unknown_errors() {
+        async fn generic_error_service() -> actix_web::Result<String, Error> {
+            Err(ErrorInternalServerError("This is not a LemmyError"))
+        }
 
-  #[actix_web::test]
-  async fn test_generic_errors_are_jsonified_as_unknown_errors() {
-    async fn generic_error_service() -> actix_web::Result<String, Error> {
-      Err(ErrorInternalServerError("This is not a LemmyError"))
+        check_for_jsonification(
+            generic_error_service,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "{\"error\":\"unknown\",\"message\":\"This is not a LemmyError\"}",
+        )
+        .await;
     }
 
-    check_for_jsonification(
-      generic_error_service,
-      StatusCode::INTERNAL_SERVER_ERROR,
-      "{\"error\":\"unknown\",\"message\":\"This is not a LemmyError\"}",
-    )
-    .await;
-  }
+    #[actix_web::test]
+    async fn test_anyhow_errors_wrapped_in_lemmy_errors_are_jsonified_correctly() {
+        async fn anyhow_error_service() -> actix_web::Result<String, LemmyError> {
+            Err(LemmyError::from(anyhow::anyhow!("This is the inner error")))
+        }
 
-  #[actix_web::test]
-  async fn test_anyhow_errors_wrapped_in_lemmy_errors_are_jsonified_correctly() {
-    async fn anyhow_error_service() -> actix_web::Result<String, LemmyError> {
-      Err(LemmyError::from(anyhow::anyhow!("This is the inner error")))
+        check_for_jsonification(
+            anyhow_error_service,
+            StatusCode::BAD_REQUEST,
+            "{\"error\":\"unknown\",\"message\":\"This is the inner error\"}",
+        )
+        .await;
     }
 
-    check_for_jsonification(
-      anyhow_error_service,
-      StatusCode::BAD_REQUEST,
-      "{\"error\":\"unknown\",\"message\":\"This is the inner error\"}",
-    )
-    .await;
-  }
+    async fn check_for_jsonification(
+        service: impl Handler<(), Output = impl Responder + 'static>,
+        expected_status_code: StatusCode,
+        expected_body: &str,
+    ) {
+        let app = test::init_service(
+            App::new()
+                .wrap(ErrorHandlers::new().default_handler(jsonify_plain_text_errors))
+                .route("/", web::get().to(service)),
+        )
+        .await;
+        let req = test::TestRequest::default().to_request();
+        let res = test::call_service(&app, req).await;
 
-  async fn check_for_jsonification(
-    service: impl Handler<(), Output = impl Responder + 'static>,
-    expected_status_code: StatusCode,
-    expected_body: &str,
-  ) {
-    let app = test::init_service(
-      App::new()
-        .wrap(ErrorHandlers::new().default_handler(jsonify_plain_text_errors))
-        .route("/", web::get().to(service)),
-    )
-    .await;
-    let req = test::TestRequest::default().to_request();
-    let res = test::call_service(&app, req).await;
+        assert_eq!(res.status(), expected_status_code);
 
-    assert_eq!(res.status(), expected_status_code);
-
-    let body = test::read_body(res).await;
-    assert_eq!(body, expected_body);
-  }
+        let body = test::read_body(res).await;
+        assert_eq!(body, expected_body);
+    }
 }

--- a/crates/utils/src/settings/mod.rs
+++ b/crates/utils/src/settings/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
-  error::LemmyError,
-  location_info,
-  settings::structs::{PictrsConfig, Settings},
+    error::LemmyError,
+    location_info,
+    settings::structs::{PictrsConfig, Settings},
 };
 use anyhow::{anyhow, Context};
 use deser_hjson::from_str;
@@ -17,95 +17,92 @@ use structs::DatabaseConnection;
 static DEFAULT_CONFIG_FILE: &str = "config/config.hjson";
 
 pub static SETTINGS: Lazy<Settings> = Lazy::new(|| {
-  Settings::init().expect("Failed to load settings file, see documentation (https://join-lemmy.org/docs/en/administration/configuration.html)")
+    Settings::init().expect("Failed to load settings file, see documentation (https://join-lemmy.org/docs/en/administration/configuration.html)")
 });
 static WEBFINGER_REGEX: Lazy<Regex> = Lazy::new(|| {
-  Regex::new(&format!(
-    "^acct:([a-zA-Z0-9_]{{3,}})@{}$",
-    SETTINGS.hostname
-  ))
-  .expect("compile webfinger regex")
+    Regex::new(&format!(
+        "^acct:([a-zA-Z0-9_]{{3,}})@{}$",
+        SETTINGS.hostname
+    ))
+    .expect("compile webfinger regex")
 });
 
 impl Settings {
-  /// Reads config from configuration file.
-  ///
-  /// Note: The env var `LEMMY_DATABASE_URL` is parsed in
-  /// `lemmy_db_schema/src/lib.rs::get_database_url_from_env()`
-  /// Warning: Only call this once.
-  pub(crate) fn init() -> Result<Self, LemmyError> {
-    // Read the config file
-    let config = from_str::<Settings>(&Self::read_config_file()?)?;
+    /// Reads config from configuration file.
+    ///
+    /// Note: The env var `LEMMY_DATABASE_URL` is parsed in
+    /// `lemmy_db_schema/src/lib.rs::get_database_url_from_env()`
+    /// Warning: Only call this once.
+    pub(crate) fn init() -> Result<Self, LemmyError> {
+        // Read the config file
+        let config = from_str::<Settings>(&Self::read_config_file()?)?;
 
-    if config.hostname == "unset" {
-      Err(anyhow!("Hostname variable is not set!").into())
-    } else {
-      Ok(config)
+        if config.hostname == "unset" {
+            Err(anyhow!("Hostname variable is not set!").into())
+        } else {
+            Ok(config)
+        }
     }
-  }
 
-  pub fn get_database_url(&self) -> String {
-    match &self.database.connection {
-      DatabaseConnection::Uri { uri } => uri.clone(),
-      DatabaseConnection::Parts(parts) => {
-        format!(
-          "postgres://{}:{}@{}:{}/{}",
-          utf8_percent_encode(&parts.user, NON_ALPHANUMERIC),
-          utf8_percent_encode(&parts.password, NON_ALPHANUMERIC),
-          parts.host,
-          parts.port,
-          utf8_percent_encode(&parts.database, NON_ALPHANUMERIC),
-        )
-      }
+    pub fn get_database_url(&self) -> String {
+        match &self.database.connection {
+            DatabaseConnection::Uri { uri } => uri.clone(),
+            DatabaseConnection::Parts(parts) => {
+                format!(
+                    "postgres://{}:{}@{}:{}/{}",
+                    utf8_percent_encode(&parts.user, NON_ALPHANUMERIC),
+                    utf8_percent_encode(&parts.password, NON_ALPHANUMERIC),
+                    parts.host,
+                    parts.port,
+                    utf8_percent_encode(&parts.database, NON_ALPHANUMERIC),
+                )
+            }
+        }
     }
-  }
 
-  fn get_config_location() -> String {
-    env::var("LEMMY_CONFIG_LOCATION").unwrap_or_else(|_| DEFAULT_CONFIG_FILE.to_string())
-  }
-
-  fn read_config_file() -> Result<String, Error> {
-    fs::read_to_string(Self::get_config_location())
-  }
-
-  /// Returns either "http" or "https", depending on tls_enabled setting
-  pub fn get_protocol_string(&self) -> &'static str {
-    if self.tls_enabled {
-      "https"
-    } else {
-      "http"
+    fn get_config_location() -> String {
+        env::var("LEMMY_CONFIG_LOCATION").unwrap_or_else(|_| DEFAULT_CONFIG_FILE.to_string())
     }
-  }
 
-  /// Returns something like `http://localhost` or `https://lemmy.ml`,
-  /// with the correct protocol and hostname.
-  pub fn get_protocol_and_hostname(&self) -> String {
-    format!("{}://{}", self.get_protocol_string(), self.hostname)
-  }
+    fn read_config_file() -> Result<String, Error> {
+        fs::read_to_string(Self::get_config_location())
+    }
 
-  /// When running the federation test setup in `api_tests/` or `docker/federation`, the `hostname`
-  /// variable will be like `lemmy-alpha:8541`. This method removes the port and returns
-  /// `lemmy-alpha` instead. It has no effect in production.
-  pub fn get_hostname_without_port(&self) -> Result<String, anyhow::Error> {
-    Ok(
-      (*self
-        .hostname
-        .split(':')
-        .collect::<Vec<&str>>()
-        .first()
-        .context(location_info!())?)
-      .to_string(),
-    )
-  }
+    /// Returns either "http" or "https", depending on tls_enabled setting
+    pub fn get_protocol_string(&self) -> &'static str {
+        if self.tls_enabled {
+            "https"
+        } else {
+            "http"
+        }
+    }
 
-  pub fn webfinger_regex(&self) -> Regex {
-    WEBFINGER_REGEX.clone()
-  }
+    /// Returns something like `http://localhost` or `https://lemmy.ml`,
+    /// with the correct protocol and hostname.
+    pub fn get_protocol_and_hostname(&self) -> String {
+        format!("{}://{}", self.get_protocol_string(), self.hostname)
+    }
 
-  pub fn pictrs_config(&self) -> Result<PictrsConfig, LemmyError> {
-    self
-      .pictrs
-      .clone()
-      .ok_or_else(|| anyhow!("images_disabled").into())
-  }
+    /// When running the federation test setup in `api_tests/` or `docker/federation`, the `hostname`
+    /// variable will be like `lemmy-alpha:8541`. This method removes the port and returns
+    /// `lemmy-alpha` instead. It has no effect in production.
+    pub fn get_hostname_without_port(&self) -> Result<String, anyhow::Error> {
+        Ok((*self
+            .hostname
+            .split(':')
+            .collect::<Vec<&str>>()
+            .first()
+            .context(location_info!())?)
+        .to_string())
+    }
+
+    pub fn webfinger_regex(&self) -> Regex {
+        WEBFINGER_REGEX.clone()
+    }
+
+    pub fn pictrs_config(&self) -> Result<PictrsConfig, LemmyError> {
+        self.pictrs
+            .clone()
+            .ok_or_else(|| anyhow!("images_disabled").into())
+    }
 }

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -6,175 +6,175 @@ use url::Url;
 #[derive(Debug, Deserialize, Serialize, Clone, SmartDefault, Document)]
 #[serde(default)]
 pub struct Settings {
-  /// settings related to the postgresql database
-  #[default(Default::default())]
-  pub database: DatabaseConfig,
-  /// Settings related to activitypub federation
-  /// Pictrs image server configuration.
-  #[default(Some(Default::default()))]
-  pub(crate) pictrs: Option<PictrsConfig>,
-  /// Email sending configuration. All options except login/password are mandatory
-  #[default(None)]
-  #[doku(example = "Some(Default::default())")]
-  pub email: Option<EmailConfig>,
-  /// Parameters for automatic configuration of new instance (only used at first start)
-  #[default(None)]
-  #[doku(example = "Some(Default::default())")]
-  pub setup: Option<SetupConfig>,
-  /// the domain name of your instance (mandatory)
-  #[default("unset")]
-  #[doku(example = "example.com")]
-  pub hostname: String,
-  /// Address where lemmy should listen for incoming requests
-  #[default(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)))]
-  #[doku(as = "String")]
-  pub bind: IpAddr,
-  /// Port where lemmy should listen for incoming requests
-  #[default(8536)]
-  pub port: u16,
-  /// Whether the site is available over TLS. Needs to be true for federation to work.
-  #[default(true)]
-  pub tls_enabled: bool,
-  /// Set the URL for opentelemetry exports. If you do not have an opentelemetry collector, do not set this option
-  #[default(None)]
-  #[doku(skip)]
-  pub opentelemetry_url: Option<Url>,
-  /// The number of activitypub federation workers that can be in-flight concurrently
-  #[default(0)]
-  pub worker_count: usize,
-  /// The number of activitypub federation retry workers that can be in-flight concurrently
-  #[default(0)]
-  pub retry_count: usize,
-  // Prometheus configuration.
-  #[default(None)]
-  #[doku(example = "Some(Default::default())")]
-  pub prometheus: Option<PrometheusConfig>,
+    /// settings related to the postgresql database
+    #[default(Default::default())]
+    pub database: DatabaseConfig,
+    /// Settings related to activitypub federation
+    /// Pictrs image server configuration.
+    #[default(Some(Default::default()))]
+    pub(crate) pictrs: Option<PictrsConfig>,
+    /// Email sending configuration. All options except login/password are mandatory
+    #[default(None)]
+    #[doku(example = "Some(Default::default())")]
+    pub email: Option<EmailConfig>,
+    /// Parameters for automatic configuration of new instance (only used at first start)
+    #[default(None)]
+    #[doku(example = "Some(Default::default())")]
+    pub setup: Option<SetupConfig>,
+    /// the domain name of your instance (mandatory)
+    #[default("unset")]
+    #[doku(example = "example.com")]
+    pub hostname: String,
+    /// Address where lemmy should listen for incoming requests
+    #[default(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)))]
+    #[doku(as = "String")]
+    pub bind: IpAddr,
+    /// Port where lemmy should listen for incoming requests
+    #[default(8536)]
+    pub port: u16,
+    /// Whether the site is available over TLS. Needs to be true for federation to work.
+    #[default(true)]
+    pub tls_enabled: bool,
+    /// Set the URL for opentelemetry exports. If you do not have an opentelemetry collector, do not set this option
+    #[default(None)]
+    #[doku(skip)]
+    pub opentelemetry_url: Option<Url>,
+    /// The number of activitypub federation workers that can be in-flight concurrently
+    #[default(0)]
+    pub worker_count: usize,
+    /// The number of activitypub federation retry workers that can be in-flight concurrently
+    #[default(0)]
+    pub retry_count: usize,
+    // Prometheus configuration.
+    #[default(None)]
+    #[doku(example = "Some(Default::default())")]
+    pub prometheus: Option<PrometheusConfig>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, SmartDefault, Document)]
 #[serde(default, deny_unknown_fields)]
 pub struct PictrsConfig {
-  /// Address where pictrs is available (for image hosting)
-  #[default(Url::parse("http://localhost:8080").expect("parse pictrs url"))]
-  #[doku(example = "http://localhost:8080")]
-  pub url: Url,
+    /// Address where pictrs is available (for image hosting)
+    #[default(Url::parse("http://localhost:8080").expect("parse pictrs url"))]
+    #[doku(example = "http://localhost:8080")]
+    pub url: Url,
 
-  /// Set a custom pictrs API key. ( Required for deleting images )
-  #[default(None)]
-  pub api_key: Option<String>,
+    /// Set a custom pictrs API key. ( Required for deleting images )
+    #[default(None)]
+    pub api_key: Option<String>,
 
-  /// Cache remote images
-  #[default(true)]
-  pub cache_remote_images: bool,
+    /// Cache remote images
+    #[default(true)]
+    pub cache_remote_images: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, SmartDefault, Document)]
 #[serde(default)]
 pub struct DatabaseConfig {
-  #[serde(flatten, default)]
-  pub connection: DatabaseConnection,
+    #[serde(flatten, default)]
+    pub connection: DatabaseConnection,
 
-  /// Maximum number of active sql connections
-  #[default(5)]
-  pub pool_size: usize,
+    /// Maximum number of active sql connections
+    #[default(5)]
+    pub pool_size: usize,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, SmartDefault, Document)]
 #[serde(untagged)]
 pub enum DatabaseConnection {
-  /// Configure the database by specifying a URI
-  ///
-  /// This is the preferred method to specify database connection details since
-  /// it is the most flexible.
-  Uri {
-    /// Connection URI pointing to a postgres instance
+    /// Configure the database by specifying a URI
     ///
-    /// This example uses peer authentication to obviate the need for creating,
-    /// configuring, and managing passwords.
-    ///
-    /// For an explanation of how to use connection URIs, see [here][0] in
-    /// PostgreSQL's documentation.
-    ///
-    /// [0]: https://www.postgresql.org/docs/current/libpq-connect.html#id-1.7.3.8.3.6
-    #[doku(example = "postgresql:///lemmy?user=lemmy&host=/var/run/postgresql")]
-    uri: String,
-  },
+    /// This is the preferred method to specify database connection details since
+    /// it is the most flexible.
+    Uri {
+        /// Connection URI pointing to a postgres instance
+        ///
+        /// This example uses peer authentication to obviate the need for creating,
+        /// configuring, and managing passwords.
+        ///
+        /// For an explanation of how to use connection URIs, see [here][0] in
+        /// PostgreSQL's documentation.
+        ///
+        /// [0]: https://www.postgresql.org/docs/current/libpq-connect.html#id-1.7.3.8.3.6
+        #[doku(example = "postgresql:///lemmy?user=lemmy&host=/var/run/postgresql")]
+        uri: String,
+    },
 
-  /// Configure the database by specifying parts of a URI
-  ///
-  /// Note that specifying the `uri` field should be preferred since it provides
-  /// greater control over how the connection is made. This merely exists for
-  /// backwards-compatibility.
-  #[default]
-  Parts(DatabaseConnectionParts),
+    /// Configure the database by specifying parts of a URI
+    ///
+    /// Note that specifying the `uri` field should be preferred since it provides
+    /// greater control over how the connection is made. This merely exists for
+    /// backwards-compatibility.
+    #[default]
+    Parts(DatabaseConnectionParts),
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, SmartDefault, Document)]
 #[serde(default)]
 pub struct DatabaseConnectionParts {
-  /// Username to connect to postgres
-  #[default("lemmy")]
-  pub(super) user: String,
-  /// Password to connect to postgres
-  #[default("password")]
-  pub password: String,
-  #[default("localhost")]
-  /// Host where postgres is running
-  pub host: String,
-  /// Port where postgres can be accessed
-  #[default(5432)]
-  pub(super) port: i32,
-  /// Name of the postgres database for lemmy
-  #[default("lemmy")]
-  pub(super) database: String,
+    /// Username to connect to postgres
+    #[default("lemmy")]
+    pub(super) user: String,
+    /// Password to connect to postgres
+    #[default("password")]
+    pub password: String,
+    #[default("localhost")]
+    /// Host where postgres is running
+    pub host: String,
+    /// Port where postgres can be accessed
+    #[default(5432)]
+    pub(super) port: i32,
+    /// Name of the postgres database for lemmy
+    #[default("lemmy")]
+    pub(super) database: String,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Document, SmartDefault)]
 #[serde(deny_unknown_fields)]
 pub struct EmailConfig {
-  /// Hostname and port of the smtp server
-  #[doku(example = "localhost:25")]
-  pub smtp_server: String,
-  /// Login name for smtp server
-  pub smtp_login: Option<String>,
-  /// Password to login to the smtp server
-  pub smtp_password: Option<String>,
-  #[doku(example = "noreply@example.com")]
-  /// Address to send emails from, eg "noreply@your-instance.com"
-  pub smtp_from_address: String,
-  /// Whether or not smtp connections should use tls. Can be none, tls, or starttls
-  #[default("none")]
-  #[doku(example = "none")]
-  pub tls_type: String,
+    /// Hostname and port of the smtp server
+    #[doku(example = "localhost:25")]
+    pub smtp_server: String,
+    /// Login name for smtp server
+    pub smtp_login: Option<String>,
+    /// Password to login to the smtp server
+    pub smtp_password: Option<String>,
+    #[doku(example = "noreply@example.com")]
+    /// Address to send emails from, eg "noreply@your-instance.com"
+    pub smtp_from_address: String,
+    /// Whether or not smtp connections should use tls. Can be none, tls, or starttls
+    #[default("none")]
+    #[doku(example = "none")]
+    pub tls_type: String,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, SmartDefault, Document)]
 #[serde(deny_unknown_fields)]
 pub struct SetupConfig {
-  /// Username for the admin user
-  #[doku(example = "admin")]
-  pub admin_username: String,
-  /// Password for the admin user. It must be at least 10 characters.
-  #[doku(example = "tf6HHDS4RolWfFhk4Rq9")]
-  pub admin_password: String,
-  /// Name of the site (can be changed later)
-  #[doku(example = "My Lemmy Instance")]
-  pub site_name: String,
-  /// Email for the admin user (optional, can be omitted and set later through the website)
-  #[doku(example = "user@example.com")]
-  #[default(None)]
-  pub admin_email: Option<String>,
+    /// Username for the admin user
+    #[doku(example = "admin")]
+    pub admin_username: String,
+    /// Password for the admin user. It must be at least 10 characters.
+    #[doku(example = "tf6HHDS4RolWfFhk4Rq9")]
+    pub admin_password: String,
+    /// Name of the site (can be changed later)
+    #[doku(example = "My Lemmy Instance")]
+    pub site_name: String,
+    /// Email for the admin user (optional, can be omitted and set later through the website)
+    #[doku(example = "user@example.com")]
+    #[default(None)]
+    pub admin_email: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, SmartDefault, Document)]
 #[serde(deny_unknown_fields)]
 pub struct PrometheusConfig {
-  // Address that the Prometheus metrics will be served on.
-  #[default(Some(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))))]
-  #[doku(example = "127.0.0.1")]
-  pub bind: Option<IpAddr>,
-  // Port that the Prometheus metrics will be served on.
-  #[default(Some(10002))]
-  #[doku(example = "10002")]
-  pub port: Option<i32>,
+    // Address that the Prometheus metrics will be served on.
+    #[default(Some(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))))]
+    #[doku(example = "127.0.0.1")]
+    pub bind: Option<IpAddr>,
+    // Port that the Prometheus metrics will be served on.
+    #[default(Some(10002))]
+    #[doku(example = "10002")]
+    pub port: Option<i32>,
 }

--- a/crates/utils/src/utils/markdown.rs
+++ b/crates/utils/src/utils/markdown.rs
@@ -4,28 +4,28 @@ use once_cell::sync::Lazy;
 mod spoiler_rule;
 
 static MARKDOWN_PARSER: Lazy<MarkdownIt> = Lazy::new(|| {
-  let mut parser = MarkdownIt::new();
-  markdown_it::plugins::cmark::add(&mut parser);
-  markdown_it::plugins::extra::add(&mut parser);
-  spoiler_rule::add(&mut parser);
+    let mut parser = MarkdownIt::new();
+    markdown_it::plugins::cmark::add(&mut parser);
+    markdown_it::plugins::extra::add(&mut parser);
+    spoiler_rule::add(&mut parser);
 
-  parser
+    parser
 });
 
 pub fn markdown_to_html(text: &str) -> String {
-  MARKDOWN_PARSER.parse(text).xrender()
+    MARKDOWN_PARSER.parse(text).xrender()
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::utils::markdown::markdown_to_html;
+    use crate::utils::markdown::markdown_to_html;
 
-  #[test]
-  fn test_basic_markdown() {
-    let tests: Vec<_> = vec![
+    #[test]
+    fn test_basic_markdown() {
+        let tests: Vec<_> = vec![
       (
         "headings",
         "# h1\n## h2\n### h3\n#### h4\n##### h5\n###### h6",
@@ -73,14 +73,14 @@ mod tests {
       ),
     ];
 
-    tests.iter().for_each(|&(msg, input, expected)| {
-      let result = markdown_to_html(input);
+        tests.iter().for_each(|&(msg, input, expected)| {
+            let result = markdown_to_html(input);
 
-      assert_eq!(
-        result, expected,
-        "Testing {}, with original input '{}'",
-        msg, input
-      );
-    });
-  }
+            assert_eq!(
+                result, expected,
+                "Testing {}, with original input '{}'",
+                msg, input
+            );
+        });
+    }
 }

--- a/crates/utils/src/utils/markdown/spoiler_rule.rs
+++ b/crates/utils/src/utils/markdown/spoiler_rule.rs
@@ -25,21 +25,18 @@
 // end fence
 
 use markdown_it::{
-  parser::{
-    block::{BlockRule, BlockState},
-    inline::InlineRoot,
-  },
-  MarkdownIt,
-  Node,
-  NodeValue,
-  Renderer,
+    parser::{
+        block::{BlockRule, BlockState},
+        inline::InlineRoot,
+    },
+    MarkdownIt, Node, NodeValue, Renderer,
 };
 use once_cell::sync::Lazy;
 use regex::Regex;
 
 #[derive(Debug)]
 struct SpoilerBlock {
-  visible_text: String,
+    visible_text: String,
 }
 
 const SPOILER_PREFIX: &str = "::: spoiler ";
@@ -47,103 +44,102 @@ const SPOILER_SUFFIX: &str = ":::";
 const SPOILER_SUFFIX_NEWLINE: &str = ":::\n";
 
 static SPOILER_REGEX: Lazy<Regex> =
-  Lazy::new(|| Regex::new(r"^::: spoiler .*$").expect("compile spoiler markdown regex."));
+    Lazy::new(|| Regex::new(r"^::: spoiler .*$").expect("compile spoiler markdown regex."));
 
 impl NodeValue for SpoilerBlock {
-  // Formats any node marked as a 'SpoilerBlock' into HTML.
-  // See the SpoilerBlockScanner#run implementation to see how these nodes get added to the tree.
-  fn render(&self, node: &Node, fmt: &mut dyn Renderer) {
-    fmt.cr();
-    fmt.open("details", &node.attrs);
-    fmt.open("summary", &[]);
-    // Not allowing special styling to the visible text to keep it simple.
-    // If allowed, would need to parse the child nodes to assign to visible vs hidden text sections.
-    fmt.text(&self.visible_text);
-    fmt.close("summary");
-    fmt.open("p", &[]);
-    fmt.contents(&node.children);
-    fmt.close("p");
-    fmt.close("details");
-    fmt.cr();
-  }
+    // Formats any node marked as a 'SpoilerBlock' into HTML.
+    // See the SpoilerBlockScanner#run implementation to see how these nodes get added to the tree.
+    fn render(&self, node: &Node, fmt: &mut dyn Renderer) {
+        fmt.cr();
+        fmt.open("details", &node.attrs);
+        fmt.open("summary", &[]);
+        // Not allowing special styling to the visible text to keep it simple.
+        // If allowed, would need to parse the child nodes to assign to visible vs hidden text sections.
+        fmt.text(&self.visible_text);
+        fmt.close("summary");
+        fmt.open("p", &[]);
+        fmt.contents(&node.children);
+        fmt.close("p");
+        fmt.close("details");
+        fmt.cr();
+    }
 }
 
 struct SpoilerBlockScanner;
 
 impl BlockRule for SpoilerBlockScanner {
-  // Invoked on every line in the provided Markdown text to check if the BlockRule applies.
-  //
-  // NOTE: This does NOT support nested spoilers at this time.
-  fn run(state: &mut BlockState) -> Option<(Node, usize)> {
-    let first_line: &str = state.get_line(state.line).trim();
-
-    // 1. Check if the first line contains the spoiler syntax...
-    if !SPOILER_REGEX.is_match(first_line) {
-      return None;
-    }
-
-    let begin_spoiler_line_idx: usize = state.line + 1;
-    let mut end_fence_line_idx: usize = begin_spoiler_line_idx;
-    let mut has_end_fence: bool = false;
-
-    // 2. Search for the end of the spoiler and find the index of the last line of the spoiler.
-    // There could potentially be multiple lines between the beginning and end of the block.
+    // Invoked on every line in the provided Markdown text to check if the BlockRule applies.
     //
-    // Block ends with a line with ':::' or ':::\n'; it must be isolated from other markdown.
-    while end_fence_line_idx < state.line_max && !has_end_fence {
-      let next_line: &str = state.get_line(end_fence_line_idx).trim();
+    // NOTE: This does NOT support nested spoilers at this time.
+    fn run(state: &mut BlockState) -> Option<(Node, usize)> {
+        let first_line: &str = state.get_line(state.line).trim();
 
-      if next_line.eq(SPOILER_SUFFIX) || next_line.eq(SPOILER_SUFFIX_NEWLINE) {
-        has_end_fence = true;
-        break;
-      }
+        // 1. Check if the first line contains the spoiler syntax...
+        if !SPOILER_REGEX.is_match(first_line) {
+            return None;
+        }
 
-      end_fence_line_idx += 1;
+        let begin_spoiler_line_idx: usize = state.line + 1;
+        let mut end_fence_line_idx: usize = begin_spoiler_line_idx;
+        let mut has_end_fence: bool = false;
+
+        // 2. Search for the end of the spoiler and find the index of the last line of the spoiler.
+        // There could potentially be multiple lines between the beginning and end of the block.
+        //
+        // Block ends with a line with ':::' or ':::\n'; it must be isolated from other markdown.
+        while end_fence_line_idx < state.line_max && !has_end_fence {
+            let next_line: &str = state.get_line(end_fence_line_idx).trim();
+
+            if next_line.eq(SPOILER_SUFFIX) || next_line.eq(SPOILER_SUFFIX_NEWLINE) {
+                has_end_fence = true;
+                break;
+            }
+
+            end_fence_line_idx += 1;
+        }
+
+        // 3. If available, construct and return the spoiler node to add to the tree.
+        if has_end_fence {
+            let (spoiler_content, mapping) = state.get_lines(
+                begin_spoiler_line_idx,
+                end_fence_line_idx,
+                state.blk_indent,
+                true,
+            );
+
+            let mut node = Node::new(SpoilerBlock {
+                visible_text: String::from(first_line.replace(SPOILER_PREFIX, "").trim()),
+            });
+
+            // Add the spoiler content as children; marking as a child tells the tree to process the
+            // node again, which means other Markdown syntax (ex: emphasis, links) can be rendered.
+            node.children
+                .push(Node::new(InlineRoot::new(spoiler_content, mapping)));
+
+            // NOTE: Not using begin_spoiler_line_idx here because of incorrect results when
+            //       state.line == 0 (subtracts an idx) vs the expected correct result (adds an idx).
+            Some((node, end_fence_line_idx - state.line + 1))
+        } else {
+            None
+        }
     }
-
-    // 3. If available, construct and return the spoiler node to add to the tree.
-    if has_end_fence {
-      let (spoiler_content, mapping) = state.get_lines(
-        begin_spoiler_line_idx,
-        end_fence_line_idx,
-        state.blk_indent,
-        true,
-      );
-
-      let mut node = Node::new(SpoilerBlock {
-        visible_text: String::from(first_line.replace(SPOILER_PREFIX, "").trim()),
-      });
-
-      // Add the spoiler content as children; marking as a child tells the tree to process the
-      // node again, which means other Markdown syntax (ex: emphasis, links) can be rendered.
-      node
-        .children
-        .push(Node::new(InlineRoot::new(spoiler_content, mapping)));
-
-      // NOTE: Not using begin_spoiler_line_idx here because of incorrect results when
-      //       state.line == 0 (subtracts an idx) vs the expected correct result (adds an idx).
-      Some((node, end_fence_line_idx - state.line + 1))
-    } else {
-      None
-    }
-  }
 }
 
 pub fn add(markdown_parser: &mut MarkdownIt) {
-  markdown_parser.block.add_rule::<SpoilerBlockScanner>();
+    markdown_parser.block.add_rule::<SpoilerBlockScanner>();
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::utils::markdown::spoiler_rule::add;
-  use markdown_it::MarkdownIt;
+    use crate::utils::markdown::spoiler_rule::add;
+    use markdown_it::MarkdownIt;
 
-  #[test]
-  fn test_spoiler_markdown() {
-    let tests: Vec<_> = vec![
+    #[test]
+    fn test_spoiler_markdown() {
+        let tests: Vec<_> = vec![
       (
         "invalid spoiler",
         "::: spoiler click to see more\nbut I never finished",
@@ -186,18 +182,18 @@ mod tests {
       )
     ];
 
-    tests.iter().for_each(|&(msg, input, expected)| {
-      let md = &mut MarkdownIt::new();
-      markdown_it::plugins::cmark::add(md);
-      add(md);
+        tests.iter().for_each(|&(msg, input, expected)| {
+            let md = &mut MarkdownIt::new();
+            markdown_it::plugins::cmark::add(md);
+            add(md);
 
-      assert_eq!(
-        md.parse(input).xrender(),
-        expected,
-        "Testing {}, with original input '{}'",
-        msg,
-        input
-      );
-    });
-  }
+            assert_eq!(
+                md.parse(input).xrender(),
+                expected,
+                "Testing {}, with original input '{}'",
+                msg,
+                input
+            );
+        });
+    }
 }

--- a/crates/utils/src/utils/mention.rs
+++ b/crates/utils/src/utils/mention.rs
@@ -3,50 +3,50 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 
 static MENTIONS_REGEX: Lazy<Regex> = Lazy::new(|| {
-  Regex::new(r"@(?P<name>[\w.]+)@(?P<domain>[a-zA-Z0-9._:-]+)").expect("compile regex")
+    Regex::new(r"@(?P<name>[\w.]+)@(?P<domain>[a-zA-Z0-9._:-]+)").expect("compile regex")
 });
 // TODO nothing is done with community / group webfingers yet, so just ignore those for now
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct MentionData {
-  pub name: String,
-  pub domain: String,
+    pub name: String,
+    pub domain: String,
 }
 
 impl MentionData {
-  pub fn is_local(&self, hostname: &str) -> bool {
-    hostname.eq(&self.domain)
-  }
-  pub fn full_name(&self) -> String {
-    format!("@{}@{}", &self.name, &self.domain)
-  }
+    pub fn is_local(&self, hostname: &str) -> bool {
+        hostname.eq(&self.domain)
+    }
+    pub fn full_name(&self) -> String {
+        format!("@{}@{}", &self.name, &self.domain)
+    }
 }
 
 pub fn scrape_text_for_mentions(text: &str) -> Vec<MentionData> {
-  let mut out: Vec<MentionData> = Vec::new();
-  for caps in MENTIONS_REGEX.captures_iter(text) {
-    if let Some(name) = caps.name("name").map(|c| c.as_str().to_string()) {
-      if let Some(domain) = caps.name("domain").map(|c| c.as_str().to_string()) {
-        out.push(MentionData { name, domain });
-      }
+    let mut out: Vec<MentionData> = Vec::new();
+    for caps in MENTIONS_REGEX.captures_iter(text) {
+        if let Some(name) = caps.name("name").map(|c| c.as_str().to_string()) {
+            if let Some(domain) = caps.name("domain").map(|c| c.as_str().to_string()) {
+                out.push(MentionData { name, domain });
+            }
+        }
     }
-  }
-  out.into_iter().unique().collect()
+    out.into_iter().unique().collect()
 }
 
 #[cfg(test)]
 mod test {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::utils::mention::scrape_text_for_mentions;
+    use crate::utils::mention::scrape_text_for_mentions;
 
-  #[test]
-  fn test_mentions_regex() {
-    let text = "Just read a great blog post by [@tedu@honk.teduangst.com](/u/test). And another by !test_community@fish.teduangst.com . Another [@lemmy@lemmy-alpha:8540](/u/fish)";
-    let mentions = scrape_text_for_mentions(text);
+    #[test]
+    fn test_mentions_regex() {
+        let text = "Just read a great blog post by [@tedu@honk.teduangst.com](/u/test). And another by !test_community@fish.teduangst.com . Another [@lemmy@lemmy-alpha:8540](/u/fish)";
+        let mentions = scrape_text_for_mentions(text);
 
-    assert_eq!(mentions[0].name, "tedu".to_string());
-    assert_eq!(mentions[0].domain, "honk.teduangst.com".to_string());
-    assert_eq!(mentions[1].domain, "lemmy-alpha:8540".to_string());
-  }
+        assert_eq!(mentions[0].name, "tedu".to_string());
+        assert_eq!(mentions[0].domain, "honk.teduangst.com".to_string());
+        assert_eq!(mentions[1].domain, "lemmy-alpha:8540".to_string());
+    }
 }

--- a/crates/utils/src/utils/slurs.rs
+++ b/crates/utils/src/utils/slurs.rs
@@ -2,108 +2,108 @@ use crate::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 use regex::{Regex, RegexBuilder};
 
 pub fn remove_slurs(test: &str, slur_regex: &Option<Regex>) -> String {
-  if let Some(slur_regex) = slur_regex {
-    slur_regex.replace_all(test, "*removed*").to_string()
-  } else {
-    test.to_string()
-  }
+    if let Some(slur_regex) = slur_regex {
+        slur_regex.replace_all(test, "*removed*").to_string()
+    } else {
+        test.to_string()
+    }
 }
 
 pub(crate) fn slur_check<'a>(
-  test: &'a str,
-  slur_regex: &'a Option<Regex>,
+    test: &'a str,
+    slur_regex: &'a Option<Regex>,
 ) -> Result<(), Vec<&'a str>> {
-  if let Some(slur_regex) = slur_regex {
-    let mut matches: Vec<&str> = slur_regex.find_iter(test).map(|mat| mat.as_str()).collect();
+    if let Some(slur_regex) = slur_regex {
+        let mut matches: Vec<&str> = slur_regex.find_iter(test).map(|mat| mat.as_str()).collect();
 
-    // Unique
-    matches.sort_unstable();
-    matches.dedup();
+        // Unique
+        matches.sort_unstable();
+        matches.dedup();
 
-    if matches.is_empty() {
-      Ok(())
+        if matches.is_empty() {
+            Ok(())
+        } else {
+            Err(matches)
+        }
     } else {
-      Err(matches)
+        Ok(())
     }
-  } else {
-    Ok(())
-  }
 }
 
 pub fn build_slur_regex(regex_str: Option<&str>) -> Option<Regex> {
-  regex_str.map(|slurs| {
-    RegexBuilder::new(slurs)
-      .case_insensitive(true)
-      .build()
-      .expect("compile regex")
-  })
+    regex_str.map(|slurs| {
+        RegexBuilder::new(slurs)
+            .case_insensitive(true)
+            .build()
+            .expect("compile regex")
+    })
 }
 
 pub fn check_slurs(text: &str, slur_regex: &Option<Regex>) -> Result<(), LemmyError> {
-  if let Err(slurs) = slur_check(text, slur_regex) {
-    Err(anyhow::anyhow!("{}", slurs_vec_to_str(&slurs))).with_lemmy_type(LemmyErrorType::Slurs)
-  } else {
-    Ok(())
-  }
+    if let Err(slurs) = slur_check(text, slur_regex) {
+        Err(anyhow::anyhow!("{}", slurs_vec_to_str(&slurs))).with_lemmy_type(LemmyErrorType::Slurs)
+    } else {
+        Ok(())
+    }
 }
 
 pub fn check_slurs_opt(
-  text: &Option<String>,
-  slur_regex: &Option<Regex>,
+    text: &Option<String>,
+    slur_regex: &Option<Regex>,
 ) -> Result<(), LemmyError> {
-  match text {
-    Some(t) => check_slurs(t, slur_regex),
-    None => Ok(()),
-  }
+    match text {
+        Some(t) => check_slurs(t, slur_regex),
+        None => Ok(()),
+    }
 }
 
 pub(crate) fn slurs_vec_to_str(slurs: &[&str]) -> String {
-  let start = "No slurs - ";
-  let combined = &slurs.join(", ");
-  [start, combined].concat()
+    let start = "No slurs - ";
+    let combined = &slurs.join(", ");
+    [start, combined].concat()
 }
 
 #[cfg(test)]
 mod test {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use crate::utils::slurs::{remove_slurs, slur_check, slurs_vec_to_str};
-  use regex::RegexBuilder;
+    use crate::utils::slurs::{remove_slurs, slur_check, slurs_vec_to_str};
+    use regex::RegexBuilder;
 
-  #[test]
-  fn test_slur_filter() {
-    let slur_regex = Some(RegexBuilder::new(r"(fag(g|got|tard)?\b|cock\s?sucker(s|ing)?|ni((g{2,}|q)+|[gq]{2,})[e3r]+(s|z)?|mudslime?s?|kikes?|\bspi(c|k)s?\b|\bchinks?|gooks?|bitch(es|ing|y)?|whor(es?|ing)|\btr(a|@)nn?(y|ies?)|\b(b|re|r)tard(ed)?s?)").case_insensitive(true).build().unwrap());
-    let test =
+    #[test]
+    fn test_slur_filter() {
+        let slur_regex = Some(RegexBuilder::new(r"(fag(g|got|tard)?\b|cock\s?sucker(s|ing)?|ni((g{2,}|q)+|[gq]{2,})[e3r]+(s|z)?|mudslime?s?|kikes?|\bspi(c|k)s?\b|\bchinks?|gooks?|bitch(es|ing|y)?|whor(es?|ing)|\btr(a|@)nn?(y|ies?)|\b(b|re|r)tard(ed)?s?)").case_insensitive(true).build().unwrap());
+        let test =
       "faggot test kike tranny cocksucker retardeds. Capitalized Niggerz. This is a bunch of other safe text.";
-    let slur_free = "No slurs here";
-    assert_eq!(
+        let slur_free = "No slurs here";
+        assert_eq!(
       remove_slurs(test, &slur_regex),
       "*removed* test *removed* *removed* *removed* *removed*. Capitalized *removed*. This is a bunch of other safe text."
         .to_string()
     );
 
-    let has_slurs_vec = vec![
-      "Niggerz",
-      "cocksucker",
-      "faggot",
-      "kike",
-      "retardeds",
-      "tranny",
-    ];
-    let has_slurs_err_str = "No slurs - Niggerz, cocksucker, faggot, kike, retardeds, tranny";
+        let has_slurs_vec = vec![
+            "Niggerz",
+            "cocksucker",
+            "faggot",
+            "kike",
+            "retardeds",
+            "tranny",
+        ];
+        let has_slurs_err_str = "No slurs - Niggerz, cocksucker, faggot, kike, retardeds, tranny";
 
-    assert_eq!(slur_check(test, &slur_regex), Err(has_slurs_vec));
-    assert_eq!(slur_check(slur_free, &slur_regex), Ok(()));
-    if let Err(slur_vec) = slur_check(test, &slur_regex) {
-      assert_eq!(&slurs_vec_to_str(&slur_vec), has_slurs_err_str);
+        assert_eq!(slur_check(test, &slur_regex), Err(has_slurs_vec));
+        assert_eq!(slur_check(slur_free, &slur_regex), Ok(()));
+        if let Err(slur_vec) = slur_check(test, &slur_regex) {
+            assert_eq!(&slurs_vec_to_str(&slur_vec), has_slurs_err_str);
+        }
     }
-  }
 
-  // These helped with testing
-  // #[test]
-  // fn test_send_email() {
-  //  let result =  send_email("not a subject", "test_email@gmail.com", "ur user", "<h1>HI there</h1>");
-  //   assert!(result.is_ok());
-  // }
+    // These helped with testing
+    // #[test]
+    // fn test_send_email() {
+    //  let result =  send_email("not a subject", "test_email@gmail.com", "ur user", "<h1>HI there</h1>");
+    //   assert!(result.is_ok());
+    // }
 }

--- a/crates/utils/src/utils/time.rs
+++ b/crates/utils/src/utils/time.rs
@@ -1,12 +1,11 @@
 use chrono::{DateTime, TimeZone, Utc};
 
 pub fn naive_from_unix(time: i64) -> DateTime<Utc> {
-  Utc
-    .timestamp_opt(time, 0)
-    .single()
-    .expect("convert datetime")
+    Utc.timestamp_opt(time, 0)
+        .single()
+        .expect("convert datetime")
 }
 
 pub fn convert_datetime(datetime: DateTime<Utc>) -> DateTime<Utc> {
-  datetime
+    datetime
 }

--- a/crates/utils/src/utils/validation.rs
+++ b/crates/utils/src/utils/validation.rs
@@ -6,15 +6,17 @@ use totp_rs::{Secret, TOTP};
 use url::Url;
 
 static VALID_ACTOR_NAME_REGEX: Lazy<Regex> =
-  Lazy::new(|| Regex::new(r"^[a-zA-Z0-9_]{3,}$").expect("compile regex"));
+    Lazy::new(|| Regex::new(r"^[a-zA-Z0-9_]{3,}$").expect("compile regex"));
 static VALID_POST_TITLE_REGEX: Lazy<Regex> =
-  Lazy::new(|| Regex::new(r".*\S{3,200}.*").expect("compile regex"));
+    Lazy::new(|| Regex::new(r".*\S{3,200}.*").expect("compile regex"));
 static VALID_MATRIX_ID_REGEX: Lazy<Regex> = Lazy::new(|| {
-  Regex::new(r"^@[A-Za-z0-9._=-]+:[A-Za-z0-9.-]+\.[A-Za-z]{2,}$").expect("compile regex")
+    Regex::new(r"^@[A-Za-z0-9._=-]+:[A-Za-z0-9.-]+\.[A-Za-z]{2,}$").expect("compile regex")
 });
 // taken from https://en.wikipedia.org/wiki/UTM_parameters
 static CLEAN_URL_PARAMS_REGEX: Lazy<Regex> = Lazy::new(|| {
-  Regex::new(r"^utm_source|utm_medium|utm_campaign|utm_term|utm_content|gclid|gclsrc|dclid|fbclid$")
+    Regex::new(
+        r"^utm_source|utm_medium|utm_campaign|utm_term|utm_content|gclid|gclsrc|dclid|fbclid$",
+    )
     .expect("compile regex")
 });
 
@@ -26,519 +28,512 @@ const SITE_NAME_MIN_LENGTH: usize = 1;
 const SITE_DESCRIPTION_MAX_LENGTH: usize = 150;
 //Invisible unicode characters, taken from https://invisible-characters.com/
 const FORBIDDEN_DISPLAY_CHARS: [char; 53] = [
-  '\u{0009}',
-  '\u{00a0}',
-  '\u{00ad}',
-  '\u{034f}',
-  '\u{061c}',
-  '\u{115f}',
-  '\u{1160}',
-  '\u{17b4}',
-  '\u{17b5}',
-  '\u{180e}',
-  '\u{2000}',
-  '\u{2001}',
-  '\u{2002}',
-  '\u{2003}',
-  '\u{2004}',
-  '\u{2005}',
-  '\u{2006}',
-  '\u{2007}',
-  '\u{2008}',
-  '\u{2009}',
-  '\u{200a}',
-  '\u{200b}',
-  '\u{200c}',
-  '\u{200d}',
-  '\u{200e}',
-  '\u{200f}',
-  '\u{202f}',
-  '\u{205f}',
-  '\u{2060}',
-  '\u{2061}',
-  '\u{2062}',
-  '\u{2063}',
-  '\u{2064}',
-  '\u{206a}',
-  '\u{206b}',
-  '\u{206c}',
-  '\u{206d}',
-  '\u{206e}',
-  '\u{206f}',
-  '\u{3000}',
-  '\u{2800}',
-  '\u{3164}',
-  '\u{feff}',
-  '\u{ffa0}',
-  '\u{1d159}',
-  '\u{1d173}',
-  '\u{1d174}',
-  '\u{1d175}',
-  '\u{1d176}',
-  '\u{1d177}',
-  '\u{1d178}',
-  '\u{1d179}',
-  '\u{1d17a}',
+    '\u{0009}',
+    '\u{00a0}',
+    '\u{00ad}',
+    '\u{034f}',
+    '\u{061c}',
+    '\u{115f}',
+    '\u{1160}',
+    '\u{17b4}',
+    '\u{17b5}',
+    '\u{180e}',
+    '\u{2000}',
+    '\u{2001}',
+    '\u{2002}',
+    '\u{2003}',
+    '\u{2004}',
+    '\u{2005}',
+    '\u{2006}',
+    '\u{2007}',
+    '\u{2008}',
+    '\u{2009}',
+    '\u{200a}',
+    '\u{200b}',
+    '\u{200c}',
+    '\u{200d}',
+    '\u{200e}',
+    '\u{200f}',
+    '\u{202f}',
+    '\u{205f}',
+    '\u{2060}',
+    '\u{2061}',
+    '\u{2062}',
+    '\u{2063}',
+    '\u{2064}',
+    '\u{206a}',
+    '\u{206b}',
+    '\u{206c}',
+    '\u{206d}',
+    '\u{206e}',
+    '\u{206f}',
+    '\u{3000}',
+    '\u{2800}',
+    '\u{3164}',
+    '\u{feff}',
+    '\u{ffa0}',
+    '\u{1d159}',
+    '\u{1d173}',
+    '\u{1d174}',
+    '\u{1d175}',
+    '\u{1d176}',
+    '\u{1d177}',
+    '\u{1d178}',
+    '\u{1d179}',
+    '\u{1d17a}',
 ];
 
 fn has_newline(name: &str) -> bool {
-  name.contains('\n')
+    name.contains('\n')
 }
 
 pub fn is_valid_actor_name(name: &str, actor_name_max_length: usize) -> LemmyResult<()> {
-  let check = name.chars().count() <= actor_name_max_length
-    && VALID_ACTOR_NAME_REGEX.is_match(name)
-    && !has_newline(name);
-  if !check {
-    Err(LemmyErrorType::InvalidName.into())
-  } else {
-    Ok(())
-  }
+    let check = name.chars().count() <= actor_name_max_length
+        && VALID_ACTOR_NAME_REGEX.is_match(name)
+        && !has_newline(name);
+    if !check {
+        Err(LemmyErrorType::InvalidName.into())
+    } else {
+        Ok(())
+    }
 }
 
 // Can't do a regex here, reverse lookarounds not supported
 pub fn is_valid_display_name(name: &str, actor_name_max_length: usize) -> LemmyResult<()> {
-  let check = !name.contains(FORBIDDEN_DISPLAY_CHARS)
-    && !name.starts_with('@')
-    && name.chars().count() >= 3
-    && name.chars().count() <= actor_name_max_length
-    && !has_newline(name);
-  if !check {
-    Err(LemmyErrorType::InvalidDisplayName.into())
-  } else {
-    Ok(())
-  }
+    let check = !name.contains(FORBIDDEN_DISPLAY_CHARS)
+        && !name.starts_with('@')
+        && name.chars().count() >= 3
+        && name.chars().count() <= actor_name_max_length
+        && !has_newline(name);
+    if !check {
+        Err(LemmyErrorType::InvalidDisplayName.into())
+    } else {
+        Ok(())
+    }
 }
 
 pub fn is_valid_matrix_id(matrix_id: &str) -> LemmyResult<()> {
-  let check = VALID_MATRIX_ID_REGEX.is_match(matrix_id) && !has_newline(matrix_id);
-  if !check {
-    Err(LemmyErrorType::InvalidMatrixId.into())
-  } else {
-    Ok(())
-  }
+    let check = VALID_MATRIX_ID_REGEX.is_match(matrix_id) && !has_newline(matrix_id);
+    if !check {
+        Err(LemmyErrorType::InvalidMatrixId.into())
+    } else {
+        Ok(())
+    }
 }
 
 pub fn is_valid_post_title(title: &str) -> LemmyResult<()> {
-  let check = VALID_POST_TITLE_REGEX.is_match(title) && !has_newline(title);
-  if !check {
-    Err(LemmyErrorType::InvalidPostTitle.into())
-  } else {
-    Ok(())
-  }
+    let check = VALID_POST_TITLE_REGEX.is_match(title) && !has_newline(title);
+    if !check {
+        Err(LemmyErrorType::InvalidPostTitle.into())
+    } else {
+        Ok(())
+    }
 }
 
 /// This could be post bodies, comments, or any description field
 pub fn is_valid_body_field(body: &Option<String>, post: bool) -> LemmyResult<()> {
-  if let Some(body) = body {
-    let check = if post {
-      body.chars().count() <= POST_BODY_MAX_LENGTH
-    } else {
-      body.chars().count() <= BODY_MAX_LENGTH
-    };
+    if let Some(body) = body {
+        let check = if post {
+            body.chars().count() <= POST_BODY_MAX_LENGTH
+        } else {
+            body.chars().count() <= BODY_MAX_LENGTH
+        };
 
-    if !check {
-      Err(LemmyErrorType::InvalidBodyField.into())
+        if !check {
+            Err(LemmyErrorType::InvalidBodyField.into())
+        } else {
+            Ok(())
+        }
     } else {
-      Ok(())
+        Ok(())
     }
-  } else {
-    Ok(())
-  }
 }
 
 pub fn is_valid_bio_field(bio: &str) -> LemmyResult<()> {
-  max_length_check(bio, BIO_MAX_LENGTH, LemmyErrorType::BioLengthOverflow)
+    max_length_check(bio, BIO_MAX_LENGTH, LemmyErrorType::BioLengthOverflow)
 }
 
 /// Checks the site name length, the limit as defined in the DB.
 pub fn site_name_length_check(name: &str) -> LemmyResult<()> {
-  min_max_length_check(
-    name,
-    SITE_NAME_MIN_LENGTH,
-    SITE_NAME_MAX_LENGTH,
-    LemmyErrorType::SiteNameRequired,
-    LemmyErrorType::SiteNameLengthOverflow,
-  )
+    min_max_length_check(
+        name,
+        SITE_NAME_MIN_LENGTH,
+        SITE_NAME_MAX_LENGTH,
+        LemmyErrorType::SiteNameRequired,
+        LemmyErrorType::SiteNameLengthOverflow,
+    )
 }
 
 /// Checks the site description length, the limit as defined in the DB.
 pub fn site_description_length_check(description: &str) -> LemmyResult<()> {
-  max_length_check(
-    description,
-    SITE_DESCRIPTION_MAX_LENGTH,
-    LemmyErrorType::SiteDescriptionLengthOverflow,
-  )
+    max_length_check(
+        description,
+        SITE_DESCRIPTION_MAX_LENGTH,
+        LemmyErrorType::SiteDescriptionLengthOverflow,
+    )
 }
 
 fn max_length_check(item: &str, max_length: usize, error_type: LemmyErrorType) -> LemmyResult<()> {
-  if item.len() > max_length {
-    Err(error_type.into())
-  } else {
-    Ok(())
-  }
+    if item.len() > max_length {
+        Err(error_type.into())
+    } else {
+        Ok(())
+    }
 }
 
 fn min_max_length_check(
-  item: &str,
-  min_length: usize,
-  max_length: usize,
-  min_msg: LemmyErrorType,
-  max_msg: LemmyErrorType,
+    item: &str,
+    min_length: usize,
+    max_length: usize,
+    min_msg: LemmyErrorType,
+    max_msg: LemmyErrorType,
 ) -> LemmyResult<()> {
-  if item.len() > max_length {
-    Err(max_msg.into())
-  } else if item.len() < min_length {
-    Err(min_msg.into())
-  } else {
-    Ok(())
-  }
+    if item.len() > max_length {
+        Err(max_msg.into())
+    } else if item.len() < min_length {
+        Err(min_msg.into())
+    } else {
+        Ok(())
+    }
 }
 
 /// Attempts to build a regex and check it for common errors before inserting into the DB.
 pub fn build_and_check_regex(regex_str_opt: &Option<&str>) -> LemmyResult<Option<Regex>> {
-  regex_str_opt.map_or_else(
-    || Ok(None::<Regex>),
-    |regex_str| {
-      if regex_str.is_empty() {
-        // If the proposed regex is empty, return as having no regex at all; this is the same
-        // behavior that happens downstream before the write to the database.
-        return Ok(None::<Regex>);
-      }
+    regex_str_opt.map_or_else(
+        || Ok(None::<Regex>),
+        |regex_str| {
+            if regex_str.is_empty() {
+                // If the proposed regex is empty, return as having no regex at all; this is the same
+                // behavior that happens downstream before the write to the database.
+                return Ok(None::<Regex>);
+            }
 
-      RegexBuilder::new(regex_str)
-        .case_insensitive(true)
-        .build()
-        .with_lemmy_type(LemmyErrorType::InvalidRegex)
-        .and_then(|regex| {
-          // NOTE: It is difficult to know, in the universe of user-crafted regex, which ones
-          // may match against any string text. To keep it simple, we'll match the regex
-          // against an innocuous string - a single number - which should help catch a regex
-          // that accidentally matches against all strings.
-          if regex.is_match("1") {
-            Err(LemmyErrorType::PermissiveRegex.into())
-          } else {
-            Ok(Some(regex))
-          }
-        })
-    },
-  )
+            RegexBuilder::new(regex_str)
+                .case_insensitive(true)
+                .build()
+                .with_lemmy_type(LemmyErrorType::InvalidRegex)
+                .and_then(|regex| {
+                    // NOTE: It is difficult to know, in the universe of user-crafted regex, which ones
+                    // may match against any string text. To keep it simple, we'll match the regex
+                    // against an innocuous string - a single number - which should help catch a regex
+                    // that accidentally matches against all strings.
+                    if regex.is_match("1") {
+                        Err(LemmyErrorType::PermissiveRegex.into())
+                    } else {
+                        Ok(Some(regex))
+                    }
+                })
+        },
+    )
 }
 
 pub fn clean_url_params(url: &Url) -> Url {
-  let mut url_out = url.clone();
-  if url.query().is_some() {
-    let new_query = url
-      .query_pairs()
-      .filter(|q| !CLEAN_URL_PARAMS_REGEX.is_match(&q.0))
-      .map(|q| format!("{}={}", q.0, q.1))
-      .join("&");
-    url_out.set_query(Some(&new_query));
-  }
-  url_out
+    let mut url_out = url.clone();
+    if url.query().is_some() {
+        let new_query = url
+            .query_pairs()
+            .filter(|q| !CLEAN_URL_PARAMS_REGEX.is_match(&q.0))
+            .map(|q| format!("{}={}", q.0, q.1))
+            .join("&");
+        url_out.set_query(Some(&new_query));
+    }
+    url_out
 }
 
 pub fn check_totp_2fa_valid(
-  totp_secret: &Option<String>,
-  totp_token: &Option<String>,
-  site_name: &str,
-  username: &str,
+    totp_secret: &Option<String>,
+    totp_token: &Option<String>,
+    site_name: &str,
+    username: &str,
 ) -> LemmyResult<()> {
-  // Check only if they have a totp_secret in the DB
-  if let Some(totp_secret) = totp_secret {
-    // Throw an error if their token is missing
-    let token = totp_token
-      .as_deref()
-      .ok_or(LemmyErrorType::MissingTotpToken)?;
+    // Check only if they have a totp_secret in the DB
+    if let Some(totp_secret) = totp_secret {
+        // Throw an error if their token is missing
+        let token = totp_token
+            .as_deref()
+            .ok_or(LemmyErrorType::MissingTotpToken)?;
 
-    let totp = build_totp_2fa(site_name, username, totp_secret)?;
+        let totp = build_totp_2fa(site_name, username, totp_secret)?;
 
-    let check_passed = totp.check_current(token)?;
-    if !check_passed {
-      Err(LemmyErrorType::IncorrectTotpToken.into())
+        let check_passed = totp.check_current(token)?;
+        if !check_passed {
+            Err(LemmyErrorType::IncorrectTotpToken.into())
+        } else {
+            Ok(())
+        }
     } else {
-      Ok(())
+        Ok(())
     }
-  } else {
-    Ok(())
-  }
 }
 
 pub fn generate_totp_2fa_secret() -> String {
-  Secret::generate_secret().to_string()
+    Secret::generate_secret().to_string()
 }
 
 pub fn build_totp_2fa(site_name: &str, username: &str, secret: &str) -> Result<TOTP, LemmyError> {
-  let sec = Secret::Raw(secret.as_bytes().to_vec());
-  let sec_bytes = sec
-    .to_bytes()
-    .map_err(|_| LemmyErrorType::CouldntParseTotpSecret)?;
+    let sec = Secret::Raw(secret.as_bytes().to_vec());
+    let sec_bytes = sec
+        .to_bytes()
+        .map_err(|_| LemmyErrorType::CouldntParseTotpSecret)?;
 
-  TOTP::new(
-    totp_rs::Algorithm::SHA256,
-    6,
-    1,
-    30,
-    sec_bytes,
-    Some(site_name.to_string()),
-    username.to_string(),
-  )
-  .with_lemmy_type(LemmyErrorType::CouldntGenerateTotp)
+    TOTP::new(
+        totp_rs::Algorithm::SHA256,
+        6,
+        1,
+        30,
+        sec_bytes,
+        Some(site_name.to_string()),
+        username.to_string(),
+    )
+    .with_lemmy_type(LemmyErrorType::CouldntGenerateTotp)
 }
 
 pub fn check_site_visibility_valid(
-  current_private_instance: bool,
-  current_federation_enabled: bool,
-  new_private_instance: &Option<bool>,
-  new_federation_enabled: &Option<bool>,
+    current_private_instance: bool,
+    current_federation_enabled: bool,
+    new_private_instance: &Option<bool>,
+    new_federation_enabled: &Option<bool>,
 ) -> LemmyResult<()> {
-  let private_instance = new_private_instance.unwrap_or(current_private_instance);
-  let federation_enabled = new_federation_enabled.unwrap_or(current_federation_enabled);
+    let private_instance = new_private_instance.unwrap_or(current_private_instance);
+    let federation_enabled = new_federation_enabled.unwrap_or(current_federation_enabled);
 
-  if private_instance && federation_enabled {
-    Err(LemmyErrorType::CantEnablePrivateInstanceAndFederationTogether.into())
-  } else {
-    Ok(())
-  }
+    if private_instance && federation_enabled {
+        Err(LemmyErrorType::CantEnablePrivateInstanceAndFederationTogether.into())
+    } else {
+        Ok(())
+    }
 }
 
 pub fn check_url_scheme(url: &Option<Url>) -> LemmyResult<()> {
-  if let Some(url) = url {
-    if url.scheme() != "http" && url.scheme() != "https" {
-      Err(LemmyErrorType::InvalidUrlScheme.into())
+    if let Some(url) = url {
+        if url.scheme() != "http" && url.scheme() != "https" {
+            Err(LemmyErrorType::InvalidUrlScheme.into())
+        } else {
+            Ok(())
+        }
     } else {
-      Ok(())
+        Ok(())
     }
-  } else {
-    Ok(())
-  }
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use super::build_totp_2fa;
-  use crate::{
-    error::LemmyErrorType,
-    utils::validation::{
-      build_and_check_regex,
-      check_site_visibility_valid,
-      check_url_scheme,
-      clean_url_params,
-      generate_totp_2fa_secret,
-      is_valid_actor_name,
-      is_valid_bio_field,
-      is_valid_display_name,
-      is_valid_matrix_id,
-      is_valid_post_title,
-      site_description_length_check,
-      site_name_length_check,
-      BIO_MAX_LENGTH,
-      SITE_DESCRIPTION_MAX_LENGTH,
-      SITE_NAME_MAX_LENGTH,
-    },
-  };
-  use url::Url;
+    use super::build_totp_2fa;
+    use crate::{
+        error::LemmyErrorType,
+        utils::validation::{
+            build_and_check_regex, check_site_visibility_valid, check_url_scheme, clean_url_params,
+            generate_totp_2fa_secret, is_valid_actor_name, is_valid_bio_field,
+            is_valid_display_name, is_valid_matrix_id, is_valid_post_title,
+            site_description_length_check, site_name_length_check, BIO_MAX_LENGTH,
+            SITE_DESCRIPTION_MAX_LENGTH, SITE_NAME_MAX_LENGTH,
+        },
+    };
+    use url::Url;
 
-  #[test]
-  fn test_clean_url_params() {
-    let url = Url::parse("https://example.com/path/123?utm_content=buffercf3b2&utm_medium=social&username=randomuser&id=123").unwrap();
-    let cleaned = clean_url_params(&url);
-    let expected = Url::parse("https://example.com/path/123?username=randomuser&id=123").unwrap();
-    assert_eq!(expected.to_string(), cleaned.to_string());
+    #[test]
+    fn test_clean_url_params() {
+        let url = Url::parse("https://example.com/path/123?utm_content=buffercf3b2&utm_medium=social&username=randomuser&id=123").unwrap();
+        let cleaned = clean_url_params(&url);
+        let expected =
+            Url::parse("https://example.com/path/123?username=randomuser&id=123").unwrap();
+        assert_eq!(expected.to_string(), cleaned.to_string());
 
-    let url = Url::parse("https://example.com/path/123").unwrap();
-    let cleaned = clean_url_params(&url);
-    assert_eq!(url.to_string(), cleaned.to_string());
-  }
+        let url = Url::parse("https://example.com/path/123").unwrap();
+        let cleaned = clean_url_params(&url);
+        assert_eq!(url.to_string(), cleaned.to_string());
+    }
 
-  #[test]
-  fn regex_checks() {
-    assert!(is_valid_post_title("hi").is_err());
-    assert!(is_valid_post_title("him").is_ok());
-    assert!(is_valid_post_title("n\n\n\n\nanother").is_err());
-    assert!(is_valid_post_title("hello there!\n this is a test.").is_err());
-    assert!(is_valid_post_title("hello there! this is a test.").is_ok());
-  }
+    #[test]
+    fn regex_checks() {
+        assert!(is_valid_post_title("hi").is_err());
+        assert!(is_valid_post_title("him").is_ok());
+        assert!(is_valid_post_title("n\n\n\n\nanother").is_err());
+        assert!(is_valid_post_title("hello there!\n this is a test.").is_err());
+        assert!(is_valid_post_title("hello there! this is a test.").is_ok());
+    }
 
-  #[test]
-  fn test_valid_actor_name() {
-    let actor_name_max_length = 20;
-    assert!(is_valid_actor_name("Hello_98", actor_name_max_length).is_ok());
-    assert!(is_valid_actor_name("ten", actor_name_max_length).is_ok());
-    assert!(is_valid_actor_name("Hello-98", actor_name_max_length).is_err());
-    assert!(is_valid_actor_name("a", actor_name_max_length).is_err());
-    assert!(is_valid_actor_name("", actor_name_max_length).is_err());
-  }
+    #[test]
+    fn test_valid_actor_name() {
+        let actor_name_max_length = 20;
+        assert!(is_valid_actor_name("Hello_98", actor_name_max_length).is_ok());
+        assert!(is_valid_actor_name("ten", actor_name_max_length).is_ok());
+        assert!(is_valid_actor_name("Hello-98", actor_name_max_length).is_err());
+        assert!(is_valid_actor_name("a", actor_name_max_length).is_err());
+        assert!(is_valid_actor_name("", actor_name_max_length).is_err());
+    }
 
-  #[test]
-  fn test_valid_display_name() {
-    let actor_name_max_length = 20;
-    assert!(is_valid_display_name("hello @there", actor_name_max_length).is_ok());
-    assert!(is_valid_display_name("@hello there", actor_name_max_length).is_err());
+    #[test]
+    fn test_valid_display_name() {
+        let actor_name_max_length = 20;
+        assert!(is_valid_display_name("hello @there", actor_name_max_length).is_ok());
+        assert!(is_valid_display_name("@hello there", actor_name_max_length).is_err());
 
-    // Make sure zero-space with an @ doesn't work
-    assert!(
-      is_valid_display_name(&format!("{}@my name is", '\u{200b}'), actor_name_max_length).is_err()
-    );
-  }
+        // Make sure zero-space with an @ doesn't work
+        assert!(is_valid_display_name(
+            &format!("{}@my name is", '\u{200b}'),
+            actor_name_max_length
+        )
+        .is_err());
+    }
 
-  #[test]
-  fn test_valid_post_title() {
-    assert!(is_valid_post_title("Post Title").is_ok());
-    assert!(is_valid_post_title("   POST TITLE 😃😃😃😃😃").is_ok());
-    assert!(is_valid_post_title("\n \n \n \n    		").is_err()); // tabs/spaces/newlines
-  }
+    #[test]
+    fn test_valid_post_title() {
+        assert!(is_valid_post_title("Post Title").is_ok());
+        assert!(is_valid_post_title("   POST TITLE 😃😃😃😃😃").is_ok());
+        assert!(is_valid_post_title("\n \n \n \n    		").is_err()); // tabs/spaces/newlines
+    }
 
-  #[test]
-  fn test_valid_matrix_id() {
-    assert!(is_valid_matrix_id("@dess:matrix.org").is_ok());
-    assert!(is_valid_matrix_id("dess:matrix.org").is_err());
-    assert!(is_valid_matrix_id(" @dess:matrix.org").is_err());
-    assert!(is_valid_matrix_id("@dess:matrix.org t").is_err());
-  }
+    #[test]
+    fn test_valid_matrix_id() {
+        assert!(is_valid_matrix_id("@dess:matrix.org").is_ok());
+        assert!(is_valid_matrix_id("dess:matrix.org").is_err());
+        assert!(is_valid_matrix_id(" @dess:matrix.org").is_err());
+        assert!(is_valid_matrix_id("@dess:matrix.org t").is_err());
+    }
 
-  #[test]
-  fn test_build_totp() {
-    let generated_secret = generate_totp_2fa_secret();
-    let totp = build_totp_2fa("lemmy", "my_name", &generated_secret);
-    assert!(totp.is_ok());
-  }
+    #[test]
+    fn test_build_totp() {
+        let generated_secret = generate_totp_2fa_secret();
+        let totp = build_totp_2fa("lemmy", "my_name", &generated_secret);
+        assert!(totp.is_ok());
+    }
 
-  #[test]
-  fn test_valid_site_name() {
-    let valid_names = [
-      (0..SITE_NAME_MAX_LENGTH).map(|_| 'A').collect::<String>(),
-      String::from("A"),
-    ];
-    let invalid_names = [
-      (
-        &(0..SITE_NAME_MAX_LENGTH + 1)
-          .map(|_| 'A')
-          .collect::<String>(),
-        LemmyErrorType::SiteNameLengthOverflow,
-      ),
-      (&String::new(), LemmyErrorType::SiteNameRequired),
-    ];
+    #[test]
+    fn test_valid_site_name() {
+        let valid_names = [
+            (0..SITE_NAME_MAX_LENGTH).map(|_| 'A').collect::<String>(),
+            String::from("A"),
+        ];
+        let invalid_names = [
+            (
+                &(0..SITE_NAME_MAX_LENGTH + 1)
+                    .map(|_| 'A')
+                    .collect::<String>(),
+                LemmyErrorType::SiteNameLengthOverflow,
+            ),
+            (&String::new(), LemmyErrorType::SiteNameRequired),
+        ];
 
-    valid_names.iter().for_each(|valid_name| {
-      assert!(
-        site_name_length_check(valid_name).is_ok(),
-        "Expected {} of length {} to be Ok.",
-        valid_name,
-        valid_name.len()
-      )
-    });
+        valid_names.iter().for_each(|valid_name| {
+            assert!(
+                site_name_length_check(valid_name).is_ok(),
+                "Expected {} of length {} to be Ok.",
+                valid_name,
+                valid_name.len()
+            )
+        });
 
-    invalid_names
-      .iter()
-      .for_each(|(invalid_name, expected_err)| {
-        let result = site_name_length_check(invalid_name);
+        invalid_names
+            .iter()
+            .for_each(|(invalid_name, expected_err)| {
+                let result = site_name_length_check(invalid_name);
 
-        assert!(result.is_err());
+                assert!(result.is_err());
+                assert!(
+                    result.unwrap_err().error_type.eq(&expected_err.clone()),
+                    "Testing {}, expected error {}",
+                    invalid_name,
+                    expected_err
+                );
+            });
+    }
+
+    #[test]
+    fn test_valid_bio() {
+        assert!(is_valid_bio_field(&(0..BIO_MAX_LENGTH).map(|_| 'A').collect::<String>()).is_ok());
+
+        let invalid_result =
+            is_valid_bio_field(&(0..BIO_MAX_LENGTH + 1).map(|_| 'A').collect::<String>());
+
         assert!(
-          result.unwrap_err().error_type.eq(&expected_err.clone()),
-          "Testing {}, expected error {}",
-          invalid_name,
-          expected_err
+            invalid_result.is_err()
+                && invalid_result
+                    .unwrap_err()
+                    .error_type
+                    .eq(&LemmyErrorType::BioLengthOverflow)
         );
-      });
-  }
+    }
 
-  #[test]
-  fn test_valid_bio() {
-    assert!(is_valid_bio_field(&(0..BIO_MAX_LENGTH).map(|_| 'A').collect::<String>()).is_ok());
+    #[test]
+    fn test_valid_site_description() {
+        assert!(site_description_length_check(
+            &(0..SITE_DESCRIPTION_MAX_LENGTH)
+                .map(|_| 'A')
+                .collect::<String>()
+        )
+        .is_ok());
 
-    let invalid_result =
-      is_valid_bio_field(&(0..BIO_MAX_LENGTH + 1).map(|_| 'A').collect::<String>());
+        let invalid_result = site_description_length_check(
+            &(0..SITE_DESCRIPTION_MAX_LENGTH + 1)
+                .map(|_| 'A')
+                .collect::<String>(),
+        );
 
-    assert!(
-      invalid_result.is_err()
-        && invalid_result
-          .unwrap_err()
-          .error_type
-          .eq(&LemmyErrorType::BioLengthOverflow)
-    );
-  }
-
-  #[test]
-  fn test_valid_site_description() {
-    assert!(site_description_length_check(
-      &(0..SITE_DESCRIPTION_MAX_LENGTH)
-        .map(|_| 'A')
-        .collect::<String>()
-    )
-    .is_ok());
-
-    let invalid_result = site_description_length_check(
-      &(0..SITE_DESCRIPTION_MAX_LENGTH + 1)
-        .map(|_| 'A')
-        .collect::<String>(),
-    );
-
-    assert!(
-      invalid_result.is_err()
-        && invalid_result
-          .unwrap_err()
-          .error_type
-          .eq(&LemmyErrorType::SiteDescriptionLengthOverflow)
-    );
-  }
-
-  #[test]
-  fn test_valid_slur_regex() {
-    let valid_regexes = [&None, &Some(""), &Some("(foo|bar)")];
-
-    valid_regexes.iter().for_each(|regex| {
-      let result = build_and_check_regex(regex);
-
-      assert!(result.is_ok(), "Testing regex: {:?}", regex);
-    });
-  }
-
-  #[test]
-  fn test_too_permissive_slur_regex() {
-    let match_everything_regexes = [
-      (&Some("["), LemmyErrorType::InvalidRegex),
-      (&Some("(foo|bar|)"), LemmyErrorType::PermissiveRegex),
-      (&Some(".*"), LemmyErrorType::PermissiveRegex),
-    ];
-
-    match_everything_regexes
-      .iter()
-      .for_each(|(regex_str, expected_err)| {
-        let result = build_and_check_regex(regex_str);
-
-        assert!(result.is_err());
         assert!(
-          result.unwrap_err().error_type.eq(&expected_err.clone()),
-          "Testing regex {:?}, expected error {}",
-          regex_str,
-          expected_err
+            invalid_result.is_err()
+                && invalid_result
+                    .unwrap_err()
+                    .error_type
+                    .eq(&LemmyErrorType::SiteDescriptionLengthOverflow)
         );
-      });
-  }
+    }
 
-  #[test]
-  fn test_check_site_visibility_valid() {
-    assert!(check_site_visibility_valid(true, true, &None, &None).is_err());
-    assert!(check_site_visibility_valid(true, false, &None, &Some(true)).is_err());
-    assert!(check_site_visibility_valid(false, true, &Some(true), &None).is_err());
-    assert!(check_site_visibility_valid(false, false, &Some(true), &Some(true)).is_err());
-    assert!(check_site_visibility_valid(true, false, &None, &None).is_ok());
-    assert!(check_site_visibility_valid(false, true, &None, &None).is_ok());
-    assert!(check_site_visibility_valid(false, false, &Some(true), &None).is_ok());
-    assert!(check_site_visibility_valid(false, false, &None, &Some(true)).is_ok());
-  }
+    #[test]
+    fn test_valid_slur_regex() {
+        let valid_regexes = [&None, &Some(""), &Some("(foo|bar)")];
 
-  #[test]
-  fn test_check_url_scheme() {
-    assert!(check_url_scheme(&None).is_ok());
-    assert!(check_url_scheme(&Some(Url::parse("http://example.com").unwrap())).is_ok());
-    assert!(check_url_scheme(&Some(Url::parse("https://example.com").unwrap())).is_ok());
-    assert!(check_url_scheme(&Some(Url::parse("ftp://example.com").unwrap())).is_err());
-    assert!(check_url_scheme(&Some(Url::parse("javascript:void").unwrap())).is_err());
-  }
+        valid_regexes.iter().for_each(|regex| {
+            let result = build_and_check_regex(regex);
+
+            assert!(result.is_ok(), "Testing regex: {:?}", regex);
+        });
+    }
+
+    #[test]
+    fn test_too_permissive_slur_regex() {
+        let match_everything_regexes = [
+            (&Some("["), LemmyErrorType::InvalidRegex),
+            (&Some("(foo|bar|)"), LemmyErrorType::PermissiveRegex),
+            (&Some(".*"), LemmyErrorType::PermissiveRegex),
+        ];
+
+        match_everything_regexes
+            .iter()
+            .for_each(|(regex_str, expected_err)| {
+                let result = build_and_check_regex(regex_str);
+
+                assert!(result.is_err());
+                assert!(
+                    result.unwrap_err().error_type.eq(&expected_err.clone()),
+                    "Testing regex {:?}, expected error {}",
+                    regex_str,
+                    expected_err
+                );
+            });
+    }
+
+    #[test]
+    fn test_check_site_visibility_valid() {
+        assert!(check_site_visibility_valid(true, true, &None, &None).is_err());
+        assert!(check_site_visibility_valid(true, false, &None, &Some(true)).is_err());
+        assert!(check_site_visibility_valid(false, true, &Some(true), &None).is_err());
+        assert!(check_site_visibility_valid(false, false, &Some(true), &Some(true)).is_err());
+        assert!(check_site_visibility_valid(true, false, &None, &None).is_ok());
+        assert!(check_site_visibility_valid(false, true, &None, &None).is_ok());
+        assert!(check_site_visibility_valid(false, false, &Some(true), &None).is_ok());
+        assert!(check_site_visibility_valid(false, false, &None, &Some(true)).is_ok());
+    }
+
+    #[test]
+    fn test_check_url_scheme() {
+        assert!(check_url_scheme(&None).is_ok());
+        assert!(check_url_scheme(&Some(Url::parse("http://example.com").unwrap())).is_ok());
+        assert!(check_url_scheme(&Some(Url::parse("https://example.com").unwrap())).is_ok());
+        assert!(check_url_scheme(&Some(Url::parse("ftp://example.com").unwrap())).is_err());
+        assert!(check_url_scheme(&Some(Url::parse("javascript:void").unwrap())).is_err());
+    }
 }

--- a/src/api_routes_http.rs
+++ b/src/api_routes_http.rs
@@ -1,328 +1,292 @@
 use actix_web::{guard, web};
 use lemmy_api::{
-  comment::{distinguish::distinguish_comment, like::like_comment, save::save_comment},
-  comment_report::{
-    create::create_comment_report,
-    list::list_comment_reports,
-    resolve::resolve_comment_report,
-  },
-  community::{
-    add_mod::add_mod_to_community,
-    ban::ban_from_community,
-    block::block_community,
-    follow::follow_community,
-    hide::hide_community,
-    transfer::transfer_community,
-  },
-  local_user::{
-    add_admin::add_admin,
-    ban_person::ban_from_site,
-    block::block_person,
-    change_password::change_password,
-    change_password_after_reset::change_password_after_reset,
-    get_captcha::get_captcha,
-    list_banned::list_banned_users,
-    login::login,
-    notifications::{
-      list_mentions::list_mentions,
-      list_replies::list_replies,
-      mark_all_read::mark_all_notifications_read,
-      mark_mention_read::mark_person_mention_as_read,
-      mark_reply_read::mark_reply_as_read,
-      unread_count::unread_count,
+    comment::{distinguish::distinguish_comment, like::like_comment, save::save_comment},
+    comment_report::{
+        create::create_comment_report, list::list_comment_reports, resolve::resolve_comment_report,
     },
-    report_count::report_count,
-    reset_password::reset_password,
-    save_settings::save_user_settings,
-    verify_email::verify_email,
-  },
-  post::{
-    feature::feature_post,
-    get_link_metadata::get_link_metadata,
-    like::like_post,
-    lock::lock_post,
-    mark_read::mark_post_as_read,
-    save::save_post,
-  },
-  post_report::{
-    create::create_post_report,
-    list::list_post_reports,
-    resolve::resolve_post_report,
-  },
-  private_message::mark_read::mark_pm_as_read,
-  private_message_report::{
-    create::create_pm_report,
-    list::list_pm_reports,
-    resolve::resolve_pm_report,
-  },
-  site::{
-    federated_instances::get_federated_instances,
-    leave_admin::leave_admin,
-    mod_log::get_mod_log,
-    purge::{
-      comment::purge_comment,
-      community::purge_community,
-      person::purge_person,
-      post::purge_post,
+    community::{
+        add_mod::add_mod_to_community, ban::ban_from_community, block::block_community,
+        follow::follow_community, hide::hide_community, transfer::transfer_community,
     },
-    registration_applications::{
-      approve::approve_registration_application,
-      list::list_registration_applications,
-      unread_count::get_unread_registration_application_count,
+    local_user::{
+        add_admin::add_admin,
+        ban_person::ban_from_site,
+        block::block_person,
+        change_password::change_password,
+        change_password_after_reset::change_password_after_reset,
+        get_captcha::get_captcha,
+        list_banned::list_banned_users,
+        login::login,
+        notifications::{
+            list_mentions::list_mentions, list_replies::list_replies,
+            mark_all_read::mark_all_notifications_read,
+            mark_mention_read::mark_person_mention_as_read, mark_reply_read::mark_reply_as_read,
+            unread_count::unread_count,
+        },
+        report_count::report_count,
+        reset_password::reset_password,
+        save_settings::save_user_settings,
+        verify_email::verify_email,
     },
-  },
-  sitemap::get_sitemap,
+    post::{
+        feature::feature_post, get_link_metadata::get_link_metadata, like::like_post,
+        lock::lock_post, mark_read::mark_post_as_read, save::save_post,
+    },
+    post_report::{
+        create::create_post_report, list::list_post_reports, resolve::resolve_post_report,
+    },
+    private_message::mark_read::mark_pm_as_read,
+    private_message_report::{
+        create::create_pm_report, list::list_pm_reports, resolve::resolve_pm_report,
+    },
+    site::{
+        federated_instances::get_federated_instances,
+        leave_admin::leave_admin,
+        mod_log::get_mod_log,
+        purge::{
+            comment::purge_comment, community::purge_community, person::purge_person,
+            post::purge_post,
+        },
+        registration_applications::{
+            approve::approve_registration_application, list::list_registration_applications,
+            unread_count::get_unread_registration_application_count,
+        },
+    },
+    sitemap::get_sitemap,
 };
 use lemmy_api_crud::{
-  comment::{
-    create::create_comment,
-    delete::delete_comment,
-    read::get_comment,
-    remove::remove_comment,
-    update::update_comment,
-  },
-  community::{
-    create::create_community,
-    delete::delete_community,
-    list::list_communities,
-    remove::remove_community,
-    update::update_community,
-  },
-  custom_emoji::{
-    create::create_custom_emoji,
-    delete::delete_custom_emoji,
-    update::update_custom_emoji,
-  },
-  post::{
-    create::create_post,
-    delete::delete_post,
-    read::get_post,
-    remove::remove_post,
-    update::update_post,
-  },
-  private_message::{
-    create::create_private_message,
-    delete::delete_private_message,
-    read::get_private_message,
-    update::update_private_message,
-  },
-  site::{create::create_site, read::get_site, update::update_site},
-  user::{create::register, delete::delete_account},
+    comment::{
+        create::create_comment, delete::delete_comment, read::get_comment, remove::remove_comment,
+        update::update_comment,
+    },
+    community::{
+        create::create_community, delete::delete_community, list::list_communities,
+        remove::remove_community, update::update_community,
+    },
+    custom_emoji::{
+        create::create_custom_emoji, delete::delete_custom_emoji, update::update_custom_emoji,
+    },
+    post::{
+        create::create_post, delete::delete_post, read::get_post, remove::remove_post,
+        update::update_post,
+    },
+    private_message::{
+        create::create_private_message, delete::delete_private_message, read::get_private_message,
+        update::update_private_message,
+    },
+    site::{create::create_site, read::get_site, update::update_site},
+    user::{create::register, delete::delete_account},
 };
 use lemmy_apub::api::{
-  list_comments::list_comments,
-  list_posts::list_posts,
-  read_community::get_community,
-  read_person::read_person,
-  resolve_object::resolve_object,
-  search::search,
+    list_comments::list_comments, list_posts::list_posts, read_community::get_community,
+    read_person::read_person, resolve_object::resolve_object, search::search,
 };
 use lemmy_utils::rate_limit::RateLimitCell;
 
 pub fn config(cfg: &mut web::ServiceConfig, rate_limit: &RateLimitCell) {
-  cfg.service(
-    web::scope("/api/v3")
-      // Site
-      .service(
-        web::scope("/site")
-          .wrap(rate_limit.message())
-          .route("", web::get().to(get_site))
-          // Admin Actions
-          .route("", web::post().to(create_site))
-          .route("", web::put().to(update_site)),
-      )
-      .service(
-        web::resource("/modlog")
-          .wrap(rate_limit.message())
-          .route(web::get().to(get_mod_log)),
-      )
-      .service(
-        web::resource("/search")
-          .wrap(rate_limit.search())
-          .route(web::get().to(search)),
-      )
-      .service(
-        web::resource("/resolve_object")
-          .wrap(rate_limit.message())
-          .route(web::get().to(resolve_object)),
-      )
-      // Community
-      .service(
-        web::resource("/community")
-          .guard(guard::Post())
-          .wrap(rate_limit.register())
-          .route(web::post().to(create_community)),
-      )
-      .service(
-        web::scope("/community")
-          .wrap(rate_limit.message())
-          .route("", web::get().to(get_community))
-          .route("", web::put().to(update_community))
-          .route("/hide", web::put().to(hide_community))
-          .route("/list", web::get().to(list_communities))
-          .route("/follow", web::post().to(follow_community))
-          .route("/block", web::post().to(block_community))
-          .route("/delete", web::post().to(delete_community))
-          // Mod Actions
-          .route("/remove", web::post().to(remove_community))
-          .route("/transfer", web::post().to(transfer_community))
-          .route("/ban_user", web::post().to(ban_from_community))
-          .route("/mod", web::post().to(add_mod_to_community)),
-      )
-      .service(
-        web::scope("/federated_instances")
-          .wrap(rate_limit.message())
-          .route("", web::get().to(get_federated_instances)),
-      )
-      // Post
-      .service(
-        // Handle POST to /post separately to add the post() rate limitter
-        web::resource("/post")
-          .guard(guard::Post())
-          .wrap(rate_limit.post())
-          .route(web::post().to(create_post)),
-      )
-      .service(
-        web::scope("/post")
-          .wrap(rate_limit.message())
-          .route("", web::get().to(get_post))
-          .route("", web::put().to(update_post))
-          .route("/delete", web::post().to(delete_post))
-          .route("/remove", web::post().to(remove_post))
-          .route("/mark_as_read", web::post().to(mark_post_as_read))
-          .route("/lock", web::post().to(lock_post))
-          .route("/feature", web::post().to(feature_post))
-          .route("/list", web::get().to(list_posts))
-          .route("/like", web::post().to(like_post))
-          .route("/save", web::put().to(save_post))
-          .route("/report", web::post().to(create_post_report))
-          .route("/report/resolve", web::put().to(resolve_post_report))
-          .route("/report/list", web::get().to(list_post_reports))
-          .route("/site_metadata", web::get().to(get_link_metadata)),
-      )
-      // Comment
-      .service(
-        // Handle POST to /comment separately to add the comment() rate limitter
-        web::resource("/comment")
-          .guard(guard::Post())
-          .wrap(rate_limit.comment())
-          .route(web::post().to(create_comment)),
-      )
-      .service(
-        web::scope("/comment")
-          .wrap(rate_limit.message())
-          .route("", web::get().to(get_comment))
-          .route("", web::put().to(update_comment))
-          .route("/delete", web::post().to(delete_comment))
-          .route("/remove", web::post().to(remove_comment))
-          .route("/mark_as_read", web::post().to(mark_reply_as_read))
-          .route("/distinguish", web::post().to(distinguish_comment))
-          .route("/like", web::post().to(like_comment))
-          .route("/save", web::put().to(save_comment))
-          .route("/list", web::get().to(list_comments))
-          .route("/report", web::post().to(create_comment_report))
-          .route("/report/resolve", web::put().to(resolve_comment_report))
-          .route("/report/list", web::get().to(list_comment_reports)),
-      )
-      // Private Message
-      .service(
-        web::scope("/private_message")
-          .wrap(rate_limit.message())
-          .route("/list", web::get().to(get_private_message))
-          .route("", web::post().to(create_private_message))
-          .route("", web::put().to(update_private_message))
-          .route("/delete", web::post().to(delete_private_message))
-          .route("/mark_as_read", web::post().to(mark_pm_as_read))
-          .route("/report", web::post().to(create_pm_report))
-          .route("/report/resolve", web::put().to(resolve_pm_report))
-          .route("/report/list", web::get().to(list_pm_reports)),
-      )
-      // User
-      .service(
-        // Account action, I don't like that it's in /user maybe /accounts
-        // Handle /user/register separately to add the register() rate limitter
-        web::resource("/user/register")
-          .guard(guard::Post())
-          .wrap(rate_limit.register())
-          .route(web::post().to(register)),
-      )
-      .service(
-        // Handle captcha separately
-        web::resource("/user/get_captcha")
-          .wrap(rate_limit.post())
-          .route(web::get().to(get_captcha)),
-      )
-      // User actions
-      .service(
-        web::scope("/user")
-          .wrap(rate_limit.message())
-          .route("", web::get().to(read_person))
-          .route("/mention", web::get().to(list_mentions))
-          .route(
-            "/mention/mark_as_read",
-            web::post().to(mark_person_mention_as_read),
-          )
-          .route("/replies", web::get().to(list_replies))
-          // Admin action. I don't like that it's in /user
-          .route("/ban", web::post().to(ban_from_site))
-          .route("/banned", web::get().to(list_banned_users))
-          .route("/block", web::post().to(block_person))
-          // Account actions. I don't like that they're in /user maybe /accounts
-          .route("/login", web::post().to(login))
-          .route("/delete_account", web::post().to(delete_account))
-          .route("/password_reset", web::post().to(reset_password))
-          .route(
-            "/password_change",
-            web::post().to(change_password_after_reset),
-          )
-          // mark_all_as_read feels off being in this section as well
-          .route(
-            "/mark_all_as_read",
-            web::post().to(mark_all_notifications_read),
-          )
-          .route("/save_user_settings", web::put().to(save_user_settings))
-          .route("/change_password", web::put().to(change_password))
-          .route("/report_count", web::get().to(report_count))
-          .route("/unread_count", web::get().to(unread_count))
-          .route("/verify_email", web::post().to(verify_email))
-          .route("/leave_admin", web::post().to(leave_admin)),
-      )
-      // Admin Actions
-      .service(
-        web::scope("/admin")
-          .wrap(rate_limit.message())
-          .route("/add", web::post().to(add_admin))
-          .route(
-            "/registration_application/count",
-            web::get().to(get_unread_registration_application_count),
-          )
-          .route(
-            "/registration_application/list",
-            web::get().to(list_registration_applications),
-          )
-          .route(
-            "/registration_application/approve",
-            web::put().to(approve_registration_application),
-          )
-          .service(
-            web::scope("/purge")
-              .route("/person", web::post().to(purge_person))
-              .route("/community", web::post().to(purge_community))
-              .route("/post", web::post().to(purge_post))
-              .route("/comment", web::post().to(purge_comment)),
-          ),
-      )
-      .service(
-        web::scope("/custom_emoji")
-          .wrap(rate_limit.message())
-          .route("", web::post().to(create_custom_emoji))
-          .route("", web::put().to(update_custom_emoji))
-          .route("/delete", web::post().to(delete_custom_emoji)),
-      ),
-  );
-  cfg.service(
-    web::scope("/sitemap.xml")
-      .wrap(rate_limit.message())
-      .route("", web::get().to(get_sitemap)),
-  );
+    cfg.service(
+        web::scope("/api/v3")
+            // Site
+            .service(
+                web::scope("/site")
+                    .wrap(rate_limit.message())
+                    .route("", web::get().to(get_site))
+                    // Admin Actions
+                    .route("", web::post().to(create_site))
+                    .route("", web::put().to(update_site)),
+            )
+            .service(
+                web::resource("/modlog")
+                    .wrap(rate_limit.message())
+                    .route(web::get().to(get_mod_log)),
+            )
+            .service(
+                web::resource("/search")
+                    .wrap(rate_limit.search())
+                    .route(web::get().to(search)),
+            )
+            .service(
+                web::resource("/resolve_object")
+                    .wrap(rate_limit.message())
+                    .route(web::get().to(resolve_object)),
+            )
+            // Community
+            .service(
+                web::resource("/community")
+                    .guard(guard::Post())
+                    .wrap(rate_limit.register())
+                    .route(web::post().to(create_community)),
+            )
+            .service(
+                web::scope("/community")
+                    .wrap(rate_limit.message())
+                    .route("", web::get().to(get_community))
+                    .route("", web::put().to(update_community))
+                    .route("/hide", web::put().to(hide_community))
+                    .route("/list", web::get().to(list_communities))
+                    .route("/follow", web::post().to(follow_community))
+                    .route("/block", web::post().to(block_community))
+                    .route("/delete", web::post().to(delete_community))
+                    // Mod Actions
+                    .route("/remove", web::post().to(remove_community))
+                    .route("/transfer", web::post().to(transfer_community))
+                    .route("/ban_user", web::post().to(ban_from_community))
+                    .route("/mod", web::post().to(add_mod_to_community)),
+            )
+            .service(
+                web::scope("/federated_instances")
+                    .wrap(rate_limit.message())
+                    .route("", web::get().to(get_federated_instances)),
+            )
+            // Post
+            .service(
+                // Handle POST to /post separately to add the post() rate limitter
+                web::resource("/post")
+                    .guard(guard::Post())
+                    .wrap(rate_limit.post())
+                    .route(web::post().to(create_post)),
+            )
+            .service(
+                web::scope("/post")
+                    .wrap(rate_limit.message())
+                    .route("", web::get().to(get_post))
+                    .route("", web::put().to(update_post))
+                    .route("/delete", web::post().to(delete_post))
+                    .route("/remove", web::post().to(remove_post))
+                    .route("/mark_as_read", web::post().to(mark_post_as_read))
+                    .route("/lock", web::post().to(lock_post))
+                    .route("/feature", web::post().to(feature_post))
+                    .route("/list", web::get().to(list_posts))
+                    .route("/like", web::post().to(like_post))
+                    .route("/save", web::put().to(save_post))
+                    .route("/report", web::post().to(create_post_report))
+                    .route("/report/resolve", web::put().to(resolve_post_report))
+                    .route("/report/list", web::get().to(list_post_reports))
+                    .route("/site_metadata", web::get().to(get_link_metadata)),
+            )
+            // Comment
+            .service(
+                // Handle POST to /comment separately to add the comment() rate limitter
+                web::resource("/comment")
+                    .guard(guard::Post())
+                    .wrap(rate_limit.comment())
+                    .route(web::post().to(create_comment)),
+            )
+            .service(
+                web::scope("/comment")
+                    .wrap(rate_limit.message())
+                    .route("", web::get().to(get_comment))
+                    .route("", web::put().to(update_comment))
+                    .route("/delete", web::post().to(delete_comment))
+                    .route("/remove", web::post().to(remove_comment))
+                    .route("/mark_as_read", web::post().to(mark_reply_as_read))
+                    .route("/distinguish", web::post().to(distinguish_comment))
+                    .route("/like", web::post().to(like_comment))
+                    .route("/save", web::put().to(save_comment))
+                    .route("/list", web::get().to(list_comments))
+                    .route("/report", web::post().to(create_comment_report))
+                    .route("/report/resolve", web::put().to(resolve_comment_report))
+                    .route("/report/list", web::get().to(list_comment_reports)),
+            )
+            // Private Message
+            .service(
+                web::scope("/private_message")
+                    .wrap(rate_limit.message())
+                    .route("/list", web::get().to(get_private_message))
+                    .route("", web::post().to(create_private_message))
+                    .route("", web::put().to(update_private_message))
+                    .route("/delete", web::post().to(delete_private_message))
+                    .route("/mark_as_read", web::post().to(mark_pm_as_read))
+                    .route("/report", web::post().to(create_pm_report))
+                    .route("/report/resolve", web::put().to(resolve_pm_report))
+                    .route("/report/list", web::get().to(list_pm_reports)),
+            )
+            // User
+            .service(
+                // Account action, I don't like that it's in /user maybe /accounts
+                // Handle /user/register separately to add the register() rate limitter
+                web::resource("/user/register")
+                    .guard(guard::Post())
+                    .wrap(rate_limit.register())
+                    .route(web::post().to(register)),
+            )
+            .service(
+                // Handle captcha separately
+                web::resource("/user/get_captcha")
+                    .wrap(rate_limit.post())
+                    .route(web::get().to(get_captcha)),
+            )
+            // User actions
+            .service(
+                web::scope("/user")
+                    .wrap(rate_limit.message())
+                    .route("", web::get().to(read_person))
+                    .route("/mention", web::get().to(list_mentions))
+                    .route(
+                        "/mention/mark_as_read",
+                        web::post().to(mark_person_mention_as_read),
+                    )
+                    .route("/replies", web::get().to(list_replies))
+                    // Admin action. I don't like that it's in /user
+                    .route("/ban", web::post().to(ban_from_site))
+                    .route("/banned", web::get().to(list_banned_users))
+                    .route("/block", web::post().to(block_person))
+                    // Account actions. I don't like that they're in /user maybe /accounts
+                    .route("/login", web::post().to(login))
+                    .route("/delete_account", web::post().to(delete_account))
+                    .route("/password_reset", web::post().to(reset_password))
+                    .route(
+                        "/password_change",
+                        web::post().to(change_password_after_reset),
+                    )
+                    // mark_all_as_read feels off being in this section as well
+                    .route(
+                        "/mark_all_as_read",
+                        web::post().to(mark_all_notifications_read),
+                    )
+                    .route("/save_user_settings", web::put().to(save_user_settings))
+                    .route("/change_password", web::put().to(change_password))
+                    .route("/report_count", web::get().to(report_count))
+                    .route("/unread_count", web::get().to(unread_count))
+                    .route("/verify_email", web::post().to(verify_email))
+                    .route("/leave_admin", web::post().to(leave_admin)),
+            )
+            // Admin Actions
+            .service(
+                web::scope("/admin")
+                    .wrap(rate_limit.message())
+                    .route("/add", web::post().to(add_admin))
+                    .route(
+                        "/registration_application/count",
+                        web::get().to(get_unread_registration_application_count),
+                    )
+                    .route(
+                        "/registration_application/list",
+                        web::get().to(list_registration_applications),
+                    )
+                    .route(
+                        "/registration_application/approve",
+                        web::put().to(approve_registration_application),
+                    )
+                    .service(
+                        web::scope("/purge")
+                            .route("/person", web::post().to(purge_person))
+                            .route("/community", web::post().to(purge_community))
+                            .route("/post", web::post().to(purge_post))
+                            .route("/comment", web::post().to(purge_comment)),
+                    ),
+            )
+            .service(
+                web::scope("/custom_emoji")
+                    .wrap(rate_limit.message())
+                    .route("", web::post().to(create_custom_emoji))
+                    .route("", web::put().to(update_custom_emoji))
+                    .route("/delete", web::post().to(delete_custom_emoji)),
+            ),
+    );
+    cfg.service(
+        web::scope("/sitemap.xml")
+            .wrap(rate_limit.message())
+            .route("", web::get().to(get_sitemap)),
+    );
 }

--- a/src/code_migrations.rs
+++ b/src/code_migrations.rs
@@ -1,339 +1,327 @@
 // This is for db migrations that require code
 use activitypub_federation::http_signatures::generate_actor_keypair;
 use diesel::{
-  sql_types::{Nullable, Text},
-  ExpressionMethods,
-  IntoSql,
-  QueryDsl,
-  TextExpressionMethods,
+    sql_types::{Nullable, Text},
+    ExpressionMethods, IntoSql, QueryDsl, TextExpressionMethods,
 };
 use diesel_async::RunQueryDsl;
 use lemmy_api_common::{
-  lemmy_db_views::structs::SiteView,
-  utils::{
-    generate_followers_url,
-    generate_inbox_url,
-    generate_local_apub_endpoint,
-    generate_shared_inbox_url,
-    generate_site_inbox_url,
-    EndpointType,
-  },
+    lemmy_db_views::structs::SiteView,
+    utils::{
+        generate_followers_url, generate_inbox_url, generate_local_apub_endpoint,
+        generate_shared_inbox_url, generate_site_inbox_url, EndpointType,
+    },
 };
 use lemmy_db_schema::{
-  source::{
-    comment::{Comment, CommentUpdateForm},
-    community::{Community, CommunityUpdateForm},
-    instance::Instance,
-    local_site::{LocalSite, LocalSiteInsertForm},
-    local_site_rate_limit::{LocalSiteRateLimit, LocalSiteRateLimitInsertForm},
-    local_user::{LocalUser, LocalUserInsertForm},
-    person::{Person, PersonInsertForm, PersonUpdateForm},
-    post::{Post, PostUpdateForm},
-    private_message::{PrivateMessage, PrivateMessageUpdateForm},
-    site::{Site, SiteInsertForm, SiteUpdateForm},
-  },
-  traits::Crud,
-  utils::{get_conn, naive_now, DbPool},
+    source::{
+        comment::{Comment, CommentUpdateForm},
+        community::{Community, CommunityUpdateForm},
+        instance::Instance,
+        local_site::{LocalSite, LocalSiteInsertForm},
+        local_site_rate_limit::{LocalSiteRateLimit, LocalSiteRateLimitInsertForm},
+        local_user::{LocalUser, LocalUserInsertForm},
+        person::{Person, PersonInsertForm, PersonUpdateForm},
+        post::{Post, PostUpdateForm},
+        private_message::{PrivateMessage, PrivateMessageUpdateForm},
+        site::{Site, SiteInsertForm, SiteUpdateForm},
+    },
+    traits::Crud,
+    utils::{get_conn, naive_now, DbPool},
 };
 use lemmy_utils::{error::LemmyError, settings::structs::Settings};
 use tracing::info;
 use url::Url;
 
 pub async fn run_advanced_migrations(
-  pool: &mut DbPool<'_>,
-  settings: &Settings,
+    pool: &mut DbPool<'_>,
+    settings: &Settings,
 ) -> Result<(), LemmyError> {
-  let protocol_and_hostname = &settings.get_protocol_and_hostname();
-  user_updates_2020_04_02(pool, protocol_and_hostname).await?;
-  community_updates_2020_04_02(pool, protocol_and_hostname).await?;
-  post_updates_2020_04_03(pool, protocol_and_hostname).await?;
-  comment_updates_2020_04_03(pool, protocol_and_hostname).await?;
-  private_message_updates_2020_05_05(pool, protocol_and_hostname).await?;
-  post_thumbnail_url_updates_2020_07_27(pool, protocol_and_hostname).await?;
-  apub_columns_2021_02_02(pool).await?;
-  instance_actor_2022_01_28(pool, protocol_and_hostname).await?;
-  regenerate_public_keys_2022_07_05(pool).await?;
-  initialize_local_site_2022_10_10(pool, settings).await?;
+    let protocol_and_hostname = &settings.get_protocol_and_hostname();
+    user_updates_2020_04_02(pool, protocol_and_hostname).await?;
+    community_updates_2020_04_02(pool, protocol_and_hostname).await?;
+    post_updates_2020_04_03(pool, protocol_and_hostname).await?;
+    comment_updates_2020_04_03(pool, protocol_and_hostname).await?;
+    private_message_updates_2020_05_05(pool, protocol_and_hostname).await?;
+    post_thumbnail_url_updates_2020_07_27(pool, protocol_and_hostname).await?;
+    apub_columns_2021_02_02(pool).await?;
+    instance_actor_2022_01_28(pool, protocol_and_hostname).await?;
+    regenerate_public_keys_2022_07_05(pool).await?;
+    initialize_local_site_2022_10_10(pool, settings).await?;
 
-  Ok(())
+    Ok(())
 }
 
 async fn user_updates_2020_04_02(
-  pool: &mut DbPool<'_>,
-  protocol_and_hostname: &str,
+    pool: &mut DbPool<'_>,
+    protocol_and_hostname: &str,
 ) -> Result<(), LemmyError> {
-  use lemmy_db_schema::schema::person::dsl::{actor_id, local, person};
-  let conn = &mut get_conn(pool).await?;
+    use lemmy_db_schema::schema::person::dsl::{actor_id, local, person};
+    let conn = &mut get_conn(pool).await?;
 
-  info!("Running user_updates_2020_04_02");
+    info!("Running user_updates_2020_04_02");
 
-  // Update the actor_id, private_key, and public_key, last_refreshed_at
-  let incorrect_persons = person
-    .filter(actor_id.like("http://changeme%"))
-    .filter(local.eq(true))
-    .load::<Person>(conn)
-    .await?;
+    // Update the actor_id, private_key, and public_key, last_refreshed_at
+    let incorrect_persons = person
+        .filter(actor_id.like("http://changeme%"))
+        .filter(local.eq(true))
+        .load::<Person>(conn)
+        .await?;
 
-  for cperson in &incorrect_persons {
-    let keypair = generate_actor_keypair()?;
+    for cperson in &incorrect_persons {
+        let keypair = generate_actor_keypair()?;
 
-    let form = PersonUpdateForm {
-      actor_id: Some(generate_local_apub_endpoint(
-        EndpointType::Person,
-        &cperson.name,
-        protocol_and_hostname,
-      )?),
-      private_key: Some(Some(keypair.private_key)),
-      public_key: Some(keypair.public_key),
-      last_refreshed_at: Some(naive_now()),
-      ..Default::default()
-    };
+        let form = PersonUpdateForm {
+            actor_id: Some(generate_local_apub_endpoint(
+                EndpointType::Person,
+                &cperson.name,
+                protocol_and_hostname,
+            )?),
+            private_key: Some(Some(keypair.private_key)),
+            public_key: Some(keypair.public_key),
+            last_refreshed_at: Some(naive_now()),
+            ..Default::default()
+        };
 
-    Person::update(pool, cperson.id, &form).await?;
-  }
+        Person::update(pool, cperson.id, &form).await?;
+    }
 
-  info!("{} person rows updated.", incorrect_persons.len());
+    info!("{} person rows updated.", incorrect_persons.len());
 
-  Ok(())
+    Ok(())
 }
 
 async fn community_updates_2020_04_02(
-  pool: &mut DbPool<'_>,
-  protocol_and_hostname: &str,
+    pool: &mut DbPool<'_>,
+    protocol_and_hostname: &str,
 ) -> Result<(), LemmyError> {
-  use lemmy_db_schema::schema::community::dsl::{actor_id, community, local};
-  let conn = &mut get_conn(pool).await?;
+    use lemmy_db_schema::schema::community::dsl::{actor_id, community, local};
+    let conn = &mut get_conn(pool).await?;
 
-  info!("Running community_updates_2020_04_02");
+    info!("Running community_updates_2020_04_02");
 
-  // Update the actor_id, private_key, and public_key, last_refreshed_at
-  let incorrect_communities = community
-    .filter(actor_id.like("http://changeme%"))
-    .filter(local.eq(true))
-    .load::<Community>(conn)
-    .await?;
+    // Update the actor_id, private_key, and public_key, last_refreshed_at
+    let incorrect_communities = community
+        .filter(actor_id.like("http://changeme%"))
+        .filter(local.eq(true))
+        .load::<Community>(conn)
+        .await?;
 
-  for ccommunity in &incorrect_communities {
-    let keypair = generate_actor_keypair()?;
-    let community_actor_id = generate_local_apub_endpoint(
-      EndpointType::Community,
-      &ccommunity.name,
-      protocol_and_hostname,
-    )?;
+    for ccommunity in &incorrect_communities {
+        let keypair = generate_actor_keypair()?;
+        let community_actor_id = generate_local_apub_endpoint(
+            EndpointType::Community,
+            &ccommunity.name,
+            protocol_and_hostname,
+        )?;
 
-    let form = CommunityUpdateForm {
-      actor_id: Some(community_actor_id.clone()),
-      private_key: Some(Some(keypair.private_key)),
-      public_key: Some(keypair.public_key),
-      last_refreshed_at: Some(naive_now()),
-      ..Default::default()
-    };
+        let form = CommunityUpdateForm {
+            actor_id: Some(community_actor_id.clone()),
+            private_key: Some(Some(keypair.private_key)),
+            public_key: Some(keypair.public_key),
+            last_refreshed_at: Some(naive_now()),
+            ..Default::default()
+        };
 
-    Community::update(pool, ccommunity.id, &form).await?;
-  }
+        Community::update(pool, ccommunity.id, &form).await?;
+    }
 
-  info!("{} community rows updated.", incorrect_communities.len());
+    info!("{} community rows updated.", incorrect_communities.len());
 
-  Ok(())
+    Ok(())
 }
 
 async fn post_updates_2020_04_03(
-  pool: &mut DbPool<'_>,
-  protocol_and_hostname: &str,
+    pool: &mut DbPool<'_>,
+    protocol_and_hostname: &str,
 ) -> Result<(), LemmyError> {
-  use lemmy_db_schema::schema::post::dsl::{ap_id, local, post};
-  let conn = &mut get_conn(pool).await?;
+    use lemmy_db_schema::schema::post::dsl::{ap_id, local, post};
+    let conn = &mut get_conn(pool).await?;
 
-  info!("Running post_updates_2020_04_03");
+    info!("Running post_updates_2020_04_03");
 
-  // Update the ap_id
-  let incorrect_posts = post
-    .filter(ap_id.like("http://changeme%"))
-    .filter(local.eq(true))
-    .load::<Post>(conn)
-    .await?;
+    // Update the ap_id
+    let incorrect_posts = post
+        .filter(ap_id.like("http://changeme%"))
+        .filter(local.eq(true))
+        .load::<Post>(conn)
+        .await?;
 
-  for cpost in &incorrect_posts {
-    let apub_id = generate_local_apub_endpoint(
-      EndpointType::Post,
-      &cpost.id.to_string(),
-      protocol_and_hostname,
-    )?;
-    Post::update(
-      pool,
-      cpost.id,
-      &PostUpdateForm {
-        ap_id: Some(apub_id),
-        ..Default::default()
-      },
-    )
-    .await?;
-  }
+    for cpost in &incorrect_posts {
+        let apub_id = generate_local_apub_endpoint(
+            EndpointType::Post,
+            &cpost.id.to_string(),
+            protocol_and_hostname,
+        )?;
+        Post::update(
+            pool,
+            cpost.id,
+            &PostUpdateForm {
+                ap_id: Some(apub_id),
+                ..Default::default()
+            },
+        )
+        .await?;
+    }
 
-  info!("{} post rows updated.", incorrect_posts.len());
+    info!("{} post rows updated.", incorrect_posts.len());
 
-  Ok(())
+    Ok(())
 }
 
 async fn comment_updates_2020_04_03(
-  pool: &mut DbPool<'_>,
-  protocol_and_hostname: &str,
+    pool: &mut DbPool<'_>,
+    protocol_and_hostname: &str,
 ) -> Result<(), LemmyError> {
-  use lemmy_db_schema::schema::comment::dsl::{ap_id, comment, local};
-  let conn = &mut get_conn(pool).await?;
+    use lemmy_db_schema::schema::comment::dsl::{ap_id, comment, local};
+    let conn = &mut get_conn(pool).await?;
 
-  info!("Running comment_updates_2020_04_03");
+    info!("Running comment_updates_2020_04_03");
 
-  // Update the ap_id
-  let incorrect_comments = comment
-    .filter(ap_id.like("http://changeme%"))
-    .filter(local.eq(true))
-    .load::<Comment>(conn)
-    .await?;
+    // Update the ap_id
+    let incorrect_comments = comment
+        .filter(ap_id.like("http://changeme%"))
+        .filter(local.eq(true))
+        .load::<Comment>(conn)
+        .await?;
 
-  for ccomment in &incorrect_comments {
-    let apub_id = generate_local_apub_endpoint(
-      EndpointType::Comment,
-      &ccomment.id.to_string(),
-      protocol_and_hostname,
-    )?;
-    Comment::update(
-      pool,
-      ccomment.id,
-      &CommentUpdateForm {
-        ap_id: Some(apub_id),
-        ..Default::default()
-      },
-    )
-    .await?;
-  }
+    for ccomment in &incorrect_comments {
+        let apub_id = generate_local_apub_endpoint(
+            EndpointType::Comment,
+            &ccomment.id.to_string(),
+            protocol_and_hostname,
+        )?;
+        Comment::update(
+            pool,
+            ccomment.id,
+            &CommentUpdateForm {
+                ap_id: Some(apub_id),
+                ..Default::default()
+            },
+        )
+        .await?;
+    }
 
-  info!("{} comment rows updated.", incorrect_comments.len());
+    info!("{} comment rows updated.", incorrect_comments.len());
 
-  Ok(())
+    Ok(())
 }
 
 async fn private_message_updates_2020_05_05(
-  pool: &mut DbPool<'_>,
-  protocol_and_hostname: &str,
+    pool: &mut DbPool<'_>,
+    protocol_and_hostname: &str,
 ) -> Result<(), LemmyError> {
-  use lemmy_db_schema::schema::private_message::dsl::{ap_id, local, private_message};
-  let conn = &mut get_conn(pool).await?;
+    use lemmy_db_schema::schema::private_message::dsl::{ap_id, local, private_message};
+    let conn = &mut get_conn(pool).await?;
 
-  info!("Running private_message_updates_2020_05_05");
+    info!("Running private_message_updates_2020_05_05");
 
-  // Update the ap_id
-  let incorrect_pms = private_message
-    .filter(ap_id.like("http://changeme%"))
-    .filter(local.eq(true))
-    .load::<PrivateMessage>(conn)
-    .await?;
+    // Update the ap_id
+    let incorrect_pms = private_message
+        .filter(ap_id.like("http://changeme%"))
+        .filter(local.eq(true))
+        .load::<PrivateMessage>(conn)
+        .await?;
 
-  for cpm in &incorrect_pms {
-    let apub_id = generate_local_apub_endpoint(
-      EndpointType::PrivateMessage,
-      &cpm.id.to_string(),
-      protocol_and_hostname,
-    )?;
-    PrivateMessage::update(
-      pool,
-      cpm.id,
-      &PrivateMessageUpdateForm {
-        ap_id: Some(apub_id),
-        ..Default::default()
-      },
-    )
-    .await?;
-  }
+    for cpm in &incorrect_pms {
+        let apub_id = generate_local_apub_endpoint(
+            EndpointType::PrivateMessage,
+            &cpm.id.to_string(),
+            protocol_and_hostname,
+        )?;
+        PrivateMessage::update(
+            pool,
+            cpm.id,
+            &PrivateMessageUpdateForm {
+                ap_id: Some(apub_id),
+                ..Default::default()
+            },
+        )
+        .await?;
+    }
 
-  info!("{} private message rows updated.", incorrect_pms.len());
+    info!("{} private message rows updated.", incorrect_pms.len());
 
-  Ok(())
+    Ok(())
 }
 
 async fn post_thumbnail_url_updates_2020_07_27(
-  pool: &mut DbPool<'_>,
-  protocol_and_hostname: &str,
+    pool: &mut DbPool<'_>,
+    protocol_and_hostname: &str,
 ) -> Result<(), LemmyError> {
-  use lemmy_db_schema::schema::post::dsl::{post, thumbnail_url};
-  let conn = &mut get_conn(pool).await?;
+    use lemmy_db_schema::schema::post::dsl::{post, thumbnail_url};
+    let conn = &mut get_conn(pool).await?;
 
-  info!("Running post_thumbnail_url_updates_2020_07_27");
+    info!("Running post_thumbnail_url_updates_2020_07_27");
 
-  let domain_prefix = format!("{protocol_and_hostname}/pictrs/image/",);
+    let domain_prefix = format!("{protocol_and_hostname}/pictrs/image/",);
 
-  let incorrect_thumbnails = post.filter(thumbnail_url.not_like("http%"));
+    let incorrect_thumbnails = post.filter(thumbnail_url.not_like("http%"));
 
-  // Prepend the rows with the update
-  let res = diesel::update(incorrect_thumbnails)
-    .set(
-      thumbnail_url.eq(
-        domain_prefix
-          .into_sql::<Nullable<Text>>()
-          .concat(thumbnail_url),
-      ),
-    )
-    .get_results::<Post>(conn)
-    .await?;
+    // Prepend the rows with the update
+    let res = diesel::update(incorrect_thumbnails)
+        .set(
+            thumbnail_url.eq(domain_prefix
+                .into_sql::<Nullable<Text>>()
+                .concat(thumbnail_url)),
+        )
+        .get_results::<Post>(conn)
+        .await?;
 
-  info!("{} Post thumbnail_url rows updated.", res.len());
+    info!("{} Post thumbnail_url rows updated.", res.len());
 
-  Ok(())
+    Ok(())
 }
 
 /// We are setting inbox and follower URLs for local and remote actors alike, because for now
 /// all federated instances are also Lemmy and use the same URL scheme.
 async fn apub_columns_2021_02_02(pool: &mut DbPool<'_>) -> Result<(), LemmyError> {
-  let conn = &mut get_conn(pool).await?;
-  info!("Running apub_columns_2021_02_02");
-  {
-    use lemmy_db_schema::schema::person::dsl::{inbox_url, person, shared_inbox_url};
-    let persons = person
-      .filter(inbox_url.like("http://changeme%"))
-      .load::<Person>(conn)
-      .await?;
+    let conn = &mut get_conn(pool).await?;
+    info!("Running apub_columns_2021_02_02");
+    {
+        use lemmy_db_schema::schema::person::dsl::{inbox_url, person, shared_inbox_url};
+        let persons = person
+            .filter(inbox_url.like("http://changeme%"))
+            .load::<Person>(conn)
+            .await?;
 
-    for p in &persons {
-      let inbox_url_ = generate_inbox_url(&p.actor_id)?;
-      let shared_inbox_url_ = generate_shared_inbox_url(&p.actor_id)?;
-      diesel::update(person.find(p.id))
-        .set((
-          inbox_url.eq(inbox_url_),
-          shared_inbox_url.eq(shared_inbox_url_),
-        ))
-        .get_result::<Person>(conn)
-        .await?;
+        for p in &persons {
+            let inbox_url_ = generate_inbox_url(&p.actor_id)?;
+            let shared_inbox_url_ = generate_shared_inbox_url(&p.actor_id)?;
+            diesel::update(person.find(p.id))
+                .set((
+                    inbox_url.eq(inbox_url_),
+                    shared_inbox_url.eq(shared_inbox_url_),
+                ))
+                .get_result::<Person>(conn)
+                .await?;
+        }
     }
-  }
 
-  {
-    use lemmy_db_schema::schema::community::dsl::{
-      community,
-      followers_url,
-      inbox_url,
-      shared_inbox_url,
-    };
-    let communities = community
-      .filter(inbox_url.like("http://changeme%"))
-      .load::<Community>(conn)
-      .await?;
+    {
+        use lemmy_db_schema::schema::community::dsl::{
+            community, followers_url, inbox_url, shared_inbox_url,
+        };
+        let communities = community
+            .filter(inbox_url.like("http://changeme%"))
+            .load::<Community>(conn)
+            .await?;
 
-    for c in &communities {
-      let followers_url_ = generate_followers_url(&c.actor_id)?;
-      let inbox_url_ = generate_inbox_url(&c.actor_id)?;
-      let shared_inbox_url_ = generate_shared_inbox_url(&c.actor_id)?;
-      diesel::update(community.find(c.id))
-        .set((
-          followers_url.eq(followers_url_),
-          inbox_url.eq(inbox_url_),
-          shared_inbox_url.eq(shared_inbox_url_),
-        ))
-        .get_result::<Community>(conn)
-        .await?;
+        for c in &communities {
+            let followers_url_ = generate_followers_url(&c.actor_id)?;
+            let inbox_url_ = generate_inbox_url(&c.actor_id)?;
+            let shared_inbox_url_ = generate_shared_inbox_url(&c.actor_id)?;
+            diesel::update(community.find(c.id))
+                .set((
+                    followers_url.eq(followers_url_),
+                    inbox_url.eq(inbox_url_),
+                    shared_inbox_url.eq(shared_inbox_url_),
+                ))
+                .get_result::<Community>(conn)
+                .await?;
+        }
     }
-  }
 
-  Ok(())
+    Ok(())
 }
 
 /// Site object turns into an actor, so that things like instance description can be federated. This
@@ -341,29 +329,29 @@ async fn apub_columns_2021_02_02(pool: &mut DbPool<'_>) -> Result<(), LemmyError
 /// Before this point, there is only a single value in the site table which refers to the local
 /// Lemmy instance, so thats all we need to update.
 async fn instance_actor_2022_01_28(
-  pool: &mut DbPool<'_>,
-  protocol_and_hostname: &str,
+    pool: &mut DbPool<'_>,
+    protocol_and_hostname: &str,
 ) -> Result<(), LemmyError> {
-  info!("Running instance_actor_2021_09_29");
-  if let Ok(site_view) = SiteView::read_local(pool).await {
-    let site = site_view.site;
-    // if site already has public key, we dont need to do anything here
-    if !site.public_key.is_empty() {
-      return Ok(());
+    info!("Running instance_actor_2021_09_29");
+    if let Ok(site_view) = SiteView::read_local(pool).await {
+        let site = site_view.site;
+        // if site already has public key, we dont need to do anything here
+        if !site.public_key.is_empty() {
+            return Ok(());
+        }
+        let key_pair = generate_actor_keypair()?;
+        let actor_id = Url::parse(protocol_and_hostname)?;
+        let site_form = SiteUpdateForm {
+            actor_id: Some(actor_id.clone().into()),
+            last_refreshed_at: Some(naive_now()),
+            inbox_url: Some(generate_site_inbox_url(&actor_id.into())?),
+            private_key: Some(Some(key_pair.private_key)),
+            public_key: Some(key_pair.public_key),
+            ..Default::default()
+        };
+        Site::update(pool, site.id, &site_form).await?;
     }
-    let key_pair = generate_actor_keypair()?;
-    let actor_id = Url::parse(protocol_and_hostname)?;
-    let site_form = SiteUpdateForm {
-      actor_id: Some(actor_id.clone().into()),
-      last_refreshed_at: Some(naive_now()),
-      inbox_url: Some(generate_site_inbox_url(&actor_id.into())?),
-      private_key: Some(Some(key_pair.private_key)),
-      public_key: Some(key_pair.public_key),
-      ..Default::default()
-    };
-    Site::update(pool, site.id, &site_form).await?;
-  }
-  Ok(())
+    Ok(())
 }
 
 /// Fix for bug #2347, which can result in community/person public keys being overwritten with
@@ -372,55 +360,55 @@ async fn instance_actor_2022_01_28(
 /// but thats more complicated and has no benefit, as federation is already broken for these actors.
 /// https://github.com/LemmyNet/lemmy/issues/2347
 async fn regenerate_public_keys_2022_07_05(pool: &mut DbPool<'_>) -> Result<(), LemmyError> {
-  let conn = &mut get_conn(pool).await?;
-  info!("Running regenerate_public_keys_2022_07_05");
+    let conn = &mut get_conn(pool).await?;
+    info!("Running regenerate_public_keys_2022_07_05");
 
-  {
-    // update communities with empty pubkey
-    use lemmy_db_schema::schema::community::dsl::{community, local, public_key};
-    let communities: Vec<Community> = community
-      .filter(local.eq(true))
-      .filter(public_key.eq(""))
-      .load::<Community>(conn)
-      .await?;
-    for community_ in communities {
-      info!(
-        "local community {} has empty public key field, regenerating key",
-        community_.name
-      );
-      let key_pair = generate_actor_keypair()?;
-      let form = CommunityUpdateForm {
-        public_key: Some(key_pair.public_key),
-        private_key: Some(Some(key_pair.private_key)),
-        ..Default::default()
-      };
-      Community::update(&mut conn.into(), community_.id, &form).await?;
+    {
+        // update communities with empty pubkey
+        use lemmy_db_schema::schema::community::dsl::{community, local, public_key};
+        let communities: Vec<Community> = community
+            .filter(local.eq(true))
+            .filter(public_key.eq(""))
+            .load::<Community>(conn)
+            .await?;
+        for community_ in communities {
+            info!(
+                "local community {} has empty public key field, regenerating key",
+                community_.name
+            );
+            let key_pair = generate_actor_keypair()?;
+            let form = CommunityUpdateForm {
+                public_key: Some(key_pair.public_key),
+                private_key: Some(Some(key_pair.private_key)),
+                ..Default::default()
+            };
+            Community::update(&mut conn.into(), community_.id, &form).await?;
+        }
     }
-  }
 
-  {
-    // update persons with empty pubkey
-    use lemmy_db_schema::schema::person::dsl::{local, person, public_key};
-    let persons = person
-      .filter(local.eq(true))
-      .filter(public_key.eq(""))
-      .load::<Person>(conn)
-      .await?;
-    for person_ in persons {
-      info!(
-        "local user {} has empty public key field, regenerating key",
-        person_.name
-      );
-      let key_pair = generate_actor_keypair()?;
-      let form = PersonUpdateForm {
-        public_key: Some(key_pair.public_key),
-        private_key: Some(Some(key_pair.private_key)),
-        ..Default::default()
-      };
-      Person::update(pool, person_.id, &form).await?;
+    {
+        // update persons with empty pubkey
+        use lemmy_db_schema::schema::person::dsl::{local, person, public_key};
+        let persons = person
+            .filter(local.eq(true))
+            .filter(public_key.eq(""))
+            .load::<Person>(conn)
+            .await?;
+        for person_ in persons {
+            info!(
+                "local user {} has empty public key field, regenerating key",
+                person_.name
+            );
+            let key_pair = generate_actor_keypair()?;
+            let form = PersonUpdateForm {
+                public_key: Some(key_pair.public_key),
+                private_key: Some(Some(key_pair.private_key)),
+                ..Default::default()
+            };
+            Person::update(pool, person_.id, &form).await?;
+        }
     }
-  }
-  Ok(())
+    Ok(())
 }
 
 /// This ensures that your local site is initialized and exists.
@@ -428,96 +416,96 @@ async fn regenerate_public_keys_2022_07_05(pool: &mut DbPool<'_>) -> Result<(), 
 /// If a site already exists, the DB migration should generate a local_site row.
 /// This will only be run for brand new sites.
 async fn initialize_local_site_2022_10_10(
-  pool: &mut DbPool<'_>,
-  settings: &Settings,
+    pool: &mut DbPool<'_>,
+    settings: &Settings,
 ) -> Result<(), LemmyError> {
-  info!("Running initialize_local_site_2022_10_10");
+    info!("Running initialize_local_site_2022_10_10");
 
-  // Check to see if local_site exists
-  if LocalSite::read(pool).await.is_ok() {
-    return Ok(());
-  }
-  info!("No Local Site found, creating it.");
+    // Check to see if local_site exists
+    if LocalSite::read(pool).await.is_ok() {
+        return Ok(());
+    }
+    info!("No Local Site found, creating it.");
 
-  let domain = settings
-    .get_hostname_without_port()
-    .expect("must have domain");
+    let domain = settings
+        .get_hostname_without_port()
+        .expect("must have domain");
 
-  // Upsert this to the instance table
-  let instance = Instance::read_or_create(pool, domain).await?;
+    // Upsert this to the instance table
+    let instance = Instance::read_or_create(pool, domain).await?;
 
-  if let Some(setup) = &settings.setup {
-    let person_keypair = generate_actor_keypair()?;
-    let person_actor_id = generate_local_apub_endpoint(
-      EndpointType::Person,
-      &setup.admin_username,
-      &settings.get_protocol_and_hostname(),
-    )?;
+    if let Some(setup) = &settings.setup {
+        let person_keypair = generate_actor_keypair()?;
+        let person_actor_id = generate_local_apub_endpoint(
+            EndpointType::Person,
+            &setup.admin_username,
+            &settings.get_protocol_and_hostname(),
+        )?;
 
-    // Register the user if there's a site setup
-    let person_form = PersonInsertForm::builder()
-      .name(setup.admin_username.clone())
-      .instance_id(instance.id)
-      .actor_id(Some(person_actor_id.clone()))
-      .private_key(Some(person_keypair.private_key))
-      .public_key(person_keypair.public_key)
-      .inbox_url(Some(generate_inbox_url(&person_actor_id)?))
-      .shared_inbox_url(Some(generate_shared_inbox_url(&person_actor_id)?))
-      .build();
-    let person_inserted = Person::create(pool, &person_form).await?;
+        // Register the user if there's a site setup
+        let person_form = PersonInsertForm::builder()
+            .name(setup.admin_username.clone())
+            .instance_id(instance.id)
+            .actor_id(Some(person_actor_id.clone()))
+            .private_key(Some(person_keypair.private_key))
+            .public_key(person_keypair.public_key)
+            .inbox_url(Some(generate_inbox_url(&person_actor_id)?))
+            .shared_inbox_url(Some(generate_shared_inbox_url(&person_actor_id)?))
+            .build();
+        let person_inserted = Person::create(pool, &person_form).await?;
 
-    let local_user_form = LocalUserInsertForm::builder()
-      .person_id(person_inserted.id)
-      .password_encrypted(setup.admin_password.clone())
-      .email(setup.admin_email.clone())
-      .admin(Some(true))
-      .build();
-    LocalUser::create(pool, &local_user_form).await?;
-  };
+        let local_user_form = LocalUserInsertForm::builder()
+            .person_id(person_inserted.id)
+            .password_encrypted(setup.admin_password.clone())
+            .email(setup.admin_email.clone())
+            .admin(Some(true))
+            .build();
+        LocalUser::create(pool, &local_user_form).await?;
+    };
 
-  // Add an entry for the site table
-  let site_key_pair = generate_actor_keypair()?;
-  let site_actor_id = Url::parse(&settings.get_protocol_and_hostname())?;
+    // Add an entry for the site table
+    let site_key_pair = generate_actor_keypair()?;
+    let site_actor_id = Url::parse(&settings.get_protocol_and_hostname())?;
 
-  let site_form = SiteInsertForm::builder()
-    .name(
-      settings
-        .setup
-        .clone()
-        .map(|s| s.site_name)
-        .unwrap_or_else(|| "New Site".to_string()),
-    )
-    .instance_id(instance.id)
-    .actor_id(Some(site_actor_id.clone().into()))
-    .last_refreshed_at(Some(naive_now()))
-    .inbox_url(Some(generate_site_inbox_url(&site_actor_id.into())?))
-    .private_key(Some(site_key_pair.private_key))
-    .public_key(Some(site_key_pair.public_key))
-    .build();
-  let site = Site::create(pool, &site_form).await?;
+    let site_form = SiteInsertForm::builder()
+        .name(
+            settings
+                .setup
+                .clone()
+                .map(|s| s.site_name)
+                .unwrap_or_else(|| "New Site".to_string()),
+        )
+        .instance_id(instance.id)
+        .actor_id(Some(site_actor_id.clone().into()))
+        .last_refreshed_at(Some(naive_now()))
+        .inbox_url(Some(generate_site_inbox_url(&site_actor_id.into())?))
+        .private_key(Some(site_key_pair.private_key))
+        .public_key(Some(site_key_pair.public_key))
+        .build();
+    let site = Site::create(pool, &site_form).await?;
 
-  // Finally create the local_site row
-  let local_site_form = LocalSiteInsertForm::builder()
-    .site_id(site.id)
-    .site_setup(Some(settings.setup.is_some()))
-    .build();
-  let local_site = LocalSite::create(pool, &local_site_form).await?;
+    // Finally create the local_site row
+    let local_site_form = LocalSiteInsertForm::builder()
+        .site_id(site.id)
+        .site_setup(Some(settings.setup.is_some()))
+        .build();
+    let local_site = LocalSite::create(pool, &local_site_form).await?;
 
-  // Create the rate limit table
-  let local_site_rate_limit_form = LocalSiteRateLimitInsertForm::builder()
-    // TODO these have to be set, because the database defaults are too low for the federation
-    // tests to pass, and there's no way to live update the rate limits without restarting the
-    // server.
-    // This can be removed once live rate limits are enabled.
-    .message(Some(999))
-    .post(Some(999))
-    .register(Some(999))
-    .image(Some(999))
-    .comment(Some(999))
-    .search(Some(999))
-    .local_site_id(local_site.id)
-    .build();
-  LocalSiteRateLimit::create(pool, &local_site_rate_limit_form).await?;
+    // Create the rate limit table
+    let local_site_rate_limit_form = LocalSiteRateLimitInsertForm::builder()
+        // TODO these have to be set, because the database defaults are too low for the federation
+        // tests to pass, and there's no way to live update the rate limits without restarting the
+        // server.
+        // This can be removed once live rate limits are enabled.
+        .message(Some(999))
+        .post(Some(999))
+        .register(Some(999))
+        .image(Some(999))
+        .comment(Some(999))
+        .search(Some(999))
+        .local_site_id(local_site.id)
+        .build();
+    LocalSiteRateLimit::create(pool, &local_site_rate_limit_form).await?;
 
-  Ok(())
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,45 +9,37 @@ pub mod session_middleware;
 pub mod telemetry;
 
 use crate::{
-  code_migrations::run_advanced_migrations,
-  root_span_builder::QuieterRootSpanBuilder,
-  session_middleware::SessionMiddleware,
+    code_migrations::run_advanced_migrations, root_span_builder::QuieterRootSpanBuilder,
+    session_middleware::SessionMiddleware,
 };
 use activitypub_federation::config::{FederationConfig, FederationMiddleware};
 use actix_cors::Cors;
 use actix_web::{
-  middleware::{self, ErrorHandlers},
-  web::Data,
-  App,
-  HttpServer,
-  Result,
+    middleware::{self, ErrorHandlers},
+    web::Data,
+    App, HttpServer, Result,
 };
 use lemmy_api_common::{
-  context::LemmyContext,
-  lemmy_db_views::structs::SiteView,
-  request::build_user_agent,
-  send_activity::{ActivityChannel, MATCH_OUTGOING_ACTIVITIES},
-  utils::{
-    check_private_instance_and_federation_enabled,
-    local_site_rate_limit_to_rate_limit_config,
-  },
+    context::LemmyContext,
+    lemmy_db_views::structs::SiteView,
+    request::build_user_agent,
+    send_activity::{ActivityChannel, MATCH_OUTGOING_ACTIVITIES},
+    utils::{
+        check_private_instance_and_federation_enabled, local_site_rate_limit_to_rate_limit_config,
+    },
 };
 use lemmy_apub::{
-  activities::{handle_outgoing_activities, match_outgoing_activities},
-  VerifyUrlData,
-  FEDERATION_HTTP_FETCH_LIMIT,
+    activities::{handle_outgoing_activities, match_outgoing_activities},
+    VerifyUrlData, FEDERATION_HTTP_FETCH_LIMIT,
 };
 use lemmy_db_schema::{
-  source::secret::Secret,
-  utils::{build_db_pool, get_database_url, run_migrations},
+    source::secret::Secret,
+    utils::{build_db_pool, get_database_url, run_migrations},
 };
 use lemmy_routes::{feeds, images, nodeinfo, webfinger};
 use lemmy_utils::{
-  error::LemmyError,
-  rate_limit::RateLimitCell,
-  response::jsonify_plain_text_errors,
-  settings::SETTINGS,
-  SYNCHRONOUS_FEDERATION,
+    error::LemmyError, rate_limit::RateLimitCell, response::jsonify_plain_text_errors,
+    settings::SETTINGS, SYNCHRONOUS_FEDERATION,
 };
 use reqwest::Client;
 use reqwest_middleware::ClientBuilder;
@@ -61,9 +53,8 @@ use tracing_subscriber::{filter::Targets, layer::SubscriberExt, Layer, Registry}
 use url::Url;
 #[cfg(feature = "prometheus-metrics")]
 use {
-  actix_web_prom::PrometheusMetricsBuilder,
-  prometheus::default_registry,
-  prometheus_metrics::serve_prometheus,
+    actix_web_prom::PrometheusMetricsBuilder, prometheus::default_registry,
+    prometheus_metrics::serve_prometheus,
 };
 
 /// Max timeout for http requests
@@ -71,204 +62,203 @@ pub(crate) const REQWEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Placing the main function in lib.rs allows other crates to import it and embed Lemmy
 pub async fn start_lemmy_server() -> Result<(), LemmyError> {
-  let args: Vec<String> = env::args().collect();
+    let args: Vec<String> = env::args().collect();
 
-  let scheduled_tasks_enabled = args.get(1) != Some(&"--disable-scheduled-tasks".to_string());
+    let scheduled_tasks_enabled = args.get(1) != Some(&"--disable-scheduled-tasks".to_string());
 
-  let settings = SETTINGS.to_owned();
+    let settings = SETTINGS.to_owned();
 
-  // Run the DB migrations
-  let db_url = get_database_url(Some(&settings));
-  run_migrations(&db_url);
+    // Run the DB migrations
+    let db_url = get_database_url(Some(&settings));
+    run_migrations(&db_url);
 
-  // Set up the connection pool
-  let pool = build_db_pool(&settings).await?;
+    // Set up the connection pool
+    let pool = build_db_pool(&settings).await?;
 
-  // Run the Code-required migrations
-  run_advanced_migrations(&mut (&pool).into(), &settings).await?;
+    // Run the Code-required migrations
+    run_advanced_migrations(&mut (&pool).into(), &settings).await?;
 
-  // Initialize the secrets
-  let secret = Secret::init(&mut (&pool).into())
-    .await
-    .expect("Couldn't initialize secrets.");
+    // Initialize the secrets
+    let secret = Secret::init(&mut (&pool).into())
+        .await
+        .expect("Couldn't initialize secrets.");
 
-  // Make sure the local site is set up.
-  let site_view = SiteView::read_local(&mut (&pool).into())
-    .await
-    .expect("local site not set up");
-  let local_site = site_view.local_site;
-  let federation_enabled = local_site.federation_enabled;
+    // Make sure the local site is set up.
+    let site_view = SiteView::read_local(&mut (&pool).into())
+        .await
+        .expect("local site not set up");
+    let local_site = site_view.local_site;
+    let federation_enabled = local_site.federation_enabled;
 
-  if federation_enabled {
-    println!("federation enabled, host is {}", &settings.hostname);
-  }
+    if federation_enabled {
+        println!("federation enabled, host is {}", &settings.hostname);
+    }
 
-  check_private_instance_and_federation_enabled(&local_site)?;
+    check_private_instance_and_federation_enabled(&local_site)?;
 
-  // Set up the rate limiter
-  let rate_limit_config =
-    local_site_rate_limit_to_rate_limit_config(&site_view.local_site_rate_limit);
-  let rate_limit_cell = RateLimitCell::new(rate_limit_config).await;
+    // Set up the rate limiter
+    let rate_limit_config =
+        local_site_rate_limit_to_rate_limit_config(&site_view.local_site_rate_limit);
+    let rate_limit_cell = RateLimitCell::new(rate_limit_config).await;
 
-  println!(
-    "Starting http server at {}:{}",
-    settings.bind, settings.port
-  );
+    println!(
+        "Starting http server at {}:{}",
+        settings.bind, settings.port
+    );
 
-  let user_agent = build_user_agent(&settings);
-  let reqwest_client = Client::builder()
-    .user_agent(user_agent.clone())
-    .timeout(REQWEST_TIMEOUT)
-    .connect_timeout(REQWEST_TIMEOUT)
-    .build()?;
+    let user_agent = build_user_agent(&settings);
+    let reqwest_client = Client::builder()
+        .user_agent(user_agent.clone())
+        .timeout(REQWEST_TIMEOUT)
+        .connect_timeout(REQWEST_TIMEOUT)
+        .build()?;
 
-  let client = ClientBuilder::new(reqwest_client.clone())
-    .with(TracingMiddleware::default())
-    .build();
+    let client = ClientBuilder::new(reqwest_client.clone())
+        .with(TracingMiddleware::default())
+        .build();
 
-  // Pictrs cannot use the retry middleware
-  let pictrs_client = ClientBuilder::new(reqwest_client.clone())
-    .with(TracingMiddleware::default())
-    .build();
+    // Pictrs cannot use the retry middleware
+    let pictrs_client = ClientBuilder::new(reqwest_client.clone())
+        .with(TracingMiddleware::default())
+        .build();
 
-  let context = LemmyContext::create(
-    pool.clone(),
-    client.clone(),
-    secret.clone(),
-    rate_limit_cell.clone(),
-  );
+    let context = LemmyContext::create(
+        pool.clone(),
+        client.clone(),
+        secret.clone(),
+        rate_limit_cell.clone(),
+    );
 
-  if scheduled_tasks_enabled {
-    // Schedules various cleanup tasks for the DB
-    thread::spawn({
-      let context = context.clone();
-      move || {
-        scheduled_tasks::setup(db_url, user_agent, context)
-          .expect("Couldn't set up scheduled_tasks");
-      }
-    });
-  }
-
-  #[cfg(feature = "prometheus-metrics")]
-  serve_prometheus(settings.prometheus.as_ref(), context.clone());
-
-  let settings_bind = settings.clone();
-
-  let federation_config = FederationConfig::builder()
-    .domain(settings.hostname.clone())
-    .app_data(context.clone())
-    .client(client.clone())
-    .http_fetch_limit(FEDERATION_HTTP_FETCH_LIMIT)
-    .worker_count(settings.worker_count)
-    .retry_count(settings.retry_count)
-    .debug(*SYNCHRONOUS_FEDERATION)
-    .http_signature_compat(true)
-    .url_verifier(Box::new(VerifyUrlData(context.inner_pool().clone())))
-    .build()
-    .await?;
-
-  // this must come before the HttpServer creation
-  // creates a middleware that populates http metrics for each path, method, and status code
-  #[cfg(feature = "prometheus-metrics")]
-  let prom_api_metrics = PrometheusMetricsBuilder::new("lemmy_api")
-    .registry(default_registry().clone())
-    .build()
-    .expect("Should always be buildable");
-
-  MATCH_OUTGOING_ACTIVITIES
-    .set(Box::new(move |d, c| {
-      Box::pin(match_outgoing_activities(d, c))
-    }))
-    .expect("set function pointer");
-  let request_data = federation_config.to_request_data();
-  let outgoing_activities_task = tokio::task::spawn(handle_outgoing_activities(request_data));
-
-  // Create Http server with websocket support
-  HttpServer::new(move || {
-    let cors_origin = env::var("LEMMY_CORS_ORIGIN");
-    let cors_config = match (cors_origin, cfg!(debug_assertions)) {
-      (Ok(origin), false) => Cors::default()
-        .allowed_origin(&origin)
-        .allowed_origin(&settings.get_protocol_and_hostname()),
-      _ => Cors::default()
-        .allow_any_origin()
-        .allow_any_method()
-        .allow_any_header()
-        .expose_any_header()
-        .max_age(3600),
-    };
-
-    let app = App::new()
-      .wrap(middleware::Logger::new(
-        // This is the default log format save for the usage of %{r}a over %a to guarantee to record the client's (forwarded) IP and not the last peer address, since the latter is frequently just a reverse proxy
-        "%{r}a '%r' %s %b '%{Referer}i' '%{User-Agent}i' %T",
-      ))
-      .wrap(middleware::Compress::default())
-      .wrap(cors_config)
-      .wrap(TracingLogger::<QuieterRootSpanBuilder>::new())
-      .wrap(ErrorHandlers::new().default_handler(jsonify_plain_text_errors))
-      .app_data(Data::new(context.clone()))
-      .app_data(Data::new(rate_limit_cell.clone()))
-      .wrap(FederationMiddleware::new(federation_config.clone()))
-      .wrap(SessionMiddleware::new(context.clone()));
+    if scheduled_tasks_enabled {
+        // Schedules various cleanup tasks for the DB
+        thread::spawn({
+            let context = context.clone();
+            move || {
+                scheduled_tasks::setup(db_url, user_agent, context)
+                    .expect("Couldn't set up scheduled_tasks");
+            }
+        });
+    }
 
     #[cfg(feature = "prometheus-metrics")]
-    let app = app.wrap(prom_api_metrics.clone());
+    serve_prometheus(settings.prometheus.as_ref(), context.clone());
 
-    // The routes
-    app
-      .configure(|cfg| api_routes_http::config(cfg, rate_limit_cell))
-      .configure(|cfg| {
-        if federation_enabled {
-          lemmy_apub::http::routes::config(cfg);
-          webfinger::config(cfg);
-        }
-      })
-      .configure(feeds::config)
-      .configure(|cfg| images::config(cfg, pictrs_client.clone(), rate_limit_cell))
-      .configure(nodeinfo::config)
-  })
-  .bind((settings_bind.bind, settings_bind.port))?
-  .run()
-  .await?;
+    let settings_bind = settings.clone();
 
-  // Wait for outgoing apub sends to complete
-  ActivityChannel::close(outgoing_activities_task).await?;
+    let federation_config = FederationConfig::builder()
+        .domain(settings.hostname.clone())
+        .app_data(context.clone())
+        .client(client.clone())
+        .http_fetch_limit(FEDERATION_HTTP_FETCH_LIMIT)
+        .worker_count(settings.worker_count)
+        .retry_count(settings.retry_count)
+        .debug(*SYNCHRONOUS_FEDERATION)
+        .http_signature_compat(true)
+        .url_verifier(Box::new(VerifyUrlData(context.inner_pool().clone())))
+        .build()
+        .await?;
 
-  Ok(())
+    // this must come before the HttpServer creation
+    // creates a middleware that populates http metrics for each path, method, and status code
+    #[cfg(feature = "prometheus-metrics")]
+    let prom_api_metrics = PrometheusMetricsBuilder::new("lemmy_api")
+        .registry(default_registry().clone())
+        .build()
+        .expect("Should always be buildable");
+
+    MATCH_OUTGOING_ACTIVITIES
+        .set(Box::new(move |d, c| {
+            Box::pin(match_outgoing_activities(d, c))
+        }))
+        .expect("set function pointer");
+    let request_data = federation_config.to_request_data();
+    let outgoing_activities_task = tokio::task::spawn(handle_outgoing_activities(request_data));
+
+    // Create Http server with websocket support
+    HttpServer::new(move || {
+        let cors_origin = env::var("LEMMY_CORS_ORIGIN");
+        let cors_config = match (cors_origin, cfg!(debug_assertions)) {
+            (Ok(origin), false) => Cors::default()
+                .allowed_origin(&origin)
+                .allowed_origin(&settings.get_protocol_and_hostname()),
+            _ => Cors::default()
+                .allow_any_origin()
+                .allow_any_method()
+                .allow_any_header()
+                .expose_any_header()
+                .max_age(3600),
+        };
+
+        let app = App::new()
+            .wrap(middleware::Logger::new(
+                // This is the default log format save for the usage of %{r}a over %a to guarantee to record the client's (forwarded) IP and not the last peer address, since the latter is frequently just a reverse proxy
+                "%{r}a '%r' %s %b '%{Referer}i' '%{User-Agent}i' %T",
+            ))
+            .wrap(middleware::Compress::default())
+            .wrap(cors_config)
+            .wrap(TracingLogger::<QuieterRootSpanBuilder>::new())
+            .wrap(ErrorHandlers::new().default_handler(jsonify_plain_text_errors))
+            .app_data(Data::new(context.clone()))
+            .app_data(Data::new(rate_limit_cell.clone()))
+            .wrap(FederationMiddleware::new(federation_config.clone()))
+            .wrap(SessionMiddleware::new(context.clone()));
+
+        #[cfg(feature = "prometheus-metrics")]
+        let app = app.wrap(prom_api_metrics.clone());
+
+        // The routes
+        app.configure(|cfg| api_routes_http::config(cfg, rate_limit_cell))
+            .configure(|cfg| {
+                if federation_enabled {
+                    lemmy_apub::http::routes::config(cfg);
+                    webfinger::config(cfg);
+                }
+            })
+            .configure(feeds::config)
+            .configure(|cfg| images::config(cfg, pictrs_client.clone(), rate_limit_cell))
+            .configure(nodeinfo::config)
+    })
+    .bind((settings_bind.bind, settings_bind.port))?
+    .run()
+    .await?;
+
+    // Wait for outgoing apub sends to complete
+    ActivityChannel::close(outgoing_activities_task).await?;
+
+    Ok(())
 }
 
 pub fn init_logging(opentelemetry_url: &Option<Url>) -> Result<(), LemmyError> {
-  LogTracer::init()?;
+    LogTracer::init()?;
 
-  let log_description = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".into());
+    let log_description = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".into());
 
-  let targets = log_description
-    .trim()
-    .trim_matches('"')
-    .parse::<Targets>()?;
+    let targets = log_description
+        .trim()
+        .trim_matches('"')
+        .parse::<Targets>()?;
 
-  let format_layer = {
-    #[cfg(feature = "json-log")]
-    let layer = tracing_subscriber::fmt::layer().json();
-    #[cfg(not(feature = "json-log"))]
-    let layer = tracing_subscriber::fmt::layer();
+    let format_layer = {
+        #[cfg(feature = "json-log")]
+        let layer = tracing_subscriber::fmt::layer().json();
+        #[cfg(not(feature = "json-log"))]
+        let layer = tracing_subscriber::fmt::layer();
 
-    layer.with_filter(targets.clone())
-  };
+        layer.with_filter(targets.clone())
+    };
 
-  let subscriber = Registry::default()
-    .with(format_layer)
-    .with(ErrorLayer::default());
+    let subscriber = Registry::default()
+        .with(format_layer)
+        .with(ErrorLayer::default());
 
-  if let Some(_url) = opentelemetry_url {
-    #[cfg(feature = "console")]
-    telemetry::init_tracing(_url.as_ref(), subscriber, targets)?;
-    #[cfg(not(feature = "console"))]
-    tracing::error!("Feature `console` must be enabled for opentelemetry tracing");
-  } else {
-    set_global_default(subscriber)?;
-  }
+    if let Some(_url) = opentelemetry_url {
+        #[cfg(feature = "console")]
+        telemetry::init_tracing(_url.as_ref(), subscriber, targets)?;
+        #[cfg(not(feature = "console"))]
+        tracing::error!("Feature `console` must be enabled for opentelemetry tracing");
+    } else {
+        set_global_default(subscriber)?;
+    }
 
-  Ok(())
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,39 +3,39 @@ use lemmy_utils::{error::LemmyError, settings::SETTINGS};
 
 #[tokio::main]
 pub async fn main() -> Result<(), LemmyError> {
-  init_logging(&SETTINGS.opentelemetry_url)?;
-  #[cfg(not(feature = "embed-pictrs"))]
-  start_lemmy_server().await?;
-  #[cfg(feature = "embed-pictrs")]
-  {
-    let pictrs_port = &SETTINGS
-      .pictrs_config()
-      .unwrap_or_default()
-      .url
-      .port()
-      .unwrap_or(8080);
-    let pictrs_address = ["127.0.0.1", &pictrs_port.to_string()].join(":");
-    pict_rs::ConfigSource::memory(serde_json::json!({
-        "server": {
-            "address": pictrs_address
-        },
-        "old_db": {
-            "path": "./pictrs/old"
-        },
-        "repo": {
-            "type": "sled",
-            "path": "./pictrs/sled-repo"
-        },
-        "store": {
-            "type": "filesystem",
-            "path": "./pictrs/files"
-        }
-    }))
-    .init::<&str>(None)
-    .expect("initialize pictrs config");
-    let (lemmy, pictrs) = tokio::join!(start_lemmy_server(), pict_rs::run());
-    lemmy?;
-    pictrs.expect("run pictrs");
-  }
-  Ok(())
+    init_logging(&SETTINGS.opentelemetry_url)?;
+    #[cfg(not(feature = "embed-pictrs"))]
+    start_lemmy_server().await?;
+    #[cfg(feature = "embed-pictrs")]
+    {
+        let pictrs_port = &SETTINGS
+            .pictrs_config()
+            .unwrap_or_default()
+            .url
+            .port()
+            .unwrap_or(8080);
+        let pictrs_address = ["127.0.0.1", &pictrs_port.to_string()].join(":");
+        pict_rs::ConfigSource::memory(serde_json::json!({
+            "server": {
+                "address": pictrs_address
+            },
+            "old_db": {
+                "path": "./pictrs/old"
+            },
+            "repo": {
+                "type": "sled",
+                "path": "./pictrs/sled-repo"
+            },
+            "store": {
+                "type": "filesystem",
+                "path": "./pictrs/files"
+            }
+        }))
+        .init::<&str>(None)
+        .expect("initialize pictrs config");
+        let (lemmy, pictrs) = tokio::join!(start_lemmy_server(), pict_rs::run());
+        lemmy?;
+        pictrs.expect("run pictrs");
+    }
+    Ok(())
 }

--- a/src/prometheus_metrics.rs
+++ b/src/prometheus_metrics.rs
@@ -5,118 +5,118 @@ use lemmy_api_common::context::LemmyContext;
 use lemmy_utils::settings::structs::PrometheusConfig;
 use prometheus::{default_registry, Encoder, Gauge, Opts, TextEncoder};
 use std::{
-  net::{IpAddr, Ipv4Addr},
-  sync::Arc,
-  thread,
+    net::{IpAddr, Ipv4Addr},
+    sync::Arc,
+    thread,
 };
 
 struct PromContext {
-  lemmy: LemmyContext,
-  db_pool_metrics: DbPoolMetrics,
+    lemmy: LemmyContext,
+    db_pool_metrics: DbPoolMetrics,
 }
 
 struct DbPoolMetrics {
-  max_size: Gauge,
-  size: Gauge,
-  available: Gauge,
+    max_size: Gauge,
+    size: Gauge,
+    available: Gauge,
 }
 
 static DEFAULT_BIND: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
 static DEFAULT_PORT: i32 = 10002;
 
 pub fn serve_prometheus(config: Option<&PrometheusConfig>, lemmy_context: LemmyContext) {
-  let context = Arc::new(PromContext {
-    lemmy: lemmy_context,
-    db_pool_metrics: create_db_pool_metrics(),
-  });
+    let context = Arc::new(PromContext {
+        lemmy: lemmy_context,
+        db_pool_metrics: create_db_pool_metrics(),
+    });
 
-  let (bind, port) = match config {
-    Some(config) => (
-      config.bind.unwrap_or(DEFAULT_BIND),
-      config.port.unwrap_or(DEFAULT_PORT),
-    ),
-    None => (DEFAULT_BIND, DEFAULT_PORT),
-  };
+    let (bind, port) = match config {
+        Some(config) => (
+            config.bind.unwrap_or(DEFAULT_BIND),
+            config.port.unwrap_or(DEFAULT_PORT),
+        ),
+        None => (DEFAULT_BIND, DEFAULT_PORT),
+    };
 
-  // spawn thread that blocks on handling requests
-  // only mapping /metrics to a handler
-  thread::spawn(move || {
-    let sys = System::new();
-    sys.block_on(async {
-      let server = HttpServer::new(move || {
-        App::new()
-          .app_data(web::Data::new(Arc::clone(&context)))
-          .route("/metrics", web::get().to(metrics))
-      })
-      .bind((bind, port as u16))
-      .unwrap_or_else(|_| panic!("Cannot bind to {}:{}", bind, port))
-      .run();
+    // spawn thread that blocks on handling requests
+    // only mapping /metrics to a handler
+    thread::spawn(move || {
+        let sys = System::new();
+        sys.block_on(async {
+            let server = HttpServer::new(move || {
+                App::new()
+                    .app_data(web::Data::new(Arc::clone(&context)))
+                    .route("/metrics", web::get().to(metrics))
+            })
+            .bind((bind, port as u16))
+            .unwrap_or_else(|_| panic!("Cannot bind to {}:{}", bind, port))
+            .run();
 
-      if let Err(err) = server.await {
-        eprintln!("Prometheus server error: {}", err);
-      }
-    })
-  });
+            if let Err(err) = server.await {
+                eprintln!("Prometheus server error: {}", err);
+            }
+        })
+    });
 }
 
 // handler for the /metrics path
 async fn metrics(context: web::Data<Arc<PromContext>>) -> impl Responder {
-  // collect metrics
-  collect_db_pool_metrics(&context).await;
+    // collect metrics
+    collect_db_pool_metrics(&context).await;
 
-  let mut buffer = Vec::new();
-  let encoder = TextEncoder::new();
+    let mut buffer = Vec::new();
+    let encoder = TextEncoder::new();
 
-  // gather metrics from registry and encode in prometheus format
-  let metric_families = prometheus::gather();
-  encoder.encode(&metric_families, &mut buffer).unwrap();
-  let output = String::from_utf8(buffer).unwrap();
+    // gather metrics from registry and encode in prometheus format
+    let metric_families = prometheus::gather();
+    encoder.encode(&metric_families, &mut buffer).unwrap();
+    let output = String::from_utf8(buffer).unwrap();
 
-  HttpResponse::Ok().body(output)
+    HttpResponse::Ok().body(output)
 }
 
 // create lemmy_db_pool_* metrics and register them with the default registry
 fn create_db_pool_metrics() -> DbPoolMetrics {
-  let metrics = DbPoolMetrics {
-    max_size: Gauge::with_opts(Opts::new(
-      "lemmy_db_pool_max_connections",
-      "Maximum number of connections in the pool",
-    ))
-    .unwrap(),
-    size: Gauge::with_opts(Opts::new(
-      "lemmy_db_pool_connections",
-      "Current number of connections in the pool",
-    ))
-    .unwrap(),
-    available: Gauge::with_opts(Opts::new(
-      "lemmy_db_pool_available_connections",
-      "Number of available connections in the pool",
-    ))
-    .unwrap(),
-  };
+    let metrics = DbPoolMetrics {
+        max_size: Gauge::with_opts(Opts::new(
+            "lemmy_db_pool_max_connections",
+            "Maximum number of connections in the pool",
+        ))
+        .unwrap(),
+        size: Gauge::with_opts(Opts::new(
+            "lemmy_db_pool_connections",
+            "Current number of connections in the pool",
+        ))
+        .unwrap(),
+        available: Gauge::with_opts(Opts::new(
+            "lemmy_db_pool_available_connections",
+            "Number of available connections in the pool",
+        ))
+        .unwrap(),
+    };
 
-  default_registry()
-    .register(Box::new(metrics.max_size.clone()))
-    .unwrap();
-  default_registry()
-    .register(Box::new(metrics.size.clone()))
-    .unwrap();
-  default_registry()
-    .register(Box::new(metrics.available.clone()))
-    .unwrap();
+    default_registry()
+        .register(Box::new(metrics.max_size.clone()))
+        .unwrap();
+    default_registry()
+        .register(Box::new(metrics.size.clone()))
+        .unwrap();
+    default_registry()
+        .register(Box::new(metrics.available.clone()))
+        .unwrap();
 
-  metrics
+    metrics
 }
 
 async fn collect_db_pool_metrics(context: &PromContext) {
-  let pool_status = context.lemmy.inner_pool().status();
-  context
-    .db_pool_metrics
-    .max_size
-    .set(pool_status.max_size as f64);
-  context.db_pool_metrics.size.set(pool_status.size as f64);
-  context
-    .db_pool_metrics
-    .available
-    .set(pool_status.available as f64);
+    let pool_status = context.lemmy.inner_pool().status();
+    context
+        .db_pool_metrics
+        .max_size
+        .set(pool_status.max_size as f64);
+    context.db_pool_metrics.size.set(pool_status.size as f64);
+    context
+        .db_pool_metrics
+        .available
+        .set(pool_status.available as f64);
 }

--- a/src/root_span_builder.rs
+++ b/src/root_span_builder.rs
@@ -69,8 +69,8 @@ fn handle_error(span: Span, status_code: StatusCode, response_error: &dyn Respon
     let debug_error = format!("{response_error:?}");
 
     tracing::info_span!(
-      parent: None,
-      "Error encountered while processing the incoming HTTP request"
+        parent: None,
+        "Error encountered while processing the incoming HTTP request"
     )
     .in_scope(|| {
         if status_code.is_client_error() {

--- a/src/root_span_builder.rs
+++ b/src/root_span_builder.rs
@@ -10,76 +10,76 @@ use tracing_actix_web::RootSpanBuilder;
 pub struct QuieterRootSpanBuilder;
 
 impl RootSpanBuilder for QuieterRootSpanBuilder {
-  fn on_request_start(request: &actix_web::dev::ServiceRequest) -> Span {
-    let request_id = tracing_actix_web::root_span_macro::private::get_request_id(request);
+    fn on_request_start(request: &actix_web::dev::ServiceRequest) -> Span {
+        let request_id = tracing_actix_web::root_span_macro::private::get_request_id(request);
 
-    tracing::info_span!(
-        "HTTP request",
-        http.method = %request.method(),
-        http.scheme = request.connection_info().scheme(),
-        http.host = %request.connection_info().host(),
-        http.target = %request.uri().path(),
-        http.status_code = tracing::field::Empty,
-        otel.kind = "server",
-        otel.status_code = tracing::field::Empty,
-        trace_id = tracing::field::Empty,
-        request_id = %request_id,
-        exception.message = tracing::field::Empty,
-        // Not proper OpenTelemetry, but their terminology is fairly exception-centric
-        exception.details = tracing::field::Empty,
-    )
-  }
+        tracing::info_span!(
+            "HTTP request",
+            http.method = %request.method(),
+            http.scheme = request.connection_info().scheme(),
+            http.host = %request.connection_info().host(),
+            http.target = %request.uri().path(),
+            http.status_code = tracing::field::Empty,
+            otel.kind = "server",
+            otel.status_code = tracing::field::Empty,
+            trace_id = tracing::field::Empty,
+            request_id = %request_id,
+            exception.message = tracing::field::Empty,
+            // Not proper OpenTelemetry, but their terminology is fairly exception-centric
+            exception.details = tracing::field::Empty,
+        )
+    }
 
-  fn on_request_end<B>(
-    span: tracing::Span,
-    outcome: &Result<actix_web::dev::ServiceResponse<B>, actix_web::Error>,
-  ) {
-    match &outcome {
-      Ok(response) => {
-        if let Some(error) = response.response().error() {
-          // use the status code already constructed for the outgoing HTTP response
-          handle_error(span, response.status(), error.as_response_error());
-        } else {
-          let code: i32 = response.response().status().as_u16().into();
-          span.record("http.status_code", code);
-          span.record("otel.status_code", "OK");
-        }
-      }
-      Err(error) => {
-        let response_error = error.as_response_error();
-        handle_error(span, response_error.status_code(), response_error);
-      }
-    };
-  }
+    fn on_request_end<B>(
+        span: tracing::Span,
+        outcome: &Result<actix_web::dev::ServiceResponse<B>, actix_web::Error>,
+    ) {
+        match &outcome {
+            Ok(response) => {
+                if let Some(error) = response.response().error() {
+                    // use the status code already constructed for the outgoing HTTP response
+                    handle_error(span, response.status(), error.as_response_error());
+                } else {
+                    let code: i32 = response.response().status().as_u16().into();
+                    span.record("http.status_code", code);
+                    span.record("otel.status_code", "OK");
+                }
+            }
+            Err(error) => {
+                let response_error = error.as_response_error();
+                handle_error(span, response_error.status_code(), response_error);
+            }
+        };
+    }
 }
 
 fn handle_error(span: Span, status_code: StatusCode, response_error: &dyn ResponseError) {
-  let code: i32 = status_code.as_u16().into();
+    let code: i32 = status_code.as_u16().into();
 
-  span.record("http.status_code", code);
+    span.record("http.status_code", code);
 
-  if status_code.is_client_error() {
-    span.record("otel.status_code", "OK");
-  } else {
-    span.record("otel.status_code", "ERROR");
-  }
-
-  // pre-formatting errors is a workaround for https://github.com/tokio-rs/tracing/issues/1565
-  let display_error = format!("{response_error}");
-  let debug_error = format!("{response_error:?}");
-
-  tracing::info_span!(
-    parent: None,
-    "Error encountered while processing the incoming HTTP request"
-  )
-  .in_scope(|| {
     if status_code.is_client_error() {
-      tracing::warn!("{}\n{}", display_error, debug_error);
+        span.record("otel.status_code", "OK");
     } else {
-      tracing::error!("{}\n{}", display_error, debug_error);
+        span.record("otel.status_code", "ERROR");
     }
-  });
 
-  span.record("exception.message", &tracing::field::display(display_error));
-  span.record("exception.details", &tracing::field::display(debug_error));
+    // pre-formatting errors is a workaround for https://github.com/tokio-rs/tracing/issues/1565
+    let display_error = format!("{response_error}");
+    let debug_error = format!("{response_error:?}");
+
+    tracing::info_span!(
+      parent: None,
+      "Error encountered while processing the incoming HTTP request"
+    )
+    .in_scope(|| {
+        if status_code.is_client_error() {
+            tracing::warn!("{}\n{}", display_error, debug_error);
+        } else {
+            tracing::error!("{}\n{}", display_error, debug_error);
+        }
+    });
+
+    span.record("exception.message", &tracing::field::display(display_error));
+    span.record("exception.details", &tracing::field::display(debug_error));
 }

--- a/src/scheduled_tasks.rs
+++ b/src/scheduled_tasks.rs
@@ -1,35 +1,25 @@
 use chrono::{DateTime, TimeZone, Utc};
 use clokwerk::{Scheduler, TimeUnits as CTimeUnits};
 use diesel::{
-  dsl::IntervalDsl,
-  sql_types::{Integer, Timestamptz},
-  Connection,
-  ExpressionMethods,
-  NullableExpressionMethods,
-  QueryDsl,
-  QueryableByName,
+    dsl::IntervalDsl,
+    sql_types::{Integer, Timestamptz},
+    Connection, ExpressionMethods, NullableExpressionMethods, QueryDsl, QueryableByName,
 };
 // Import week days and WeekDay
 use diesel::{sql_query, PgConnection, RunQueryDsl};
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::{
-  schema::{
-    captcha_answer,
-    comment,
-    community_person_ban,
-    instance,
-    person,
-    post,
-    received_activity,
-    sent_activity,
-  },
-  source::instance::{Instance, InstanceForm},
-  utils::{naive_now, now, DELETED_REPLACEMENT_TEXT},
+    schema::{
+        captcha_answer, comment, community_person_ban, instance, person, post, received_activity,
+        sent_activity,
+    },
+    source::instance::{Instance, InstanceForm},
+    utils::{naive_now, now, DELETED_REPLACEMENT_TEXT},
 };
 use lemmy_routes::nodeinfo::NodeInfo;
 use lemmy_utils::{
-  error::{LemmyError, LemmyResult},
-  REQWEST_TIMEOUT,
+    error::{LemmyError, LemmyResult},
+    REQWEST_TIMEOUT,
 };
 use reqwest::blocking::Client;
 use std::{thread, time::Duration};
@@ -37,152 +27,152 @@ use tracing::{error, info, warn};
 
 /// Schedules various cleanup tasks for lemmy in a background thread
 pub fn setup(
-  db_url: String,
-  user_agent: String,
-  context_1: LemmyContext,
+    db_url: String,
+    user_agent: String,
+    context_1: LemmyContext,
 ) -> Result<(), LemmyError> {
-  // Setup the connections
-  let mut scheduler = Scheduler::new();
+    // Setup the connections
+    let mut scheduler = Scheduler::new();
 
-  startup_jobs(&db_url);
+    startup_jobs(&db_url);
 
-  // Update active counts every hour
-  let url = db_url.clone();
-  scheduler.every(CTimeUnits::hour(1)).run(move || {
-    PgConnection::establish(&url)
-      .map(|mut conn| {
-        active_counts(&mut conn);
-        update_banned_when_expired(&mut conn);
-      })
-      .map_err(|e| {
-        error!("Failed to establish db connection for active counts update: {e}");
-      })
-      .ok();
-  });
+    // Update active counts every hour
+    let url = db_url.clone();
+    scheduler.every(CTimeUnits::hour(1)).run(move || {
+        PgConnection::establish(&url)
+            .map(|mut conn| {
+                active_counts(&mut conn);
+                update_banned_when_expired(&mut conn);
+            })
+            .map_err(|e| {
+                error!("Failed to establish db connection for active counts update: {e}");
+            })
+            .ok();
+    });
 
-  // Update hot ranks every 15 minutes
-  let url = db_url.clone();
-  scheduler.every(CTimeUnits::minutes(15)).run(move || {
-    PgConnection::establish(&url)
-      .map(|mut conn| {
-        update_hot_ranks(&mut conn);
-      })
-      .map_err(|e| {
-        error!("Failed to establish db connection for hot ranks update: {e}");
-      })
-      .ok();
-  });
+    // Update hot ranks every 15 minutes
+    let url = db_url.clone();
+    scheduler.every(CTimeUnits::minutes(15)).run(move || {
+        PgConnection::establish(&url)
+            .map(|mut conn| {
+                update_hot_ranks(&mut conn);
+            })
+            .map_err(|e| {
+                error!("Failed to establish db connection for hot ranks update: {e}");
+            })
+            .ok();
+    });
 
-  // Delete any captcha answers older than ten minutes, every ten minutes
-  let url = db_url.clone();
-  scheduler.every(CTimeUnits::minutes(10)).run(move || {
-    PgConnection::establish(&url)
-      .map(|mut conn| {
-        delete_expired_captcha_answers(&mut conn);
-      })
-      .map_err(|e| {
-        error!("Failed to establish db connection for captcha cleanup: {e}");
-      })
-      .ok();
-  });
+    // Delete any captcha answers older than ten minutes, every ten minutes
+    let url = db_url.clone();
+    scheduler.every(CTimeUnits::minutes(10)).run(move || {
+        PgConnection::establish(&url)
+            .map(|mut conn| {
+                delete_expired_captcha_answers(&mut conn);
+            })
+            .map_err(|e| {
+                error!("Failed to establish db connection for captcha cleanup: {e}");
+            })
+            .ok();
+    });
 
-  // Clear old activities every week
-  let url = db_url.clone();
-  scheduler.every(CTimeUnits::weeks(1)).run(move || {
-    PgConnection::establish(&url)
-      .map(|mut conn| {
-        clear_old_activities(&mut conn);
-      })
-      .map_err(|e| {
-        error!("Failed to establish db connection for activity cleanup: {e}");
-      })
-      .ok();
-  });
+    // Clear old activities every week
+    let url = db_url.clone();
+    scheduler.every(CTimeUnits::weeks(1)).run(move || {
+        PgConnection::establish(&url)
+            .map(|mut conn| {
+                clear_old_activities(&mut conn);
+            })
+            .map_err(|e| {
+                error!("Failed to establish db connection for activity cleanup: {e}");
+            })
+            .ok();
+    });
 
-  // Remove old rate limit buckets after 1 to 2 hours of inactivity
-  scheduler.every(CTimeUnits::hour(1)).run(move || {
-    let hour = Duration::from_secs(3600);
-    context_1.settings_updated_channel().remove_older_than(hour);
-  });
+    // Remove old rate limit buckets after 1 to 2 hours of inactivity
+    scheduler.every(CTimeUnits::hour(1)).run(move || {
+        let hour = Duration::from_secs(3600);
+        context_1.settings_updated_channel().remove_older_than(hour);
+    });
 
-  // Overwrite deleted & removed posts and comments every day
-  let url = db_url.clone();
-  scheduler.every(CTimeUnits::days(1)).run(move || {
-    PgConnection::establish(&db_url)
-      .map(|mut conn| {
-        overwrite_deleted_posts_and_comments(&mut conn);
-      })
-      .map_err(|e| {
-        error!("Failed to establish db connection for deleted content cleanup: {e}");
-      })
-      .ok();
-  });
+    // Overwrite deleted & removed posts and comments every day
+    let url = db_url.clone();
+    scheduler.every(CTimeUnits::days(1)).run(move || {
+        PgConnection::establish(&db_url)
+            .map(|mut conn| {
+                overwrite_deleted_posts_and_comments(&mut conn);
+            })
+            .map_err(|e| {
+                error!("Failed to establish db connection for deleted content cleanup: {e}");
+            })
+            .ok();
+    });
 
-  // Update the Instance Software
-  scheduler.every(CTimeUnits::days(1)).run(move || {
-    PgConnection::establish(&url)
-      .map(|mut conn| {
-        update_instance_software(&mut conn, &user_agent)
-          .map_err(|e| warn!("Failed to update instance software: {e}"))
-          .ok();
-      })
-      .map_err(|e| {
-        error!("Failed to establish db connection for instance software update: {e}");
-      })
-      .ok();
-  });
+    // Update the Instance Software
+    scheduler.every(CTimeUnits::days(1)).run(move || {
+        PgConnection::establish(&url)
+            .map(|mut conn| {
+                update_instance_software(&mut conn, &user_agent)
+                    .map_err(|e| warn!("Failed to update instance software: {e}"))
+                    .ok();
+            })
+            .map_err(|e| {
+                error!("Failed to establish db connection for instance software update: {e}");
+            })
+            .ok();
+    });
 
-  // Manually run the scheduler in an event loop
-  loop {
-    scheduler.run_pending();
-    thread::sleep(Duration::from_millis(1000));
-  }
+    // Manually run the scheduler in an event loop
+    loop {
+        scheduler.run_pending();
+        thread::sleep(Duration::from_millis(1000));
+    }
 }
 
 /// Run these on server startup
 fn startup_jobs(db_url: &str) {
-  let mut conn = PgConnection::establish(db_url).expect("could not establish connection");
-  active_counts(&mut conn);
-  update_hot_ranks(&mut conn);
-  update_banned_when_expired(&mut conn);
-  clear_old_activities(&mut conn);
-  overwrite_deleted_posts_and_comments(&mut conn);
+    let mut conn = PgConnection::establish(db_url).expect("could not establish connection");
+    active_counts(&mut conn);
+    update_hot_ranks(&mut conn);
+    update_banned_when_expired(&mut conn);
+    clear_old_activities(&mut conn);
+    overwrite_deleted_posts_and_comments(&mut conn);
 }
 
 /// Update the hot_rank columns for the aggregates tables
 /// Runs in batches until all necessary rows are updated once
 fn update_hot_ranks(conn: &mut PgConnection) {
-  info!("Updating hot ranks for all history...");
+    info!("Updating hot ranks for all history...");
 
-  process_hot_ranks_in_batches(
-    conn,
-    "post_aggregates",
-    "a.hot_rank != 0 OR a.hot_rank_active != 0",
-    "SET hot_rank = hot_rank(a.score, a.published),
+    process_hot_ranks_in_batches(
+        conn,
+        "post_aggregates",
+        "a.hot_rank != 0 OR a.hot_rank_active != 0",
+        "SET hot_rank = hot_rank(a.score, a.published),
          hot_rank_active = hot_rank(a.score, a.newest_comment_time_necro)",
-  );
+    );
 
-  process_hot_ranks_in_batches(
-    conn,
-    "comment_aggregates",
-    "a.hot_rank != 0",
-    "SET hot_rank = hot_rank(a.score, a.published)",
-  );
+    process_hot_ranks_in_batches(
+        conn,
+        "comment_aggregates",
+        "a.hot_rank != 0",
+        "SET hot_rank = hot_rank(a.score, a.published)",
+    );
 
-  process_hot_ranks_in_batches(
-    conn,
-    "community_aggregates",
-    "a.hot_rank != 0",
-    "SET hot_rank = hot_rank(a.subscribers, a.published)",
-  );
+    process_hot_ranks_in_batches(
+        conn,
+        "community_aggregates",
+        "a.hot_rank != 0",
+        "SET hot_rank = hot_rank(a.subscribers, a.published)",
+    );
 
-  info!("Finished hot ranks update!");
+    info!("Finished hot ranks update!");
 }
 
 #[derive(QueryableByName)]
 struct HotRanksUpdateResult {
-  #[diesel(sql_type = Timestamptz)]
-  published: DateTime<Utc>,
+    #[diesel(sql_type = Timestamptz)]
+    published: DateTime<Utc>,
 }
 
 /// Runs the hot rank update query in batches until all rows have been processed.
@@ -190,24 +180,24 @@ struct HotRanksUpdateResult {
 /// Locked rows are skipped in order to prevent deadlocks (they will likely get updated on the next
 /// run)
 fn process_hot_ranks_in_batches(
-  conn: &mut PgConnection,
-  table_name: &str,
-  where_clause: &str,
-  set_clause: &str,
+    conn: &mut PgConnection,
+    table_name: &str,
+    where_clause: &str,
+    set_clause: &str,
 ) {
-  let process_start_time: DateTime<Utc> = Utc
-    .timestamp_opt(0, 0)
-    .single()
-    .expect("0 timestamp creation");
+    let process_start_time: DateTime<Utc> = Utc
+        .timestamp_opt(0, 0)
+        .single()
+        .expect("0 timestamp creation");
 
-  let update_batch_size = 1000; // Bigger batches than this tend to cause seq scans
-  let mut processed_rows_count = 0;
-  let mut previous_batch_result = Some(process_start_time);
-  while let Some(previous_batch_last_published) = previous_batch_result {
-    // Raw `sql_query` is used as a performance optimization - Diesel does not support doing this
-    // in a single query (neither as a CTE, nor using a subquery)
-    let result = sql_query(format!(
-      r#"WITH batch AS (SELECT a.id
+    let update_batch_size = 1000; // Bigger batches than this tend to cause seq scans
+    let mut processed_rows_count = 0;
+    let mut previous_batch_result = Some(process_start_time);
+    while let Some(previous_batch_last_published) = previous_batch_result {
+        // Raw `sql_query` is used as a performance optimization - Diesel does not support doing this
+        // in a single query (neither as a CTE, nor using a subquery)
+        let result = sql_query(format!(
+            r#"WITH batch AS (SELECT a.id
                FROM {aggregates_table} a
                WHERE a.published > $1 AND ({where_clause})
                ORDER BY a.published
@@ -216,147 +206,148 @@ fn process_hot_ranks_in_batches(
          UPDATE {aggregates_table} a {set_clause}
              FROM batch WHERE a.id = batch.id RETURNING a.published;
     "#,
-      aggregates_table = table_name,
-      set_clause = set_clause,
-      where_clause = where_clause
-    ))
-    .bind::<Timestamptz, _>(previous_batch_last_published)
-    .bind::<Integer, _>(update_batch_size)
-    .get_results::<HotRanksUpdateResult>(conn);
+            aggregates_table = table_name,
+            set_clause = set_clause,
+            where_clause = where_clause
+        ))
+        .bind::<Timestamptz, _>(previous_batch_last_published)
+        .bind::<Integer, _>(update_batch_size)
+        .get_results::<HotRanksUpdateResult>(conn);
 
-    match result {
-      Ok(updated_rows) => {
-        processed_rows_count += updated_rows.len();
-        previous_batch_result = updated_rows.last().map(|row| row.published);
-      }
-      Err(e) => {
-        error!("Failed to update {} hot_ranks: {}", table_name, e);
-        break;
-      }
+        match result {
+            Ok(updated_rows) => {
+                processed_rows_count += updated_rows.len();
+                previous_batch_result = updated_rows.last().map(|row| row.published);
+            }
+            Err(e) => {
+                error!("Failed to update {} hot_ranks: {}", table_name, e);
+                break;
+            }
+        }
     }
-  }
-  info!(
-    "Finished process_hot_ranks_in_batches execution for {} (processed {} rows)",
-    table_name, processed_rows_count
-  );
+    info!(
+        "Finished process_hot_ranks_in_batches execution for {} (processed {} rows)",
+        table_name, processed_rows_count
+    );
 }
 
 fn delete_expired_captcha_answers(conn: &mut PgConnection) {
-  diesel::delete(
-    captcha_answer::table.filter(captcha_answer::published.lt(now() - IntervalDsl::minutes(10))),
-  )
-  .execute(conn)
-  .map(|_| {
-    info!("Done.");
-  })
-  .map_err(|e| error!("Failed to clear old captcha answers: {e}"))
-  .ok();
+    diesel::delete(
+        captcha_answer::table
+            .filter(captcha_answer::published.lt(now() - IntervalDsl::minutes(10))),
+    )
+    .execute(conn)
+    .map(|_| {
+        info!("Done.");
+    })
+    .map_err(|e| error!("Failed to clear old captcha answers: {e}"))
+    .ok();
 }
 
 /// Clear old activities (this table gets very large)
 fn clear_old_activities(conn: &mut PgConnection) {
-  info!("Clearing old activities...");
-  diesel::delete(sent_activity::table.filter(sent_activity::published.lt(now() - 3.months())))
-    .execute(conn)
-    .map_err(|e| error!("Failed to clear old sent activities: {e}"))
-    .ok();
+    info!("Clearing old activities...");
+    diesel::delete(sent_activity::table.filter(sent_activity::published.lt(now() - 3.months())))
+        .execute(conn)
+        .map_err(|e| error!("Failed to clear old sent activities: {e}"))
+        .ok();
 
-  diesel::delete(
-    received_activity::table.filter(received_activity::published.lt(now() - 3.months())),
-  )
-  .execute(conn)
-  .map(|_| info!("Done."))
-  .map_err(|e| error!("Failed to clear old received activities: {e}"))
-  .ok();
+    diesel::delete(
+        received_activity::table.filter(received_activity::published.lt(now() - 3.months())),
+    )
+    .execute(conn)
+    .map(|_| info!("Done."))
+    .map_err(|e| error!("Failed to clear old received activities: {e}"))
+    .ok();
 }
 
 /// overwrite posts and comments 30d after deletion
 fn overwrite_deleted_posts_and_comments(conn: &mut PgConnection) {
-  info!("Overwriting deleted posts...");
-  diesel::update(
-    post::table
-      .filter(post::deleted.eq(true))
-      .filter(post::updated.lt(now().nullable() - 1.months()))
-      .filter(post::body.ne(DELETED_REPLACEMENT_TEXT)),
-  )
-  .set((
-    post::body.eq(DELETED_REPLACEMENT_TEXT),
-    post::name.eq(DELETED_REPLACEMENT_TEXT),
-  ))
-  .execute(conn)
-  .map(|_| {
-    info!("Done.");
-  })
-  .map_err(|e| error!("Failed to overwrite deleted posts: {e}"))
-  .ok();
+    info!("Overwriting deleted posts...");
+    diesel::update(
+        post::table
+            .filter(post::deleted.eq(true))
+            .filter(post::updated.lt(now().nullable() - 1.months()))
+            .filter(post::body.ne(DELETED_REPLACEMENT_TEXT)),
+    )
+    .set((
+        post::body.eq(DELETED_REPLACEMENT_TEXT),
+        post::name.eq(DELETED_REPLACEMENT_TEXT),
+    ))
+    .execute(conn)
+    .map(|_| {
+        info!("Done.");
+    })
+    .map_err(|e| error!("Failed to overwrite deleted posts: {e}"))
+    .ok();
 
-  info!("Overwriting deleted comments...");
-  diesel::update(
-    comment::table
-      .filter(comment::deleted.eq(true))
-      .filter(comment::updated.lt(now().nullable() - 1.months()))
-      .filter(comment::content.ne(DELETED_REPLACEMENT_TEXT)),
-  )
-  .set(comment::content.eq(DELETED_REPLACEMENT_TEXT))
-  .execute(conn)
-  .map(|_| {
-    info!("Done.");
-  })
-  .map_err(|e| error!("Failed to overwrite deleted comments: {e}"))
-  .ok();
+    info!("Overwriting deleted comments...");
+    diesel::update(
+        comment::table
+            .filter(comment::deleted.eq(true))
+            .filter(comment::updated.lt(now().nullable() - 1.months()))
+            .filter(comment::content.ne(DELETED_REPLACEMENT_TEXT)),
+    )
+    .set(comment::content.eq(DELETED_REPLACEMENT_TEXT))
+    .execute(conn)
+    .map(|_| {
+        info!("Done.");
+    })
+    .map_err(|e| error!("Failed to overwrite deleted comments: {e}"))
+    .ok();
 }
 
 /// Re-calculate the site and community active counts every 12 hours
 fn active_counts(conn: &mut PgConnection) {
-  info!("Updating active site and community aggregates ...");
+    info!("Updating active site and community aggregates ...");
 
-  let intervals = vec![
-    ("1 day", "day"),
-    ("1 week", "week"),
-    ("1 month", "month"),
-    ("6 months", "half_year"),
-  ];
+    let intervals = vec![
+        ("1 day", "day"),
+        ("1 week", "week"),
+        ("1 month", "month"),
+        ("6 months", "half_year"),
+    ];
 
-  for i in &intervals {
-    let update_site_stmt = format!(
+    for i in &intervals {
+        let update_site_stmt = format!(
       "update site_aggregates set users_active_{} = (select * from site_aggregates_activity('{}')) where site_id = 1",
       i.1, i.0
     );
-    sql_query(update_site_stmt)
-      .execute(conn)
-      .map_err(|e| error!("Failed to update site stats: {e}"))
-      .ok();
+        sql_query(update_site_stmt)
+            .execute(conn)
+            .map_err(|e| error!("Failed to update site stats: {e}"))
+            .ok();
 
-    let update_community_stmt = format!("update community_aggregates ca set users_active_{} = mv.count_ from community_aggregates_activity('{}') mv where ca.community_id = mv.community_id_", i.1, i.0);
-    sql_query(update_community_stmt)
-      .execute(conn)
-      .map_err(|e| error!("Failed to update community stats: {e}"))
-      .ok();
-  }
+        let update_community_stmt = format!("update community_aggregates ca set users_active_{} = mv.count_ from community_aggregates_activity('{}') mv where ca.community_id = mv.community_id_", i.1, i.0);
+        sql_query(update_community_stmt)
+            .execute(conn)
+            .map_err(|e| error!("Failed to update community stats: {e}"))
+            .ok();
+    }
 
-  info!("Done.");
+    info!("Done.");
 }
 
 /// Set banned to false after ban expires
 fn update_banned_when_expired(conn: &mut PgConnection) {
-  info!("Updating banned column if it expires ...");
+    info!("Updating banned column if it expires ...");
 
-  diesel::update(
-    person::table
-      .filter(person::banned.eq(true))
-      .filter(person::ban_expires.lt(now().nullable())),
-  )
-  .set(person::banned.eq(false))
-  .execute(conn)
-  .map_err(|e| error!("Failed to update person.banned when expires: {e}"))
-  .ok();
+    diesel::update(
+        person::table
+            .filter(person::banned.eq(true))
+            .filter(person::ban_expires.lt(now().nullable())),
+    )
+    .set(person::banned.eq(false))
+    .execute(conn)
+    .map_err(|e| error!("Failed to update person.banned when expires: {e}"))
+    .ok();
 
-  diesel::delete(
-    community_person_ban::table.filter(community_person_ban::expires.lt(now().nullable())),
-  )
-  .execute(conn)
-  .map_err(|e| error!("Failed to remove community_ban expired rows: {e}"))
-  .ok();
+    diesel::delete(
+        community_person_ban::table.filter(community_person_ban::expires.lt(now().nullable())),
+    )
+    .execute(conn)
+    .map_err(|e| error!("Failed to remove community_ban expired rows: {e}"))
+    .ok();
 }
 
 /// Updates the instance software and version
@@ -364,86 +355,86 @@ fn update_banned_when_expired(conn: &mut PgConnection) {
 /// TODO: this should be async
 /// TODO: if instance has been dead for a long time, it should be checked less frequently
 fn update_instance_software(conn: &mut PgConnection, user_agent: &str) -> LemmyResult<()> {
-  info!("Updating instances software and versions...");
+    info!("Updating instances software and versions...");
 
-  let client = Client::builder()
-    .user_agent(user_agent)
-    .timeout(REQWEST_TIMEOUT)
-    .connect_timeout(REQWEST_TIMEOUT)
-    .build()?;
+    let client = Client::builder()
+        .user_agent(user_agent)
+        .timeout(REQWEST_TIMEOUT)
+        .connect_timeout(REQWEST_TIMEOUT)
+        .build()?;
 
-  let instances = instance::table.get_results::<Instance>(conn)?;
+    let instances = instance::table.get_results::<Instance>(conn)?;
 
-  for instance in instances {
-    let node_info_url = format!("https://{}/nodeinfo/2.0.json", instance.domain);
+    for instance in instances {
+        let node_info_url = format!("https://{}/nodeinfo/2.0.json", instance.domain);
 
-    // The `updated` column is used to check if instances are alive. If it is more than three days
-    // in the past, no outgoing activities will be sent to that instance. However not every
-    // Fediverse instance has a valid Nodeinfo endpoint (its not required for Activitypub). That's
-    // why we always need to mark instances as updated if they are alive.
-    let default_form = InstanceForm::builder()
-      .domain(instance.domain.clone())
-      .updated(Some(naive_now()))
-      .build();
-    let form = match client.get(&node_info_url).send() {
-      Ok(res) if res.status().is_client_error() => {
-        // Instance doesnt have nodeinfo but sent a response, consider it alive
-        Some(default_form)
-      }
-      Ok(res) => match res.json::<NodeInfo>() {
-        Ok(node_info) => {
-          // Instance sent valid nodeinfo, write it to db
-          let software = node_info.software.as_ref();
-          Some(
-            InstanceForm::builder()
-              .domain(instance.domain)
-              .updated(Some(naive_now()))
-              .software(software.and_then(|s| s.name.clone()))
-              .version(software.and_then(|s| s.version.clone()))
-              .build(),
-          )
+        // The `updated` column is used to check if instances are alive. If it is more than three days
+        // in the past, no outgoing activities will be sent to that instance. However not every
+        // Fediverse instance has a valid Nodeinfo endpoint (its not required for Activitypub). That's
+        // why we always need to mark instances as updated if they are alive.
+        let default_form = InstanceForm::builder()
+            .domain(instance.domain.clone())
+            .updated(Some(naive_now()))
+            .build();
+        let form = match client.get(&node_info_url).send() {
+            Ok(res) if res.status().is_client_error() => {
+                // Instance doesnt have nodeinfo but sent a response, consider it alive
+                Some(default_form)
+            }
+            Ok(res) => match res.json::<NodeInfo>() {
+                Ok(node_info) => {
+                    // Instance sent valid nodeinfo, write it to db
+                    let software = node_info.software.as_ref();
+                    Some(
+                        InstanceForm::builder()
+                            .domain(instance.domain)
+                            .updated(Some(naive_now()))
+                            .software(software.and_then(|s| s.name.clone()))
+                            .version(software.and_then(|s| s.version.clone()))
+                            .build(),
+                    )
+                }
+                Err(_) => {
+                    // No valid nodeinfo but valid HTTP response, consider instance alive
+                    Some(default_form)
+                }
+            },
+            Err(_) => {
+                // dead instance, do nothing
+                None
+            }
+        };
+        if let Some(form) = form {
+            diesel::update(instance::table.find(instance.id))
+                .set(form)
+                .execute(conn)?;
         }
-        Err(_) => {
-          // No valid nodeinfo but valid HTTP response, consider instance alive
-          Some(default_form)
-        }
-      },
-      Err(_) => {
-        // dead instance, do nothing
-        None
-      }
-    };
-    if let Some(form) = form {
-      diesel::update(instance::table.find(instance.id))
-        .set(form)
-        .execute(conn)?;
     }
-  }
-  info!("Finished updating instances software and versions...");
-  Ok(())
+    info!("Finished updating instances software and versions...");
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-  #![allow(clippy::unwrap_used)]
-  #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
-  use lemmy_routes::nodeinfo::NodeInfo;
-  use reqwest::Client;
+    use lemmy_routes::nodeinfo::NodeInfo;
+    use reqwest::Client;
 
-  #[tokio::test]
-  #[ignore]
-  async fn test_nodeinfo() {
-    let client = Client::builder().build().unwrap();
-    let lemmy_ml_nodeinfo = client
-      .get("https://lemmy.ml/nodeinfo/2.0.json")
-      .send()
-      .await
-      .unwrap()
-      .json::<NodeInfo>()
-      .await
-      .unwrap();
+    #[tokio::test]
+    #[ignore]
+    async fn test_nodeinfo() {
+        let client = Client::builder().build().unwrap();
+        let lemmy_ml_nodeinfo = client
+            .get("https://lemmy.ml/nodeinfo/2.0.json")
+            .send()
+            .await
+            .unwrap()
+            .json::<NodeInfo>()
+            .await
+            .unwrap();
 
-    assert_eq!(lemmy_ml_nodeinfo.software.unwrap().name.unwrap(), "lemmy");
-  }
+        assert_eq!(lemmy_ml_nodeinfo.software.unwrap().name.unwrap(), "lemmy");
+    }
 }

--- a/src/session_middleware.rs
+++ b/src/session_middleware.rs
@@ -1,10 +1,9 @@
 use actix_web::{
-  body::MessageBody,
-  cookie::SameSite,
-  dev::{forward_ready, Service, ServiceRequest, ServiceResponse, Transform},
-  http::header::CACHE_CONTROL,
-  Error,
-  HttpMessage,
+    body::MessageBody,
+    cookie::SameSite,
+    dev::{forward_ready, Service, ServiceRequest, ServiceResponse, Transform},
+    http::header::CACHE_CONTROL,
+    Error, HttpMessage,
 };
 use core::future::Ready;
 use futures_util::future::LocalBoxFuture;
@@ -17,104 +16,103 @@ static AUTH_COOKIE_NAME: &str = "auth";
 
 #[derive(Clone)]
 pub struct SessionMiddleware {
-  context: LemmyContext,
+    context: LemmyContext,
 }
 
 impl SessionMiddleware {
-  pub fn new(context: LemmyContext) -> Self {
-    SessionMiddleware { context }
-  }
+    pub fn new(context: LemmyContext) -> Self {
+        SessionMiddleware { context }
+    }
 }
 impl<S, B> Transform<S, ServiceRequest> for SessionMiddleware
 where
-  S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
-  S::Future: 'static,
-  B: MessageBody + 'static,
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    S::Future: 'static,
+    B: MessageBody + 'static,
 {
-  type Response = ServiceResponse<B>;
-  type Error = Error;
-  type Transform = SessionService<S>;
-  type InitError = ();
-  type Future = Ready<Result<Self::Transform, Self::InitError>>;
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type Transform = SessionService<S>;
+    type InitError = ();
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
 
-  fn new_transform(&self, service: S) -> Self::Future {
-    ready(Ok(SessionService {
-      service: Rc::new(service),
-      context: self.context.clone(),
-    }))
-  }
+    fn new_transform(&self, service: S) -> Self::Future {
+        ready(Ok(SessionService {
+            service: Rc::new(service),
+            context: self.context.clone(),
+        }))
+    }
 }
 
 pub struct SessionService<S> {
-  service: Rc<S>,
-  context: LemmyContext,
+    service: Rc<S>,
+    context: LemmyContext,
 }
 
 impl<S, B> Service<ServiceRequest> for SessionService<S>
 where
-  S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
-  S::Future: 'static,
-  B: 'static,
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    S::Future: 'static,
+    B: 'static,
 {
-  type Response = ServiceResponse<B>;
-  type Error = Error;
-  type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
 
-  forward_ready!(service);
+    forward_ready!(service);
 
-  fn call(&self, req: ServiceRequest) -> Self::Future {
-    let svc = self.service.clone();
-    let context = self.context.clone();
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        let svc = self.service.clone();
+        let context = self.context.clone();
 
-    Box::pin(async move {
-      // Try reading jwt from auth header
-      let auth_header = req
-        .headers()
-        .get(AUTH_COOKIE_NAME)
-        .and_then(|h| h.to_str().ok());
-      let jwt = if let Some(a) = auth_header {
-        Some(a.to_string())
-      }
-      // If that fails, try auth cookie. Dont use the `jwt` cookie from lemmy-ui because
-      // its not http-only.
-      else {
-        let auth_cookie = req.cookie(AUTH_COOKIE_NAME);
-        if let Some(a) = &auth_cookie {
-          // ensure that its marked as httponly and secure
-          let secure = a.secure().unwrap_or_default();
-          let http_only = a.http_only().unwrap_or_default();
-          let same_site = a.same_site();
-          if !secure || !http_only || same_site != Some(SameSite::Strict) {
-            return Err(LemmyError::from(LemmyErrorType::AuthCookieInsecure).into());
-          }
-        }
-        auth_cookie.map(|c| c.value().to_string())
-      };
+        Box::pin(async move {
+            // Try reading jwt from auth header
+            let auth_header = req
+                .headers()
+                .get(AUTH_COOKIE_NAME)
+                .and_then(|h| h.to_str().ok());
+            let jwt = if let Some(a) = auth_header {
+                Some(a.to_string())
+            }
+            // If that fails, try auth cookie. Dont use the `jwt` cookie from lemmy-ui because
+            // its not http-only.
+            else {
+                let auth_cookie = req.cookie(AUTH_COOKIE_NAME);
+                if let Some(a) = &auth_cookie {
+                    // ensure that its marked as httponly and secure
+                    let secure = a.secure().unwrap_or_default();
+                    let http_only = a.http_only().unwrap_or_default();
+                    let same_site = a.same_site();
+                    if !secure || !http_only || same_site != Some(SameSite::Strict) {
+                        return Err(LemmyError::from(LemmyErrorType::AuthCookieInsecure).into());
+                    }
+                }
+                auth_cookie.map(|c| c.value().to_string())
+            };
 
-      if let Some(jwt) = &jwt {
-        // Ignore any invalid auth so the site can still be used
-        // TODO: this means it will be impossible to get any error message for invalid jwt. Need
-        //       to add a separate endpoint for that.
-        //       https://github.com/LemmyNet/lemmy/issues/3702
-        let local_user_view = local_user_view_from_jwt(jwt, &context).await.ok();
-        if let Some(local_user_view) = local_user_view {
-          req.extensions_mut().insert(local_user_view);
-        }
-      }
+            if let Some(jwt) = &jwt {
+                // Ignore any invalid auth so the site can still be used
+                // TODO: this means it will be impossible to get any error message for invalid jwt. Need
+                //       to add a separate endpoint for that.
+                //       https://github.com/LemmyNet/lemmy/issues/3702
+                let local_user_view = local_user_view_from_jwt(jwt, &context).await.ok();
+                if let Some(local_user_view) = local_user_view {
+                    req.extensions_mut().insert(local_user_view);
+                }
+            }
 
-      let mut res = svc.call(req).await?;
+            let mut res = svc.call(req).await?;
 
-      // Add cache-control header. If user is authenticated, mark as private. Otherwise cache
-      // up to one minute.
-      let cache_value = if jwt.is_some() {
-        "private"
-      } else {
-        "public, max-age=60"
-      };
-      res
-        .headers_mut()
-        .insert(CACHE_CONTROL, HeaderValue::from_static(cache_value));
-      Ok(res)
-    })
-  }
+            // Add cache-control header. If user is authenticated, mark as private. Otherwise cache
+            // up to one minute.
+            let cache_value = if jwt.is_some() {
+                "private"
+            } else {
+                "public, max-age=60"
+            };
+            res.headers_mut()
+                .insert(CACHE_CONTROL, HeaderValue::from_static(cache_value));
+            Ok(res)
+        })
+    }
 }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,51 +1,51 @@
 use console_subscriber::ConsoleLayer;
 use lemmy_utils::error::LemmyError;
 use opentelemetry::{
-  sdk::{propagation::TraceContextPropagator, Resource},
-  KeyValue,
+    sdk::{propagation::TraceContextPropagator, Resource},
+    KeyValue,
 };
 use opentelemetry_otlp::WithExportConfig;
 use tracing::{subscriber::set_global_default, Subscriber};
 use tracing_subscriber::{filter::Targets, layer::SubscriberExt, registry::LookupSpan, Layer};
 
 pub fn init_tracing<S>(
-  opentelemetry_url: &str,
-  subscriber: S,
-  targets: Targets,
+    opentelemetry_url: &str,
+    subscriber: S,
+    targets: Targets,
 ) -> Result<(), LemmyError>
 where
-  S: Subscriber + for<'a> LookupSpan<'a> + Send + Sync + 'static,
+    S: Subscriber + for<'a> LookupSpan<'a> + Send + Sync + 'static,
 {
-  opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+    opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
 
-  let console_layer = ConsoleLayer::builder()
-    .with_default_env()
-    .server_addr(([0, 0, 0, 0], 6669))
-    .event_buffer_capacity(1024 * 1024)
-    .spawn();
+    let console_layer = ConsoleLayer::builder()
+        .with_default_env()
+        .server_addr(([0, 0, 0, 0], 6669))
+        .event_buffer_capacity(1024 * 1024)
+        .spawn();
 
-  let subscriber = subscriber.with(console_layer);
+    let subscriber = subscriber.with(console_layer);
 
-  let tracer = opentelemetry_otlp::new_pipeline()
-    .tracing()
-    .with_trace_config(
-      opentelemetry::sdk::trace::config()
-        .with_resource(Resource::new(vec![KeyValue::new("service.name", "lemmy")])),
-    )
-    .with_exporter(
-      opentelemetry_otlp::new_exporter()
-        .tonic()
-        .with_endpoint(opentelemetry_url),
-    )
-    .install_batch(opentelemetry::runtime::Tokio)?;
+    let tracer = opentelemetry_otlp::new_pipeline()
+        .tracing()
+        .with_trace_config(
+            opentelemetry::sdk::trace::config()
+                .with_resource(Resource::new(vec![KeyValue::new("service.name", "lemmy")])),
+        )
+        .with_exporter(
+            opentelemetry_otlp::new_exporter()
+                .tonic()
+                .with_endpoint(opentelemetry_url),
+        )
+        .install_batch(opentelemetry::runtime::Tokio)?;
 
-  let otel_layer = tracing_opentelemetry::layer()
-    .with_tracer(tracer)
-    .with_filter(targets);
+    let otel_layer = tracing_opentelemetry::layer()
+        .with_tracer(tracer)
+        .with_filter(targets);
 
-  let subscriber = subscriber.with(otel_layer);
+    let subscriber = subscriber.with(otel_layer);
 
-  set_global_default(subscriber)?;
+    set_global_default(subscriber)?;
 
-  Ok(())
+    Ok(())
 }


### PR DESCRIPTION
Excuses for the _massive_ PR, but it's actually just a deletion of `.rustfmt.toml` followed by a `cargo fmt` command (and a slight change to the `cargo_fmt` CI job).

I feel it is best for an open source project such as Lemmy to use the standard Rust format, as Rust contributors would be most familiar with the standard format. Personal preferences should come second.