### PR TITLE
Rename cache_remote_images setting to cache_external_link_previews

### DIFF
--- a/config/defaults.hjson
+++ b/config/defaults.hjson
@@ -43,8 +43,15 @@
     url: "http://localhost:8080/"
     # Set a custom pictrs API key. ( Required for deleting images )
     api_key: "string"
-    # Cache remote images
-    cache_remote_images: true
+    # By default the thumbnails for external links are stored in pict-rs. This ensures that they
+    # can be reliably retrieved and can be resized using pict-rs APIs. However it also increases
+    # storage usage. In case this is disabled, the Opengraph image is directly returned as
+    # thumbnail.
+    # 
+    # In some countries it is forbidden to copy preview images from newspaper articles and only
+    # hotlinking is allowed. If that is the case for your instance, make sure that this setting is
+    # disabled.
+    cache_external_link_previews: true
   }
   # Email sending configuration. All options except login/password are mandatory
   email: {

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -124,7 +124,7 @@ pub(crate) async fn fetch_pictrs(
   let pictrs_config = settings.pictrs_config()?;
   is_image_content_type(client, image_url).await?;
 
-  if pictrs_config.cache_remote_images {
+  if pictrs_config.cache_external_link_previews {
     // fetch remote non-pictrs images for persistent thumbnail link
     let fetch_url = format!(
       "{}image/download?url={}",

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -79,9 +79,17 @@ pub struct PictrsConfig {
   #[default(None)]
   pub api_key: Option<String>,
 
-  /// Cache remote images
+
+  /// By default the thumbnails for external links are stored in pict-rs. This ensures that they
+  /// can be reliably retrieved and can be resized using pict-rs APIs. However it also increases
+  /// storage usage. In case this is disabled, the Opengraph image is directly returned as
+  /// thumbnail.
+  ///
+  /// In some countries it is forbidden to copy preview images from newspaper articles and only
+  /// hotlinking is allowed. If that is the case for your instance, make sure that this setting is
+  /// disabled.
   #[default(true)]
-  pub cache_remote_images: bool,
+  pub cache_external_link_previews: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, SmartDefault, Document)]

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -79,7 +79,6 @@ pub struct PictrsConfig {
   #[default(None)]
   pub api_key: Option<String>,
 
-
   /// By default the thumbnails for external links are stored in pict-rs. This ensures that they
   /// can be reliably retrieved and can be resized using pict-rs APIs. However it also increases
   /// storage usage. In case this is disabled, the Opengraph image is directly returned as


### PR DESCRIPTION
I renamed that setting in #4035 to a clearer name. As that PR likely wont make it into 0.19, Im making a separate PR for this rename to avoid a breaking change in minor version when it is merged. So this should go into 0.19