### PR TITLE
Reduce size of received_activity table (fixes #4110)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2673,6 +2673,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serial_test",
+ "sha256",
  "strum",
  "strum_macros",
  "tokio",
@@ -4798,6 +4799,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sha256"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7895c8ae88588ccead14ff438b939b0c569cd619116f14b4d13fdff7b8333386"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "hex",
+ "sha2",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/db_schema/Cargo.toml
+++ b/crates/db_schema/Cargo.toml
@@ -33,6 +33,7 @@ full = [
   "tokio-postgres",
   "tokio-postgres-rustls",
   "rustls",
+  "sha256",
 ]
 
 [dependencies]
@@ -73,6 +74,7 @@ tokio-postgres = { workspace = true, optional = true }
 tokio-postgres-rustls = { workspace = true, optional = true }
 rustls = { workspace = true, optional = true }
 uuid = { workspace = true, features = ["v4"] }
+sha256 = { version = "1.4.0", optional = true }
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/crates/db_schema/src/impls/activity.rs
+++ b/crates/db_schema/src/impls/activity.rs
@@ -43,7 +43,7 @@ impl ReceivedActivity {
     let conn = &mut get_conn(pool).await?;
     let hash = sha256::digest(ap_id_.as_str());
     let res = insert_into(received_activity)
-      .values(ap_id_hash.eq(&hash.as_str()[0..32]))
+      .values(ap_id_hash.eq(&hash.as_str().get(0..32).expect("hash slice")))
       .on_conflict_do_nothing()
       .returning(ap_id_hash)
       .get_result::<String>(conn)

--- a/crates/db_schema/src/schema.rs
+++ b/crates/db_schema/src/schema.rs
@@ -814,10 +814,10 @@ diesel::table! {
 }
 
 diesel::table! {
-    received_activity (id) {
-        id -> Int8,
-        ap_id -> Text,
+    received_activity (ap_id_hash) {
         published -> Timestamptz,
+        #[max_length = 32]
+        ap_id_hash -> Varchar,
     }
 }
 

--- a/crates/db_schema/src/source/activity.rs
+++ b/crates/db_schema/src/source/activity.rs
@@ -90,7 +90,6 @@ pub enum ActorType {
 #[derive(PartialEq, Eq, Debug, Queryable)]
 #[diesel(table_name = received_activity)]
 pub struct ReceivedActivity {
-  pub id: i64,
-  pub ap_id: DbUrl,
   pub published: DateTime<Utc>,
+  pub ap_id_hash: String,
 }

--- a/migrations/2023-11-03-114049_optimize-send-activity-size/down.sql
+++ b/migrations/2023-11-03-114049_optimize-send-activity-size/down.sql
@@ -1,0 +1,15 @@
+-- We can't restore ap_id values from hash, so drop all existing rows and restore schema.
+DELETE FROM received_activity;
+
+ALTER TABLE received_activity
+    DROP COLUMN ap_id_hash;
+
+ALTER TABLE received_activity
+    ADD COLUMN id serial;
+
+ALTER TABLE received_activity
+    ADD COLUMN ap_id text NOT NULL;
+
+ALTER TABLE received_activity
+    ADD PRIMARY KEY (ap_id);
+

--- a/migrations/2023-11-03-114049_optimize-send-activity-size/up.sql
+++ b/migrations/2023-11-03-114049_optimize-send-activity-size/up.sql
@@ -1,0 +1,31 @@
+-- Change the received_activity table to use less space. Instead of storing the full ap_id url,
+-- only store first 32 chars of hash which is enough to catch duplicates. This reduces the size
+-- of that column from from ~70 bytes to 33 bytes. Also drop id column which is unnecessary.
+-- The `published` time is stored by postgres as unix timestamp, so it only takes 8 bytes already.
+ALTER TABLE received_activity
+    ADD COLUMN ap_id_hash varchar(32);
+
+UPDATE
+    received_activity
+SET
+    -- cast to string and drop ` \x` from start of hash, limit length
+    ap_id_hash = substring(cast(subquery.hash AS text)
+        FROM 3 FOR 32)
+FROM (
+    SELECT
+        id,
+        digest(a.ap_id, 'sha256') AS hash
+    FROM
+        received_activity AS a) AS subquery
+WHERE
+    received_activity.id = subquery.id;
+
+ALTER TABLE received_activity
+    DROP COLUMN id;
+
+ALTER TABLE received_activity
+    DROP COLUMN ap_id;
+
+ALTER TABLE received_activity
+    ADD PRIMARY KEY (ap_id_hash);
+

--- a/src/scheduled_tasks.rs
+++ b/src/scheduled_tasks.rs
@@ -302,7 +302,7 @@ async fn clear_old_activities(pool: &mut DbPool<'_>) {
         .ok();
 
       diesel::delete(
-        received_activity::table.filter(received_activity::published.lt(now() - 3.months())),
+        received_activity::table.filter(received_activity::published.lt(now() - 1.months())),
       )
       .execute(&mut conn)
       .await


### PR DESCRIPTION
By storing only a partial hash of ap_id instead of the full url, as well as dropping id column, the size of each row is reduced by half. Also reduce cleanup interval from 3 months to 1 month. So the total table size should be reduced to 1/6 of the current.