### PR TITLE
Add parameter to fetch_site_data

### DIFF
--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -225,6 +225,7 @@ pub async fn fetch_site_data(
   settings: &Settings,
   url: Option<&Url>,
   include_image: bool,
+  is_local: bool,
 ) -> (Option<SiteMetadata>, Option<DbUrl>) {
   match &url {
     Some(url) => {

--- a/crates/api_crud/src/post/create.rs
+++ b/crates/api_crud/src/post/create.rs
@@ -83,7 +83,7 @@ pub async fn create_post(
 
   // Fetch post links and pictrs cached image
   let (metadata_res, thumbnail_url) =
-    fetch_site_data(context.client(), context.settings(), data_url, true).await;
+    fetch_site_data(context.client(), context.settings(), data_url, true, true).await;
   let (embed_title, embed_description, embed_video_url) = metadata_res
     .map(|u| (u.title, u.description, u.embed_video_url))
     .unwrap_or_default();

--- a/crates/api_crud/src/post/update.rs
+++ b/crates/api_crud/src/post/update.rs
@@ -70,7 +70,7 @@ pub async fn update_post(
   // Fetch post links and Pictrs cached image
   let data_url = data.url.as_ref();
   let (metadata_res, thumbnail_url) =
-    fetch_site_data(context.client(), context.settings(), data_url, true).await;
+    fetch_site_data(context.client(), context.settings(), data_url, true, true).await;
   let (embed_title, embed_description, embed_video_url) = metadata_res
     .map(|u| (Some(u.title), Some(u.description), Some(u.embed_video_url)))
     .unwrap_or_default();

--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -222,6 +222,7 @@ impl Object for ApubPost {
             context.settings(),
             Some(url),
             include_image,
+            false,
           )
           .await
         }


### PR DESCRIPTION
Currently, the `fetch_site_data` function cannot tell if its called for a federated post (created through activitypub/federation) or a local post (created through the api).

In order to fix https://github.com/LemmyNet/lemmy/issues/4067 the `fetch_site_data` function must be able to make a difference between those two cases, in order to set the correct `thumbnail_url` when the post is not federated.

So this pull request adds a simple flag `is_local` to that function. Its only the first step in solving the problem, but the next pull request will depend on this flag.