### PR TITLE
Set explicit limit for getPosts/getComments in tests

### DIFF
--- a/api_tests/run-federation-test.sh
+++ b/api_tests/run-federation-test.sh
@@ -11,7 +11,7 @@ killall -s1 lemmy_server || true
 popd
 
 yarn
-yarn api-test || true
+yarn api-test-community || true
 
 killall -s1 lemmy_server || true
 killall -s1 pict-rs || true

--- a/api_tests/run-federation-test.sh
+++ b/api_tests/run-federation-test.sh
@@ -11,7 +11,7 @@ killall -s1 lemmy_server || true
 popd
 
 yarn
-yarn api-test-community || true
+yarn api-test || true
 
 killall -s1 lemmy_server || true
 killall -s1 pict-rs || true

--- a/api_tests/src/community.spec.ts
+++ b/api_tests/src/community.spec.ts
@@ -249,7 +249,7 @@ test("Admin actions in remote community are not federated to origin", async () =
   expect(gammaPost2.post_view.creator_banned_from_community).toBe(false);
 });
 
-test("moderator view", async () => {
+test.only("moderator view", async () => {
   // register a new user with their own community on alpha and post to it
   let otherUser = await registerUser(alpha, alphaUrl);
 

--- a/api_tests/src/shared.ts
+++ b/api_tests/src/shared.ts
@@ -329,6 +329,7 @@ export async function getComments(
     post_id: post_id,
     type_: listingType,
     sort: "New",
+    limit: 50
   };
   return api.getComments(form);
 }
@@ -793,6 +794,7 @@ export function getPosts(
 ): Promise<GetPostsResponse> {
   let form: GetPosts = {
     type_: listingType,
+    limit: 50
   };
   return api.getPosts(form);
 }

--- a/api_tests/src/shared.ts
+++ b/api_tests/src/shared.ts
@@ -329,7 +329,7 @@ export async function getComments(
     post_id: post_id,
     type_: listingType,
     sort: "New",
-    limit: 50
+    limit: 50,
   };
   return api.getComments(form);
 }
@@ -794,7 +794,7 @@ export function getPosts(
 ): Promise<GetPostsResponse> {
   let form: GetPosts = {
     type_: listingType,
-    limit: 50
+    limit: 50,
   };
   return api.getPosts(form);
 }


### PR DESCRIPTION
Looking at CI test failures, I noticed there were a couple cases where the expected value wasnt found in return value from `getPosts()`:
```

  ● moderator view

    expect(received).toContain(expected) // indexOf

    Expected value: 35
    Received array: [34, 27, 26, 22, 21, 20, 19, 15, 14, 13]

      295 |   let commentIds = comments.map(comment => comment.comment.id);
      296 |
    > 297 |   expect(postIds).toContain(otherPost.post.id);
          |                   ^
      298 |   expect(commentIds).toContain(otherComment.comment.id);
      299 |
      300 |   expect(postIds).toContain(alphaPost.post.id);

      at Object.<anonymous> (src/community.spec.ts:297:19)
```

https://woodpecker.join-lemmy.org/repos/129/pipeline/4262/20
https://woodpecker.join-lemmy.org/repos/129/pipeline/4276/20

This seems to happen because it uses the default limit which is 10, but there are more posts than that and the expected value is not returned. So setting an explicit, high limit should resolve this.