### PR TITLE
Fix creation of lemmy group and user in docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -113,8 +113,8 @@ RUN apk add --no-cache \
 
 COPY --from=build --chmod=0755 /lemmy/lemmy /usr/local/bin
 
-RUN addgroup -S -g ${GID} lemmy && \
-    adduser -S -H -D -G lemmy -u ${UID} -g "" -s /sbin/nologin lemmy
+RUN addgroup --sytem --gid ${GID} lemmy && \
+    adduser --system --no-create-home --debug --gid ${GID} --uid ${UID} --shell /sbin/nologin lemmy
 
 USER lemmy
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -113,7 +113,7 @@ RUN apk add --no-cache \
 
 COPY --from=build --chmod=0755 /lemmy/lemmy /usr/local/bin
 
-RUN addgroup --sytem --gid ${GID} lemmy && \
+RUN addgroup --system --gid ${GID} lemmy && \
     adduser --system --no-create-home --debug --gid ${GID} --uid ${UID} --shell /sbin/nologin lemmy
 
 USER lemmy


### PR DESCRIPTION
If you try running the current docker image for 0.19.0-beta.5 it runs as root instead of lemmy. This is because the lemmy user is not created. If you run a shell on the image instead, you can see why:
```
> docker run -it docker.io/dessalines/lemmy:0.19.0-beta.5 bash
root@d16132935ed2:/# addgroup -S -g 991 lemmy
Option s is ambiguous (shell, system)
Option g is ambiguous (gecos, gid, group)
adduser [--uid id] [--firstuid id] [--lastuid id]
        [--gid id] [--firstgid id] [--lastgid id] [--ingroup group]
        [--add-extra-groups] [--shell shell]
        [--comment comment] [--home dir] [--no-create-home]
        [--allow-all-names] [--allow-bad-names]
        [--disabled-password] [--disabled-login]
        [--conf file] [--quiet] [--verbose] [--debug]
        user
    Add a normal user

adduser --system
        [--uid id] [--group] [--ingroup group] [--gid id]
        [--shell shell] [--comment comment] [--home dir] [--no-create-home]
        [--conf file] [--quiet] [--verbose] [--debug]
        user
   Add a system user

adduser --group
        [--gid ID] [--firstgid id] [--lastgid id]
        [--conf file] [--quiet] [--verbose] [--debug]
        group
addgroup
        [--gid ID] [--firstgid id] [--lastgid id]
        [--conf file] [--quiet] [--verbose] [--debug]
        group
   Add a user group

addgroup --system
        [--gid id]
        [--conf file] [--quiet] [--verbose] [--debug]
        group
   Add a system group

adduser USER GROUP
   Add an existing user to an existing group
```
If you fix the 2 errors:
> Option s is ambiguous (shell, system)
> Option g is ambiguous (gecos, gid, group)

```
root@d16132935ed2:/# addgroup --system --gid 991 lemmy
Adding group `lemmy' (GID 991) ...
Done.
```

Now try creating a user:
```
root@d16132935ed2:/# adduser -S -H -D -G lemmy -u ${UID} -g "" -s /sbin/nologin lemmy
Option s is ambiguous (shell, system)
adduser [--uid id] [--firstuid id] [--lastuid id]
        [--gid id] [--firstgid id] [--lastgid id] [--ingroup group]
        [--add-extra-groups] [--shell shell]
        [--comment comment] [--home dir] [--no-create-home]
        [--allow-all-names] [--allow-bad-names]
        [--disabled-password] [--disabled-login]
        [--conf file] [--quiet] [--verbose] [--debug]
        user
    Add a normal user

adduser --system
        [--uid id] [--group] [--ingroup group] [--gid id]
        [--shell shell] [--comment comment] [--home dir] [--no-create-home]
        [--conf file] [--quiet] [--verbose] [--debug]
        user
   Add a system user

adduser --group
        [--gid ID] [--firstgid id] [--lastgid id]
        [--conf file] [--quiet] [--verbose] [--debug]
        group
addgroup
        [--gid ID] [--firstgid id] [--lastgid id]
        [--conf file] [--quiet] [--verbose] [--debug]
        group
   Add a user group

addgroup --system
        [--gid id]
        [--conf file] [--quiet] [--verbose] [--debug]
        group
   Add a system group

adduser USER GROUP
   Add an existing user to an existing group
```
This time it complains just about:
> Option s is ambiguous (shell, system)

However, it really doesn't like a few things and just won't tell you what those are:
```
root@d16132935ed2:/# adduser --system -H -D -G lemmy -u ${UID} -g "" -s /sbin/nologin lemmy
adduser [--uid id] [--firstuid id] [--lastuid id]
        [--gid id] [--firstgid id] [--lastgid id] [--ingroup group]
        [--add-extra-groups] [--shell shell]
        [--comment comment] [--home dir] [--no-create-home]
        [--allow-all-names] [--allow-bad-names]
        [--disabled-password] [--disabled-login]
        [--conf file] [--quiet] [--verbose] [--debug]
        user
    Add a normal user

adduser --system
        [--uid id] [--group] [--ingroup group] [--gid id]
        [--shell shell] [--comment comment] [--home dir] [--no-create-home]
        [--conf file] [--quiet] [--verbose] [--debug]
        user
   Add a system user

adduser --group
        [--gid ID] [--firstgid id] [--lastgid id]
        [--conf file] [--quiet] [--verbose] [--debug]
        group
addgroup
        [--gid ID] [--firstgid id] [--lastgid id]
        [--conf file] [--quiet] [--verbose] [--debug]
        group
   Add a user group

addgroup --system
        [--gid id]
        [--conf file] [--quiet] [--verbose] [--debug]
        group
   Add a system group

adduser USER GROUP
   Add an existing user to an existing group
```

I've fixed it by using:
```
root@d16132935ed2:/# adduser --system --no-create-home --debug --gid 991 --uid 991 --shell /sbin/nologin lemmy
DEBUG: adduser: read configuration file /etc/adduser.conf
DEBUG: adduser: check_user_group 1 called, make_group_also 0
DEBUG: adduser: return from check_user_group
Adding system user `lemmy' (UID 991) ...
Adding new user `lemmy' (UID 991) with group `lemmy' ...
/usr/sbin/useradd -r -K SYS_UID_MIN=100 -K SYS_UID_MAX=999 -d /nonexistent -g lemmy -s /sbin/nologin -u 991 lemmy
Not creating `/nonexistent'.
```