### PR TITLE
Show oldest registration applications first (ref #4122)

### DIFF
--- a/crates/db_views/src/registration_application_view.rs
+++ b/crates/db_views/src/registration_application_view.rs
@@ -308,7 +308,7 @@ mod tests {
 
     assert_eq!(
       apps,
-      [read_jess_app_view.clone(), expected_sara_app_view.clone()]
+      [expected_sara_app_view.clone(), read_jess_app_view.clone()]
     );
 
     // Make sure the counts are correct

--- a/crates/db_views/src/registration_application_view.rs
+++ b/crates/db_views/src/registration_application_view.rs
@@ -62,7 +62,7 @@ fn queries<'a>() -> Queries<
     query = query
       .limit(limit)
       .offset(offset)
-      .order_by(registration_application::published.desc());
+      .order_by(registration_application::published.asc());
 
     query.load::<RegistrationApplicationView>(&mut conn).await
   };


### PR DESCRIPTION
It seems better to show oldest first so that they can be taken care of, and avoid individual users waiting a long time to be accepted. We could do the same for reports, not sure.