### PR TITLE
Add ts(skip) attributes to fix js client code generation

### DIFF
--- a/crates/db_schema/src/source/community.rs
+++ b/crates/db_schema/src/source/community.rs
@@ -46,10 +46,10 @@ pub struct Community {
   pub icon: Option<DbUrl>,
   /// A URL for a banner.
   pub banner: Option<DbUrl>,
-  #[ts(skip)]
+  #[cfg_attr(feature = "full", ts(skip))]
   #[serde(skip, default = "placeholder_apub_url")]
   pub followers_url: DbUrl,
-  #[ts(skip)]
+  #[cfg_attr(feature = "full", ts(skip))]
   #[serde(skip, default = "placeholder_apub_url")]
   pub inbox_url: DbUrl,
   #[serde(skip)]

--- a/crates/db_schema/src/source/community.rs
+++ b/crates/db_schema/src/source/community.rs
@@ -46,8 +46,10 @@ pub struct Community {
   pub icon: Option<DbUrl>,
   /// A URL for a banner.
   pub banner: Option<DbUrl>,
+  #[ts(skip)]
   #[serde(skip, default = "placeholder_apub_url")]
   pub followers_url: DbUrl,
+  #[ts(skip)]
   #[serde(skip, default = "placeholder_apub_url")]
   pub inbox_url: DbUrl,
   #[serde(skip)]

--- a/crates/db_schema/src/source/person.rs
+++ b/crates/db_schema/src/source/person.rs
@@ -44,6 +44,7 @@ pub struct Person {
   pub banner: Option<DbUrl>,
   /// Whether the person is deleted.
   pub deleted: bool,
+  #[ts(skip)]
   #[serde(skip, default = "placeholder_apub_url")]
   pub inbox_url: DbUrl,
   #[serde(skip)]

--- a/crates/db_schema/src/source/person.rs
+++ b/crates/db_schema/src/source/person.rs
@@ -44,7 +44,7 @@ pub struct Person {
   pub banner: Option<DbUrl>,
   /// Whether the person is deleted.
   pub deleted: bool,
-  #[ts(skip)]
+  #[cfg_attr(feature = "full", ts(skip))]
   #[serde(skip, default = "placeholder_apub_url")]
   pub inbox_url: DbUrl,
   #[serde(skip)]


### PR DESCRIPTION
This is a problem in ts-rs. It only supports `#[serde(skip)]` but not `#[serde(skip, default = "placeholder_apub_url")]`. [Upstream issue here](https://github.com/Aleph-Alpha/ts-rs/issues/107). So we need to mark these as `#[ts(skip)]` explicitly.

Originally reported in https://github.com/LemmyNet/lemmy-js-client/issues/179