### PR TITLE
Make sure my_vote is consistently missing if not voted. Fixes #3197

### DIFF
--- a/crates/api_common/src/post.rs
+++ b/crates/api_common/src/post.rs
@@ -47,6 +47,7 @@ pub struct GetPost {
   pub comment_id: Option<CommentId>,
 }
 
+#[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "full", derive(TS))]
 #[cfg_attr(feature = "full", ts(export))]

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -546,12 +546,6 @@ impl PostView {
       .read(pool, (post_id, my_person_id, is_mod_or_admin))
       .await?;
 
-    // If a person is given, then my_vote, if None, should be 0, not null
-    // Necessary to differentiate between other person's votes
-    if my_person_id.is_some() && res.my_vote.is_none() {
-      res.my_vote = Some(0)
-    };
-
     Ok(res)
   }
 }

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -871,7 +871,7 @@ mod tests {
     assert_eq!(1, read_post_listing.len());
 
     assert_eq!(expected_post_listing_with_user, read_post_listing[0]);
-    expected_post_listing_with_user.my_vote = Some(0);
+    expected_post_listing_with_user.my_vote = None;
     assert_eq!(
       expected_post_listing_with_user,
       post_listing_single_with_person

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -542,7 +542,7 @@ impl PostView {
     my_person_id: Option<PersonId>,
     is_mod_or_admin: bool,
   ) -> Result<Self, Error> {
-    let mut res = queries()
+    let res = queries()
       .read(pool, (post_id, my_person_id, is_mod_or_admin))
       .await?;
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -55,7 +55,7 @@ services:
 
   lemmy-ui:
     # use "image" to pull down an already compiled lemmy-ui. make sure to comment out "build".
-    image: dessalines/lemmy-ui:0.18.4
+    image: dessalines/lemmy-ui:0.19.0-rc.3
     # platform: linux/x86_64 # no arm64 support. uncomment platform if using m1.
     # use "build" to build your local lemmy ui image for development. make sure to comment out "image".
     # run: docker compose up --build


### PR DESCRIPTION
There seemed to be a weird kludge related to websockets I included, that isn't necessary anymore.

Now both get_post and list_posts consistently are missing the `my_vote` if its null. It'd be very strange to rewrite all the joined rows for list_posts, in the same way I did for a single get_post, so its better to be consistent and remove the websocket kludge.