### PR TITLE
Return HTTP status 503 to all requests during startup (fixes #3780)

### DIFF
--- a/crates/api_crud/src/site/read.rs
+++ b/crates/api_crud/src/site/read.rs
@@ -28,7 +28,6 @@ pub async fn get_site(
   local_user_view: Option<LocalUserView>,
 ) -> Result<Json<GetSiteResponse>, LemmyError> {
   let site_view = SiteView::read_local(&mut context.pool()).await?;
-  Err(LemmyErrorType::SystemErrLogin)?;
 
   let admins = PersonView::admins(&mut context.pool()).await?;
 

--- a/crates/api_crud/src/site/read.rs
+++ b/crates/api_crud/src/site/read.rs
@@ -28,6 +28,7 @@ pub async fn get_site(
   local_user_view: Option<LocalUserView>,
 ) -> Result<Json<GetSiteResponse>, LemmyError> {
   let site_view = SiteView::read_local(&mut context.pool()).await?;
+  Err(LemmyErrorType::SystemErrLogin)?;
 
   let admins = PersonView::admins(&mut context.pool()).await?;
 

--- a/crates/utils/src/response.rs
+++ b/crates/utils/src/response.rs
@@ -1,9 +1,5 @@
 use crate::error::{LemmyError, LemmyErrorType};
-use actix_web::{
-  dev::ServiceResponse,
-  middleware::ErrorHandlerResponse,
-  HttpResponse,
-};
+use actix_web::{dev::ServiceResponse, middleware::ErrorHandlerResponse, HttpResponse};
 
 pub fn jsonify_plain_text_errors<BODY>(
   res: ServiceResponse<BODY>,

--- a/crates/utils/src/response.rs
+++ b/crates/utils/src/response.rs
@@ -1,7 +1,6 @@
 use crate::error::{LemmyError, LemmyErrorType};
 use actix_web::{
   dev::ServiceResponse,
-  http::header,
   middleware::ErrorHandlerResponse,
   HttpResponse,
 };
@@ -28,9 +27,7 @@ pub fn jsonify_plain_text_errors<BODY>(
   let error = res
     .error()
     .expect("expected an error object in the response");
-  let response = HttpResponse::build(res.status())
-    .append_header(header::ContentType::json())
-    .json(LemmyErrorType::Unknown(error.to_string()));
+  let response = HttpResponse::build(res.status()).json(LemmyErrorType::Unknown(error.to_string()));
 
   let service_response = ServiceResponse::new(req, response);
   Ok(ErrorHandlerResponse::Response(


### PR DESCRIPTION
Creates a temporary HTTP server during startup which returns status 503 to all requests. The issue suggests that in case of migration errors Lemmy should keep running and respond with status 500, but I think it makes more sense to shutdown so that it can be automatically restarted.