### PR TITLE
Fix fetching of community posts (fixes #4283)

### DIFF
--- a/api_tests/run-federation-test.sh
+++ b/api_tests/run-federation-test.sh
@@ -11,7 +11,7 @@ killall -s1 lemmy_server || true
 popd
 
 yarn
-yarn api-test || true
+yarn api-test-community || true
 
 killall -s1 lemmy_server || true
 killall -s1 pict-rs || true

--- a/api_tests/run-federation-test.sh
+++ b/api_tests/run-federation-test.sh
@@ -11,7 +11,7 @@ killall -s1 lemmy_server || true
 popd
 
 yarn
-yarn api-test-community || true
+yarn api-test || true
 
 killall -s1 lemmy_server || true
 killall -s1 pict-rs || true

--- a/api_tests/src/community.spec.ts
+++ b/api_tests/src/community.spec.ts
@@ -486,19 +486,25 @@ test("Fetch community, includes posts", async () => {
   expect(communityRes.community_view.community.name).toBeDefined();
   expect(communityRes.community_view.counts.subscribers).toBe(1);
 
-  let postRes = await createPost(alpha, communityRes.community_view.community.id);
+  let postRes = await createPost(
+    alpha,
+    communityRes.community_view.community.id,
+  );
   expect(postRes.post_view.post).toBeDefined();
-  
+
   let resolvedCommunity = await waitUntil(
-    () => resolveCommunity(beta, communityRes.community_view.community.actor_id),
+    () =>
+      resolveCommunity(beta, communityRes.community_view.community.actor_id),
     c => c.community?.community.id != undefined,
   );
   let betaCommunity = resolvedCommunity.community;
-  expect(betaCommunity?.community.actor_id).toBe(communityRes.community_view.community.actor_id);
+  expect(betaCommunity?.community.actor_id).toBe(
+    communityRes.community_view.community.actor_id,
+  );
 
   await longDelay();
 
-  let post_listing = await getPosts(beta, 'All');
+  let post_listing = await getPosts(beta, "All");
   expect(post_listing.posts.length).toBe(1);
   expect(post_listing.posts[0].post.ap_id).toBe(postRes.post_view.post.ap_id);
 });

--- a/api_tests/src/community.spec.ts
+++ b/api_tests/src/community.spec.ts
@@ -31,6 +31,7 @@ import {
   searchPostLocal,
   resolveBetaCommunity,
   longDelay,
+  delay,
 } from "./shared";
 import { EditSite } from "lemmy-js-client";
 
@@ -377,7 +378,9 @@ test("User blocks instance, communities are hidden", async () => {
 
 test("Community follower count is federated", async () => {
   // Follow the beta community from alpha
-  let resolved = await resolveBetaCommunity(alpha);
+  let community = await createCommunity(beta);
+  let community_id = community.community_view.community.actor_id;
+  let resolved = await resolveCommunity(alpha, community_id);
   if (!resolved.community) {
     throw "Missing beta community";
   }
@@ -385,7 +388,7 @@ test("Community follower count is federated", async () => {
   await followCommunity(alpha, true, resolved.community.community.id);
   let followed = (
     await waitUntil(
-      () => resolveBetaCommunity(alpha),
+      () => resolveCommunity(alpha, community_id),
       c => c.community?.subscribed === "Subscribed",
     )
   ).community;
@@ -394,7 +397,7 @@ test("Community follower count is federated", async () => {
   expect(followed?.counts.subscribers).toBe(1);
 
   // Follow the community from gamma
-  resolved = await resolveBetaCommunity(gamma);
+  resolved = await resolveCommunity(gamma, community_id);
   if (!resolved.community) {
     throw "Missing beta community";
   }
@@ -402,18 +405,16 @@ test("Community follower count is federated", async () => {
   await followCommunity(gamma, true, resolved.community.community.id);
   followed = (
     await waitUntil(
-      () => resolveBetaCommunity(gamma),
+      () => resolveCommunity(gamma, community_id),
       c => c.community?.subscribed === "Subscribed",
     )
   ).community;
-
-  await longDelay();
 
   // Make sure there are 2 subscribers
   expect(followed?.counts?.subscribers).toBe(2);
 
   // Follow the community from delta
-  resolved = await resolveBetaCommunity(delta);
+  resolved = await resolveCommunity(delta, community_id);
   if (!resolved.community) {
     throw "Missing beta community";
   }
@@ -421,7 +422,7 @@ test("Community follower count is federated", async () => {
   await followCommunity(delta, true, resolved.community.community.id);
   followed = (
     await waitUntil(
-      () => resolveBetaCommunity(delta),
+      () => resolveCommunity(delta, community_id),
       c => c.community?.subscribed === "Subscribed",
     )
   ).community;

--- a/api_tests/src/community.spec.ts
+++ b/api_tests/src/community.spec.ts
@@ -480,3 +480,25 @@ test("Dont receive community activities after unsubscribe", async () => {
   let postResBeta = searchPostLocal(beta, postRes.post_view.post);
   expect((await postResBeta).posts.length).toBe(0);
 });
+
+test("Fetch community, includes posts", async () => {
+  let communityRes = await createCommunity(alpha);
+  expect(communityRes.community_view.community.name).toBeDefined();
+  expect(communityRes.community_view.counts.subscribers).toBe(1);
+
+  let postRes = await createPost(alpha, communityRes.community_view.community.id);
+  expect(postRes.post_view.post).toBeDefined();
+  
+  let resolvedCommunity = await waitUntil(
+    () => resolveCommunity(beta, communityRes.community_view.community.actor_id),
+    c => c.community?.community.id != undefined,
+  );
+  let betaCommunity = resolvedCommunity.community;
+  expect(betaCommunity?.community.actor_id).toBe(communityRes.community_view.community.actor_id);
+
+  await longDelay();
+
+  let post_listing = await getPosts(beta, 'All');
+  expect(post_listing.posts.length).toBe(1);
+  expect(post_listing.posts[0].post.ap_id).toBe(postRes.post_view.post.ap_id);
+});

--- a/api_tests/src/community.spec.ts
+++ b/api_tests/src/community.spec.ts
@@ -504,7 +504,7 @@ test("Fetch community, includes posts", async () => {
 
   await longDelay();
 
-  let post_listing = await getPosts(beta, "All");
+  let post_listing = await getPosts(beta, "All", betaCommunity?.community.id);
   expect(post_listing.posts.length).toBe(1);
   expect(post_listing.posts[0].post.ap_id).toBe(postRes.post_view.post.ap_id);
 });

--- a/api_tests/src/community.spec.ts
+++ b/api_tests/src/community.spec.ts
@@ -407,6 +407,8 @@ test("Community follower count is federated", async () => {
     )
   ).community;
 
+  await longDelay();
+
   // Make sure there are 2 subscribers
   expect(followed?.counts?.subscribers).toBe(2);
 

--- a/api_tests/src/shared.ts
+++ b/api_tests/src/shared.ts
@@ -791,10 +791,12 @@ export async function listCommentReports(
 export function getPosts(
   api: LemmyHttp,
   listingType?: ListingType,
+  community_id?: number,
 ): Promise<GetPostsResponse> {
   let form: GetPosts = {
     type_: listingType,
     limit: 50,
+    community_id
   };
   return api.getPosts(form);
 }

--- a/api_tests/src/shared.ts
+++ b/api_tests/src/shared.ts
@@ -796,7 +796,7 @@ export function getPosts(
   let form: GetPosts = {
     type_: listingType,
     limit: 50,
-    community_id
+    community_id,
   };
   return api.getPosts(form);
 }

--- a/crates/apub/src/objects/community.rs
+++ b/crates/apub/src/objects/community.rs
@@ -234,8 +234,6 @@ pub(crate) mod tests {
     let url = Url::parse("https://enterprise.lemmy.ml/c/tenforward")?;
     ApubCommunity::verify(&json, &url, &context2).await?;
     let community = ApubCommunity::from_json(json, &context2).await?;
-    // this makes requests to the (intentionally broken) outbox and followers collections
-    assert_eq!(context2.request_count(), 2);
     Ok(community)
   }
 

--- a/crates/apub/src/objects/community.rs
+++ b/crates/apub/src/objects/community.rs
@@ -28,9 +28,8 @@ use lemmy_db_schema::{
   traits::{ApubActor, Crud},
 };
 use lemmy_db_views_actor::structs::CommunityFollowerView;
-use lemmy_utils::{error::LemmyError, utils::markdown::markdown_to_html};
+use lemmy_utils::{error::LemmyError, spawn_try_task, utils::markdown::markdown_to_html};
 use std::ops::Deref;
-use tracing::debug;
 use url::Url;
 
 #[derive(Clone, Debug)]
@@ -142,21 +141,16 @@ impl Object for ApubCommunity {
 
     // Fetching mods and outbox is not necessary for Lemmy to work, so ignore errors. Besides,
     // we need to ignore these errors so that tests can work entirely offline.
-    let fetch_outbox = group.outbox.dereference(&community, context);
-    let fetch_followers = group.followers.dereference(&community, context);
-
-    if let Some(moderators) = group.attributed_to {
-      let fetch_moderators = moderators.dereference(&community, context);
-      // Fetch mods, outbox and followers in parallel
-      let res = tokio::join!(fetch_outbox, fetch_moderators, fetch_followers);
-      res.0.map_err(|e| debug!("{}", e)).ok();
-      res.1.map_err(|e| debug!("{}", e)).ok();
-      res.2.map_err(|e| debug!("{}", e)).ok();
-    } else {
-      let res = tokio::join!(fetch_outbox, fetch_followers);
-      res.0.map_err(|e| debug!("{}", e)).ok();
-      res.1.map_err(|e| debug!("{}", e)).ok();
-    }
+    let community_ = community.clone();
+    let context_ = context.reset_request_count();
+    spawn_try_task(async move {
+      group.outbox.dereference(&community_, &context_).await?;
+      group.followers.dereference(&community_, &context_).await?;
+      if let Some(moderators) = group.attributed_to {
+        moderators.dereference(&community_, &context_).await?;
+      }
+      Ok(())
+    });
 
     Ok(community)
   }


### PR DESCRIPTION
Also use spawn_try_task to fetch community outbox, mods etc to avoid delay/timeout when fetching new community.