### PR TITLE
Dont overwrite cache-control header in session middleware

### DIFF
--- a/src/session_middleware.rs
+++ b/src/session_middleware.rs
@@ -79,16 +79,19 @@ where
 
       let mut res = svc.call(req).await?;
 
-      // Add cache-control header. If user is authenticated, mark as private. Otherwise cache
-      // up to one minute.
-      let cache_value = if jwt.is_some() {
-        "private"
-      } else {
-        "public, max-age=60"
-      };
-      res
-        .headers_mut()
-        .insert(CACHE_CONTROL, HeaderValue::from_static(cache_value));
+      // Add cache-control header if none is present
+      if !res.headers().contains_key(CACHE_CONTROL) {
+        // If user is authenticated, mark as private. Otherwise cache
+        // up to one minute.
+        let cache_value = if jwt.is_some() {
+          "private"
+        } else {
+          "public, max-age=60"
+        };
+        res
+          .headers_mut()
+          .insert(CACHE_CONTROL, HeaderValue::from_static(cache_value));
+      }
       Ok(res)
     })
   }


### PR DESCRIPTION
The session middleware currently sets cache-control headers unconditionally, which overwrites the explicit cache-control headers for routes like node info, rss and federation. Its only a minor problem which means that the cache isnt being used in some cases.