### PR TITLE
Auth fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-web-httpauth"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d613edf08a42ccc6864c941d30fe14e1b676a77d16f1dbadc1174d065a0a775"
+dependencies = [
+ "actix-utils",
+ "actix-web",
+ "base64 0.21.2",
+ "futures-core",
+ "futures-util",
+ "log",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "actix-web-prom"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2671,6 +2686,7 @@ version = "0.18.1"
 dependencies = [
  "activitypub_federation",
  "actix-web",
+ "actix-web-httpauth",
  "async-trait",
  "bcrypt",
  "chrono",
@@ -2866,6 +2882,7 @@ dependencies = [
  "activitypub_federation",
  "actix-cors",
  "actix-web",
+ "actix-web-httpauth",
  "actix-web-prom",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ actix-web = { version = "4.3.1", default-features = false, features = [
   "compress-gzip",
   "compress-zstd",
 ] }
+actix-web-httpauth = "0.8.1"
 tracing = "0.1.37"
 tracing-actix-web = { version = "0.7.5", default-features = false }
 tracing-error = "0.2.0"
@@ -168,3 +169,4 @@ prometheus = { version = "0.13.3", features = ["process"], optional = true }
 actix-web-prom = { version = "0.6.0", optional = true }
 clap = { version = "4.3.19", features = ["derive"] }
 lemmy_federate = { version = "0.18.1", path = "crates/federate" }
+actix-web-httpauth = { workspace = true }

--- a/crates/api_crud/Cargo.toml
+++ b/crates/api_crud/Cargo.toml
@@ -18,6 +18,7 @@ activitypub_federation = { workspace = true }
 bcrypt = { workspace = true }
 serde = { workspace = true }
 actix-web = { workspace = true }
+actix-web-httpauth = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/db_views/src/local_user_view.rs
+++ b/crates/db_views/src/local_user_view.rs
@@ -1,4 +1,4 @@
-use crate::structs::LocalUserView;
+use crate::structs::{LocalUserView, MaybeLocalUserView};
 use actix_web::{dev::Payload, FromRequest, HttpMessage, HttpRequest};
 use diesel::{result::Error, BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl};
 use diesel_async::RunQueryDsl;
@@ -113,5 +113,17 @@ impl FromRequest for LocalUserView {
       Some(c) => Ok(c.clone()),
       None => Err(LemmyErrorType::IncorrectLogin.into()),
     })
+  }
+}
+
+impl FromRequest for MaybeLocalUserView {
+  type Error = LemmyError;
+  type Future = Ready<Result<Self, Self::Error>>;
+
+  fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
+    let maybe_local_user_view = req.extensions().get::<MaybeLocalUserView>().cloned();
+    ready(Ok(
+      maybe_local_user_view.unwrap_or(MaybeLocalUserView(None)),
+    ))
   }
 }

--- a/crates/db_views/src/structs.rs
+++ b/crates/db_views/src/structs.rs
@@ -72,6 +72,9 @@ pub struct LocalUserView {
   pub counts: PersonAggregates,
 }
 
+#[derive(Debug, Clone)]
+pub struct MaybeLocalUserView(pub Option<LocalUserView>);
+
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "full", derive(TS, Queryable))]

--- a/src/session_middleware.rs
+++ b/src/session_middleware.rs
@@ -71,7 +71,6 @@ where
     let svc = self.service.clone();
     let context = self.context.clone();
 
-    println!("headers: {:#?}", req.headers());
     Box::pin(async move {
       // Try reading jwt from auth header
       let auth_header = Authorization::<Bearer>::parse(&req).ok();


### PR DESCRIPTION
I brought this issue up in the maintainer matrix chat. The way authorization was handled after the change made it so that the local user info wouldn't be returned from the get site API call even if the token was successfully parsed in the session middleware.

I also changed the way the auth header is handled to [meet internet standards](https://datatracker.ietf.org/doc/html/rfc6750#section-2.1) and updated the translations submodule.