### PR TITLE
Quick fix for Peertube federation (fixes #4261)

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -6,7 +6,8 @@ variables:
   - &slow_check_paths
     - path:
         # rust source code
-        - "**/*.rs"
+        - "crates/**"
+        - "src/**"
         - "**/Cargo.toml"
         - "Cargo.lock"
         # database migrations

--- a/crates/apub/assets/peertube/objects/group.json
+++ b/crates/apub/assets/peertube/objects/group.json
@@ -1,30 +1,4 @@
 {
-  "type": "Group",
-  "id": "https://framatube.org/video-channels/joinpeertube",
-  "following": "https://framatube.org/video-channels/joinpeertube/following",
-  "followers": "https://framatube.org/video-channels/joinpeertube/followers",
-  "playlists": "https://framatube.org/video-channels/joinpeertube/playlists",
-  "inbox": "https://framatube.org/video-channels/joinpeertube/inbox",
-  "outbox": "https://framatube.org/video-channels/joinpeertube/outbox",
-  "preferredUsername": "joinpeertube",
-  "url": "https://framatube.org/video-channels/joinpeertube",
-  "name": "A propos de PeerTube",
-  "endpoints": {
-    "sharedInbox": "https://framatube.org/inbox"
-  },
-  "publicKey": {
-    "id": "https://framatube.org/video-channels/joinpeertube#main-key",
-    "owner": "https://framatube.org/video-channels/joinpeertube",
-    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsJCIZJga+4Kumb9Wrmpy\ntyV7kWdINImoXBiFkGG+6OHreHN2C3UPwTu9IkX/e20NaX6Ly6c0busieW7yh//q\nomHl2U8zz2Z5xQHUN/2ljQjUNO+89OV6cFIGyEvcwc6QhuqGvrcxonjrEkux7xSv\nxQM4kZ3YW1Sii4piFpGGIm1pcUkOxFab8PWVB5Hzpg/df2/XOmH8UECT5vaMRPE6\ns6hNiQNE34z9QmPiG6nUlaWb/WDcMYbma3sUVWW3DI008ukLlwLaLIm30ax8CEYt\nHEv2jOQb1E1sXtBPe1FI+dXRgTIk40KF50KLqcgwJH1y5ck7c8IEeooj+tYGVqPr\npQIDAQAB\n-----END PUBLIC KEY-----"
-  },
-  "published": "2021-08-09T14:26:09.514Z",
-  "icon": {
-    "type": "Image",
-    "mediaType": "image/png",
-    "height": 120,
-    "width": 120,
-    "url": "https://framatube.org/lazy-static/avatars/a2c2ff10-9da6-4c6c-9b25-2e557fa74b66.png"
-  },
   "@context": [
     "https://www.w3.org/ns/activitystreams",
     "https://w3id.org/security/v1",
@@ -33,99 +7,66 @@
     },
     {
       "pt": "https://joinpeertube.org/ns#",
-      "sc": "http://schema.org#",
-      "Hashtag": "as:Hashtag",
-      "uuid": "sc:identifier",
-      "category": "sc:category",
-      "licence": "sc:license",
-      "subtitleLanguage": "sc:subtitleLanguage",
-      "sensitive": "as:sensitive",
-      "language": "sc:inLanguage",
-      "isLiveBroadcast": "sc:isLiveBroadcast",
-      "liveSaveReplay": {
-        "@type": "sc:Boolean",
-        "@id": "pt:liveSaveReplay"
-      },
-      "permanentLive": {
-        "@type": "sc:Boolean",
-        "@id": "pt:permanentLive"
-      },
-      "Infohash": "pt:Infohash",
-      "Playlist": "pt:Playlist",
-      "PlaylistElement": "pt:PlaylistElement",
-      "originallyPublishedAt": "sc:datePublished",
-      "views": {
-        "@type": "sc:Number",
-        "@id": "pt:views"
-      },
-      "state": {
-        "@type": "sc:Number",
-        "@id": "pt:state"
-      },
-      "size": {
-        "@type": "sc:Number",
-        "@id": "pt:size"
-      },
-      "fps": {
-        "@type": "sc:Number",
-        "@id": "pt:fps"
-      },
-      "startTimestamp": {
-        "@type": "sc:Number",
-        "@id": "pt:startTimestamp"
-      },
-      "stopTimestamp": {
-        "@type": "sc:Number",
-        "@id": "pt:stopTimestamp"
-      },
-      "position": {
-        "@type": "sc:Number",
-        "@id": "pt:position"
-      },
-      "commentsEnabled": {
-        "@type": "sc:Boolean",
-        "@id": "pt:commentsEnabled"
-      },
-      "downloadEnabled": {
-        "@type": "sc:Boolean",
-        "@id": "pt:downloadEnabled"
-      },
-      "waitTranscoding": {
-        "@type": "sc:Boolean",
-        "@id": "pt:waitTranscoding"
+      "sc": "http://schema.org/",
+      "playlists": {
+        "@id": "pt:playlists",
+        "@type": "@id"
       },
       "support": {
         "@type": "sc:Text",
         "@id": "pt:support"
       },
-      "likes": {
-        "@id": "as:likes",
-        "@type": "@id"
-      },
-      "dislikes": {
-        "@id": "as:dislikes",
-        "@type": "@id"
-      },
-      "playlists": {
-        "@id": "pt:playlists",
-        "@type": "@id"
-      },
-      "shares": {
-        "@id": "as:shares",
-        "@type": "@id"
-      },
-      "comments": {
-        "@id": "as:comments",
-        "@type": "@id"
-      }
+      "icons": "as:icon"
     }
   ],
-  "summary": "Un logiciel libre pour reprendre le contrôle de vos vidéos",
-  "support": null,
+  "type": "Group",
+  "id": "https://peertube.stream/video-channels/vu",
+  "following": "https://peertube.stream/video-channels/vu/following",
+  "followers": "https://peertube.stream/video-channels/vu/followers",
+  "playlists": "https://peertube.stream/video-channels/vu/playlists",
+  "inbox": "https://peertube.stream/video-channels/vu/inbox",
+  "outbox": "https://peertube.stream/video-channels/vu/outbox",
+  "preferredUsername": "vu",
+  "url": "https://peertube.stream/video-channels/vu",
+  "name": "VU",
+  "endpoints": {
+    "sharedInbox": "https://peertube.stream/inbox"
+  },
+  "publicKey": {
+    "id": "https://peertube.stream/video-channels/vu#main-key",
+    "owner": "https://peertube.stream/video-channels/vu",
+    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtcWpN7efQx5C7ecWkw3r\nX4ViPy/bl3d3iyVLyP6z/3+WAUKJxqR+QKlNzxM7NglzB0B48NYu2cg4iuwKkSK9\ntrfMC/Ze0H10Wo/5kUH5YQKzLo4syHOuuM+1rbZFBbzVFwk4k0qqLFTXQ+Y6WNSS\nG9OlFYZNpRaUkgF8Q/KCsngn68qsZ0gLly9FJb+6+j3IppLJNXrBpFB5qulWibL+\neN+3XMnaTm6ge6X+rFti5r6dh10grL0KU/eZKmGyadgdwYdvR/LLtBWwFIwSJShk\nuIPhcz2zbkwrV3AixLe76TLGXX5M9qczfsVYLupyU7TwPlFM2ENDtDdfp41sWaZa\nxQIDAQAB\n-----END PUBLIC KEY-----"
+  },
+  "published": "2020-12-10T16:07:08.406Z",
+  "icon": [
+    {
+      "type": "Image",
+      "mediaType": "image/jpeg",
+      "height": 48,
+      "width": 48,
+      "url": "https://peertube.stream/lazy-static/avatars/45ec87d5-c8ec-4fcf-948f-d5a928b56496.jpg"
+    },
+    {
+      "type": "Image",
+      "mediaType": "image/jpeg",
+      "height": 120,
+      "width": 120,
+      "url": "https://peertube.stream/lazy-static/avatars/3296c098-abbb-4fda-a67a-ab88e447ca19.jpg"
+    }
+  ],
+  "image": {
+    "type": "Image",
+    "mediaType": "image/jpeg",
+    "height": 317,
+    "width": 1920,
+    "url": "https://peertube.stream/lazy-static/banners/550c0541-3021-4d4b-8654-54d0c4cda96d.jpg"
+  },
+  "summary": "VU c'est du lundi au samedi sur France 5 à 20h00 \nRetrouvez les meilleurs moments de la télévision, en 6 minutes.\n\nChaîne PeerTube non-officielle.",
+  "support": "Suivre VU :\n- Twitter : https://twitter.com/vufrancetv\n- Facebook :https://www.facebook.com/vufrancetv/\n- Site : https://www.france.tv/france-5/vu/",
   "attributedTo": [
     {
       "type": "Person",
-      "id": "https://framatube.org/accounts/framasoft"
+      "id": "https://peertube.stream/accounts/createurs"
     }
   ]
 }

--- a/crates/apub/assets/peertube/objects/person.json
+++ b/crates/apub/assets/peertube/objects/person.json
@@ -1,30 +1,4 @@
 {
-  "type": "Person",
-  "id": "https://framatube.org/accounts/framasoft",
-  "following": "https://framatube.org/accounts/framasoft/following",
-  "followers": "https://framatube.org/accounts/framasoft/followers",
-  "playlists": "https://framatube.org/accounts/framasoft/playlists",
-  "inbox": "https://framatube.org/accounts/framasoft/inbox",
-  "outbox": "https://framatube.org/accounts/framasoft/outbox",
-  "preferredUsername": "framasoft",
-  "url": "https://framatube.org/accounts/framasoft",
-  "name": "Framasoft",
-  "endpoints": {
-    "sharedInbox": "https://framatube.org/inbox"
-  },
-  "publicKey": {
-    "id": "https://framatube.org/accounts/framasoft#main-key",
-    "owner": "https://framatube.org/accounts/framasoft",
-    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuRh3frgIg866D0y0FThp\nSUkJImMcHGkUvpYQYv2iUgarZZtEbwT8PfQf0bJazy+cP8KqQmMDf5PBhT7dfdny\nf/GKGMw9Olc+QISeKDj3sqZ3Csrm4KV4avMGCfth6eSU7LozojeSGCXdUFz/8UgE\nfhV4mJjEX/FbwRYoKlagv5rY9mkX5XomzZU+z9j6ZVXyofwOwJvmI1hq0SYDv2bc\neB/RgIh/H0nyMtF8o+0CT42FNEET9j9m1BKOBtPzwZHmitKRkEmui5cK256s1laB\nT61KHpcD9gQKkQ+I3sFEzCBUJYfVo6fUe+GehBZuAfq4qDhd15SfE4K9veDscDFI\nTwIDAQAB\n-----END PUBLIC KEY-----"
-  },
-  "published": "2018-03-01T15:16:17.118Z",
-  "icon": {
-    "type": "Image",
-    "mediaType": "image/png",
-    "height": null,
-    "width": null,
-    "url": "https://framatube.org/lazy-static/avatars/f73876f5-1d45-4f8a-942a-d3d5d5ac5dc1.png"
-  },
   "@context": [
     "https://www.w3.org/ns/activitystreams",
     "https://w3id.org/security/v1",
@@ -33,92 +7,52 @@
     },
     {
       "pt": "https://joinpeertube.org/ns#",
-      "sc": "http://schema.org#",
-      "Hashtag": "as:Hashtag",
-      "uuid": "sc:identifier",
-      "category": "sc:category",
-      "licence": "sc:license",
-      "subtitleLanguage": "sc:subtitleLanguage",
-      "sensitive": "as:sensitive",
-      "language": "sc:inLanguage",
-      "isLiveBroadcast": "sc:isLiveBroadcast",
-      "liveSaveReplay": {
-        "@type": "sc:Boolean",
-        "@id": "pt:liveSaveReplay"
-      },
-      "permanentLive": {
-        "@type": "sc:Boolean",
-        "@id": "pt:permanentLive"
-      },
-      "Infohash": "pt:Infohash",
-      "Playlist": "pt:Playlist",
-      "PlaylistElement": "pt:PlaylistElement",
-      "originallyPublishedAt": "sc:datePublished",
-      "views": {
-        "@type": "sc:Number",
-        "@id": "pt:views"
-      },
-      "state": {
-        "@type": "sc:Number",
-        "@id": "pt:state"
-      },
-      "size": {
-        "@type": "sc:Number",
-        "@id": "pt:size"
-      },
-      "fps": {
-        "@type": "sc:Number",
-        "@id": "pt:fps"
-      },
-      "startTimestamp": {
-        "@type": "sc:Number",
-        "@id": "pt:startTimestamp"
-      },
-      "stopTimestamp": {
-        "@type": "sc:Number",
-        "@id": "pt:stopTimestamp"
-      },
-      "position": {
-        "@type": "sc:Number",
-        "@id": "pt:position"
-      },
-      "commentsEnabled": {
-        "@type": "sc:Boolean",
-        "@id": "pt:commentsEnabled"
-      },
-      "downloadEnabled": {
-        "@type": "sc:Boolean",
-        "@id": "pt:downloadEnabled"
-      },
-      "waitTranscoding": {
-        "@type": "sc:Boolean",
-        "@id": "pt:waitTranscoding"
+      "sc": "http://schema.org/",
+      "playlists": {
+        "@id": "pt:playlists",
+        "@type": "@id"
       },
       "support": {
         "@type": "sc:Text",
         "@id": "pt:support"
       },
-      "likes": {
-        "@id": "as:likes",
-        "@type": "@id"
-      },
-      "dislikes": {
-        "@id": "as:dislikes",
-        "@type": "@id"
-      },
-      "playlists": {
-        "@id": "pt:playlists",
-        "@type": "@id"
-      },
-      "shares": {
-        "@id": "as:shares",
-        "@type": "@id"
-      },
-      "comments": {
-        "@id": "as:comments",
-        "@type": "@id"
-      }
+      "icons": "as:icon"
     }
   ],
-  "summary": null
+  "type": "Person",
+  "id": "https://peertube.stream/accounts/createurs",
+  "following": "https://peertube.stream/accounts/createurs/following",
+  "followers": "https://peertube.stream/accounts/createurs/followers",
+  "playlists": "https://peertube.stream/accounts/createurs/playlists",
+  "inbox": "https://peertube.stream/accounts/createurs/inbox",
+  "outbox": "https://peertube.stream/accounts/createurs/outbox",
+  "preferredUsername": "createurs",
+  "url": "https://peertube.stream/accounts/createurs",
+  "name": "Créateurs",
+  "endpoints": {
+    "sharedInbox": "https://peertube.stream/inbox"
+  },
+  "publicKey": {
+    "id": "https://peertube.stream/accounts/createurs#main-key",
+    "owner": "https://peertube.stream/accounts/createurs",
+    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxqkQhbRYbA81+WTYjorR\n2lEMad3kYCnzDjGTLr4I92eanzFHxyELGnjzP6TpEvjOiB9NrCRrqU/iFPLdgrq2\nwIFcXPWdCq6Gcg7QLlaeMM0JoJmr0KTEhzg0XKCo96UsyTzaF4DISxqi8RyoyWeU\nEkgiOzlkdYTlouq3MlQH+p1PBAsNUQfIEUsU+l6k1vzbm8JRwlT+D1bNde4I/Lqs\n4uB5ru3zzInwZ2hz9+heiriNoGEBv74rZHYn966tZVX8iMGx2+m6okozEdEQbqCl\n0ekqDcd8P6CoFqqeeu8coh82OUtuFI/XsbetdWA55YQmSHyMiTsIwVbeoogIETbI\n4QIDAQAB\n-----END PUBLIC KEY-----"
+  },
+  "published": "2020-11-11T17:12:37.243Z",
+  "icon": [
+    {
+      "type": "Image",
+      "mediaType": "image/png",
+      "height": 48,
+      "width": 48,
+      "url": "https://peertube.stream/lazy-static/avatars/1760df9a-3c96-45fc-9342-c313a3bf2210.png"
+    },
+    {
+      "type": "Image",
+      "mediaType": "image/png",
+      "height": 120,
+      "width": 120,
+      "url": "https://peertube.stream/lazy-static/avatars/c27b672d-ad8f-498a-adbe-553af8da56f9.png"
+    }
+  ],
+  "summary": "Centralisation de miroirs de chaînes. La grande majorité a été contactée ou diffuse sous licence avec paternité.\n\nCompte maintenu par [Raph](https://tooter.social/@raph)."
 }

--- a/crates/apub/assets/peertube/objects/video.json
+++ b/crates/apub/assets/peertube/objects/video.json
@@ -95,12 +95,8 @@
       }
     }
   ],
-  "to": [
-    "https://www.w3.org/ns/activitystreams#Public"
-  ],
-  "cc": [
-    "https://peertube.stream/accounts/createurs/followers"
-  ],
+  "to": ["https://www.w3.org/ns/activitystreams#Public"],
+  "cc": ["https://peertube.stream/accounts/createurs/followers"],
   "type": "Video",
   "id": "https://peertube.stream/videos/watch/46cc7342-fdd5-4583-ae16-2eeb340d3b60",
   "name": "VU du 12/12/23 : Démission \"refrusée\"",
@@ -152,9 +148,7 @@
   "preview": [
     {
       "type": "Image",
-      "rel": [
-        "storyboard"
-      ],
+      "rel": ["storyboard"],
       "url": [
         {
           "mediaType": "image/jpeg",
@@ -223,10 +217,7 @@
         },
         {
           "type": "Link",
-          "rel": [
-            "metadata",
-            "video/mp4"
-          ],
+          "rel": ["metadata", "video/mp4"],
           "mediaType": "application/json",
           "href": "https://peertube.stream/api/v1/videos/46cc7342-fdd5-4583-ae16-2eeb340d3b60/metadata/1570438",
           "height": 1080,
@@ -254,10 +245,7 @@
         },
         {
           "type": "Link",
-          "rel": [
-            "metadata",
-            "video/mp4"
-          ],
+          "rel": ["metadata", "video/mp4"],
           "mediaType": "application/json",
           "href": "https://peertube.stream/api/v1/videos/46cc7342-fdd5-4583-ae16-2eeb340d3b60/metadata/1570447",
           "height": 720,
@@ -285,10 +273,7 @@
         },
         {
           "type": "Link",
-          "rel": [
-            "metadata",
-            "video/mp4"
-          ],
+          "rel": ["metadata", "video/mp4"],
           "mediaType": "application/json",
           "href": "https://peertube.stream/api/v1/videos/46cc7342-fdd5-4583-ae16-2eeb340d3b60/metadata/1570441",
           "height": 480,
@@ -316,10 +301,7 @@
         },
         {
           "type": "Link",
-          "rel": [
-            "metadata",
-            "video/mp4"
-          ],
+          "rel": ["metadata", "video/mp4"],
           "mediaType": "application/json",
           "href": "https://peertube.stream/api/v1/videos/46cc7342-fdd5-4583-ae16-2eeb340d3b60/metadata/1570442",
           "height": 360,
@@ -347,10 +329,7 @@
         },
         {
           "type": "Link",
-          "rel": [
-            "metadata",
-            "video/mp4"
-          ],
+          "rel": ["metadata", "video/mp4"],
           "mediaType": "application/json",
           "href": "https://peertube.stream/api/v1/videos/46cc7342-fdd5-4583-ae16-2eeb340d3b60/metadata/1570448",
           "height": 240,
@@ -378,10 +357,7 @@
         },
         {
           "type": "Link",
-          "rel": [
-            "metadata",
-            "video/mp4"
-          ],
+          "rel": ["metadata", "video/mp4"],
           "mediaType": "application/json",
           "href": "https://peertube.stream/api/v1/videos/46cc7342-fdd5-4583-ae16-2eeb340d3b60/metadata/1570449",
           "height": 144,
@@ -409,10 +385,7 @@
         },
         {
           "type": "Link",
-          "rel": [
-            "metadata",
-            "video/mp4"
-          ],
+          "rel": ["metadata", "video/mp4"],
           "mediaType": "application/json",
           "href": "https://peertube.stream/api/v1/videos/46cc7342-fdd5-4583-ae16-2eeb340d3b60/metadata/1570439",
           "height": 0,
@@ -435,19 +408,13 @@
     {
       "type": "Link",
       "name": "tracker-http",
-      "rel": [
-        "tracker",
-        "http"
-      ],
+      "rel": ["tracker", "http"],
       "href": "https://peertube.stream/tracker/announce"
     },
     {
       "type": "Link",
       "name": "tracker-websocket",
-      "rel": [
-        "tracker",
-        "websocket"
-      ],
+      "rel": ["tracker", "websocket"],
       "href": "wss://peertube.stream:443/tracker/socket"
     }
   ],

--- a/crates/apub/assets/peertube/objects/video.json
+++ b/crates/apub/assets/peertube/objects/video.json
@@ -1,372 +1,4 @@
 {
-  "type": "Video",
-  "id": "https://framatube.org/videos/watch/4294a720-f263-4ea4-9392-cf9cea4d5277",
-  "name": "What is the Fediverse?",
-  "duration": "PT98S",
-  "uuid": "4294a720-f263-4ea4-9392-cf9cea4d5277",
-  "tag": [
-    {
-      "type": "Hashtag",
-      "name": "fediverse"
-    },
-    {
-      "type": "Hashtag",
-      "name": "framasoft"
-    },
-    {
-      "type": "Hashtag",
-      "name": "Mastodon"
-    },
-    {
-      "type": "Hashtag",
-      "name": "PeerTube "
-    }
-  ],
-  "category": {
-    "identifier": "15",
-    "name": "Science & Technology"
-  },
-  "licence": {
-    "identifier": "2",
-    "name": "Attribution - Share Alike"
-  },
-  "language": {
-    "identifier": "en",
-    "name": "English"
-  },
-  "views": 4805,
-  "sensitive": false,
-  "waitTranscoding": true,
-  "isLiveBroadcast": false,
-  "liveSaveReplay": null,
-  "permanentLive": null,
-  "state": 1,
-  "commentsEnabled": true,
-  "downloadEnabled": true,
-  "published": "2022-04-28T11:51:16.293Z",
-  "originallyPublishedAt": null,
-  "updated": "2022-05-03T11:39:02.489Z",
-  "mediaType": "text/markdown",
-  "content": "Help us translate the subtitles [on our translation tool](https://weblate.framasoft.org/projects/what-is-the-fediverse-video/subtitles/).\r\n\r\n**Animation Produced by** [LILA](https://libreart.info/) - [ZeMarmot Team](https://film.zemarmot.net/)\r\n**Direction & Animation** by Aryeom\r\n**Script & Technology** by Jehan\r\n**Voice by** Paul Peterson\r\n**Licence**: [CC-By-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)\r\n\r\n**Sponsored by** [Framasoft](https://framasoft.org/)\r\n\r\n**Sound by** ORL - [AMMD](https://ammd.net/)\r\n\r\n**Music**: \"Dolling\" by CyberSDF - [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/)",
-  "support": null,
-  "subtitleLanguage": [
-    {
-      "identifier": "ca",
-      "name": "Catalan",
-      "url": "https://framatube.org/lazy-static/video-captions/6f8aedd2-c61b-47f6-a2c9-75b15af24d14-ca.vtt"
-    },
-    {
-      "identifier": "en",
-      "name": "English",
-      "url": "https://framatube.org/lazy-static/video-captions/2f199e59-5cf8-4529-a033-9d6dd4a858ca-en.vtt"
-    },
-    {
-      "identifier": "es",
-      "name": "Spanish",
-      "url": "https://framatube.org/lazy-static/video-captions/3f74c16b-925f-45e1-8388-e358428c2436-es.vtt"
-    },
-    {
-      "identifier": "eu",
-      "name": "Basque",
-      "url": "https://framatube.org/lazy-static/video-captions/c4c88e7e-b9d4-4192-bcf2-caf025ddc9fd-eu.vtt"
-    },
-    {
-      "identifier": "fr",
-      "name": "French",
-      "url": "https://framatube.org/lazy-static/video-captions/c18906e3-6257-43e7-90e4-fa2c8ded258b-fr.vtt"
-    },
-    {
-      "identifier": "hu",
-      "name": "Hungarian",
-      "url": "https://framatube.org/lazy-static/video-captions/0a8a295d-a288-404b-b7b3-a2272bc2a6fb-hu.vtt"
-    },
-    {
-      "identifier": "it",
-      "name": "Italian",
-      "url": "https://framatube.org/lazy-static/video-captions/cf857bd9-8b04-4018-af9a-23fa1ff7662d-it.vtt"
-    },
-    {
-      "identifier": "nb",
-      "name": "Norwegian Bokmål",
-      "url": "https://framatube.org/lazy-static/video-captions/12e3a0e9-a29e-4b06-8538-91bed2a11242-nb.vtt"
-    },
-    {
-      "identifier": "oc",
-      "name": "Occitan",
-      "url": "https://framatube.org/lazy-static/video-captions/d841af30-97bf-4a0c-b1f9-e163ba77f23f-oc.vtt"
-    },
-    {
-      "identifier": "sh",
-      "name": "Serbo-Croatian",
-      "url": "https://framatube.org/lazy-static/video-captions/7afe4dae-745f-4769-9f17-9c3a079235cf-sh.vtt"
-    },
-    {
-      "identifier": "tr",
-      "name": "Turkish",
-      "url": "https://framatube.org/lazy-static/video-captions/1b2ea189-760c-4a3e-98d3-16f596c151f0-tr.vtt"
-    },
-    {
-      "identifier": "vi",
-      "name": "Vietnamese",
-      "url": "https://framatube.org/lazy-static/video-captions/552b4086-54ab-4eb3-a8b3-7611a2175e77-vi.vtt"
-    }
-  ],
-  "icon": [
-    {
-      "type": "Image",
-      "url": "https://framatube.org/static/thumbnails/1f9eb76e-c089-4bdd-af14-602935a6db72.jpg",
-      "mediaType": "image/jpeg",
-      "width": 280,
-      "height": 157
-    },
-    {
-      "type": "Image",
-      "url": "https://framatube.org/lazy-static/previews/8f89d4d8-696f-4512-9a1a-72f1d12caede.jpg",
-      "mediaType": "image/jpeg",
-      "width": 850,
-      "height": 480
-    }
-  ],
-  "url": [
-    {
-      "type": "Link",
-      "mediaType": "text/html",
-      "href": "https://framatube.org/videos/watch/4294a720-f263-4ea4-9392-cf9cea4d5277"
-    },
-    {
-      "type": "Link",
-      "mediaType": "application/x-mpegURL",
-      "href": "https://framatube.org/static/streaming-playlists/hls/4294a720-f263-4ea4-9392-cf9cea4d5277/adc259cb-06f7-496c-8a50-599e58358b29-master.m3u8",
-      "tag": [
-        {
-          "type": "Infohash",
-          "name": "caf7178ddd2013e28c9fbcbb7be28df25d03a023"
-        },
-        {
-          "type": "Infohash",
-          "name": "cc18bb140f51f64090ba41c951fba85705cafa38"
-        },
-        {
-          "type": "Infohash",
-          "name": "595513d823a1aecc18abacac94a1ebb0c31ec009"
-        },
-        {
-          "type": "Infohash",
-          "name": "6ae0ce749a57d0f8ff70286878ea7661f85eebf7"
-        },
-        {
-          "type": "Infohash",
-          "name": "4eb799f42d461929ed8dd4befae274c9a4404b99"
-        },
-        {
-          "type": "Infohash",
-          "name": "b48d1ea795657668783544fd1c9baf637198a323"
-        },
-        {
-          "type": "Link",
-          "name": "sha256",
-          "mediaType": "application/json",
-          "href": "https://framatube.org/static/streaming-playlists/hls/4294a720-f263-4ea4-9392-cf9cea4d5277/b414eda3-c8af-4271-8dde-253db28aacd1-segments-sha256.json"
-        },
-        {
-          "type": "Link",
-          "mediaType": "video/mp4",
-          "href": "https://framatube.org/static/streaming-playlists/hls/4294a720-f263-4ea4-9392-cf9cea4d5277/64147344-1957-480d-9106-59dd7bbf5661-1080-fragmented.mp4",
-          "height": 1080,
-          "size": 14653991,
-          "fps": 24
-        },
-        {
-          "type": "Link",
-          "rel": ["metadata", "video/mp4"],
-          "mediaType": "application/json",
-          "href": "https://framatube.org/api/v1/videos/4294a720-f263-4ea4-9392-cf9cea4d5277/metadata/1421492",
-          "height": 1080,
-          "fps": 24
-        },
-        {
-          "type": "Link",
-          "mediaType": "application/x-bittorrent",
-          "href": "https://framatube.org/lazy-static/torrents/83fa27e3-aba7-4e01-9e66-931086374176-1080-hls.torrent",
-          "height": 1080
-        },
-        {
-          "type": "Link",
-          "mediaType": "application/x-bittorrent;x-scheme-handler/magnet",
-          "href": "magnet:?xs=https%3A%2F%2Fframatube.org%2Flazy-static%2Ftorrents%2F83fa27e3-aba7-4e01-9e66-931086374176-1080-hls.torrent&xt=urn:btih:5651916e4301c812412f51381c5af0c1f627bfcb&dn=What+is+the+Fediverse%3F&tr=https%3A%2F%2Fframatube.org%2Ftracker%2Fannounce&tr=wss%3A%2F%2Fframatube.org%3A443%2Ftracker%2Fsocket&ws=https%3A%2F%2Fframatube.org%2Fstatic%2Fstreaming-playlists%2Fhls%2F4294a720-f263-4ea4-9392-cf9cea4d5277%2F64147344-1957-480d-9106-59dd7bbf5661-1080-fragmented.mp4",
-          "height": 1080
-        },
-        {
-          "type": "Link",
-          "mediaType": "video/mp4",
-          "href": "https://framatube.org/static/streaming-playlists/hls/4294a720-f263-4ea4-9392-cf9cea4d5277/0efaeae5-7468-4c45-ade5-d3b6c732621f-720-fragmented.mp4",
-          "height": 720,
-          "size": 9939723,
-          "fps": 24
-        },
-        {
-          "type": "Link",
-          "rel": ["metadata", "video/mp4"],
-          "mediaType": "application/json",
-          "href": "https://framatube.org/api/v1/videos/4294a720-f263-4ea4-9392-cf9cea4d5277/metadata/1421496",
-          "height": 720,
-          "fps": 24
-        },
-        {
-          "type": "Link",
-          "mediaType": "application/x-bittorrent",
-          "href": "https://framatube.org/lazy-static/torrents/b325c824-c052-46e2-9b46-887595055521-720-hls.torrent",
-          "height": 720
-        },
-        {
-          "type": "Link",
-          "mediaType": "application/x-bittorrent;x-scheme-handler/magnet",
-          "href": "magnet:?xs=https%3A%2F%2Fframatube.org%2Flazy-static%2Ftorrents%2Fb325c824-c052-46e2-9b46-887595055521-720-hls.torrent&xt=urn:btih:b5a1db245fe156edab7f1981693178dcd47075d2&dn=What+is+the+Fediverse%3F&tr=https%3A%2F%2Fframatube.org%2Ftracker%2Fannounce&tr=wss%3A%2F%2Fframatube.org%3A443%2Ftracker%2Fsocket&ws=https%3A%2F%2Fframatube.org%2Fstatic%2Fstreaming-playlists%2Fhls%2F4294a720-f263-4ea4-9392-cf9cea4d5277%2F0efaeae5-7468-4c45-ade5-d3b6c732621f-720-fragmented.mp4",
-          "height": 720
-        },
-        {
-          "type": "Link",
-          "mediaType": "video/mp4",
-          "href": "https://framatube.org/static/streaming-playlists/hls/4294a720-f263-4ea4-9392-cf9cea4d5277/201f9772-4971-4bc3-8356-9b85b405ae5d-480-fragmented.mp4",
-          "height": 480,
-          "size": 7398758,
-          "fps": 24
-        },
-        {
-          "type": "Link",
-          "rel": ["metadata", "video/mp4"],
-          "mediaType": "application/json",
-          "href": "https://framatube.org/api/v1/videos/4294a720-f263-4ea4-9392-cf9cea4d5277/metadata/1421494",
-          "height": 480,
-          "fps": 24
-        },
-        {
-          "type": "Link",
-          "mediaType": "application/x-bittorrent",
-          "href": "https://framatube.org/lazy-static/torrents/bd99f84e-e9bc-4d36-bea6-6f06000f87c5-480-hls.torrent",
-          "height": 480
-        },
-        {
-          "type": "Link",
-          "mediaType": "application/x-bittorrent;x-scheme-handler/magnet",
-          "href": "magnet:?xs=https%3A%2F%2Fframatube.org%2Flazy-static%2Ftorrents%2Fbd99f84e-e9bc-4d36-bea6-6f06000f87c5-480-hls.torrent&xt=urn:btih:6cbe09b50cf7788923a2ec4852a3b2bfd1cd1907&dn=What+is+the+Fediverse%3F&tr=https%3A%2F%2Fframatube.org%2Ftracker%2Fannounce&tr=wss%3A%2F%2Fframatube.org%3A443%2Ftracker%2Fsocket&ws=https%3A%2F%2Fframatube.org%2Fstatic%2Fstreaming-playlists%2Fhls%2F4294a720-f263-4ea4-9392-cf9cea4d5277%2F201f9772-4971-4bc3-8356-9b85b405ae5d-480-fragmented.mp4",
-          "height": 480
-        },
-        {
-          "type": "Link",
-          "mediaType": "video/mp4",
-          "href": "https://framatube.org/static/streaming-playlists/hls/4294a720-f263-4ea4-9392-cf9cea4d5277/b2313ae6-da36-4fe3-bec5-aa352824a38a-360-fragmented.mp4",
-          "height": 360,
-          "size": 6133890,
-          "fps": 24
-        },
-        {
-          "type": "Link",
-          "rel": ["metadata", "video/mp4"],
-          "mediaType": "application/json",
-          "href": "https://framatube.org/api/v1/videos/4294a720-f263-4ea4-9392-cf9cea4d5277/metadata/1421495",
-          "height": 360,
-          "fps": 24
-        },
-        {
-          "type": "Link",
-          "mediaType": "application/x-bittorrent",
-          "href": "https://framatube.org/lazy-static/torrents/b939430a-fdfd-4da7-a030-759ecafa6ac7-360-hls.torrent",
-          "height": 360
-        },
-        {
-          "type": "Link",
-          "mediaType": "application/x-bittorrent;x-scheme-handler/magnet",
-          "href": "magnet:?xs=https%3A%2F%2Fframatube.org%2Flazy-static%2Ftorrents%2Fb939430a-fdfd-4da7-a030-759ecafa6ac7-360-hls.torrent&xt=urn:btih:16693f14ad9e53fc41d335e3fa409c2f943d7b68&dn=What+is+the+Fediverse%3F&tr=https%3A%2F%2Fframatube.org%2Ftracker%2Fannounce&tr=wss%3A%2F%2Fframatube.org%3A443%2Ftracker%2Fsocket&ws=https%3A%2F%2Fframatube.org%2Fstatic%2Fstreaming-playlists%2Fhls%2F4294a720-f263-4ea4-9392-cf9cea4d5277%2Fb2313ae6-da36-4fe3-bec5-aa352824a38a-360-fragmented.mp4",
-          "height": 360
-        },
-        {
-          "type": "Link",
-          "mediaType": "video/mp4",
-          "href": "https://framatube.org/static/streaming-playlists/hls/4294a720-f263-4ea4-9392-cf9cea4d5277/06a866f2-0527-4d68-93b7-c656d7374e86-240-fragmented.mp4",
-          "height": 240,
-          "size": 4861464,
-          "fps": 24
-        },
-        {
-          "type": "Link",
-          "rel": ["metadata", "video/mp4"],
-          "mediaType": "application/json",
-          "href": "https://framatube.org/api/v1/videos/4294a720-f263-4ea4-9392-cf9cea4d5277/metadata/1421497",
-          "height": 240,
-          "fps": 24
-        },
-        {
-          "type": "Link",
-          "mediaType": "application/x-bittorrent",
-          "href": "https://framatube.org/lazy-static/torrents/072001ee-18ad-4859-af10-9d7bf12d640c-240-hls.torrent",
-          "height": 240
-        },
-        {
-          "type": "Link",
-          "mediaType": "application/x-bittorrent;x-scheme-handler/magnet",
-          "href": "magnet:?xs=https%3A%2F%2Fframatube.org%2Flazy-static%2Ftorrents%2F072001ee-18ad-4859-af10-9d7bf12d640c-240-hls.torrent&xt=urn:btih:b823f54d8cd73f9d7a55266ce683f43bf772d26a&dn=What+is+the+Fediverse%3F&tr=https%3A%2F%2Fframatube.org%2Ftracker%2Fannounce&tr=wss%3A%2F%2Fframatube.org%3A443%2Ftracker%2Fsocket&ws=https%3A%2F%2Fframatube.org%2Fstatic%2Fstreaming-playlists%2Fhls%2F4294a720-f263-4ea4-9392-cf9cea4d5277%2F06a866f2-0527-4d68-93b7-c656d7374e86-240-fragmented.mp4",
-          "height": 240
-        },
-        {
-          "type": "Link",
-          "mediaType": "video/mp4",
-          "href": "https://framatube.org/static/streaming-playlists/hls/4294a720-f263-4ea4-9392-cf9cea4d5277/f8a1caed-057f-4700-a28e-004efc158b15-0-fragmented.mp4",
-          "height": 0,
-          "size": 3141179,
-          "fps": 0
-        },
-        {
-          "type": "Link",
-          "rel": ["metadata", "video/mp4"],
-          "mediaType": "application/json",
-          "href": "https://framatube.org/api/v1/videos/4294a720-f263-4ea4-9392-cf9cea4d5277/metadata/1421493",
-          "height": 0,
-          "fps": 0
-        },
-        {
-          "type": "Link",
-          "mediaType": "application/x-bittorrent",
-          "href": "https://framatube.org/lazy-static/torrents/77cb6940-7e90-48d1-a391-bfa463b9600c-0-hls.torrent",
-          "height": 0
-        },
-        {
-          "type": "Link",
-          "mediaType": "application/x-bittorrent;x-scheme-handler/magnet",
-          "href": "magnet:?xs=https%3A%2F%2Fframatube.org%2Flazy-static%2Ftorrents%2F77cb6940-7e90-48d1-a391-bfa463b9600c-0-hls.torrent&xt=urn:btih:9bc7717ed01869507041e31a7e65baffa78ba651&dn=What+is+the+Fediverse%3F&tr=https%3A%2F%2Fframatube.org%2Ftracker%2Fannounce&tr=wss%3A%2F%2Fframatube.org%3A443%2Ftracker%2Fsocket&ws=https%3A%2F%2Fframatube.org%2Fstatic%2Fstreaming-playlists%2Fhls%2F4294a720-f263-4ea4-9392-cf9cea4d5277%2Ff8a1caed-057f-4700-a28e-004efc158b15-0-fragmented.mp4",
-          "height": 0
-        }
-      ]
-    },
-    {
-      "type": "Link",
-      "name": "tracker-http",
-      "rel": ["tracker", "http"],
-      "href": "https://framatube.org/tracker/announce"
-    },
-    {
-      "type": "Link",
-      "name": "tracker-websocket",
-      "rel": ["tracker", "websocket"],
-      "href": "wss://framatube.org:443/tracker/socket"
-    }
-  ],
-  "likes": "https://framatube.org/videos/watch/4294a720-f263-4ea4-9392-cf9cea4d5277/likes",
-  "dislikes": "https://framatube.org/videos/watch/4294a720-f263-4ea4-9392-cf9cea4d5277/dislikes",
-  "shares": "https://framatube.org/videos/watch/4294a720-f263-4ea4-9392-cf9cea4d5277/announces",
-  "comments": "https://framatube.org/videos/watch/4294a720-f263-4ea4-9392-cf9cea4d5277/comments",
-  "attributedTo": [
-    {
-      "type": "Person",
-      "id": "https://framatube.org/accounts/framasoft"
-    },
-    {
-      "type": "Group",
-      "id": "https://framatube.org/video-channels/joinpeertube"
-    }
-  ],
-  "to": ["https://www.w3.org/ns/activitystreams#Public"],
-  "cc": ["https://framatube.org/accounts/framasoft/followers"],
   "@context": [
     "https://www.w3.org/ns/activitystreams",
     "https://w3id.org/security/v1",
@@ -375,7 +7,7 @@
     },
     {
       "pt": "https://joinpeertube.org/ns#",
-      "sc": "http://schema.org#",
+      "sc": "http://schema.org/",
       "Hashtag": "as:Hashtag",
       "uuid": "sc:identifier",
       "category": "sc:category",
@@ -383,6 +15,7 @@
       "subtitleLanguage": "sc:subtitleLanguage",
       "sensitive": "as:sensitive",
       "language": "sc:inLanguage",
+      "identifier": "sc:identifier",
       "isLiveBroadcast": "sc:isLiveBroadcast",
       "liveSaveReplay": {
         "@type": "sc:Boolean",
@@ -392,10 +25,26 @@
         "@type": "sc:Boolean",
         "@id": "pt:permanentLive"
       },
+      "latencyMode": {
+        "@type": "sc:Number",
+        "@id": "pt:latencyMode"
+      },
       "Infohash": "pt:Infohash",
-      "Playlist": "pt:Playlist",
-      "PlaylistElement": "pt:PlaylistElement",
+      "tileWidth": {
+        "@type": "sc:Number",
+        "@id": "pt:tileWidth"
+      },
+      "tileHeight": {
+        "@type": "sc:Number",
+        "@id": "pt:tileHeight"
+      },
+      "tileDuration": {
+        "@type": "sc:Number",
+        "@id": "pt:tileDuration"
+      },
       "originallyPublishedAt": "sc:datePublished",
+      "uploadDate": "sc:uploadDate",
+      "hasParts": "sc:hasParts",
       "views": {
         "@type": "sc:Number",
         "@id": "pt:views"
@@ -411,18 +60,6 @@
       "fps": {
         "@type": "sc:Number",
         "@id": "pt:fps"
-      },
-      "startTimestamp": {
-        "@type": "sc:Number",
-        "@id": "pt:startTimestamp"
-      },
-      "stopTimestamp": {
-        "@type": "sc:Number",
-        "@id": "pt:stopTimestamp"
-      },
-      "position": {
-        "@type": "sc:Number",
-        "@id": "pt:position"
       },
       "commentsEnabled": {
         "@type": "sc:Boolean",
@@ -448,10 +85,6 @@
         "@id": "as:dislikes",
         "@type": "@id"
       },
-      "playlists": {
-        "@id": "pt:playlists",
-        "@type": "@id"
-      },
       "shares": {
         "@id": "as:shares",
         "@type": "@id"
@@ -461,5 +94,381 @@
         "@type": "@id"
       }
     }
-  ]
+  ],
+  "to": [
+    "https://www.w3.org/ns/activitystreams#Public"
+  ],
+  "cc": [
+    "https://peertube.stream/accounts/createurs/followers"
+  ],
+  "type": "Video",
+  "id": "https://peertube.stream/videos/watch/46cc7342-fdd5-4583-ae16-2eeb340d3b60",
+  "name": "VU du 12/12/23 : Démission \"refrusée\"",
+  "duration": "PT383S",
+  "uuid": "46cc7342-fdd5-4583-ae16-2eeb340d3b60",
+  "category": {
+    "identifier": "11",
+    "name": "News & Politics"
+  },
+  "views": 83,
+  "sensitive": false,
+  "waitTranscoding": true,
+  "state": 1,
+  "commentsEnabled": true,
+  "downloadEnabled": true,
+  "published": "2023-12-12T17:02:02.188Z",
+  "originallyPublishedAt": "2023-12-11T23:00:00.000Z",
+  "updated": "2023-12-14T06:40:34.279Z",
+  "tag": [
+    {
+      "type": "Hashtag",
+      "name": "France3"
+    },
+    {
+      "type": "Hashtag",
+      "name": "lezapping"
+    }
+  ],
+  "mediaType": "text/markdown",
+  "content": "Un regard impertinent et libre, orchestré par Patrick Menais et son équipe, sur le monde de l’image.\n\nEn avant-première du lundi au samedi à17h00 sur Facebook, Twitter et YouTube.\n\nDu lundi au samedi à 20h00 sur France 5.\n\nhttps://www.facebook.com/vufrancetv\nhttps://twitter.com/VuFrancetv",
+  "support": null,
+  "subtitleLanguage": [],
+  "icon": [
+    {
+      "type": "Image",
+      "url": "https://peertube.stream/lazy-static/thumbnails/208d2248-6fa3-4a58-a2e6-c6f176559457.jpg",
+      "mediaType": "image/jpeg",
+      "width": 280,
+      "height": 157
+    },
+    {
+      "type": "Image",
+      "url": "https://peertube.stream/lazy-static/previews/73d34e91-0233-443b-a1c3-d98a7ec6a87c.jpg",
+      "mediaType": "image/jpeg",
+      "width": 850,
+      "height": 480
+    }
+  ],
+  "preview": [
+    {
+      "type": "Image",
+      "rel": [
+        "storyboard"
+      ],
+      "url": [
+        {
+          "mediaType": "image/jpeg",
+          "href": "https://peertube.stream/lazy-static/storyboards/fb103d5f-8f76-4c8b-bc81-f952961cacfd.jpg",
+          "width": 1920,
+          "height": 1080,
+          "tileWidth": 192,
+          "tileHeight": 108,
+          "tileDuration": "PT4S"
+        }
+      ]
+    }
+  ],
+  "url": [
+    {
+      "type": "Link",
+      "mediaType": "text/html",
+      "href": "https://peertube.stream/videos/watch/46cc7342-fdd5-4583-ae16-2eeb340d3b60"
+    },
+    {
+      "type": "Link",
+      "mediaType": "application/x-mpegURL",
+      "href": "https://peertube.stream/static/streaming-playlists/hls/46cc7342-fdd5-4583-ae16-2eeb340d3b60/7847c00b-17f0-4cd9-b788-94283bd96d5b-master.m3u8",
+      "tag": [
+        {
+          "type": "Infohash",
+          "name": "f50d9a3e851756a1fc1da7fe8b6e40f849c1f3a1"
+        },
+        {
+          "type": "Infohash",
+          "name": "fdddadfcf01c52808a5716ac9c0f09e379a1ca69"
+        },
+        {
+          "type": "Infohash",
+          "name": "c309597f071c6ab59e1a6935be3dc1ceb58c9250"
+        },
+        {
+          "type": "Infohash",
+          "name": "5c28ed3e05102a678dc047a126650fe53d45ded4"
+        },
+        {
+          "type": "Infohash",
+          "name": "085f2c72c69af02913177534ec601349ca2b4f01"
+        },
+        {
+          "type": "Infohash",
+          "name": "37b9dbeab6f433e94f80a614f888e9a1e9ee3534"
+        },
+        {
+          "type": "Infohash",
+          "name": "cc15513891e63a92743730ba65ab256f8825f071"
+        },
+        {
+          "type": "Link",
+          "name": "sha256",
+          "mediaType": "application/json",
+          "href": "https://peertube.stream/static/streaming-playlists/hls/46cc7342-fdd5-4583-ae16-2eeb340d3b60/a3f5af94-ba6b-4349-a4b0-151cebdf9af6-segments-sha256.json"
+        },
+        {
+          "type": "Link",
+          "mediaType": "video/mp4",
+          "href": "https://peertube.stream/static/streaming-playlists/hls/46cc7342-fdd5-4583-ae16-2eeb340d3b60/5a3db28f-a4b2-49ae-963e-7fd9414efe7c-1080-fragmented.mp4",
+          "height": 1080,
+          "size": 90186372,
+          "fps": 25
+        },
+        {
+          "type": "Link",
+          "rel": [
+            "metadata",
+            "video/mp4"
+          ],
+          "mediaType": "application/json",
+          "href": "https://peertube.stream/api/v1/videos/46cc7342-fdd5-4583-ae16-2eeb340d3b60/metadata/1570438",
+          "height": 1080,
+          "fps": 25
+        },
+        {
+          "type": "Link",
+          "mediaType": "application/x-bittorrent",
+          "href": "https://peertube.stream/lazy-static/torrents/c3dd78f2-ff9b-41f1-899d-55440f512e09-1080-hls.torrent",
+          "height": 1080
+        },
+        {
+          "type": "Link",
+          "mediaType": "application/x-bittorrent;x-scheme-handler/magnet",
+          "href": "magnet:?xs=https%3A%2F%2Fpeertube.stream%2Flazy-static%2Ftorrents%2Fc3dd78f2-ff9b-41f1-899d-55440f512e09-1080-hls.torrent&xt=urn:btih:944323d8a38e077cdea5c1b1aa82300d1f49076a&dn=VU+du+12%2F12%2F23+%3A+D%C3%A9mission+%22refrus%C3%A9e%22&tr=https%3A%2F%2Fpeertube.stream%2Ftracker%2Fannounce&tr=wss%3A%2F%2Fpeertube.stream%3A443%2Ftracker%2Fsocket&ws=https%3A%2F%2Fpeertube.stream%2Fstatic%2Fstreaming-playlists%2Fhls%2F46cc7342-fdd5-4583-ae16-2eeb340d3b60%2F5a3db28f-a4b2-49ae-963e-7fd9414efe7c-1080-fragmented.mp4",
+          "height": 1080
+        },
+        {
+          "type": "Link",
+          "mediaType": "video/mp4",
+          "href": "https://peertube.stream/static/streaming-playlists/hls/46cc7342-fdd5-4583-ae16-2eeb340d3b60/557f45f0-60b7-418c-bddd-e55701b387bb-720-fragmented.mp4",
+          "height": 720,
+          "size": 50950797,
+          "fps": 25
+        },
+        {
+          "type": "Link",
+          "rel": [
+            "metadata",
+            "video/mp4"
+          ],
+          "mediaType": "application/json",
+          "href": "https://peertube.stream/api/v1/videos/46cc7342-fdd5-4583-ae16-2eeb340d3b60/metadata/1570447",
+          "height": 720,
+          "fps": 25
+        },
+        {
+          "type": "Link",
+          "mediaType": "application/x-bittorrent",
+          "href": "https://peertube.stream/lazy-static/torrents/0529c736-0c49-4efd-a9ff-c4989b4c2071-720-hls.torrent",
+          "height": 720
+        },
+        {
+          "type": "Link",
+          "mediaType": "application/x-bittorrent;x-scheme-handler/magnet",
+          "href": "magnet:?xs=https%3A%2F%2Fpeertube.stream%2Flazy-static%2Ftorrents%2F0529c736-0c49-4efd-a9ff-c4989b4c2071-720-hls.torrent&xt=urn:btih:a2662d0714edf3882193f782814441eb904460be&dn=VU+du+12%2F12%2F23+%3A+D%C3%A9mission+%22refrus%C3%A9e%22&tr=https%3A%2F%2Fpeertube.stream%2Ftracker%2Fannounce&tr=wss%3A%2F%2Fpeertube.stream%3A443%2Ftracker%2Fsocket&ws=https%3A%2F%2Fpeertube.stream%2Fstatic%2Fstreaming-playlists%2Fhls%2F46cc7342-fdd5-4583-ae16-2eeb340d3b60%2F557f45f0-60b7-418c-bddd-e55701b387bb-720-fragmented.mp4",
+          "height": 720
+        },
+        {
+          "type": "Link",
+          "mediaType": "video/mp4",
+          "href": "https://peertube.stream/static/streaming-playlists/hls/46cc7342-fdd5-4583-ae16-2eeb340d3b60/097e6338-4c6e-4c21-8fed-7df0a245c9b3-480-fragmented.mp4",
+          "height": 480,
+          "size": 31542462,
+          "fps": 25
+        },
+        {
+          "type": "Link",
+          "rel": [
+            "metadata",
+            "video/mp4"
+          ],
+          "mediaType": "application/json",
+          "href": "https://peertube.stream/api/v1/videos/46cc7342-fdd5-4583-ae16-2eeb340d3b60/metadata/1570441",
+          "height": 480,
+          "fps": 25
+        },
+        {
+          "type": "Link",
+          "mediaType": "application/x-bittorrent",
+          "href": "https://peertube.stream/lazy-static/torrents/56b47f85-b2de-44b1-9089-db13c8534e1c-480-hls.torrent",
+          "height": 480
+        },
+        {
+          "type": "Link",
+          "mediaType": "application/x-bittorrent;x-scheme-handler/magnet",
+          "href": "magnet:?xs=https%3A%2F%2Fpeertube.stream%2Flazy-static%2Ftorrents%2F56b47f85-b2de-44b1-9089-db13c8534e1c-480-hls.torrent&xt=urn:btih:9d1cc84a448ba531d2f5422a8910fd79580768ff&dn=VU+du+12%2F12%2F23+%3A+D%C3%A9mission+%22refrus%C3%A9e%22&tr=https%3A%2F%2Fpeertube.stream%2Ftracker%2Fannounce&tr=wss%3A%2F%2Fpeertube.stream%3A443%2Ftracker%2Fsocket&ws=https%3A%2F%2Fpeertube.stream%2Fstatic%2Fstreaming-playlists%2Fhls%2F46cc7342-fdd5-4583-ae16-2eeb340d3b60%2F097e6338-4c6e-4c21-8fed-7df0a245c9b3-480-fragmented.mp4",
+          "height": 480
+        },
+        {
+          "type": "Link",
+          "mediaType": "video/mp4",
+          "href": "https://peertube.stream/static/streaming-playlists/hls/46cc7342-fdd5-4583-ae16-2eeb340d3b60/b6db1f0c-0b6f-4f26-b811-d38631f4c42b-360-fragmented.mp4",
+          "height": 360,
+          "size": 23389554,
+          "fps": 25
+        },
+        {
+          "type": "Link",
+          "rel": [
+            "metadata",
+            "video/mp4"
+          ],
+          "mediaType": "application/json",
+          "href": "https://peertube.stream/api/v1/videos/46cc7342-fdd5-4583-ae16-2eeb340d3b60/metadata/1570442",
+          "height": 360,
+          "fps": 25
+        },
+        {
+          "type": "Link",
+          "mediaType": "application/x-bittorrent",
+          "href": "https://peertube.stream/lazy-static/torrents/89df203a-586e-4d09-b645-21c321ae81c2-360-hls.torrent",
+          "height": 360
+        },
+        {
+          "type": "Link",
+          "mediaType": "application/x-bittorrent;x-scheme-handler/magnet",
+          "href": "magnet:?xs=https%3A%2F%2Fpeertube.stream%2Flazy-static%2Ftorrents%2F89df203a-586e-4d09-b645-21c321ae81c2-360-hls.torrent&xt=urn:btih:40dbe1b6fb96d87d0750b32b26fd52913f22c84e&dn=VU+du+12%2F12%2F23+%3A+D%C3%A9mission+%22refrus%C3%A9e%22&tr=https%3A%2F%2Fpeertube.stream%2Ftracker%2Fannounce&tr=wss%3A%2F%2Fpeertube.stream%3A443%2Ftracker%2Fsocket&ws=https%3A%2F%2Fpeertube.stream%2Fstatic%2Fstreaming-playlists%2Fhls%2F46cc7342-fdd5-4583-ae16-2eeb340d3b60%2Fb6db1f0c-0b6f-4f26-b811-d38631f4c42b-360-fragmented.mp4",
+          "height": 360
+        },
+        {
+          "type": "Link",
+          "mediaType": "video/mp4",
+          "href": "https://peertube.stream/static/streaming-playlists/hls/46cc7342-fdd5-4583-ae16-2eeb340d3b60/d0d23e04-a7b2-47f9-8072-94a06dc0c402-240-fragmented.mp4",
+          "height": 240,
+          "size": 16040535,
+          "fps": 25
+        },
+        {
+          "type": "Link",
+          "rel": [
+            "metadata",
+            "video/mp4"
+          ],
+          "mediaType": "application/json",
+          "href": "https://peertube.stream/api/v1/videos/46cc7342-fdd5-4583-ae16-2eeb340d3b60/metadata/1570448",
+          "height": 240,
+          "fps": 25
+        },
+        {
+          "type": "Link",
+          "mediaType": "application/x-bittorrent",
+          "href": "https://peertube.stream/lazy-static/torrents/29c43d5c-b26f-404c-a286-7aff2e2bb139-240-hls.torrent",
+          "height": 240
+        },
+        {
+          "type": "Link",
+          "mediaType": "application/x-bittorrent;x-scheme-handler/magnet",
+          "href": "magnet:?xs=https%3A%2F%2Fpeertube.stream%2Flazy-static%2Ftorrents%2F29c43d5c-b26f-404c-a286-7aff2e2bb139-240-hls.torrent&xt=urn:btih:f3f102c22d48b8a0aec19be463d8f04fb3a3f499&dn=VU+du+12%2F12%2F23+%3A+D%C3%A9mission+%22refrus%C3%A9e%22&tr=https%3A%2F%2Fpeertube.stream%2Ftracker%2Fannounce&tr=wss%3A%2F%2Fpeertube.stream%3A443%2Ftracker%2Fsocket&ws=https%3A%2F%2Fpeertube.stream%2Fstatic%2Fstreaming-playlists%2Fhls%2F46cc7342-fdd5-4583-ae16-2eeb340d3b60%2Fd0d23e04-a7b2-47f9-8072-94a06dc0c402-240-fragmented.mp4",
+          "height": 240
+        },
+        {
+          "type": "Link",
+          "mediaType": "video/mp4",
+          "href": "https://peertube.stream/static/streaming-playlists/hls/46cc7342-fdd5-4583-ae16-2eeb340d3b60/6f3b1939-67c4-45f0-bd93-2508721dda69-144-fragmented.mp4",
+          "height": 144,
+          "size": 10969421,
+          "fps": 25
+        },
+        {
+          "type": "Link",
+          "rel": [
+            "metadata",
+            "video/mp4"
+          ],
+          "mediaType": "application/json",
+          "href": "https://peertube.stream/api/v1/videos/46cc7342-fdd5-4583-ae16-2eeb340d3b60/metadata/1570449",
+          "height": 144,
+          "fps": 25
+        },
+        {
+          "type": "Link",
+          "mediaType": "application/x-bittorrent",
+          "href": "https://peertube.stream/lazy-static/torrents/e39095d9-8fa2-4543-a66f-b4b9d6165a4e-144-hls.torrent",
+          "height": 144
+        },
+        {
+          "type": "Link",
+          "mediaType": "application/x-bittorrent;x-scheme-handler/magnet",
+          "href": "magnet:?xs=https%3A%2F%2Fpeertube.stream%2Flazy-static%2Ftorrents%2Fe39095d9-8fa2-4543-a66f-b4b9d6165a4e-144-hls.torrent&xt=urn:btih:8b263d7e814d611597a36dcd9655d959c86605a4&dn=VU+du+12%2F12%2F23+%3A+D%C3%A9mission+%22refrus%C3%A9e%22&tr=https%3A%2F%2Fpeertube.stream%2Ftracker%2Fannounce&tr=wss%3A%2F%2Fpeertube.stream%3A443%2Ftracker%2Fsocket&ws=https%3A%2F%2Fpeertube.stream%2Fstatic%2Fstreaming-playlists%2Fhls%2F46cc7342-fdd5-4583-ae16-2eeb340d3b60%2F6f3b1939-67c4-45f0-bd93-2508721dda69-144-fragmented.mp4",
+          "height": 144
+        },
+        {
+          "type": "Link",
+          "mediaType": "video/mp4",
+          "href": "https://peertube.stream/static/streaming-playlists/hls/46cc7342-fdd5-4583-ae16-2eeb340d3b60/86ab6cca-46e5-4c6e-9c2c-8aef803b85f2-0-fragmented.mp4",
+          "height": 0,
+          "size": 6074306,
+          "fps": 0
+        },
+        {
+          "type": "Link",
+          "rel": [
+            "metadata",
+            "video/mp4"
+          ],
+          "mediaType": "application/json",
+          "href": "https://peertube.stream/api/v1/videos/46cc7342-fdd5-4583-ae16-2eeb340d3b60/metadata/1570439",
+          "height": 0,
+          "fps": 0
+        },
+        {
+          "type": "Link",
+          "mediaType": "application/x-bittorrent",
+          "href": "https://peertube.stream/lazy-static/torrents/25ae194d-c3ec-412a-886f-3b0d02599ca7-0-hls.torrent",
+          "height": 0
+        },
+        {
+          "type": "Link",
+          "mediaType": "application/x-bittorrent;x-scheme-handler/magnet",
+          "href": "magnet:?xs=https%3A%2F%2Fpeertube.stream%2Flazy-static%2Ftorrents%2F25ae194d-c3ec-412a-886f-3b0d02599ca7-0-hls.torrent&xt=urn:btih:e4458f2445732a228e9a83e2ae53a103f5e1097e&dn=VU+du+12%2F12%2F23+%3A+D%C3%A9mission+%22refrus%C3%A9e%22&tr=https%3A%2F%2Fpeertube.stream%2Ftracker%2Fannounce&tr=wss%3A%2F%2Fpeertube.stream%3A443%2Ftracker%2Fsocket&ws=https%3A%2F%2Fpeertube.stream%2Fstatic%2Fstreaming-playlists%2Fhls%2F46cc7342-fdd5-4583-ae16-2eeb340d3b60%2F86ab6cca-46e5-4c6e-9c2c-8aef803b85f2-0-fragmented.mp4",
+          "height": 0
+        }
+      ]
+    },
+    {
+      "type": "Link",
+      "name": "tracker-http",
+      "rel": [
+        "tracker",
+        "http"
+      ],
+      "href": "https://peertube.stream/tracker/announce"
+    },
+    {
+      "type": "Link",
+      "name": "tracker-websocket",
+      "rel": [
+        "tracker",
+        "websocket"
+      ],
+      "href": "wss://peertube.stream:443/tracker/socket"
+    }
+  ],
+  "likes": "https://peertube.stream/videos/watch/46cc7342-fdd5-4583-ae16-2eeb340d3b60/likes",
+  "dislikes": "https://peertube.stream/videos/watch/46cc7342-fdd5-4583-ae16-2eeb340d3b60/dislikes",
+  "shares": "https://peertube.stream/videos/watch/46cc7342-fdd5-4583-ae16-2eeb340d3b60/announces",
+  "comments": "https://peertube.stream/videos/watch/46cc7342-fdd5-4583-ae16-2eeb340d3b60/comments",
+  "hasParts": "https://peertube.stream/videos/watch/46cc7342-fdd5-4583-ae16-2eeb340d3b60/chapters",
+  "attributedTo": [
+    {
+      "type": "Person",
+      "id": "https://peertube.stream/accounts/createurs"
+    },
+    {
+      "type": "Group",
+      "id": "https://peertube.stream/video-channels/vu"
+    }
+  ],
+  "isLiveBroadcast": false,
+  "liveSaveReplay": null,
+  "permanentLive": null,
+  "latencyMode": null,
+  "peertubeLiveChat": false
 }

--- a/crates/apub/src/protocol/objects/group.rs
+++ b/crates/apub/src/protocol/objects/group.rs
@@ -57,6 +57,7 @@ pub struct Group {
   pub(crate) summary: Option<String>,
   #[serde(deserialize_with = "deserialize_skip_error", default)]
   pub(crate) source: Option<Source>,
+  #[serde(deserialize_with = "deserialize_skip_error", default)]
   pub(crate) icon: Option<ImageObject>,
   /// banner
   pub(crate) image: Option<ImageObject>,

--- a/crates/apub/src/protocol/objects/person.rs
+++ b/crates/apub/src/protocol/objects/person.rs
@@ -38,6 +38,7 @@ pub struct Person {
   #[serde(deserialize_with = "deserialize_skip_error", default)]
   pub(crate) source: Option<Source>,
   /// user avatar
+  #[serde(deserialize_with = "deserialize_skip_error", default)]
   pub(crate) icon: Option<ImageObject>,
   /// user banner
   pub(crate) image: Option<ImageObject>,


### PR DESCRIPTION
With Peertube 6.0 they started to include two avatar variants for each user/channel in different sizes. It broke federation because Lemmy only expects a single image. This is a quick fix which ignores any deserialization errors for the field. It means that avatars for Peertube users and channels will be broken, but thats better than completely broken federation.