### PR TITLE
Removing cookie secure check.

### DIFF
--- a/api_tests/package.json
+++ b/api_tests/package.json
@@ -27,7 +27,7 @@
     "eslint": "^8.54.0",
     "eslint-plugin-prettier": "^5.0.1",
     "jest": "^29.5.0",
-    "lemmy-js-client": "0.19.0-alpha.18",
+    "lemmy-js-client": "0.19.0-rc.19",
     "prettier": "^3.1.0",
     "ts-jest": "^29.1.0",
     "typescript": "^5.3.2"

--- a/api_tests/yarn.lock
+++ b/api_tests/yarn.lock
@@ -2286,10 +2286,10 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-lemmy-js-client@0.19.0-alpha.18:
-  version "0.19.0-alpha.18"
-  resolved "https://registry.yarnpkg.com/lemmy-js-client/-/lemmy-js-client-0.19.0-alpha.18.tgz#f94841681cabdf9d5c4ce7048eacb57557f68724"
-  integrity sha512-cKJfKKnjK+ijk0Yd6ydtne3Y4FILp2RbQg05pCru9n6PCyPAa85eQL4QxPB1PPed20ckSZRcHLcnr/bYFDgpaw==
+lemmy-js-client@0.19.0-rc.19:
+  version "0.19.0-rc.19"
+  resolved "https://registry.yarnpkg.com/lemmy-js-client/-/lemmy-js-client-0.19.0-rc.19.tgz#13932ab2b40cf16aa5218715509ebdc48f874f84"
+  integrity sha512-kae8V33QixbyYIA+pn7+sCeOOWL3eRgnFaNkZU8Y8vxhwZExIhkZus9jzVt/BoyPddVlafyBHxgAUsWXLA4tRA==
   dependencies:
     cross-fetch "^3.1.5"
     form-data "^4.0.0"

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -82,15 +82,7 @@ pub fn read_auth_token(req: &HttpRequest) -> Result<Option<String>, LemmyError> 
   }
   // If that fails, try to read from cookie
   else if let Some(cookie) = &req.cookie(AUTH_COOKIE_NAME) {
-    // ensure that its marked as httponly and secure
-    let secure = cookie.secure().unwrap_or_default();
-    let is_debug_mode = cfg!(debug_assertions);
-
-    if !is_debug_mode && !secure {
-      Err(LemmyError::from(LemmyErrorType::AuthCookieInsecure))
-    } else {
-      Ok(Some(cookie.value().to_string()))
-    }
+    Ok(Some(cookie.value().to_string()))
   }
   // Otherwise, there's no auth
   else {

--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -221,8 +221,6 @@ pub enum LemmyErrorType {
   CouldntSendWebmention,
   ContradictingFilters,
   InstanceBlockAlreadyExists,
-  /// `jwt` cookie must be marked secure and httponly
-  AuthCookieInsecure,
   /// Thrown when an API call is submitted with more than 1000 array elements, see [[MAX_API_PARAM_ELEMENTS]]
   TooManyItems,
   CommunityHasNoFollowers,


### PR DESCRIPTION
With the new `auth` cookie, some people are noting that even picture fetches are being marked as `auth_cookie_insecure` . 

Example: try viewing when logged in: https://lemmy.ml/pictrs/image/5a234108-4bde-48cb-ada7-cdfc040a7ac6.jpeg?format=webp&thumbnail=256



This should fix.