### PR TITLE
Dont allow blocking local instance (fixes #4241)

### DIFF
--- a/crates/api/src/site/block.rs
+++ b/crates/api/src/site/block.rs
@@ -8,7 +8,7 @@ use lemmy_db_schema::{
   source::instance_block::{InstanceBlock, InstanceBlockForm},
   traits::Blockable,
 };
-use lemmy_db_views::structs::{LocalUserView, SiteView};
+use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
@@ -19,8 +19,7 @@ pub async fn block_instance(
 ) -> Result<Json<BlockInstanceResponse>, LemmyError> {
   let instance_id = data.instance_id;
   let person_id = local_user_view.person.id;
-  let local_site = SiteView::read_local(&mut context.pool()).await?;
-  if local_site.site.instance_id == instance_id {
+  if local_user_view.person.instance_id == instance_id {
     return Err(LemmyErrorType::CantBlockLocalInstance)?;
   }
 

--- a/crates/api/src/site/block.rs
+++ b/crates/api/src/site/block.rs
@@ -8,7 +8,7 @@ use lemmy_db_schema::{
   source::instance_block::{InstanceBlock, InstanceBlockForm},
   traits::Blockable,
 };
-use lemmy_db_views::structs::LocalUserView;
+use lemmy_db_views::structs::{LocalUserView, SiteView};
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
 #[tracing::instrument(skip(context))]
@@ -19,6 +19,11 @@ pub async fn block_instance(
 ) -> Result<Json<BlockInstanceResponse>, LemmyError> {
   let instance_id = data.instance_id;
   let person_id = local_user_view.person.id;
+  let local_site = SiteView::read_local(&mut context.pool()).await?;
+  if local_site.site.instance_id == instance_id {
+    return Err(LemmyErrorType::CantBlockLocalInstance)?;
+  }
+
   let instance_block_form = InstanceBlockForm {
     person_id,
     instance_id,

--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -227,6 +227,7 @@ pub enum LemmyErrorType {
   BanExpirationInPast,
   InvalidUnixTime,
   InvalidBotAction,
+  CantBlockLocalInstance,
   Unknown(String),
 }
 


### PR DESCRIPTION
This should be prevented as its most likely unintentional. Even if its intentional, its a bad idea as it would prevent the user from seeing important announcements from admins.