### PR TITLE
Disable ansi coloring in logs. Fixes #3975

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,9 +352,9 @@ pub fn init_logging(opentelemetry_url: &Option<Url>) -> Result<(), LemmyError> {
 
   let format_layer = {
     #[cfg(feature = "json-log")]
-    let layer = tracing_subscriber::fmt::layer().json();
+    let layer = tracing_subscriber::fmt::layer().with_ansi(false).json();
     #[cfg(not(feature = "json-log"))]
-    let layer = tracing_subscriber::fmt::layer();
+    let layer = tracing_subscriber::fmt::layer().with_ansi(false);
 
     layer.with_filter(targets.clone())
   };


### PR DESCRIPTION
These cause a ton of problems viewing them outputted from docker anyway.