### PR TITLE
Adding skip_serializing_none to federation state.

### DIFF
--- a/crates/api_common/src/site.rs
+++ b/crates/api_common/src/site.rs
@@ -328,6 +328,7 @@ pub struct FederatedInstances {
   pub blocked: Vec<InstanceWithFederationState>,
 }
 
+#[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "full", derive(TS))]
 #[cfg_attr(feature = "full", ts(export))]
@@ -350,6 +351,7 @@ impl From<FederationQueueState> for ReadableFederationState {
   }
 }
 
+#[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "full", derive(TS))]
 #[cfg_attr(feature = "full", ts(export))]

--- a/crates/db_schema/src/source/federation_queue_state.rs
+++ b/crates/db_schema/src/source/federation_queue_state.rs
@@ -3,9 +3,11 @@ use chrono::{DateTime, Utc};
 #[cfg(feature = "full")]
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 #[cfg(feature = "full")]
 use ts_rs::TS;
 
+#[skip_serializing_none]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(
   feature = "full",


### PR DESCRIPTION
Necessary for lemmy-js-client.