### PR TITLE
Add voters to active users

### DIFF
--- a/migrations/2023-12-06-180359_edit_active_users/down.sql
+++ b/migrations/2023-12-06-180359_edit_active_users/down.sql
@@ -29,8 +29,7 @@ BEGIN
             INNER JOIN person pe ON p.creator_id = pe.id
         WHERE
             p.published > ('now'::timestamp - i::interval)
-            AND pe.bot_account = FALSE
-    ) a
+            AND pe.bot_account = FALSE) a
 GROUP BY
     community_id;
 END;
@@ -70,3 +69,4 @@ BEGIN
     RETURN count_;
 END;
 $$;
+

--- a/migrations/2023-12-06-180359_edit_active_users/down.sql
+++ b/migrations/2023-12-06-180359_edit_active_users/down.sql
@@ -1,0 +1,72 @@
+CREATE OR REPLACE FUNCTION community_aggregates_activity (i text)
+    RETURNS TABLE (
+        count_ bigint,
+        community_id_ integer)
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    RETURN query
+    SELECT
+        count(*),
+        community_id
+    FROM (
+        SELECT
+            c.creator_id,
+            p.community_id
+        FROM
+            comment c
+            INNER JOIN post p ON c.post_id = p.id
+            INNER JOIN person pe ON c.creator_id = pe.id
+        WHERE
+            c.published > ('now'::timestamp - i::interval)
+            AND pe.bot_account = FALSE
+        UNION
+        SELECT
+            p.creator_id,
+            p.community_id
+        FROM
+            post p
+            INNER JOIN person pe ON p.creator_id = pe.id
+        WHERE
+            p.published > ('now'::timestamp - i::interval)
+            AND pe.bot_account = FALSE
+    ) a
+GROUP BY
+    community_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION site_aggregates_activity (i text)
+    RETURNS integer
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    count_ integer;
+BEGIN
+    SELECT
+        count(*) INTO count_
+    FROM (
+        SELECT
+            c.creator_id
+        FROM
+            comment c
+            INNER JOIN person u ON c.creator_id = u.id
+            INNER JOIN person pe ON c.creator_id = pe.id
+        WHERE
+            c.published > ('now'::timestamp - i::interval)
+            AND u.local = TRUE
+            AND pe.bot_account = FALSE
+        UNION
+        SELECT
+            p.creator_id
+        FROM
+            post p
+            INNER JOIN person u ON p.creator_id = u.id
+            INNER JOIN person pe ON p.creator_id = pe.id
+        WHERE
+            p.published > ('now'::timestamp - i::interval)
+            AND u.local = TRUE
+            AND pe.bot_account = FALSE) a;
+    RETURN count_;
+END;
+$$;

--- a/migrations/2023-12-06-180359_edit_active_users/up.sql
+++ b/migrations/2023-12-06-180359_edit_active_users/up.sql
@@ -33,13 +33,14 @@ BEGIN
             AND pe.bot_account = FALSE
         UNION
         SELECT
-            pl.person_id, p.community_id
+            pl.person_id, 
+            p.community_id
         FROM 
             post_like pl
             INNER JOIN post p ON pl.post_id = p.id
             INNER JOIN person pe ON c.creator_id = pe.id
         WHERE
-            pl.published > ('now'::timestamp - i::INTERVAL)
+            pl.published > ('now'::timestamp - i::interval)
             AND pe.bot_account = FALSE
         UNION
         SELECT
@@ -49,9 +50,8 @@ BEGIN
             INNER JOIN post p ON cl.post_id = p.id
             INNER JOIN person pe ON c.creator_id = pe.id
         WHERE
-            cl.published > ('now'::timestamp - i::INTERVAL)
-            AND pe.bot_account = FALSE
-    ) a
+            cl.published > ('now'::timestamp - i::interval)
+            AND pe.bot_account = FALSE) a
 GROUP BY
     community_id;
 END;
@@ -116,8 +116,7 @@ BEGIN
         WHERE
             pr.published > ('now'::timestamp - i::interval)
             AND pe.local = TRUE
-            AND pe.bot_account = FALSE
-    ) a;
+            AND pe.bot_account = FALSE) a;
     RETURN count_;
 END;
 $$;

--- a/migrations/2023-12-06-180359_edit_active_users/up.sql
+++ b/migrations/2023-12-06-180359_edit_active_users/up.sql
@@ -107,16 +107,6 @@ BEGIN
         WHERE
             cl.published > ('now'::timestamp - i::interval)
             AND pe.local = TRUE
-            AND pe.bot_account = FALSE
-        UNION
-        SELECT
-            pr.person_id
-        FROM
-            post_read pr
-            INNER JOIN person pe ON pr.person_id = pe.id
-        WHERE
-            pr.published > ('now'::timestamp - i::interval)
-            AND pe.local = TRUE
             AND pe.bot_account = FALSE) a;
     RETURN count_;
 END;

--- a/migrations/2023-12-06-180359_edit_active_users/up.sql
+++ b/migrations/2023-12-06-180359_edit_active_users/up.sql
@@ -27,7 +27,7 @@ BEGIN
             p.community_id
         FROM
             post p
-            INNER JOIN person pe ON c.creator_id = pe.id
+            INNER JOIN person pe ON p.creator_id = pe.id
         WHERE
             p.published > ('now'::timestamp - i::interval)
             AND pe.bot_account = FALSE
@@ -38,7 +38,7 @@ BEGIN
         FROM
             post_like pl
             INNER JOIN post p ON pl.post_id = p.id
-            INNER JOIN person pe ON c.creator_id = pe.id
+            INNER JOIN person pe ON pl.person_id = pe.id
         WHERE
             pl.published > ('now'::timestamp - i::interval)
             AND pe.bot_account = FALSE
@@ -49,7 +49,7 @@ BEGIN
         FROM
             comment_like cl
             INNER JOIN post p ON cl.post_id = p.id
-            INNER JOIN person pe ON c.creator_id = pe.id
+            INNER JOIN person pe ON cl.person_id = pe.id
         WHERE
             cl.published > ('now'::timestamp - i::interval)
             AND pe.bot_account = FALSE) a

--- a/migrations/2023-12-06-180359_edit_active_users/up.sql
+++ b/migrations/2023-12-06-180359_edit_active_users/up.sql
@@ -33,9 +33,9 @@ BEGIN
             AND pe.bot_account = FALSE
         UNION
         SELECT
-            pl.person_id, 
+            pl.person_id,
             p.community_id
-        FROM 
+        FROM
             post_like pl
             INNER JOIN post p ON pl.post_id = p.id
             INNER JOIN person pe ON c.creator_id = pe.id
@@ -44,8 +44,9 @@ BEGIN
             AND pe.bot_account = FALSE
         UNION
         SELECT
-            cl.person_id, p.community_id
-        FROM 
+            cl.person_id,
+            p.community_id
+        FROM
             comment_like cl
             INNER JOIN post p ON cl.post_id = p.id
             INNER JOIN person pe ON c.creator_id = pe.id
@@ -120,3 +121,4 @@ BEGIN
     RETURN count_;
 END;
 $$;
+

--- a/migrations/2023-12-06-180359_edit_active_users/up.sql
+++ b/migrations/2023-12-06-180359_edit_active_users/up.sql
@@ -1,0 +1,123 @@
+-- Edit community aggregates to include voters as active users
+CREATE OR REPLACE FUNCTION community_aggregates_activity (i text)
+    RETURNS TABLE (
+        count_ bigint,
+        community_id_ integer)
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    RETURN query
+    SELECT
+        count(*),
+        community_id
+    FROM (
+        SELECT
+            c.creator_id,
+            p.community_id
+        FROM
+            comment c
+            INNER JOIN post p ON c.post_id = p.id
+            INNER JOIN person pe ON c.creator_id = pe.id
+        WHERE
+            c.published > ('now'::timestamp - i::interval)
+            AND pe.bot_account = FALSE
+        UNION
+        SELECT
+            p.creator_id,
+            p.community_id
+        FROM
+            post p
+            INNER JOIN person pe ON c.creator_id = pe.id
+        WHERE
+            p.published > ('now'::timestamp - i::interval)
+            AND pe.bot_account = FALSE
+        UNION
+        SELECT
+            pl.person_id, p.community_id
+        FROM 
+            post_like pl
+            INNER JOIN post p ON pl.post_id = p.id
+            INNER JOIN person pe ON c.creator_id = pe.id
+        WHERE
+            pl.published > ('now'::timestamp - i::INTERVAL)
+            AND pe.bot_account = FALSE
+        UNION
+        SELECT
+            cl.person_id, p.community_id
+        FROM 
+            comment_like cl
+            INNER JOIN post p ON cl.post_id = p.id
+            INNER JOIN person pe ON c.creator_id = pe.id
+        WHERE
+            cl.published > ('now'::timestamp - i::INTERVAL)
+            AND pe.bot_account = FALSE
+    ) a
+GROUP BY
+    community_id;
+END;
+$$;
+
+-- Edit site aggregates to include voters and people who have read posts as active users
+CREATE OR REPLACE FUNCTION site_aggregates_activity (i text)
+    RETURNS integer
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    count_ integer;
+BEGIN
+    SELECT
+        count(*) INTO count_
+    FROM (
+        SELECT
+            c.creator_id
+        FROM
+            comment c
+            INNER JOIN person pe ON c.creator_id = pe.id
+        WHERE
+            c.published > ('now'::timestamp - i::interval)
+            AND pe.local = TRUE
+            AND pe.bot_account = FALSE
+        UNION
+        SELECT
+            p.creator_id
+        FROM
+            post p
+            INNER JOIN person pe ON p.creator_id = pe.id
+        WHERE
+            p.published > ('now'::timestamp - i::interval)
+            AND pe.local = TRUE
+            AND pe.bot_account = FALSE
+        UNION
+        SELECT
+            pl.person_id
+        FROM
+            post_like pl
+            INNER JOIN person pe ON pl.person_id = pe.id
+        WHERE
+            pl.published > ('now'::timestamp - i::interval)
+            AND pe.local = TRUE
+            AND pe.bot_account = FALSE
+        UNION
+        SELECT
+            cl.person_id
+        FROM
+            comment_like cl
+            INNER JOIN person pe ON cl.person_id = pe.id
+        WHERE
+            cl.published > ('now'::timestamp - i::interval)
+            AND pe.local = TRUE
+            AND pe.bot_account = FALSE
+        UNION
+        SELECT
+            pr.person_id
+        FROM
+            post_read pr
+            INNER JOIN person pe ON pr.person_id = pe.id
+        WHERE
+            pr.published > ('now'::timestamp - i::interval)
+            AND pe.local = TRUE
+            AND pe.bot_account = FALSE
+    ) a;
+    RETURN count_;
+END;
+$$;


### PR DESCRIPTION
Pushed a change to the function that handles how active users are calculated

For communities:
- Includes people who have liked a comment
- Includes people who have liked a post

For instances
- Includes people who have read a post
- Includes people who have liked a comment
- Includes people who have liked a post

The current function tends to not gauge actual activity that well unless the community is one that tends to get more comments than average. Something such as a photography community may have a lot of people visiting it and upvoting things but not comment as much but theyre below the communities on the community list such as tech, politics, etc. that get more discussion 

This also helps make lemmy feel more alive as people have been taking the current counts as this is how many users lemmy has which is very inaccurate

Communities doesnt include people who have read a post as only an instance knows what the people in their instance read so counts would be different across instances. For instances themselves it doesnt matter since only the instance makes that stat