### PR TITLE
Sort by post id in post view

### DIFF
--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -482,16 +482,9 @@ fn queries<'a>() -> Queries<
       query = query.filter(post_aggregates::published.gt(now() - interval));
     }
 
-    let tie_breaker = match options.sort.unwrap_or(SortType::Hot) {
-      // A second time-based sort would not be very useful
-      SortType::New | SortType::Old | SortType::NewComments => None,
-      _ => Some((Ord::Desc, field!(published))),
-    };
-
     let sorts = [
       Some((Ord::Desc, featured_field)),
       Some(main_sort),
-      tie_breaker,
       Some((Ord::Desc, field!(post_id))),
     ];
     let sorts_iter = sorts.iter().flatten();

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -492,6 +492,7 @@ fn queries<'a>() -> Queries<
       Some((Ord::Desc, featured_field)),
       Some(main_sort),
       tie_breaker,
+      Some((Ord::Desc, field!(post_id))),
     ];
     let sorts_iter = sorts.iter().flatten();
 


### PR DESCRIPTION
Without this, pagination would get stuck if all posts on a page and at least one after have the same values for the fields used for sort and pagination because the offset would only skip the first post with matching values. A malicious instance (possibly created by Steve Huffman) could abuse this by federating a small amount of posts with the same publish time.