### PR TITLE
Dont set duplicate context for activities

### DIFF
--- a/crates/apub/src/http/mod.rs
+++ b/crates/apub/src/http/mod.rs
@@ -96,6 +96,13 @@ pub(crate) async fn get_activity(
   if sensitive {
     Ok(HttpResponse::Forbidden().finish())
   } else {
-    create_apub_response(&activity.data)
+    // Don't use create_apub_response() to avoid duplicate context (the activity stored in db
+    // already includes context).
+    let json = serde_json::to_string_pretty(&activity.data)?;
+    Ok(
+      HttpResponse::Ok()
+        .content_type(FEDERATION_CONTENT_TYPE)
+        .body(json),
+    )
   }
 }


### PR DESCRIPTION
I noticed that activities served over HTTP were sending a duplicate context, eg:
```
curl -H 'Accept: application/activity+json' https://lemmy.world/activities/announce/48488319-5cc1-4706-a3fc-ad91124a9b30
```
```json
{
    "@context":[
        "https://www.w3.org/ns/activitystreams",
        "https://w3id.org/security/v1",
        {
            "lemmy":"https://join-lemmy.org/ns#",
            "litepub":"http://litepub.social/ns#",
            "pt":"https://joinpeertube.org/ns#",
            "sc":"http://schema.org/",
            "ChatMessage":"litepub:ChatMessage",
            "commentsEnabled":"pt:commentsEnabled",
            "sensitive":"as:sensitive",
            "matrixUserId":"lemmy:matrixUserId",
            "postingRestrictedToMods":"lemmy:postingRestrictedToMods",
            "removeData":"lemmy:removeData",
            "stickied":"lemmy:stickied",
            "moderators":{
                "@type":"@id",
                "@id":"lemmy:moderators"
            },
            "expires":"as:endTime",
            "distinguished":"lemmy:distinguished",
            "language":"sc:inLanguage",
            "identifier":"sc:identifier"
        }
    ],
    "@context":[
        "https://www.w3.org/ns/activitystreams",
        "https://w3id.org/security/v1",
        {
            "lemmy":"https://join-lemmy.org/ns#",
            "litepub":"http://litepub.social/ns#",
            "pt":"https://joinpeertube.org/ns#",
            "sc":"http://schema.org/",
            "ChatMessage":"litepub:ChatMessage",
            "commentsEnabled":"pt:commentsEnabled",
            "sensitive":"as:sensitive",
            "matrixUserId":"lemmy:matrixUserId",
            "postingRestrictedToMods":"lemmy:postingRestrictedToMods",
            "removeData":"lemmy:removeData",
            "stickied":"lemmy:stickied",
            "moderators":{
                "@type":"@id",
                "@id":"lemmy:moderators"
            },
            "expires":"as:endTime",
            "distinguished":"lemmy:distinguished",
            "language":"sc:inLanguage",
            "identifier":"sc:identifier"
        }
    ],
    "actor":"https://lemmy.world/c/games",
    "to":[
        "https://www.w3.org/ns/activitystreams#Public"
    ],
    "object": ...,
    "cc":[
        "https://lemmy.world/c/games/followers"
    ],
    "type":"Announce",
    "id":"https://lemmy.world/activities/announce/48488319-5cc1-4706-a3fc-ad91124a9b30"
}"                                                                                                                                                  
```

Thats because one context is stored in the database with the activity, while another is added in the HTTP handler by `create_apub_response()`.