### PR TITLE
Make docker hjson config work with latest changes

### DIFF
--- a/docker/lemmy.hjson
+++ b/docker/lemmy.hjson
@@ -21,7 +21,7 @@
   pictrs: {
     url: "http://pictrs:8080/"
     # api_key: "API_KEY"
-    cache_remote_images: true
+    cache_external_link_previews: true
   }
 
   #opentelemetry_url: "http://otel:4137"


### PR DESCRIPTION
The latest change made it so that running the server locally with docker was broken. This PR fixes that.