### PR TITLE
Adding cors_origin to settings. Fixes #3665

### DIFF
--- a/config/defaults.hjson
+++ b/config/defaults.hjson
@@ -86,4 +86,5 @@
     bind: "127.0.0.1"
     port: 10002
   }
+  cors_origin: "string"
 }

--- a/config/defaults.hjson
+++ b/config/defaults.hjson
@@ -86,5 +86,7 @@
     bind: "127.0.0.1"
     port: 10002
   }
+  # Sets a response Access-Control-Allow-Origin CORS header
+  # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
   cors_origin: "*"
 }

--- a/config/defaults.hjson
+++ b/config/defaults.hjson
@@ -86,5 +86,5 @@
     bind: "127.0.0.1"
     port: 10002
   }
-  cors_origin: "string"
+  cors_origin: "*"
 }

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -49,6 +49,8 @@ pub struct Settings {
   #[default(None)]
   #[doku(example = "Some(Default::default())")]
   pub prometheus: Option<PrometheusConfig>,
+  #[default(None)]
+  pub cors_origin: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, SmartDefault, Document)]

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -49,6 +49,8 @@ pub struct Settings {
   #[default(None)]
   #[doku(example = "Some(Default::default())")]
   pub prometheus: Option<PrometheusConfig>,
+  /// Sets a response Access-Control-Allow-Origin CORS header
+  /// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
   #[default(None)]
   #[doku(example = "*")]
   pub cors_origin: Option<String>,

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -50,6 +50,7 @@ pub struct Settings {
   #[doku(example = "Some(Default::default())")]
   pub prometheus: Option<PrometheusConfig>,
   #[default(None)]
+  #[doku(example = "*")]
   pub cors_origin: Option<String>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,11 +287,14 @@ fn create_http_server(
   let context: LemmyContext = federation_config.deref().clone();
   let rate_limit_cell = federation_config.rate_limit_cell().clone();
   let self_origin = settings.get_protocol_and_hostname();
+  let cors_origin_setting = settings.cors_origin;
   // Create Http server with websocket support
   let server = HttpServer::new(move || {
-    let cors_origin = env::var("LEMMY_CORS_ORIGIN").ok().or(settings.cors_origin);
+    let cors_origin = env::var("LEMMY_CORS_ORIGIN")
+      .ok()
+      .or(cors_origin_setting.clone());
     let cors_config = match (cors_origin, cfg!(debug_assertions)) {
-      (Ok(origin), false) => Cors::default()
+      (Some(origin), false) => Cors::default()
         .allowed_origin(&origin)
         .allowed_origin(&self_origin),
       _ => Cors::default()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,7 +289,7 @@ fn create_http_server(
   let self_origin = settings.get_protocol_and_hostname();
   // Create Http server with websocket support
   let server = HttpServer::new(move || {
-    let cors_origin = env::var("LEMMY_CORS_ORIGIN");
+    let cors_origin = env::var("LEMMY_CORS_ORIGIN").ok().or(settings.cors_origin);
     let cors_config = match (cors_origin, cfg!(debug_assertions)) {
       (Ok(origin), false) => Cors::default()
         .allowed_origin(&origin)


### PR DESCRIPTION
Surprisingly this was the only env var that I could find (besides one other federation test one), that wasn't in our config.