### PR TITLE
Enable missing code for prometheus actix-web stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-web-prom"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23f332a652836b8f3a6876103c70c9ed436d0e69fa779ab5d7f57b1d5c8d488"
+dependencies = [
+ "actix-web",
+ "futures-core",
+ "pin-project-lite",
+ "prometheus",
+ "regex",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2776,6 +2789,7 @@ dependencies = [
  "activitypub_federation",
  "actix-cors",
  "actix-web",
+ "actix-web-prom",
  "chrono",
  "clap",
  "clokwerk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,3 +191,4 @@ chrono = { workspace = true }
 prometheus = { version = "0.13.3", features = ["process"] }
 serial_test = { workspace = true }
 clap = { version = "4.4.10", features = ["derive"] }
+actix-web-prom = "0.7.0"

--- a/config/config.hjson
+++ b/config/config.hjson
@@ -2,4 +2,8 @@
 # https://join-lemmy.org/docs/en/administration/configuration.html
 {
   hostname: lemmy-alpha
+  prometheus: {
+    bind: "127.0.0.1"
+    port: 10002
+  }
 }

--- a/config/config.hjson
+++ b/config/config.hjson
@@ -2,8 +2,4 @@
 # https://join-lemmy.org/docs/en/administration/configuration.html
 {
   hostname: lemmy-alpha
-  prometheus: {
-    bind: "127.0.0.1"
-    port: 10002
-  }
 }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -43,8 +43,8 @@ services:
       - RUST_LOG="warn,lemmy_server=debug,lemmy_api=debug,lemmy_api_common=debug,lemmy_api_crud=debug,lemmy_apub=debug,lemmy_db_schema=debug,lemmy_db_views=debug,lemmy_db_views_actor=debug,lemmy_db_views_moderator=debug,lemmy_routes=debug,lemmy_utils=debug,lemmy_websocket=debug"
       - RUST_BACKTRACE=full
     ports:
-      # prometheus metrics available at the path /metrics on port 10002 by default
-      # enable prometheus metrics by setting the CARGO_BUILD_FEATURES build arg above to "prometheus-metrics"
+      # prometheus metrics can be enabled with the `prometheus` config option. they are available on
+      # port 10002, path /metrics by default
       - "10002:10002"
     volumes:
       - ./lemmy.hjson:/config/config.hjson:Z

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use activitypub_federation::config::{FederationConfig, FederationMiddleware};
 use actix_cors::Cors;
 use actix_web::{
   dev::{ServerHandle, ServiceResponse},
-  middleware::{self, ErrorHandlerResponse, ErrorHandlers},
+  middleware::{self, Condition, ErrorHandlerResponse, ErrorHandlers},
   web::Data,
   App,
   HttpResponse,
@@ -298,7 +298,10 @@ fn create_http_server(
       .app_data(Data::new(rate_limit_cell.clone()))
       .wrap(FederationMiddleware::new(federation_config.clone()))
       .wrap(SessionMiddleware::new(context.clone()))
-      .wrap(prom_api_metrics.clone());
+      .wrap(Condition::new(
+        SETTINGS.prometheus.is_some(),
+        prom_api_metrics.clone(),
+      ));
 
     // The routes
     app

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ use actix_web::{
   HttpServer,
   Result,
 };
+use actix_web_prom::PrometheusMetricsBuilder;
 use clap::{ArgAction, Parser};
 use lemmy_api_common::{
   context::LemmyContext,
@@ -49,6 +50,7 @@ use lemmy_utils::{
   response::jsonify_plain_text_errors,
   settings::{structs::Settings, SETTINGS},
 };
+use prometheus::default_registry;
 use prometheus_metrics::serve_prometheus;
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use reqwest_tracing::TracingMiddleware;
@@ -271,7 +273,6 @@ fn create_http_server(
 ) -> Result<ServerHandle, LemmyError> {
   // this must come before the HttpServer creation
   // creates a middleware that populates http metrics for each path, method, and status code
-  #[cfg(feature = "prometheus-metrics")]
   let prom_api_metrics = PrometheusMetricsBuilder::new("lemmy_api")
     .registry(default_registry().clone())
     .build()
@@ -296,7 +297,8 @@ fn create_http_server(
       .app_data(Data::new(context.clone()))
       .app_data(Data::new(rate_limit_cell.clone()))
       .wrap(FederationMiddleware::new(federation_config.clone()))
-      .wrap(SessionMiddleware::new(context.clone()));
+      .wrap(SessionMiddleware::new(context.clone()))
+      .wrap(prom_api_metrics.clone());
 
     // The routes
     app


### PR DESCRIPTION
I failed to remove the feature flag from this code in https://github.com/LemmyNet/lemmy/pull/4071 which means that there are currently no stats generated for invidual HTTP requests.