### PR TITLE
Fixing an issue with timezone migration.

### DIFF
--- a/migrations/2023-08-02-174444_fix-timezones/up.sql
+++ b/migrations/2023-08-02-174444_fix-timezones/up.sql
@@ -1,3 +1,5 @@
+DROP FUNCTION IF EXISTS hot_rank CASCADE;
+
 SET timezone = 'UTC';
 
 --  Allow ALTER TABLE ... SET DATA TYPE changing between timestamp and timestamptz to avoid a table rewrite when the session time zone is UTC (Noah Misch)


### PR DESCRIPTION
This migration failed with some older production DBs, adding the drop function before setting the timezone seemed to fix it.