### PR TITLE
Reduce initial federation retry delay

### DIFF
--- a/crates/api_common/src/lib.rs
+++ b/crates/api_common/src/lib.rs
@@ -43,5 +43,5 @@ impl Default for SuccessResponse {
 
 /// how long to sleep based on how many retries have already happened
 pub fn federate_retry_sleep_duration(retry_count: i32) -> Duration {
-  Duration::from_secs_f64(10.0 * 2.0_f64.powf(f64::from(retry_count)))
+  Duration::from_secs_f64(2.0_f64.powf(f64::from(retry_count)))
 }


### PR DESCRIPTION
When recovering from an outgoing federation outage on lemm.ee, I discovered that the current initial retry delay of 20 seconds can result in the workers never catching up with the queue, specifically when the target instance is dropping requests intermittently.

For example, with lemm.ee -> lemmy.world federation, I was seeing an average of 2-3 timeouts per minute, so with an initial retry delay of 20 seconds, the worker was only actively sending a couple federation events every minute. This resulted in the worker constantly falling behind. 

I propose reducing the initial retry from 20 seconds to 2 seconds (perhaps even less?) - the delay will still grow quite quickly if the target instance is really unavailable, but a lower initial delay will ensure that constant intermittent timeouts do not completely stop federation.