### PR TITLE
Remove unnecessary API POST responses

### DIFF
--- a/crates/api/src/comment/like.rs
+++ b/crates/api/src/comment/like.rs
@@ -1,11 +1,11 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  build_response::build_comment_response,
-  comment::{CommentResponse, CreateCommentLike},
+  comment::CreateCommentLike,
   context::LemmyContext,
   send_activity::{ActivityChannel, SendActivityData},
   utils::{check_community_ban, check_downvotes_enabled, local_user_view_from_jwt},
+  SuccessResponse,
 };
 use lemmy_db_schema::{
   newtypes::LocalUserId,
@@ -18,13 +18,12 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views::structs::{CommentView, LocalUserView};
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
-use std::ops::Deref;
 
 #[tracing::instrument(skip(context))]
 pub async fn like_comment(
   data: Json<CreateCommentLike>,
   context: Data<LemmyContext>,
-) -> Result<Json<CommentResponse>, LemmyError> {
+) -> Result<Json<SuccessResponse>, LemmyError> {
   let local_site = LocalSite::read(&mut context.pool()).await?;
   let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
@@ -84,13 +83,5 @@ pub async fn like_comment(
   )
   .await?;
 
-  Ok(Json(
-    build_comment_response(
-      context.deref(),
-      comment_id,
-      Some(local_user_view),
-      recipient_ids,
-    )
-    .await?,
-  ))
+  Ok(Json(Default::default()))
 }

--- a/crates/api/src/comment/save.rs
+++ b/crates/api/src/comment/save.rs
@@ -1,21 +1,21 @@
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  comment::{CommentResponse, SaveComment},
+  comment::SaveComment,
   context::LemmyContext,
   utils::local_user_view_from_jwt,
+  SuccessResponse,
 };
 use lemmy_db_schema::{
   source::comment::{CommentSaved, CommentSavedForm},
   traits::Saveable,
 };
-use lemmy_db_views::structs::CommentView;
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn save_comment(
   data: Json<SaveComment>,
   context: Data<LemmyContext>,
-) -> Result<Json<CommentResponse>, LemmyError> {
+) -> Result<Json<SuccessResponse>, LemmyError> {
   let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
   let comment_saved_form = CommentSavedForm {
@@ -33,12 +33,5 @@ pub async fn save_comment(
       .with_lemmy_type(LemmyErrorType::CouldntSaveComment)?;
   }
 
-  let comment_id = data.comment_id;
-  let person_id = local_user_view.person.id;
-  let comment_view = CommentView::read(&mut context.pool(), comment_id, Some(person_id)).await?;
-
-  Ok(Json(CommentResponse {
-    comment_view,
-    recipient_ids: Vec::new(),
-  }))
+  Ok(Json(Default::default()))
 }

--- a/crates/api/src/comment_report/create.rs
+++ b/crates/api/src/comment_report/create.rs
@@ -2,7 +2,7 @@ use crate::check_report_reason;
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  comment::{CommentReportResponse, CreateCommentReport},
+  comment::CreateCommentReport,
   context::LemmyContext,
   send_activity::{ActivityChannel, SendActivityData},
   utils::{
@@ -11,6 +11,7 @@ use lemmy_api_common::{
     sanitize_html_api,
     send_new_report_email_to_admins,
   },
+  SuccessResponse,
 };
 use lemmy_db_schema::{
   source::{
@@ -27,7 +28,7 @@ use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 pub async fn create_comment_report(
   data: Json<CreateCommentReport>,
   context: Data<LemmyContext>,
-) -> Result<Json<CommentReportResponse>, LemmyError> {
+) -> Result<Json<SuccessResponse>, LemmyError> {
   let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
   let local_site = LocalSite::read(&mut context.pool()).await?;
 
@@ -76,7 +77,5 @@ pub async fn create_comment_report(
   )
   .await?;
 
-  Ok(Json(CommentReportResponse {
-    comment_report_view,
-  }))
+  Ok(Json(Default::default()))
 }

--- a/crates/api/src/comment_report/resolve.rs
+++ b/crates/api/src/comment_report/resolve.rs
@@ -1,8 +1,9 @@
 use actix_web::web::{Data, Json};
 use lemmy_api_common::{
-  comment::{CommentReportResponse, ResolveCommentReport},
+  comment::ResolveCommentReport,
   context::LemmyContext,
   utils::{is_mod_or_admin, local_user_view_from_jwt},
+  SuccessResponse,
 };
 use lemmy_db_schema::{source::comment_report::CommentReport, traits::Reportable};
 use lemmy_db_views::structs::CommentReportView;
@@ -13,7 +14,7 @@ use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 pub async fn resolve_comment_report(
   data: Json<ResolveCommentReport>,
   context: Data<LemmyContext>,
-) -> Result<Json<CommentReportResponse>, LemmyError> {
+) -> Result<Json<SuccessResponse>, LemmyError> {
   let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
   let report_id = data.report_id;
@@ -33,11 +34,5 @@ pub async fn resolve_comment_report(
       .with_lemmy_type(LemmyErrorType::CouldntResolveReport)?;
   }
 
-  let report_id = data.report_id;
-  let comment_report_view =
-    CommentReportView::read(&mut context.pool(), report_id, person_id).await?;
-
-  Ok(Json(CommentReportResponse {
-    comment_report_view,
-  }))
+  Ok(Json(Default::default()))
 }

--- a/crates/api/src/community/ban.rs
+++ b/crates/api/src/community/ban.rs
@@ -1,7 +1,7 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  community::{BanFromCommunity, BanFromCommunityResponse},
+  community::BanFromCommunity,
   context::LemmyContext,
   send_activity::{ActivityChannel, SendActivityData},
   utils::{
@@ -10,6 +10,7 @@ use lemmy_api_common::{
     remove_user_data_in_community,
     sanitize_html_api_opt,
   },
+  SuccessResponse,
 };
 use lemmy_db_schema::{
   source::{
@@ -33,7 +34,7 @@ use lemmy_utils::{
 pub async fn ban_from_community(
   data: Json<BanFromCommunity>,
   context: Data<LemmyContext>,
-) -> Result<Json<BanFromCommunityResponse>, LemmyError> {
+) -> Result<Json<SuccessResponse>, LemmyError> {
   let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
   let banned_person_id = data.person_id;
@@ -106,8 +107,5 @@ pub async fn ban_from_community(
   )
   .await?;
 
-  Ok(Json(BanFromCommunityResponse {
-    person_view,
-    banned: data.ban,
-  }))
+  Ok(Json(Default::default()))
 }

--- a/crates/api/src/community/block.rs
+++ b/crates/api/src/community/block.rs
@@ -1,10 +1,11 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  community::{BlockCommunity, BlockCommunityResponse},
+  community::BlockCommunity,
   context::LemmyContext,
   send_activity::{ActivityChannel, SendActivityData},
   utils::local_user_view_from_jwt,
+  SuccessResponse,
 };
 use lemmy_db_schema::{
   source::{
@@ -20,7 +21,7 @@ use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 pub async fn block_community(
   data: Json<BlockCommunity>,
   context: Data<LemmyContext>,
-) -> Result<Json<BlockCommunityResponse>, LemmyError> {
+) -> Result<Json<SuccessResponse>, LemmyError> {
   let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
   let community_id = data.community_id;
@@ -64,8 +65,5 @@ pub async fn block_community(
   )
   .await?;
 
-  Ok(Json(BlockCommunityResponse {
-    blocked: data.block,
-    community_view,
-  }))
+  Ok(Json(Default::default()))
 }

--- a/crates/api/src/community/follow.rs
+++ b/crates/api/src/community/follow.rs
@@ -1,26 +1,23 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  community::{CommunityResponse, FollowCommunity},
+  community::FollowCommunity,
   context::LemmyContext,
   send_activity::{ActivityChannel, SendActivityData},
   utils::{check_community_ban, check_community_deleted_or_removed, local_user_view_from_jwt},
+  SuccessResponse,
 };
 use lemmy_db_schema::{
-  source::{
-    actor_language::CommunityLanguage,
-    community::{Community, CommunityFollower, CommunityFollowerForm},
-  },
+  source::community::{Community, CommunityFollower, CommunityFollowerForm},
   traits::{Crud, Followable},
 };
-use lemmy_db_views_actor::structs::CommunityView;
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
 pub async fn follow_community(
   data: Json<FollowCommunity>,
   context: Data<LemmyContext>,
-) -> Result<Json<CommunityResponse>, LemmyError> {
+) -> Result<Json<SuccessResponse>, LemmyError> {
   let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
 
   let community = Community::read(&mut context.pool(), data.community_id).await?;
@@ -58,14 +55,5 @@ pub async fn follow_community(
   )
   .await?;
 
-  let community_id = data.community_id;
-  let person_id = local_user_view.person.id;
-  let community_view =
-    CommunityView::read(&mut context.pool(), community_id, Some(person_id), false).await?;
-  let discussion_languages = CommunityLanguage::read(&mut context.pool(), community_id).await?;
-
-  Ok(Json(CommunityResponse {
-    community_view,
-    discussion_languages,
-  }))
+  Ok(Json(Default::default()))
 }

--- a/crates/api/src/community/hide.rs
+++ b/crates/api/src/community/hide.rs
@@ -1,11 +1,11 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  build_response::build_community_response,
-  community::{CommunityResponse, HideCommunity},
+  community::HideCommunity,
   context::LemmyContext,
   send_activity::{ActivityChannel, SendActivityData},
   utils::{is_admin, local_user_view_from_jwt, sanitize_html_api_opt},
+  SuccessResponse,
 };
 use lemmy_db_schema::{
   source::{
@@ -20,7 +20,7 @@ use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 pub async fn hide_community(
   data: Json<HideCommunity>,
   context: Data<LemmyContext>,
-) -> Result<Json<CommunityResponse>, LemmyError> {
+) -> Result<Json<SuccessResponse>, LemmyError> {
   // Verify its a admin (only admin can hide or unhide it)
   let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
   is_admin(&local_user_view)?;
@@ -50,5 +50,5 @@ pub async fn hide_community(
   )
   .await?;
 
-  build_community_response(&context, local_user_view, community_id).await
+  Ok(Json(Default::default()))
 }

--- a/crates/api/src/local_user/verify_email.rs
+++ b/crates/api/src/local_user/verify_email.rs
@@ -1,8 +1,5 @@
 use actix_web::web::{Data, Json};
-use lemmy_api_common::{
-  context::LemmyContext,
-  person::{VerifyEmail, VerifyEmailResponse},
-};
+use lemmy_api_common::{context::LemmyContext, person::VerifyEmail, SuccessResponse};
 use lemmy_db_schema::{
   source::{
     email_verification::EmailVerification,
@@ -15,7 +12,7 @@ use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 pub async fn verify_email(
   data: Json<VerifyEmail>,
   context: Data<LemmyContext>,
-) -> Result<Json<VerifyEmailResponse>, LemmyError> {
+) -> Result<Json<SuccessResponse>, LemmyError> {
   let token = data.token.clone();
   let verification = EmailVerification::read_for_token(&mut context.pool(), &token)
     .await
@@ -34,5 +31,5 @@ pub async fn verify_email(
 
   EmailVerification::delete_old_tokens_for_local_user(&mut context.pool(), local_user_id).await?;
 
-  Ok(Json(VerifyEmailResponse {}))
+  Ok(Json(Default::default()))
 }

--- a/crates/api/src/post/like.rs
+++ b/crates/api/src/post/like.rs
@@ -1,9 +1,8 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
-  build_response::build_post_response,
   context::LemmyContext,
-  post::{CreatePostLike, PostResponse},
+  post::CreatePostLike,
   send_activity::{ActivityChannel, SendActivityData},
   utils::{
     check_community_ban,
@@ -12,6 +11,7 @@ use lemmy_api_common::{
     local_user_view_from_jwt,
     mark_post_as_read,
   },
+  SuccessResponse,
 };
 use lemmy_db_schema::{
   source::{
@@ -22,13 +22,12 @@ use lemmy_db_schema::{
   traits::{Crud, Likeable},
 };
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
-use std::ops::Deref;
 
 #[tracing::instrument(skip(context))]
 pub async fn like_post(
   data: Json<CreatePostLike>,
   context: Data<LemmyContext>,
-) -> Result<Json<PostResponse>, LemmyError> {
+) -> Result<Json<SuccessResponse>, LemmyError> {
   let local_user_view = local_user_view_from_jwt(&data.auth, &context).await?;
   let local_site = LocalSite::read(&mut context.pool()).await?;
 
@@ -80,11 +79,5 @@ pub async fn like_post(
   )
   .await?;
 
-  build_post_response(
-    context.deref(),
-    post.community_id,
-    local_user_view.person.id,
-    post_id,
-  )
-  .await
+  Ok(Json(Default::default()))
 }

--- a/crates/api_common/src/community.rs
+++ b/crates/api_common/src/community.rs
@@ -5,7 +5,7 @@ use lemmy_db_schema::{
   ListingType,
   SortType,
 };
-use lemmy_db_views_actor::structs::{CommunityModeratorView, CommunityView, PersonView};
+use lemmy_db_views_actor::structs::{CommunityModeratorView, CommunityView};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 #[cfg(feature = "full")]
@@ -105,15 +105,6 @@ pub struct BanFromCommunity {
   pub auth: Sensitive<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[cfg_attr(feature = "full", derive(TS))]
-#[cfg_attr(feature = "full", ts(export))]
-/// The response for banning a user from a community.
-pub struct BanFromCommunityResponse {
-  pub person_view: PersonView,
-  pub banned: bool,
-}
-
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 #[cfg_attr(feature = "full", derive(TS))]
 #[cfg_attr(feature = "full", ts(export))]
@@ -211,16 +202,6 @@ pub struct BlockCommunity {
   pub community_id: CommunityId,
   pub block: bool,
   pub auth: Sensitive<String>,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[cfg_attr(feature = "full", derive(TS))]
-#[cfg_attr(feature = "full", ts(export))]
-/// The block community response.
-pub struct BlockCommunityResponse {
-  pub community_view: CommunityView,
-  pub blocked: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]

--- a/crates/api_common/src/lib.rs
+++ b/crates/api_common/src/lib.rs
@@ -21,3 +21,19 @@ pub extern crate lemmy_db_schema;
 pub extern crate lemmy_db_views;
 pub extern crate lemmy_db_views_actor;
 pub extern crate lemmy_db_views_moderator;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "full", derive(ts_rs::TS))]
+#[cfg_attr(feature = "full", ts(export))]
+/// Saves settings for your user.
+pub struct SuccessResponse {
+  pub success: bool,
+}
+
+impl Default for SuccessResponse {
+  fn default() -> Self {
+    SuccessResponse { success: true }
+  }
+}

--- a/crates/api_common/src/person.rs
+++ b/crates/api_common/src/person.rs
@@ -437,9 +437,3 @@ pub struct GetUnreadCountResponse {
 pub struct VerifyEmail {
   pub token: String,
 }
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[cfg_attr(feature = "full", derive(TS))]
-#[cfg_attr(feature = "full", ts(export))]
-/// A response to verifying your email.
-pub struct VerifyEmailResponse {}


### PR DESCRIPTION
Many POST endpoints return unnecessary data, such as a comment like returning a full comment view including comment, creator, post, community and more. All of this is likely unnecessary because the client already fetched it in order to show the like button. Instead a simple `success: true` is returned.

This is still work in progress, there are many more that can be removed.