### PR TITLE
Increase default database connections (fixes #3394)

### DIFF
--- a/config/defaults.hjson
+++ b/config/defaults.hjson
@@ -34,7 +34,7 @@
     # Name of the postgres database for lemmy
     database: "string"
     # Maximum number of active sql connections
-    pool_size: 5
+    pool_size: 95
   }
   # Settings related to activitypub federation
   # Pictrs image server configuration.

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -75,7 +75,7 @@ pub struct DatabaseConfig {
   pub connection: DatabaseConnection,
 
   /// Maximum number of active sql connections
-  #[default(5)]
+  #[default(95)]
   pub pool_size: usize,
 }
 


### PR DESCRIPTION
Postgres allows [100 connections by default](https://www.postgresql.org/docs/current/runtime-config-connection.html), so I chose a slightly lower value to not exhaust the db. lemmy.ml has also been running with 95 connections for a while now, without any problems.