### PR TITLE
Make import and export settings endpoints reachable

### DIFF
--- a/src/api_routes_http.rs
+++ b/src/api_routes_http.rs
@@ -298,13 +298,13 @@ pub fn config(cfg: &mut web::ServiceConfig, rate_limit: &RateLimitCell) {
           .route("/totp/generate", web::post().to(generate_totp_secret))
           .route("/totp/update", web::post().to(update_totp))
           .route("/list_logins", web::get().to(list_logins))
-          .route("/validate_auth", web::get().to(validate_auth)),
-      )
-      .service(
-        web::scope("/user")
-          .wrap(rate_limit.import_user_settings())
-          .route("/export_settings", web::get().to(export_settings))
-          .route("/import_settings", web::post().to(import_settings)),
+          .route("/validate_auth", web::get().to(validate_auth))
+          .service(
+            web::scope("/settings")
+              .wrap(rate_limit.import_user_settings())
+              .route("/export", web::get().to(export_settings))
+              .route("/import", web::post().to(import_settings)),
+          ),
       )
       // Admin Actions
       .service(

--- a/src/api_routes_http.rs
+++ b/src/api_routes_http.rs
@@ -260,6 +260,16 @@ pub fn config(cfg: &mut web::ServiceConfig, rate_limit: &RateLimitCell) {
           .wrap(rate_limit.post())
           .route(web::get().to(get_captcha)),
       )
+      .service(
+        web::resource("/user/export_settings")
+          .wrap(rate_limit.import_user_settings())
+          .route(web::get().to(export_settings)),
+      )
+      .service(
+        web::resource("/user/import_settings")
+          .wrap(rate_limit.import_user_settings())
+          .route(web::post().to(import_settings)),
+      )
       // User actions
       .service(
         web::scope("/user")
@@ -298,13 +308,7 @@ pub fn config(cfg: &mut web::ServiceConfig, rate_limit: &RateLimitCell) {
           .route("/totp/generate", web::post().to(generate_totp_secret))
           .route("/totp/update", web::post().to(update_totp))
           .route("/list_logins", web::get().to(list_logins))
-          .route("/validate_auth", web::get().to(validate_auth))
-          .service(
-            web::scope("/settings")
-              .wrap(rate_limit.import_user_settings())
-              .route("/export", web::get().to(export_settings))
-              .route("/import", web::post().to(import_settings)),
-          ),
+          .route("/validate_auth", web::get().to(validate_auth)),
       )
       // Admin Actions
       .service(


### PR DESCRIPTION
When I was trying to implement this for the UI, I couldn't reach the import or export endpoints: I got 404 errors. I believe the issue was using the "/users" scope more than once. I am able to reach the endpoints with these changes. Let me know if I'm using sensible routes for the endpoints, e.g. if `/user/settings/export` and `/user/settings/import` are acceptable.