### PR TITLE
feat(docker/docs): explain how building lemmy works

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,66 @@
+# Building Lemmy Images
+
+## Introduction
+
+Lemmy images are of two kind:
+- `builder` (Including rust and toolchains to compile the project)
+- `runner` (Lightweight image that will run on the final users' infrastructure)
+
+## Constraints
+
+### Multi-architecture
+
+We have multi-architecture constraints to build and distribute Lemmy.
+Users may run Lemmy on AMD64 or ARM64, contributors may build on ARM64
+(e.g. if you have an Apple Silicon)...
+
+The Lemmy project has a strong constraint as of this writing:
+We use GitHub-hosted runners that are **amd64** only.
+
+Which means our official CD and release pipeline can only use `amd64 builder` images.
+And that our compilation performance are pretty bad as GitHub runners are
+low-end machine.
+
+It also means we need a `aarch64-unknown-linux-gnu` toolchain that will be responsible
+for linking Lemmy *code objects* and the shared libraries when running on an
+**amd64** platform.
+
+### Shared Libraries
+
+The project uses two shared libraries:
+- `libssl-dev`
+- `pg`
+
+Where I (@raskyld) got confused the most (and where most readers uninformed on
+how the linker process work will get too) is that we may believe because
+they are shared libraries they are not needed when we build the project.
+
+This is true at **compile-time** but it *may* not be at **linking-time**!
+
+When it comes to shared libraries, the resolution of dependencies can be mixed
+between **run-time** (on the user infrastructure) and the **linking-time**, which
+happens after `rustc` compiled our code.
+
+> Disclaimer: The following part is my own interpretation and may be incorrect.
+
+On Unix systems, it seems common to prefer **linking-time** over of **run-time** for
+optimization and performance reason. The **run-time** resolution can be interpreted as
+a **plugin** system in the sense that our program will contains code responsible for
+loading shared libraries we have absolutely no knowledge of.
+
+This is done by invoking [`ld-linux`][ld-linux-man] which is not done by hand but is the
+result of using the C library [`dlopen()`][dlopen-man] provided by `glibc` or `musl`.
+
+> End of Disclaimer
+
+In our specific case, all our dependencies are linked at **linking-time** this means
+the *libraries objects* need to be present in the builder context and they need to
+be compiled for the targeted architecture.
+
+#### References
+
+- [The Linux Documentation Project on Shared Libraries][tldp-lib]
+
+[tldp-lib]: https://tldp.org/HOWTO/Program-Library-HOWTO/shared-libraries.html
+[ld-linux-man]: https://linux.die.net/man/8/ld-linux
+[dlopen-man]: https://linux.die.net/man/3/dlopen


### PR DESCRIPTION
This PR aims to refactor the way we build Lemmy in containers taking care of multi-arch and cross-compilation concerns.
I also try to document my observations in `docker/README.md` to make anyone capable of contributing to it in the future.

### Issues

- Solves #3102

### Documentation

- [x] Write the README.md

### Cross-compilation

We are trying to achieve a [canadian toolchain](https://crosstool-ng.github.io/docs/toolchain-types/) because we want to deliver different builders for `linux/arm64` and `linux/amd64` from **amd64** GitHub runners and each of those builder should be able to
cross-compile to a platform different then the platform building Lemmy. (e.g. A Lemmy instance owner builds Lemmy for their **amd64** infrastructure but they do the build on an **arm64**).

### Proposed Design

We will maintain two image:
- `lemmy-builder-` prefixed for our builders.
- `lemmy` for our runners.

Users not interested in building Lemmy themselves can just pull the `lemmy` image.
For ease of usage, both images should be multi-arch.

#### Builders

For now, two images `lemmy-builder-linux-{arch}` that targets `linux/{arch}` and that are multi-arch.

Each of those image should have a stage per **platform** architecture which means they adapt the build process depending on the host that will run this container image. This works with *BuildKit* because it doesn't run stage the user won't need (see [this](https://docs.docker.com/build/building/multi-stage/#differences-between-legacy-builder-and-buildkit))

We will use a base image from the [`dockcross`](https://github.com/dockcross/dockcross) project which contains pre-built cross toolchains and add our required libraries otherwise producing toolchain from scratch on GitHub runners can take several hours...

There is a limitation: `dockcross` prebuilt images are **not** multi-arch so for the arm64 builder, if we want a cross-compile stage, we would need to build it from scratch 😒

- [ ] Create `lemmy-builder-linux-amd64` (this will makes us able to compile from GitHub runners)
  - [ ] Native: `builder-amd64` toolchain stage.
  - [ ] Cross: `builder-arm64` toolchain stage.
- [ ] Create `lemmy-build-linux-arm64` (this will make collaborators able to compile from Apple Silicon for example)
  - [ ] Native: `builder-arm64` toolchain stage.
  - ~[ ] Cross: `builder-amd64` toolchain stage.~ **(PLANNED FOR LATER!)**

#### Runners

TBD, idk on which image you want lemmy instances to run.
