### PR TITLE
Debug random test failure

### DIFF
--- a/crates/db_views_actor/src/person_view.rs
+++ b/crates/db_views_actor/src/person_view.rs
@@ -230,6 +230,7 @@ mod tests {
 
   #[tokio::test]
   #[serial]
+  #[allow(clippy::dbg_macro)]
   async fn exclude_deleted() {
     let pool = &build_db_pool_for_tests().await;
     let pool = &mut pool.into();
@@ -256,6 +257,7 @@ mod tests {
     .list(pool)
     .await
     .unwrap();
+    dbg!(&list);
     assert_eq!(list.len(), 1);
     assert_eq!(list[0].person.id, data.bob.id);
 


### PR DESCRIPTION
This test keeps failing randomly in CI. I believe its because some other test isnt doing proper cleanup. With this info being logged we can hopefully figure out where the problem is. Its the same problem as #4269 but this approach is cleaner.