### PR TITLE
Cleanup public api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2808,6 +2808,8 @@ dependencies = [
  "lemmy_db_schema",
  "serde",
  "serde_with",
+ "strum",
+ "strum_macros",
  "ts-rs",
 ]
 

--- a/crates/apub/src/api/search.rs
+++ b/crates/apub/src/api/search.rs
@@ -8,7 +8,7 @@ use lemmy_api_common::{
 };
 use lemmy_db_schema::{
   source::{community::Community, local_site::LocalSite},
-  utils::{post_to_comment_sort_type, post_to_person_sort_type},
+  utils::post_to_comment_sort_type,
   SearchType,
 };
 use lemmy_db_views::{comment_view::CommentQuery, post_view::PostQuery, structs::LocalUserView};
@@ -101,7 +101,7 @@ pub async fn search(
     }
     SearchType::Users => {
       users = PersonQuery {
-        sort: (sort.map(post_to_person_sort_type)),
+        sort,
         search_term: (Some(q)),
         page: (page),
         limit: (limit),
@@ -171,7 +171,7 @@ pub async fn search(
         vec![]
       } else {
         PersonQuery {
-          sort: (sort.map(post_to_person_sort_type)),
+          sort,
           search_term: (Some(q)),
           page: (page),
           limit: (limit),

--- a/crates/db_schema/src/aggregates/structs.rs
+++ b/crates/db_schema/src/aggregates/structs.rs
@@ -27,7 +27,9 @@ pub struct CommentAggregates {
   pub published: DateTime<Utc>,
   /// The total number of children in this comment branch.
   pub child_count: i32,
+  #[serde(skip)]
   pub hot_rank: f64,
+  #[serde(skip)]
   pub controversy_rank: f64,
 }
 
@@ -55,6 +57,7 @@ pub struct CommunityAggregates {
   pub users_active_month: i64,
   /// The number of users with any activity in the last year.
   pub users_active_half_year: i64,
+  #[serde(skip)]
   pub hot_rank: f64,
 }
 
@@ -87,21 +90,32 @@ pub struct PostAggregates {
   pub upvotes: i64,
   pub downvotes: i64,
   pub published: DateTime<Utc>,
-  /// A newest comment time, limited to 2 days, to prevent necrobumping  
+  #[serde(skip)]
+  /// A newest comment time, limited to 2 days, to prevent necrobumping
   pub newest_comment_time_necro: DateTime<Utc>,
   /// The time of the newest comment in the post.
+  #[serde(skip)]
   pub newest_comment_time: DateTime<Utc>,
   /// If the post is featured on the community.
+  #[serde(skip)]
   pub featured_community: bool,
   /// If the post is featured on the site / to local.
+  #[serde(skip)]
   pub featured_local: bool,
+  #[serde(skip)]
   pub hot_rank: f64,
+  #[serde(skip)]
   pub hot_rank_active: f64,
+  #[serde(skip)]
   pub community_id: CommunityId,
+  #[serde(skip)]
   pub creator_id: PersonId,
+  #[serde(skip)]
   pub controversy_rank: f64,
+  #[serde(skip)]
   pub instance_id: InstanceId,
   /// A rank that amplifies smaller communities
+  #[serde(skip)]
   pub scaled_rank: f64,
 }
 

--- a/crates/db_schema/src/lib.rs
+++ b/crates/db_schema/src/lib.rs
@@ -91,19 +91,6 @@ pub enum CommentSortType {
   Controversial,
 }
 
-#[derive(EnumString, Display, Debug, Serialize, Deserialize, Clone, Copy)]
-#[cfg_attr(feature = "full", derive(TS))]
-#[cfg_attr(feature = "full", ts(export))]
-/// The person sort types. See here for descriptions: https://join-lemmy.org/docs/en/users/03-votes-and-ranking.html
-pub enum PersonSortType {
-  New,
-  Old,
-  MostComments,
-  CommentScore,
-  PostScore,
-  PostCount,
-}
-
 #[derive(
   EnumString, Display, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Default,
 )]

--- a/crates/db_schema/src/utils.rs
+++ b/crates/db_schema/src/utils.rs
@@ -3,7 +3,6 @@ use crate::{
   diesel_migrations::MigrationHarness,
   newtypes::DbUrl,
   CommentSortType,
-  PersonSortType,
   SortType,
 };
 use activitypub_federation::{fetch::object_id::ObjectId, traits::Object};
@@ -362,16 +361,6 @@ pub fn post_to_comment_sort_type(sort: SortType) -> CommentSortType {
     | SortType::TopThreeMonths
     | SortType::TopSixMonths
     | SortType::TopNineMonths => CommentSortType::Top,
-  }
-}
-
-pub fn post_to_person_sort_type(sort: SortType) -> PersonSortType {
-  match sort {
-    SortType::Active | SortType::Hot | SortType::Controversial => PersonSortType::CommentScore,
-    SortType::New | SortType::NewComments => PersonSortType::New,
-    SortType::MostComments => PersonSortType::MostComments,
-    SortType::Old => PersonSortType::Old,
-    _ => PersonSortType::CommentScore,
   }
 }
 

--- a/crates/db_views_actor/Cargo.toml
+++ b/crates/db_views_actor/Cargo.toml
@@ -29,3 +29,5 @@ serde = { workspace = true }
 serde_with = { workspace = true }
 ts-rs = { workspace = true, optional = true }
 chrono.workspace = true
+strum = { workspace = true }
+strum_macros = { workspace = true }


### PR DESCRIPTION
As noted by @MV-GH there are some parts of the public API which seem completely unnecessary:
- `PersonSortType` is only used internally, with automatic conversion from `SortType`, moved it and made it private
- Fields like `PostAggregate.hot_rank` or `PostAggregate.community_id` seem irrelevant for clients, marked them as `serde(skip)`