### PR TITLE
Fixing GetPostsResponse serialization.

### DIFF
--- a/crates/api_common/src/post.rs
+++ b/crates/api_common/src/post.rs
@@ -82,6 +82,7 @@ pub struct GetPosts {
   pub page_cursor: Option<PaginationCursor>,
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[cfg_attr(feature = "full", derive(TS))]
 #[cfg_attr(feature = "full", ts(export))]


### PR DESCRIPTION
Necessary for lemmy-js-client 