### PR TITLE
#3102 update documentation - remove arm support until it work again

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ Each Lemmy server can set its own moderation policy; appointing site-wide admins
 - High performance.
   - Server is written in rust.
   - Front end is `~80kB` gzipped.
-  - Supports arm64 / Raspberry Pi.
 
 ## Installation
 


### PR DESCRIPTION
Until issue #3102 is open, remove "Supports arm64 / Raspberry Pi."