### PR TITLE
Fix banning remote user (fixes #4169)

### DIFF
--- a/crates/api/src/local_user/ban_person.rs
+++ b/crates/api/src/local_user/ban_person.rs
@@ -46,11 +46,11 @@ pub async fn ban_from_site(
   .await
   .with_lemmy_type(LemmyErrorType::CouldntUpdateUser)?;
 
-  let local_user_id = LocalUserView::read_person(&mut context.pool(), data.person_id)
-    .await?
-    .local_user
-    .id;
-  LoginToken::invalidate_all(&mut context.pool(), local_user_id).await?;
+  // if its a local user, invalidate logins
+  let local_user = LocalUserView::read_person(&mut context.pool(), data.person_id).await;
+  if let Ok(local_user) = local_user {
+    LoginToken::invalidate_all(&mut context.pool(), local_user.local_user.id).await?;
+  }
 
   // Remove their data if that's desired
   let remove_data = data.remove_data.unwrap_or(false);


### PR DESCRIPTION
It would throw an error when attempting to read LocalUserView which doesnt exist for remote user.