### PR TITLE
Reduce default db pool size to 30, remove db timeout (ref #4282)

### DIFF
--- a/config/defaults.hjson
+++ b/config/defaults.hjson
@@ -34,7 +34,7 @@
     # Name of the postgres database for lemmy
     database: "string"
     # Maximum number of active sql connections
-    pool_size: 95
+    pool_size: 30
   }
   # Settings related to activitypub federation
   # Pictrs image server configuration.

--- a/crates/db_schema/src/utils.rs
+++ b/crates/db_schema/src/utils.rs
@@ -42,7 +42,7 @@ use rustls::{
 use std::{
   ops::{Deref, DerefMut},
   sync::Arc,
-  time::{Duration, SystemTime},
+  time::SystemTime,
 };
 use tracing::{error, info};
 use url::Url;
@@ -51,7 +51,6 @@ const FETCH_LIMIT_DEFAULT: i64 = 10;
 pub const FETCH_LIMIT_MAX: i64 = 50;
 pub const SITEMAP_LIMIT: i64 = 50000;
 pub const SITEMAP_DAYS: i64 = 31;
-const POOL_TIMEOUT: Option<Duration> = Some(Duration::from_secs(5));
 pub const RANK_DEFAULT: f64 = 0.0001;
 
 pub type ActualDbPool = Pool<AsyncPgConnection>;
@@ -302,9 +301,6 @@ pub async fn build_db_pool() -> Result<ActualDbPool, LemmyError> {
   };
   let pool = Pool::builder(manager)
     .max_size(SETTINGS.database.pool_size)
-    .wait_timeout(POOL_TIMEOUT)
-    .create_timeout(POOL_TIMEOUT)
-    .recycle_timeout(POOL_TIMEOUT)
     .runtime(Runtime::Tokio1)
     .build()?;
 

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -102,7 +102,7 @@ pub struct DatabaseConfig {
   pub(crate) connection: DatabaseConnection,
 
   /// Maximum number of active sql connections
-  #[default(95)]
+  #[default(30)]
   pub pool_size: usize,
 }
 


### PR DESCRIPTION
Apparently pool size 95 causes high memory, so the default should be reduced to work well on small servers. Bigger servers can be expected to do some manual tuning as they have more manpower available.

@phiresky What do you think about default db pool?