### PR TITLE
Print version to log

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ pub struct CmdArgs {
 /// Placing the main function in lib.rs allows other crates to import it and embed Lemmy
 pub async fn start_lemmy_server(args: CmdArgs) -> Result<(), LemmyError> {
   // Print version number to log
-  println!("Lemmy v{}", version::VERSION.to_string());
+  println!("Lemmy v{}", version::VERSION);
 
   // return error 503 while running db migrations and startup tasks
   let mut startup_server_handle = None;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ use lemmy_db_schema::{source::secret::Secret, utils::build_db_pool};
 use lemmy_federate::{start_stop_federation_workers_cancellable, Opts};
 use lemmy_routes::{feeds, images, nodeinfo, webfinger};
 use lemmy_utils::{
+  version,
   error::LemmyError,
   rate_limit::RateLimitCell,
   response::jsonify_plain_text_errors,
@@ -106,6 +107,9 @@ pub struct CmdArgs {
 
 /// Placing the main function in lib.rs allows other crates to import it and embed Lemmy
 pub async fn start_lemmy_server(args: CmdArgs) -> Result<(), LemmyError> {
+
+  println!("Lemmy v{}", version::VERSION.to_string());
+  
   // return error 503 while running db migrations and startup tasks
   let mut startup_server_handle = None;
   if args.http_server {
@@ -131,7 +135,7 @@ pub async fn start_lemmy_server(args: CmdArgs) -> Result<(), LemmyError> {
   let federation_enabled = local_site.federation_enabled;
 
   if federation_enabled {
-    println!("federation enabled, host is {}", &SETTINGS.hostname);
+    println!("Federation enabled, host is {}", &SETTINGS.hostname);
   }
 
   check_private_instance_and_federation_enabled(&local_site)?;
@@ -142,7 +146,7 @@ pub async fn start_lemmy_server(args: CmdArgs) -> Result<(), LemmyError> {
   let rate_limit_cell = RateLimitCell::new(rate_limit_config);
 
   println!(
-    "Starting http server at {}:{}",
+    "Starting HTTP server at {}:{}",
     SETTINGS.bind, SETTINGS.port
   );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,11 +44,11 @@ use lemmy_db_schema::{source::secret::Secret, utils::build_db_pool};
 use lemmy_federate::{start_stop_federation_workers_cancellable, Opts};
 use lemmy_routes::{feeds, images, nodeinfo, webfinger};
 use lemmy_utils::{
-  version,
   error::LemmyError,
   rate_limit::RateLimitCell,
   response::jsonify_plain_text_errors,
   settings::{structs::Settings, SETTINGS},
+  version,  
 };
 use prometheus_metrics::serve_prometheus;
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
@@ -107,7 +107,7 @@ pub struct CmdArgs {
 
 /// Placing the main function in lib.rs allows other crates to import it and embed Lemmy
 pub async fn start_lemmy_server(args: CmdArgs) -> Result<(), LemmyError> {
-
+  // Print version number to log
   println!("Lemmy v{}", version::VERSION.to_string());
   
   // return error 503 while running db migrations and startup tasks

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ use lemmy_utils::{
   rate_limit::RateLimitCell,
   response::jsonify_plain_text_errors,
   settings::{structs::Settings, SETTINGS},
-  version,  
+  version,
 };
 use prometheus_metrics::serve_prometheus;
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
@@ -109,7 +109,7 @@ pub struct CmdArgs {
 pub async fn start_lemmy_server(args: CmdArgs) -> Result<(), LemmyError> {
   // Print version number to log
   println!("Lemmy v{}", version::VERSION.to_string());
-  
+
   // return error 503 while running db migrations and startup tasks
   let mut startup_server_handle = None;
   if args.http_server {


### PR DESCRIPTION
There was no indication that Lemmy was starting, which can be confusing because a long-running database migration might be in process for example.

So this pull requests prints the version number to the log, which is always useful when users post their logfiles, and at the same time serves as an indication that Lemmy is running.