### PR TITLE
Revert debug auth

### DIFF
--- a/config/defaults.hjson
+++ b/config/defaults.hjson
@@ -98,6 +98,4 @@
   # Sets a response Access-Control-Allow-Origin CORS header
   # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
   cors_origin: "*"
-  # Always send cache-control: private header for api responses, avoid problems with wrong caching.
-  disable_cache_control: true
 }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -15,7 +15,6 @@ use lemmy_utils::{
 };
 use std::io::Cursor;
 use totp_rs::{Secret, TOTP};
-use tracing::log::warn;
 
 pub mod comment;
 pub mod comment_report;
@@ -83,11 +82,6 @@ pub fn read_auth_token(req: &HttpRequest) -> Result<Option<String>, LemmyError> 
   }
   // If that fails, try to read from cookie
   else if let Some(cookie) = &req.cookie(AUTH_COOKIE_NAME) {
-    Ok(Some(cookie.value().to_string()))
-  }
-  // Read old auth cookie
-  else if let Some(cookie) = &req.cookie("jwt") {
-    warn!("Falling back to jwt cookie");
     Ok(Some(cookie.value().to_string()))
   }
   // Otherwise, there's no auth

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -43,7 +43,7 @@ use std::collections::HashSet;
 use tracing::warn;
 use url::{ParseError, Url};
 
-pub static AUTH_COOKIE_NAME: &str = "auth";
+pub static AUTH_COOKIE_NAME: &str = "jwt";
 
 #[tracing::instrument(skip_all)]
 pub async fn is_mod_or_admin(

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -57,9 +57,6 @@ pub struct Settings {
   #[default(None)]
   #[doku(example = "*")]
   cors_origin: Option<String>,
-  /// Always send cache-control: private header for api responses, avoid problems with wrong caching.
-  #[default(None)]
-  pub disable_cache_control: Option<bool>,
 }
 
 impl Settings {

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -5,7 +5,7 @@ CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 
 cd $CWD/../
 
-cargo clippy --workspace --fix --allow-staged --allow-dirty --tests --all-targets -- -D warnings
+cargo clippy --workspace --fix --allow-staged --allow-dirty --tests --all-targets --all-features -- -D warnings
 
 # Format rust files
 cargo +nightly fmt

--- a/src/session_middleware.rs
+++ b/src/session_middleware.rs
@@ -11,7 +11,6 @@ use lemmy_api::{local_user_view_from_jwt, read_auth_token};
 use lemmy_api_common::context::LemmyContext;
 use reqwest::header::HeaderValue;
 use std::{future::ready, rc::Rc};
-use tracing::log::warn;
 
 #[derive(Clone)]
 pub struct SessionMiddleware {
@@ -72,11 +71,8 @@ where
         // TODO: this means it will be impossible to get any error message for invalid jwt. Need
         //       to add a separate endpoint for that.
         //       https://github.com/LemmyNet/lemmy/issues/3702
-        let local_user_view = local_user_view_from_jwt(jwt, &context).await;
-        if let Err(e) = &local_user_view {
-          warn!("Failed to handle user login: {e}");
-        }
-        if let Ok(local_user_view) = local_user_view {
+        let local_user_view = local_user_view_from_jwt(jwt, &context).await.ok();
+        if let Some(local_user_view) = local_user_view {
           req.extensions_mut().insert(local_user_view);
         }
       }
@@ -85,14 +81,11 @@ where
 
       // Add cache-control header. If user is authenticated, mark as private. Otherwise cache
       // up to one minute.
-
-      let disable_cache = context.settings().disable_cache_control.unwrap_or(false);
-      let cache_value = if jwt.is_some() || disable_cache {
+      let cache_value = if jwt.is_some() {
         "private"
       } else {
         "public, max-age=60"
       };
-
       res
         .headers_mut()
         .insert(CACHE_CONTROL, HeaderValue::from_static(cache_value));


### PR DESCRIPTION
Reverts https://github.com/LemmyNet/lemmy/pull/4220.

I also suggest changing the cookie name back from `auth` to `jwt` because thats a completely unnecessary breaking change.