### PR TITLE
Allow Arabic and Cyrillic usernames/community names (fixes #1764)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,8 +11,6 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "activitypub_federation"
 version = "0.5.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509cbafa1b42e01b7ca76c26298814a6638825df4fd67aef2f4c9d36a39c2b6d"
 dependencies = [
  "activitystreams-kinds",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ lemmy_routes = { version = "=0.19.0-rc.3", path = "./crates/routes" }
 lemmy_db_views = { version = "=0.19.0-rc.3", path = "./crates/db_views" }
 lemmy_db_views_actor = { version = "=0.19.0-rc.3", path = "./crates/db_views_actor" }
 lemmy_db_views_moderator = { version = "=0.19.0-rc.3", path = "./crates/db_views_moderator" }
-activitypub_federation = { version = "0.5.0-beta.3", default-features = false, features = [
+activitypub_federation = { git = "https://github.com/LemmyNet/activitypub-federation-rust.git", branch = "webfinger-alphabets", default-features = false, features = [
   "actix-web",
 ] }
 diesel = "2.1.0"

--- a/api_tests/src/user.spec.ts
+++ b/api_tests/src/user.spec.ts
@@ -119,3 +119,21 @@ test("Requests with invalid auth should be treated as unauthenticated", async ()
   let posts = invalid_auth.getPosts(form);
   expect((await posts).posts).toBeDefined();
 });
+
+test("Create user with Arabic name", async () => {
+  let userRes = await registerUser(alpha, "تجريب");
+  expect(userRes.jwt).toBeDefined();
+  let user = new LemmyHttp(alphaUrl, {
+    headers: { Authorization: `Bearer ${userRes.jwt ?? ""}` },
+  });
+
+  let site = await getSite(user);
+  expect(site.my_user).toBeDefined();
+  if (!site.my_user) {
+    throw "Missing site user";
+  }
+  apShortname = `@${site.my_user.local_user_view.person.name}@lemmy-alpha:8541`;
+
+  let alphaPerson = (await resolvePerson(alpha, apShortname)).person;
+  expect(alphaPerson).toBeDefined();
+});

--- a/crates/utils/src/utils/validation.rs
+++ b/crates/utils/src/utils/validation.rs
@@ -93,7 +93,7 @@ pub fn is_valid_actor_name(name: &str, actor_name_max_length: usize) -> LemmyRes
   let check = name.chars().count() <= actor_name_max_length && !has_newline(name);
 
   // Only allow characters from a single alphabet per username. This avoids problems with lookalike
-  // characters like `o` which look identical in different alphabets, and can be used to imitate
+  // characters like `o` which looks identical in Latin and Cyrillic, and can be used to imitate
   // other users. Checks for additional alphabets can be added in the same way.
   let lang_check = VALID_ACTOR_NAME_REGEX_EN.is_match(name)
     || VALID_ACTOR_NAME_REGEX_AR.is_match(name)


### PR DESCRIPTION
For security reasons it only allows characters from a single alphabet per username. This avoids problems with lookalike characters like `o` which looks identical in Latin and Cyrillic, and can be used to imitate other users. Checks for additional alphabets can be added in the same way.

Requires https://github.com/LemmyNet/activitypub-federation-rust/pull/78