### PR TITLE
Only keep sent and received activities for 7 days (fixes #4113, fixes #4110)

### DIFF
--- a/src/scheduled_tasks.rs
+++ b/src/scheduled_tasks.rs
@@ -295,14 +295,17 @@ async fn clear_old_activities(pool: &mut DbPool<'_>) {
 
   match conn {
     Ok(mut conn) => {
-      diesel::delete(sent_activity::table.filter(sent_activity::published.lt(now() - 3.months())))
-        .execute(&mut conn)
-        .await
-        .map_err(|e| error!("Failed to clear old sent activities: {e}"))
-        .ok();
+      diesel::delete(
+        sent_activity::table.filter(sent_activity::published.lt(now() - IntervalDsl::days(7))),
+      )
+      .execute(&mut conn)
+      .await
+      .map_err(|e| error!("Failed to clear old sent activities: {e}"))
+      .ok();
 
       diesel::delete(
-        received_activity::table.filter(received_activity::published.lt(now() - 3.months())),
+        received_activity::table
+          .filter(received_activity::published.lt(now() - IntervalDsl::days(7))),
       )
       .execute(&mut conn)
       .await


### PR DESCRIPTION
Will reduce size of the table to 1/12. 