### PR TITLE
Fix #4048, return an error if post title is longer than 200 characters

### DIFF
--- a/crates/api_crud/src/post/create.rs
+++ b/crates/api_crud/src/post/create.rs
@@ -7,12 +7,8 @@ use lemmy_api_common::{
   request::fetch_site_data,
   send_activity::{ActivityChannel, SendActivityData},
   utils::{
-    check_community_user_action,
-    generate_local_apub_endpoint,
-    honeypot_check,
-    local_site_to_slur_regex,
-    mark_post_as_read,
-    EndpointType,
+    check_community_user_action, generate_local_apub_endpoint, honeypot_check,
+    local_site_to_slur_regex, mark_post_as_read, EndpointType,
   },
 };
 use lemmy_db_schema::{
@@ -32,7 +28,10 @@ use lemmy_utils::{
   spawn_try_task,
   utils::{
     slurs::{check_slurs, check_slurs_opt},
-    validation::{check_url_scheme, clean_url_params, is_valid_body_field, is_valid_post_title, is_valid_post_title_length},
+    validation::{
+      check_url_scheme, clean_url_params, is_valid_body_field, is_valid_post_title,
+      is_valid_post_title_length,
+    },
   },
 };
 use tracing::Instrument;

--- a/crates/api_crud/src/post/create.rs
+++ b/crates/api_crud/src/post/create.rs
@@ -32,7 +32,7 @@ use lemmy_utils::{
   spawn_try_task,
   utils::{
     slurs::{check_slurs, check_slurs_opt},
-    validation::{check_url_scheme, clean_url_params, is_valid_body_field, is_valid_post_title},
+    validation::{check_url_scheme, clean_url_params, is_valid_body_field, is_valid_post_title, is_valid_post_title_length},
   },
 };
 use tracing::Instrument;
@@ -56,6 +56,7 @@ pub async fn create_post(
   let url = data_url.map(clean_url_params).map(Into::into); // TODO no good way to handle a "clear"
 
   is_valid_post_title(&data.name)?;
+  is_valid_post_title_length(&data.name)?;
   is_valid_body_field(&data.body, true)?;
   check_url_scheme(&data.url)?;
 

--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -165,6 +165,7 @@ pub enum LemmyErrorType {
   InvalidDisplayName,
   InvalidMatrixId,
   InvalidPostTitle,
+  InvalidPostTitleLength,
   InvalidBodyField,
   BioLengthOverflow,
   MissingTotpToken,

--- a/crates/utils/src/utils/validation.rs
+++ b/crates/utils/src/utils/validation.rs
@@ -25,6 +25,7 @@ const BIO_MAX_LENGTH: usize = 300;
 const SITE_NAME_MAX_LENGTH: usize = 20;
 const SITE_NAME_MIN_LENGTH: usize = 1;
 const SITE_DESCRIPTION_MAX_LENGTH: usize = 150;
+const MAX_POST_TITLE_LEN: usize = 200;
 //Invisible unicode characters, taken from https://invisible-characters.com/
 const FORBIDDEN_DISPLAY_CHARS: [char; 53] = [
   '\u{0009}',
@@ -153,6 +154,16 @@ pub fn is_valid_post_title(title: &str) -> LemmyResult<()> {
   let check = VALID_POST_TITLE_REGEX.is_match(title) && !has_newline(title);
   if !check {
     Err(LemmyErrorType::InvalidPostTitle.into())
+  } else {
+    Ok(())
+  }
+}
+
+pub fn is_valid_post_title_length(title: &str) -> LemmyResult<()> {
+  let title_len = title.trim().len();
+  let check = title_len > 0 && title_len <= MAX_POST_TITLE_LEN;
+  if !check {
+    Err(LemmyErrorType::InvalidPostTitleLength.into())
   } else {
     Ok(())
   }
@@ -305,6 +316,7 @@ mod tests {
       is_valid_display_name,
       is_valid_matrix_id,
       is_valid_post_title,
+      is_valid_post_title_length,
       site_description_length_check,
       site_name_length_check,
       BIO_MAX_LENGTH,
@@ -333,6 +345,14 @@ mod tests {
     assert!(is_valid_post_title("n\n\n\n\nanother").is_err());
     assert!(is_valid_post_title("hello there!\n this is a test.").is_err());
     assert!(is_valid_post_title("hello there! this is a test.").is_ok());
+  }
+
+  #[test]
+  fn post_title_check() {
+    assert!(is_valid_post_title_length("Lemmy is Awesome").is_ok());
+    assert!(is_valid_post_title_length("  ").is_err());
+    assert!(is_valid_post_title_length("abcd".repeat(50).as_str()).is_ok());
+    assert!(is_valid_post_title_length(("abcd".repeat(50) + "x").as_str()).is_err());
   }
 
   #[test]


### PR DESCRIPTION
Fix LemmyNet/lemmy#4048.

Prevalidate that a post title is longer than 200 characters, which is the length of the post name column on the database. So, that Lemmy could handle the error more gracefully.