### PR TITLE
Remove httpOnly requirement.

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -84,10 +84,9 @@ pub fn read_auth_token(req: &HttpRequest) -> Result<Option<String>, LemmyError> 
   else if let Some(cookie) = &req.cookie(AUTH_COOKIE_NAME) {
     // ensure that its marked as httponly and secure
     let secure = cookie.secure().unwrap_or_default();
-    let http_only = cookie.http_only().unwrap_or_default();
     let is_debug_mode = cfg!(debug_assertions);
 
-    if !is_debug_mode && (!secure || !http_only) {
+    if !is_debug_mode && !secure {
       Err(LemmyError::from(LemmyErrorType::AuthCookieInsecure))
     } else {
       Ok(Some(cookie.value().to_string()))


### PR DESCRIPTION
Necessary for the back end to be able to read cookies set by lemmy-ui . 