### PR TITLE
federate less noisy

### DIFF
--- a/crates/federate/src/worker.rs
+++ b/crates/federate/src/worker.rs
@@ -221,7 +221,7 @@ impl InstanceWorker {
       SendActivityTask::prepare(object, actor.as_ref(), inbox_urls, &self.context).await?;
     for task in requests {
       // usually only one due to shared inbox
-      tracing::info!("sending out {}", task);
+      tracing::debug!("sending out {}", task);
       while let Err(e) = task.sign_and_send(&self.context).await {
         self.state.fail_count += 1;
         self.state.last_retry = Some(Utc::now());


### PR DESCRIPTION
this makes the federation queue component logging less noisy mainly be moving the output when an activity is sent to debug. 

this should make it viable to run with `RUST_LOG=lemmy_federate=info` in a production environment