### PR TITLE
Extend sitemap span

### DIFF
--- a/crates/api/src/sitemap.rs
+++ b/crates/api/src/sitemap.rs
@@ -1,4 +1,3 @@
-use crate::utils::{SITEMAP_DAYS, SITEMAP_LIMIT};
 use actix_web::{
   http::header::{self, CacheDirective},
   web::Data,
@@ -27,10 +26,6 @@ async fn generate_urlset(
 }
 
 pub async fn get_sitemap(context: Data<LemmyContext>) -> LemmyResult<HttpResponse> {
-  info!(
-    "Generating sitemap with posts from last {} days...",
-    SITEMAP_DAYS
-  );
   let posts = Post::list_for_sitemap(&mut context.pool()).await?;
   info!("Loaded latest {} posts", posts.len());
 

--- a/crates/api/src/sitemap.rs
+++ b/crates/api/src/sitemap.rs
@@ -1,3 +1,9 @@
+use crate::{
+  utils::{
+    SITEMAP_DAYS,
+    SITEMAP_LIMIT,
+  },
+};
 use actix_web::{
   http::header::{self, CacheDirective},
   web::Data,
@@ -26,7 +32,7 @@ async fn generate_urlset(
 }
 
 pub async fn get_sitemap(context: Data<LemmyContext>) -> LemmyResult<HttpResponse> {
-  info!("Generating sitemap with posts from last {} hours...", 24);
+  info!("Generating sitemap with posts from last {} days...", SITEMAP_DAYS);
   let posts = Post::list_for_sitemap(&mut context.pool()).await?;
   info!("Loaded latest {} posts", posts.len());
 
@@ -36,7 +42,7 @@ pub async fn get_sitemap(context: Data<LemmyContext>) -> LemmyResult<HttpRespons
   Ok(
     HttpResponse::Ok()
       .content_type("application/xml")
-      .insert_header(header::CacheControl(vec![CacheDirective::MaxAge(86_400)])) // 24 h
+      .insert_header(header::CacheControl(vec![CacheDirective::MaxAge(3_600)])) // 1 h
       .body(buf),
   )
 }

--- a/crates/api/src/sitemap.rs
+++ b/crates/api/src/sitemap.rs
@@ -26,6 +26,7 @@ async fn generate_urlset(
 }
 
 pub async fn get_sitemap(context: Data<LemmyContext>) -> LemmyResult<HttpResponse> {
+  info!("Generating sitemap...",);
   let posts = Post::list_for_sitemap(&mut context.pool()).await?;
   info!("Loaded latest {} posts", posts.len());
 

--- a/crates/api/src/sitemap.rs
+++ b/crates/api/src/sitemap.rs
@@ -1,9 +1,4 @@
-use crate::{
-  utils::{
-    SITEMAP_DAYS,
-    SITEMAP_LIMIT,
-  },
-};
+use crate::utils::{SITEMAP_DAYS, SITEMAP_LIMIT};
 use actix_web::{
   http::header::{self, CacheDirective},
   web::Data,
@@ -32,7 +27,10 @@ async fn generate_urlset(
 }
 
 pub async fn get_sitemap(context: Data<LemmyContext>) -> LemmyResult<HttpResponse> {
-  info!("Generating sitemap with posts from last {} days...", SITEMAP_DAYS);
+  info!(
+    "Generating sitemap with posts from last {} days...",
+    SITEMAP_DAYS
+  );
   let posts = Post::list_for_sitemap(&mut context.pool()).await?;
   info!("Loaded latest {} posts", posts.len());
 

--- a/crates/db_schema/src/impls/post.rs
+++ b/crates/db_schema/src/impls/post.rs
@@ -29,7 +29,14 @@ use crate::{
     PostUpdateForm,
   },
   traits::{Crud, Likeable, Saveable},
-  utils::{get_conn, naive_now, DbPool, DELETED_REPLACEMENT_TEXT, FETCH_LIMIT_MAX, FETCH_LIMIT_SITEMAP},
+  utils::{
+    get_conn,
+    naive_now,
+    DbPool,
+    DELETED_REPLACEMENT_TEXT,
+    FETCH_LIMIT_MAX,
+    FETCH_LIMIT_SITEMAP,
+  },
 };
 use ::url::Url;
 use chrono::{Duration, Utc};

--- a/crates/db_schema/src/impls/post.rs
+++ b/crates/db_schema/src/impls/post.rs
@@ -111,7 +111,7 @@ impl Post {
       .filter(removed.eq(false))
       .filter(published.ge(Utc::now().naive_utc() - Duration::days(7)))
       .order(published.desc())
-      .limit(50000)    
+      .limit(50000)
       .load::<(DbUrl, chrono::DateTime<Utc>)>(conn)
       .await
   }

--- a/crates/db_schema/src/impls/post.rs
+++ b/crates/db_schema/src/impls/post.rs
@@ -29,7 +29,7 @@ use crate::{
     PostUpdateForm,
   },
   traits::{Crud, Likeable, Saveable},
-  utils::{get_conn, naive_now, DbPool, DELETED_REPLACEMENT_TEXT, FETCH_LIMIT_MAX},
+  utils::{get_conn, naive_now, DbPool, DELETED_REPLACEMENT_TEXT, FETCH_LIMIT_MAX, FETCH_LIMIT_SITEMAP},
 };
 use ::url::Url;
 use chrono::{Duration, Utc};
@@ -111,7 +111,7 @@ impl Post {
       .filter(removed.eq(false))
       .filter(published.ge(Utc::now().naive_utc() - Duration::days(7)))
       .order(published.desc())
-      .limit(50000)
+      .limit(FETCH_LIMIT_SITEMAP)
       .load::<(DbUrl, chrono::DateTime<Utc>)>(conn)
       .await
   }

--- a/crates/db_schema/src/impls/post.rs
+++ b/crates/db_schema/src/impls/post.rs
@@ -35,7 +35,8 @@ use crate::{
     DbPool,
     DELETED_REPLACEMENT_TEXT,
     FETCH_LIMIT_MAX,
-    FETCH_LIMIT_SITEMAP,
+    SITEMAP_LIMIT,
+    SITEMAP_DAYS,
   },
 };
 use ::url::Url;
@@ -116,9 +117,9 @@ impl Post {
       .filter(local.eq(true))
       .filter(deleted.eq(false))
       .filter(removed.eq(false))
-      .filter(published.ge(Utc::now().naive_utc() - Duration::days(7)))
+      .filter(published.ge(Utc::now().naive_utc() - Duration::days(SITEMAP_DAYS)))
       .order(published.desc())
-      .limit(FETCH_LIMIT_SITEMAP)
+      .limit(SITEMAP_LIMIT)
       .load::<(DbUrl, chrono::DateTime<Utc>)>(conn)
       .await
   }

--- a/crates/db_schema/src/impls/post.rs
+++ b/crates/db_schema/src/impls/post.rs
@@ -109,8 +109,9 @@ impl Post {
       .filter(local.eq(true))
       .filter(deleted.eq(false))
       .filter(removed.eq(false))
-      .filter(published.ge(Utc::now().naive_utc() - Duration::days(1)))
+      .filter(published.ge(Utc::now().naive_utc() - Duration::days(7)))
       .order(published.desc())
+      .limit(50000)    
       .load::<(DbUrl, chrono::DateTime<Utc>)>(conn)
       .await
   }

--- a/crates/db_schema/src/impls/post.rs
+++ b/crates/db_schema/src/impls/post.rs
@@ -35,8 +35,8 @@ use crate::{
     DbPool,
     DELETED_REPLACEMENT_TEXT,
     FETCH_LIMIT_MAX,
-    SITEMAP_LIMIT,
     SITEMAP_DAYS,
+    SITEMAP_LIMIT,
   },
 };
 use ::url::Url;

--- a/crates/db_schema/src/utils.rs
+++ b/crates/db_schema/src/utils.rs
@@ -49,7 +49,8 @@ use url::Url;
 
 const FETCH_LIMIT_DEFAULT: i64 = 10;
 pub const FETCH_LIMIT_MAX: i64 = 50;
-pub const FETCH_LIMIT_SITEMAP: i64 = 50000;
+pub const SITEMAP_LIMIT: i64 = 50000;
+pub const SITEMAP_DAYS: i64 = 7;
 const POOL_TIMEOUT: Option<Duration> = Some(Duration::from_secs(5));
 pub const RANK_DEFAULT: f64 = 0.0001;
 

--- a/crates/db_schema/src/utils.rs
+++ b/crates/db_schema/src/utils.rs
@@ -49,6 +49,7 @@ use url::Url;
 
 const FETCH_LIMIT_DEFAULT: i64 = 10;
 pub const FETCH_LIMIT_MAX: i64 = 50;
+pub const FETCH_LIMIT_SITEMAP: i64 = 50000;
 const POOL_TIMEOUT: Option<Duration> = Some(Duration::from_secs(5));
 pub const RANK_DEFAULT: f64 = 0.0001;
 

--- a/crates/db_schema/src/utils.rs
+++ b/crates/db_schema/src/utils.rs
@@ -50,7 +50,7 @@ use url::Url;
 const FETCH_LIMIT_DEFAULT: i64 = 10;
 pub const FETCH_LIMIT_MAX: i64 = 50;
 pub const SITEMAP_LIMIT: i64 = 50000;
-pub const SITEMAP_DAYS: i64 = 7;
+pub const SITEMAP_DAYS: i64 = 31;
 const POOL_TIMEOUT: Option<Duration> = Some(Duration::from_secs(5));
 pub const RANK_DEFAULT: f64 = 0.0001;
 


### PR DESCRIPTION
Currently the ```/sitemap.xml``` returns only posts from the last 24 hours, but this is on the short side, as the Google/Bing crawlers will not always fetch it that often for low-traffic sites. This will cause them miss posts.

This pullrequest changes that timespan to 7 days (even though 31 days would be my personal preference). And also limits the total amount of items returned to 50.000, because that is the maximum amount allowed according to the spec.