### PR TITLE
Dont create :latest docker tag (fixes #3996)

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -242,7 +242,6 @@ steps:
       platforms: linux/amd64,linux/arm64
       build_args:
         - RUST_RELEASE_MODE=release
-      auto_tag: true
     when:
       event: tag
 

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -242,6 +242,7 @@ steps:
       platforms: linux/amd64,linux/arm64
       build_args:
         - RUST_RELEASE_MODE=release
+      tag: ${CI_COMMIT_TAG}
     when:
       event: tag
 


### PR DESCRIPTION
This seems like the easiest way to solve the problem of `:latest` containing unstable releases. It also means that we dont get docker tags like `0.18` but I think thats fine.

After this is merged we need to delete `:latest` manually from docker hub.