### PR TITLE
Only allow distinguishing own comments (fixes #4216)

### DIFF
--- a/crates/api/src/comment/distinguish.rs
+++ b/crates/api/src/comment/distinguish.rs
@@ -26,6 +26,11 @@ pub async fn distinguish_comment(
   )
   .await?;
 
+  // Verify that only the creator can distinguish
+  if local_user_view.person.id != orig_comment.creator.id {
+    Err(LemmyErrorType::NoCommentEditAllowed)?
+  }
+
   // Verify that only a mod or admin can distinguish a comment
   check_community_mod_action(
     &local_user_view.person,


### PR DESCRIPTION
This check was present in the [original implementation](https://github.com/LemmyNet/lemmy/pull/2391/files#r939051087), but apparently got lost when distinguish was moved to a separate endpoint.