### PR TITLE
Fixing metadata endpoint.

### DIFF
--- a/crates/api/src/post/get_link_metadata.rs
+++ b/crates/api/src/post/get_link_metadata.rs
@@ -1,4 +1,4 @@
-use actix_web::web::{Data, Json};
+use actix_web::web::{Data, Json, Query};
 use lemmy_api_common::{
   context::LemmyContext,
   post::{GetSiteMetadata, GetSiteMetadataResponse},
@@ -8,7 +8,7 @@ use lemmy_utils::error::LemmyError;
 
 #[tracing::instrument(skip(context))]
 pub async fn get_link_metadata(
-  data: Json<GetSiteMetadata>,
+  data: Query<GetSiteMetadata>,
   context: Data<LemmyContext>,
 ) -> Result<Json<GetSiteMetadataResponse>, LemmyError> {
   let metadata = fetch_site_metadata(context.client(), &data.url).await?;


### PR DESCRIPTION
The metadata endpoint is a `web::get`, which needs Query, not Json.