### PR TITLE
Bring back newest-first tie breaker in post view

### DIFF
--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -490,9 +490,16 @@ fn queries<'a>() -> Queries<
       query = query.filter(post_aggregates::published.gt(now() - interval));
     }
 
+    let tie_breaker = match options.sort.unwrap_or(SortType::Hot) {
+      // A second time-based sort would not be very useful
+      SortType::New | SortType::Old | SortType::NewComments => None,
+      _ => Some((Ord::Desc, field!(published))),
+    };
+
     let sorts = [
       Some((Ord::Desc, featured_field)),
       Some(main_sort),
+      tie_breaker,
       Some((Ord::Desc, field!(post_id))),
     ];
     let sorts_iter = sorts.iter().flatten();


### PR DESCRIPTION
This can sometimes be useful for putting more relevant posts first, like when sorting by top week in a community that's not very active and therefore doesn't have many distinct post scores. Post id is not as good for this because posts from federated instances can be inserted out of order.

This change also allows better use of the index because post_id is not in the index.