### PR TITLE
Making mark post read fields optional.

### DIFF
--- a/crates/api/src/post/mark_read.rs
+++ b/crates/api/src/post/mark_read.rs
@@ -13,7 +13,7 @@ pub async fn mark_post_as_read(
 ) -> Result<Json<SuccessResponse>, LemmyError> {
   let mut post_ids = HashSet::new();
   if let Some(post_ids_) = &data.post_ids {
-    post_ids.extend(post_ids_.iter().cloned().collect::<HashSet<_>>());
+    post_ids.extend(post_ids_.iter().cloned());
   }
 
   if let Some(post_id) = data.post_id {

--- a/crates/api/src/post/mark_read.rs
+++ b/crates/api/src/post/mark_read.rs
@@ -20,10 +20,6 @@ pub async fn mark_post_as_read(
     post_ids.insert(post_id);
   }
 
-  if post_ids.is_empty() {
-    Err(LemmyErrorType::CouldntMarkPostAsRead)?;
-  }
-
   if post_ids.len() > MAX_API_PARAM_ELEMENTS {
     Err(LemmyErrorType::TooManyItems)?;
   }

--- a/crates/api/src/post/mark_read.rs
+++ b/crates/api/src/post/mark_read.rs
@@ -11,11 +11,7 @@ pub async fn mark_post_as_read(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> Result<Json<SuccessResponse>, LemmyError> {
-  let mut post_ids = HashSet::new();
-  if let Some(post_ids_) = &data.post_ids {
-    post_ids.extend(post_ids_.iter().cloned());
-  }
-
+  let mut post_ids = data.post_ids.iter().cloned().collect::<HashSet<_>>();
   if let Some(post_id) = data.post_id {
     post_ids.insert(post_id);
   }

--- a/crates/api/src/post/mark_read.rs
+++ b/crates/api/src/post/mark_read.rs
@@ -11,13 +11,24 @@ pub async fn mark_post_as_read(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> Result<Json<SuccessResponse>, LemmyError> {
-  let mut post_ids = data.post_ids.iter().cloned().collect::<HashSet<_>>();
-  post_ids.insert(data.post_id);
-  let person_id = local_user_view.person.id;
+  let mut post_ids = HashSet::new();
+  if let Some(post_ids_) = &data.post_ids {
+    post_ids.extend(&post_ids_.iter().cloned().collect::<HashSet<_>>());
+  }
+
+  if let Some(post_id) = data.post_id {
+    post_ids.insert(post_id);
+  }
+
+  if post_ids.is_empty() {
+    Err(LemmyErrorType::CouldntMarkPostAsRead)?;
+  }
 
   if post_ids.len() > MAX_API_PARAM_ELEMENTS {
     Err(LemmyErrorType::TooManyItems)?;
   }
+
+  let person_id = local_user_view.person.id;
 
   // Mark the post as read / unread
   if data.read {

--- a/crates/api/src/post/mark_read.rs
+++ b/crates/api/src/post/mark_read.rs
@@ -11,7 +11,11 @@ pub async fn mark_post_as_read(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> Result<Json<SuccessResponse>, LemmyError> {
-  let mut post_ids = data.post_ids.iter().cloned().collect::<HashSet<_>>();
+  let mut post_ids = HashSet::new();
+  if let Some(post_ids_) = &data.post_ids {
+    post_ids.extend(post_ids_.iter().cloned());
+  }
+
   if let Some(post_id) = data.post_id {
     post_ids.insert(post_id);
   }

--- a/crates/api/src/post/mark_read.rs
+++ b/crates/api/src/post/mark_read.rs
@@ -13,7 +13,7 @@ pub async fn mark_post_as_read(
 ) -> Result<Json<SuccessResponse>, LemmyError> {
   let mut post_ids = HashSet::new();
   if let Some(post_ids_) = &data.post_ids {
-    post_ids.extend(&post_ids_.iter().cloned().collect::<HashSet<_>>());
+    post_ids.extend(post_ids_.iter().cloned().collect::<HashSet<_>>());
   }
 
   if let Some(post_id) = data.post_id {

--- a/crates/api_common/src/post.rs
+++ b/crates/api_common/src/post.rs
@@ -135,14 +135,15 @@ pub struct RemovePost {
   pub reason: Option<String>,
 }
 
+#[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 #[cfg_attr(feature = "full", derive(TS))]
 #[cfg_attr(feature = "full", ts(export))]
 /// Mark a post as read.
 pub struct MarkPostAsRead {
   /// TODO: deprecated, send `post_ids` instead
-  pub post_id: PostId,
-  pub post_ids: Vec<PostId>,
+  pub post_id: Option<PostId>,
+  pub post_ids: Option<Vec<PostId>>,
   pub read: bool,
 }
 

--- a/crates/api_common/src/post.rs
+++ b/crates/api_common/src/post.rs
@@ -143,7 +143,8 @@ pub struct RemovePost {
 pub struct MarkPostAsRead {
   /// TODO: deprecated, send `post_ids` instead
   pub post_id: Option<PostId>,
-  pub post_ids: Option<Vec<PostId>>,
+  #[serde(default)]
+  pub post_ids: Vec<PostId>,
   pub read: bool,
 }
 

--- a/crates/api_common/src/post.rs
+++ b/crates/api_common/src/post.rs
@@ -143,8 +143,7 @@ pub struct RemovePost {
 pub struct MarkPostAsRead {
   /// TODO: deprecated, send `post_ids` instead
   pub post_id: Option<PostId>,
-  #[serde(default)]
-  pub post_ids: Vec<PostId>,
+  pub post_ids: Option<Vec<PostId>>,
   pub read: bool,
 }
 


### PR DESCRIPTION
Ran into this issue with lemmy-ui : it required a `post_id` and `post_ids`, neither optional.

I'd rather not do it this way, and just remove the old one now, but this lets them both stay for the time being.