### PR TITLE
Fix legacy pagination for Subscribed feed

### DIFF
--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -629,7 +629,7 @@ impl<'a> PostQuery<'a> {
       },
     };
     let (limit, offset) = limit_and_offset(self.page, self.limit)?;
-    if offset != 0 {
+    if offset != 0 && self.page_after.is_some() {
       return Err(Error::QueryBuilderError(
         "legacy pagination cannot be combined with v2 pagination".into(),
       ));


### PR DESCRIPTION
This is the fix suggested in #4019

I've manually tested both legacy pagination (`page=2&limit=20`) as well as the new pagination (`page_cursor=XXXXXXX&limit=20`) using the same endpoint as #4019, and both methods appear to work as expected.