### PR TITLE
Change comparisons in cursor-based pagination

### DIFF
--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -537,14 +537,14 @@ fn queries<'a>() -> Queries<
 
       for (i, (order, field)) in sorts_iter.clone().enumerate() {
         let compare = if (*order == Ord::Desc) ^ reverse_direction {
-          field.ge
+          field.gt
         } else {
-          field.le
+          field.lt
         };
 
         // Combines comparisons using `and`
         let mut subcondition: Box<dyn BoxableExpression<_, Pg, SqlType = sql_types::Bool>> =
-          Box::new(compare(field)(&cursor_data.0));
+          Box::new(compare(&cursor_data.0));
 
         // For each field that was sorted before the current one, require it to equal the cursor's
         // corresponding value for `subcondition` to be true.

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -536,7 +536,7 @@ fn queries<'a>() -> Queries<
         Box::new(false.into_sql::<sql_types::Bool>());
 
       for (i, (order, field)) in sorts_iter.clone().enumerate() {
-        let compare = if (order == Ord::Desc) ^ reverse_direction {
+        let compare = if (*order == Ord::Desc) ^ reverse_direction {
           field.ge
         } else {
           field.le

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -524,8 +524,8 @@ fn queries<'a>() -> Queries<
     // that's sorted after other fields is only compared if the row and the cursor
     // are in the same group created by the previous sort. This is checked with a
     // condition like `(a > 0) OR (a = 0 AND b > 1) OR (a = 0 AND b = 1 AND c > 2)`.
-    let lt = |field: &_| field.lt;
-    let gt = |field: &_| field.gt;
+    let lt = |field: &PaginationCursorField<_, _>| field.lt;
+    let gt = |field: &PaginationCursorField<_, _>| field.gt;
     for (cursor_data, compare_desc, compare_asc) in [
       (&options.page_after, lt, gt),
       (&options.page_before, gt, lt),

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -498,7 +498,7 @@ fn queries<'a>() -> Queries<
     ];
     let sorts_iter = sorts.iter().flatten();
 
-    for (order, field) in sorts_iter().clone() {
+    for (order, field) in sorts_iter.clone() {
       query = match order {
         Ord::Desc => (field.then_order_by_desc)(query),
         Ord::Asc => (field.then_order_by_asc)(query),
@@ -536,7 +536,7 @@ fn queries<'a>() -> Queries<
       let mut condition: Box<dyn BoxableExpression<_, Pg, SqlType = sql_types::Bool>> =
         Box::new(false.into_sql::<sql_types::Bool>());
 
-      for (i, (order, field)) in sorts_iter().clone().enumerate() {
+      for (i, (order, field)) in sorts_iter.clone().enumerate() {
         let compare = match order {
           Ord::Desc => compare_desc,
           Ord::Asc => compare_asc,

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -37,7 +37,7 @@ use lemmy_db_schema::{
     post_read,
     post_saved,
   },
-  utils::
+  utils::{
     functions::coalesce,
     fuzzy_search,
     get_conn,

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -524,9 +524,11 @@ fn queries<'a>() -> Queries<
     // that's sorted after other fields is only compared if the row and the cursor
     // are in the same group created by the previous sort. This is checked with a
     // condition like `(a > 0) OR (a = 0 AND b > 1) OR (a = 0 AND b = 1 AND c > 2)`.
+    let lt = |field: &_| field.lt;
+    let gt = |field: &_| field.gt;
     for (cursor_data, compare_desc, compare_asc) in [
-      (&options.page_after, |f| f.lt, |f| f.gt),
-      (&options.page_before, |f| f.gt, |f| f.lt),
+      (&options.page_after, lt, gt),
+      (&options.page_before, gt, lt),
     ] {
       let Some(cursor_data) = cursor_data else {
         continue;

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -537,9 +537,9 @@ fn queries<'a>() -> Queries<
 
       for (i, (order, field)) in sorts_iter.clone().enumerate() {
         let compare = if (*order == Ord::Desc) ^ reverse_direction {
-          field.gt
-        } else {
           field.lt
+        } else {
+          field.gt
         };
 
         // Combines comparisons using `and`

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -37,8 +37,7 @@ use lemmy_db_schema::{
     post_read,
     post_saved,
   },
-  utils::{
-    FETCH_LIMIT_MAX,
+  utils::
     functions::coalesce,
     fuzzy_search,
     get_conn,
@@ -49,6 +48,7 @@ use lemmy_db_schema::{
     ListFn,
     Queries,
     ReadFn,
+    FETCH_LIMIT_MAX,
   },
   ListingType,
   SortType,

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -536,7 +536,7 @@ fn queries<'a>() -> Queries<
         Box::new(false.into_sql::<sql_types::Bool>());
 
       for (i, (order, field)) in sorts_iter.clone().enumerate() {
-        let compare = if order == Ord::Desc ^ reverse_direction {
+        let compare = if (order == Ord::Desc) ^ reverse_direction {
           field.ge
         } else {
           field.le

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -524,10 +524,9 @@ fn queries<'a>() -> Queries<
     // that's sorted after other fields is only compared if the row and the cursor
     // are in the same group created by the previous sort. This is checked with a
     // condition like `(a > 0) OR (a = 0 AND b > 1) OR (a = 0 AND b = 1 AND c > 2)`.
-    for (cursor_data, reverse_direction) in [
-      (&options.page_after, false),
-      (&options.page_before, true),
-    ] {
+    for (cursor_data, reverse_direction) in
+      [(&options.page_after, false), (&options.page_before, true)]
+    {
       let Some(cursor_data) = cursor_data else {
         continue;
       };


### PR DESCRIPTION
Currently, posts are compared with the cursor with a condition like this:

```
(a >= 1) AND (a != 1 OR b >= 2) AND (a != 1 OR b != 2 OR b >= 3)
```

This PR changes it to:

```
(a > 1) OR (a = 1 AND b > 2) OR (a = 1 AND b = 2 AND c > 3)
```

This should make better use of the index. At worst it should be 3 very efficient index scans that are combined together. The 3 comparison groups closely resemble examples of index-friendly conditions in the PostgreSQL manual. Because they are combined with OR, the scan of items that aren't included in the final result should only be caused by other filters that don't use the index, such as deleted = false.