### PR TITLE
Use `pretty_assertions` for assertions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1511,6 +1511,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2540,6 +2546,7 @@ dependencies = [
  "lemmy_db_views_actor",
  "lemmy_db_views_moderator",
  "lemmy_utils",
+ "pretty_assertions",
  "serial_test",
  "sitemap-rs",
  "tokio",
@@ -2568,6 +2575,7 @@ dependencies = [
  "lemmy_utils",
  "once_cell",
  "percent-encoding",
+ "pretty_assertions",
  "regex",
  "reqwest",
  "reqwest-middleware",
@@ -2629,6 +2637,7 @@ dependencies = [
  "lemmy_utils",
  "moka",
  "once_cell",
+ "pretty_assertions",
  "reqwest",
  "reqwest-middleware",
  "serde",
@@ -2662,6 +2671,7 @@ dependencies = [
  "futures-util",
  "lemmy_utils",
  "once_cell",
+ "pretty_assertions",
  "regex",
  "rustls 0.21.10",
  "serde",
@@ -2691,6 +2701,7 @@ dependencies = [
  "diesel_ltree",
  "lemmy_db_schema",
  "lemmy_utils",
+ "pretty_assertions",
  "serde",
  "serde_with",
  "serial_test",
@@ -2707,6 +2718,7 @@ dependencies = [
  "diesel",
  "diesel-async",
  "lemmy_db_schema",
+ "pretty_assertions",
  "serde",
  "serde_with",
  "serial_test",
@@ -2801,6 +2813,7 @@ dependencies = [
  "opentelemetry 0.19.0",
  "opentelemetry-otlp 0.12.0",
  "pict-rs",
+ "pretty_assertions",
  "prometheus",
  "reqwest",
  "reqwest-middleware",
@@ -2836,6 +2849,7 @@ dependencies = [
  "once_cell",
  "openssl",
  "percent-encoding",
+ "pretty_assertions",
  "regex",
  "reqwest",
  "reqwest-middleware",
@@ -3941,6 +3955,16 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -6442,6 +6466,12 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,7 @@ tokio-postgres = "0.7.10"
 tokio-postgres-rustls = "0.10.0"
 enum-map = "2.7"
 moka = { version = "0.12.1", features = ["future"] }
+pretty_assertions = "1.4.0"
 
 [dependencies]
 lemmy_api = { workspace = true }
@@ -194,3 +195,6 @@ prometheus = { version = "0.13.3", features = ["process"] }
 serial_test = { workspace = true }
 clap = { version = "4.4.11", features = ["derive"] }
 actix-web-prom = "0.7.0"
+
+[dev-dependencies]
+pretty_assertions = { workspace = true }

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -42,3 +42,4 @@ actix-web-httpauth = "0.8.1"
 serial_test = { workspace = true }
 tokio = { workspace = true }
 elementtree = "1.2.3"
+pretty_assertions = { workspace = true }

--- a/crates/api/src/sitemap.rs
+++ b/crates/api/src/sitemap.rs
@@ -49,6 +49,7 @@ pub(crate) mod tests {
   use chrono::{DateTime, NaiveDate, Utc};
   use elementtree::Element;
   use lemmy_db_schema::newtypes::DbUrl;
+  use pretty_assertions::assert_eq;
   use url::Url;
 
   #[tokio::test]

--- a/crates/api_common/Cargo.toml
+++ b/crates/api_common/Cargo.toml
@@ -77,3 +77,4 @@ ignored = ["getrandom"]
 [dev-dependencies]
 serial_test = { workspace = true }
 reqwest-middleware = { workspace = true }
+pretty_assertions = { workspace = true }

--- a/crates/api_common/src/claims.rs
+++ b/crates/api_common/src/claims.rs
@@ -88,6 +88,7 @@ mod tests {
     utils::build_db_pool_for_tests,
   };
   use lemmy_utils::rate_limit::RateLimitCell;
+  use pretty_assertions::assert_eq;
   use reqwest::Client;
   use reqwest_middleware::ClientBuilder;
   use serial_test::serial;

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -309,6 +309,7 @@ mod tests {
 
   use crate::request::{client_builder, fetch_site_metadata, html_to_site_metadata, SiteMetadata};
   use lemmy_utils::settings::SETTINGS;
+  use pretty_assertions::assert_eq;
   use url::Url;
 
   // These helped with testing

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -842,6 +842,7 @@ mod tests {
 
   use crate::utils::{honeypot_check, limit_expire_time, password_length_check};
   use chrono::{Days, Utc};
+  use pretty_assertions::assert_eq;
 
   #[test]
   #[rustfmt::skip]

--- a/crates/apub/Cargo.toml
+++ b/crates/apub/Cargo.toml
@@ -53,3 +53,4 @@ serial_test = { workspace = true }
 reqwest-middleware = { workspace = true }
 task-local-extensions = "0.1.4"
 assert-json-diff = "2.0.2"
+pretty_assertions = { workspace = true }

--- a/crates/apub/src/api/user_settings_backup.rs
+++ b/crates/apub/src/api/user_settings_backup.rs
@@ -316,6 +316,7 @@ mod tests {
   use lemmy_db_views::structs::LocalUserView;
   use lemmy_db_views_actor::structs::CommunityFollowerView;
   use lemmy_utils::error::{LemmyErrorType, LemmyResult};
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
   use std::time::Duration;
   use tokio::time::sleep;

--- a/crates/apub/src/collections/community_moderators.rs
+++ b/crates/apub/src/collections/community_moderators.rs
@@ -123,6 +123,7 @@ mod tests {
     traits::Crud,
   };
   use lemmy_utils::error::LemmyResult;
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   #[tokio::test]

--- a/crates/apub/src/objects/comment.rs
+++ b/crates/apub/src/objects/comment.rs
@@ -198,6 +198,7 @@ pub(crate) mod tests {
   use html2md::parse_html;
   use lemmy_db_schema::source::site::Site;
   use lemmy_utils::error::LemmyResult;
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   async fn prepare_comment_test(

--- a/crates/apub/src/objects/community.rs
+++ b/crates/apub/src/objects/community.rs
@@ -224,6 +224,7 @@ pub(crate) mod tests {
   use activitypub_federation::fetch::collection_id::CollectionId;
   use lemmy_db_schema::{source::site::Site, traits::Crud};
   use lemmy_utils::error::LemmyResult;
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   pub(crate) async fn parse_lemmy_community(

--- a/crates/apub/src/objects/instance.rs
+++ b/crates/apub/src/objects/instance.rs
@@ -208,6 +208,7 @@ pub(crate) mod tests {
   use crate::{objects::tests::init_context, protocol::tests::file_to_json_object};
   use lemmy_db_schema::traits::Crud;
   use lemmy_utils::error::LemmyResult;
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   pub(crate) async fn parse_lemmy_instance(context: &Data<LemmyContext>) -> LemmyResult<ApubSite> {

--- a/crates/apub/src/objects/person.rs
+++ b/crates/apub/src/objects/person.rs
@@ -219,6 +219,7 @@ pub(crate) mod tests {
   use activitypub_federation::fetch::object_id::ObjectId;
   use lemmy_db_schema::{source::site::Site, traits::Crud};
   use lemmy_utils::error::LemmyResult;
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   pub(crate) async fn parse_lemmy_person(

--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -305,6 +305,7 @@ mod tests {
   };
   use lemmy_db_schema::source::site::Site;
   use lemmy_utils::error::LemmyResult;
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   #[tokio::test]

--- a/crates/apub/src/objects/private_message.rs
+++ b/crates/apub/src/objects/private_message.rs
@@ -153,6 +153,7 @@ mod tests {
   use assert_json_diff::assert_json_include;
   use lemmy_db_schema::source::site::Site;
   use lemmy_utils::error::LemmyResult;
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   async fn prepare_comment_test(

--- a/crates/apub/src/protocol/collections/mod.rs
+++ b/crates/apub/src/protocol/collections/mod.rs
@@ -16,8 +16,8 @@ mod tests {
     },
     tests::{test_json, test_parse_lemmy_item},
   };
-  use pretty_assertions::assert_eq;
   use lemmy_utils::error::LemmyResult;
+  use pretty_assertions::assert_eq;
 
   #[test]
   fn test_parse_lemmy_collections() -> LemmyResult<()> {

--- a/crates/apub/src/protocol/collections/mod.rs
+++ b/crates/apub/src/protocol/collections/mod.rs
@@ -16,6 +16,7 @@ mod tests {
     },
     tests::{test_json, test_parse_lemmy_item},
   };
+  use pretty_assertions::assert_eq;
   use lemmy_utils::error::LemmyResult;
 
   #[test]

--- a/crates/db_schema/Cargo.toml
+++ b/crates/db_schema/Cargo.toml
@@ -79,6 +79,7 @@ uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
 serial_test = { workspace = true }
+pretty_assertions = { workspace = true }
 
 [package.metadata.cargo-machete]
 ignored = ["strum"]

--- a/crates/db_schema/src/aggregates/comment_aggregates.rs
+++ b/crates/db_schema/src/aggregates/comment_aggregates.rs
@@ -49,6 +49,7 @@ mod tests {
     traits::{Crud, Likeable},
     utils::build_db_pool_for_tests,
   };
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   #[tokio::test]

--- a/crates/db_schema/src/aggregates/community_aggregates.rs
+++ b/crates/db_schema/src/aggregates/community_aggregates.rs
@@ -47,6 +47,7 @@ mod tests {
     traits::{Crud, Followable},
     utils::build_db_pool_for_tests,
   };
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   #[tokio::test]

--- a/crates/db_schema/src/aggregates/person_aggregates.rs
+++ b/crates/db_schema/src/aggregates/person_aggregates.rs
@@ -34,6 +34,7 @@ mod tests {
     traits::{Crud, Likeable},
     utils::build_db_pool_for_tests,
   };
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   #[tokio::test]

--- a/crates/db_schema/src/aggregates/post_aggregates.rs
+++ b/crates/db_schema/src/aggregates/post_aggregates.rs
@@ -68,6 +68,7 @@ mod tests {
     traits::{Crud, Likeable},
     utils::build_db_pool_for_tests,
   };
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   #[tokio::test]

--- a/crates/db_schema/src/aggregates/site_aggregates.rs
+++ b/crates/db_schema/src/aggregates/site_aggregates.rs
@@ -31,6 +31,7 @@ mod tests {
     traits::Crud,
     utils::{build_db_pool_for_tests, DbPool},
   };
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   async fn prepare_site_with_community(

--- a/crates/db_schema/src/impls/activity.rs
+++ b/crates/db_schema/src/impls/activity.rs
@@ -67,6 +67,7 @@ mod tests {
 
   use super::*;
   use crate::{source::activity::ActorType, utils::build_db_pool_for_tests};
+  use pretty_assertions::assert_eq;
   use serde_json::json;
   use serial_test::serial;
   use url::Url;

--- a/crates/db_schema/src/impls/actor_language.rs
+++ b/crates/db_schema/src/impls/actor_language.rs
@@ -412,6 +412,7 @@ mod tests {
     traits::Crud,
     utils::build_db_pool_for_tests,
   };
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   async fn test_langs1(pool: &mut DbPool<'_>) -> Vec<LanguageId> {

--- a/crates/db_schema/src/impls/comment.rs
+++ b/crates/db_schema/src/impls/comment.rs
@@ -263,6 +263,7 @@ mod tests {
     utils::build_db_pool_for_tests,
   };
   use diesel_ltree::Ltree;
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   #[tokio::test]

--- a/crates/db_schema/src/impls/comment_reply.rs
+++ b/crates/db_schema/src/impls/comment_reply.rs
@@ -89,6 +89,7 @@ mod tests {
     traits::Crud,
     utils::build_db_pool_for_tests,
   };
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   #[tokio::test]

--- a/crates/db_schema/src/impls/community.rs
+++ b/crates/db_schema/src/impls/community.rs
@@ -366,6 +366,7 @@ mod tests {
     traits::{Bannable, Crud, Followable, Joinable},
     utils::build_db_pool_for_tests,
   };
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   #[tokio::test]

--- a/crates/db_schema/src/impls/federation_allowlist.rs
+++ b/crates/db_schema/src/impls/federation_allowlist.rs
@@ -56,6 +56,7 @@ mod tests {
     source::{federation_allowlist::FederationAllowList, instance::Instance},
     utils::build_db_pool_for_tests,
   };
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   #[tokio::test]

--- a/crates/db_schema/src/impls/language.rs
+++ b/crates/db_schema/src/impls/language.rs
@@ -46,6 +46,7 @@ mod tests {
   #![allow(clippy::indexing_slicing)]
 
   use crate::{source::language::Language, utils::build_db_pool_for_tests};
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   #[tokio::test]

--- a/crates/db_schema/src/impls/moderator.rs
+++ b/crates/db_schema/src/impls/moderator.rs
@@ -500,6 +500,7 @@ mod tests {
     traits::Crud,
     utils::build_db_pool_for_tests,
   };
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   #[tokio::test]

--- a/crates/db_schema/src/impls/password_reset_request.rs
+++ b/crates/db_schema/src/impls/password_reset_request.rs
@@ -95,6 +95,7 @@ mod tests {
     traits::Crud,
     utils::build_db_pool_for_tests,
   };
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   #[tokio::test]

--- a/crates/db_schema/src/impls/person.rs
+++ b/crates/db_schema/src/impls/person.rs
@@ -191,6 +191,7 @@ mod tests {
     traits::{Crud, Followable},
     utils::build_db_pool_for_tests,
   };
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   #[tokio::test]

--- a/crates/db_schema/src/impls/person_mention.rs
+++ b/crates/db_schema/src/impls/person_mention.rs
@@ -90,6 +90,7 @@ mod tests {
     traits::Crud,
     utils::build_db_pool_for_tests,
   };
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   #[tokio::test]

--- a/crates/db_schema/src/impls/post.rs
+++ b/crates/db_schema/src/impls/post.rs
@@ -366,6 +366,7 @@ mod tests {
     traits::{Crud, Likeable, Saveable},
     utils::build_db_pool_for_tests,
   };
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
   use std::collections::HashSet;
 

--- a/crates/db_schema/src/impls/post_report.rs
+++ b/crates/db_schema/src/impls/post_report.rs
@@ -75,6 +75,7 @@ mod tests {
     traits::Crud,
     utils::build_db_pool_for_tests,
   };
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   async fn init(pool: &mut DbPool<'_>) -> (Person, PostReport) {

--- a/crates/db_schema/src/impls/private_message.rs
+++ b/crates/db_schema/src/impls/private_message.rs
@@ -87,6 +87,7 @@ mod tests {
     traits::Crud,
     utils::build_db_pool_for_tests,
   };
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   #[tokio::test]

--- a/crates/db_schema/src/utils.rs
+++ b/crates/db_schema/src/utils.rs
@@ -468,6 +468,7 @@ mod tests {
 
   use super::{fuzzy_search, *};
   use crate::utils::is_email_regex;
+  use pretty_assertions::assert_eq;
 
   #[test]
   fn test_fuzzy_search() {

--- a/crates/db_views/Cargo.toml
+++ b/crates/db_views/Cargo.toml
@@ -42,3 +42,4 @@ actix-web = { workspace = true, optional = true }
 serial_test = { workspace = true }
 tokio = { workspace = true }
 chrono = { workspace = true }
+pretty_assertions = { workspace = true }

--- a/crates/db_views/src/comment_report_view.rs
+++ b/crates/db_views/src/comment_report_view.rs
@@ -234,6 +234,7 @@ mod tests {
     traits::{Crud, Joinable, Reportable},
     utils::{build_db_pool_for_tests, RANK_DEFAULT},
   };
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   #[tokio::test]

--- a/crates/db_views/src/comment_view.rs
+++ b/crates/db_views/src/comment_view.rs
@@ -416,6 +416,7 @@ mod tests {
     utils::{build_db_pool_for_tests, RANK_DEFAULT},
     SubscribedType,
   };
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   struct Data {

--- a/crates/db_views/src/post_report_view.rs
+++ b/crates/db_views/src/post_report_view.rs
@@ -208,6 +208,7 @@ mod tests {
     traits::{Crud, Joinable, Reportable},
     utils::build_db_pool_for_tests,
   };
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   #[tokio::test]

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -749,6 +749,7 @@ mod tests {
     SortType,
     SubscribedType,
   };
+  use pretty_assertions::{assert_eq, assert_ne};
   use serial_test::serial;
   use std::{collections::HashSet, time::Duration};
 

--- a/crates/db_views/src/private_message_report_view.rs
+++ b/crates/db_views/src/private_message_report_view.rs
@@ -121,6 +121,7 @@ mod tests {
     traits::{Crud, Reportable},
     utils::build_db_pool_for_tests,
   };
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   #[tokio::test]

--- a/crates/db_views/src/private_message_view.rs
+++ b/crates/db_views/src/private_message_view.rs
@@ -168,6 +168,7 @@ mod tests {
     traits::{Blockable, Crud},
     utils::build_db_pool_for_tests,
   };
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   #[tokio::test]

--- a/crates/db_views/src/registration_application_view.rs
+++ b/crates/db_views/src/registration_application_view.rs
@@ -149,6 +149,7 @@ mod tests {
     traits::Crud,
     utils::build_db_pool_for_tests,
   };
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   #[tokio::test]

--- a/crates/db_views/src/vote_view.rs
+++ b/crates/db_views/src/vote_view.rs
@@ -66,6 +66,7 @@ mod tests {
     traits::{Crud, Likeable},
     utils::build_db_pool_for_tests,
   };
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   #[tokio::test]

--- a/crates/db_views_actor/Cargo.toml
+++ b/crates/db_views_actor/Cargo.toml
@@ -38,6 +38,7 @@ strum_macros = { workspace = true }
 [dev-dependencies]
 serial_test = { workspace = true }
 tokio = { workspace = true }
+pretty_assertions = { workspace = true }
 
 [package.metadata.cargo-machete]
 ignored = ["strum"]

--- a/crates/db_views_actor/src/person_view.rs
+++ b/crates/db_views_actor/src/person_view.rs
@@ -167,6 +167,7 @@ mod tests {
     traits::Crud,
     utils::build_db_pool_for_tests,
   };
+  use pretty_assertions::assert_eq;
   use serial_test::serial;
 
   struct Data {

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -52,6 +52,7 @@ enum-map = { workspace = true }
 
 [dev-dependencies]
 reqwest = { workspace = true }
+pretty_assertions = { workspace = true }
 
 [build-dependencies]
 rosetta-build = { version = "0.1.3", default-features = false }

--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -279,6 +279,7 @@ mod tests {
   #![allow(clippy::indexing_slicing)]
   use super::*;
   use actix_web::{body::MessageBody, ResponseError};
+  use pretty_assertions::assert_eq;
   use std::fs::read_to_string;
   use strum::IntoEnumIterator;
 

--- a/crates/utils/src/rate_limit/rate_limiter.rs
+++ b/crates/utils/src/rate_limit/rate_limiter.rs
@@ -310,6 +310,7 @@ mod tests {
   #![allow(clippy::indexing_slicing)]
 
   use super::{ActionType, BucketConfig, InstantSecs, RateLimitState, RateLimitedGroup};
+  use pretty_assertions::assert_eq;
 
   #[test]
   fn test_split_ipv6() {

--- a/crates/utils/src/response.rs
+++ b/crates/utils/src/response.rs
@@ -46,6 +46,7 @@ mod tests {
     Responder,
   };
   use http::StatusCode;
+  use pretty_assertions::assert_eq;
 
   #[actix_web::test]
   async fn test_non_error_responses_are_not_modified() {

--- a/crates/utils/src/utils/markdown.rs
+++ b/crates/utils/src/utils/markdown.rs
@@ -36,6 +36,7 @@ mod tests {
   #![allow(clippy::indexing_slicing)]
 
   use super::*;
+  use pretty_assertions::assert_eq;
 
   #[test]
   fn test_basic_markdown() {

--- a/crates/utils/src/utils/markdown/spoiler_rule.rs
+++ b/crates/utils/src/utils/markdown/spoiler_rule.rs
@@ -140,6 +140,7 @@ mod tests {
 
   use crate::utils::markdown::spoiler_rule::add;
   use markdown_it::MarkdownIt;
+  use pretty_assertions::assert_eq;
 
   #[test]
   fn test_spoiler_markdown() {

--- a/crates/utils/src/utils/mention.rs
+++ b/crates/utils/src/utils/mention.rs
@@ -39,6 +39,7 @@ mod test {
   #![allow(clippy::indexing_slicing)]
 
   use crate::utils::mention::scrape_text_for_mentions;
+  use pretty_assertions::assert_eq;
 
   #[test]
   fn test_mentions_regex() {

--- a/crates/utils/src/utils/slurs.rs
+++ b/crates/utils/src/utils/slurs.rs
@@ -69,6 +69,7 @@ mod test {
   #![allow(clippy::indexing_slicing)]
 
   use crate::utils::slurs::{remove_slurs, slur_check, slurs_vec_to_str};
+  use pretty_assertions::assert_eq;
   use regex::RegexBuilder;
 
   #[test]

--- a/crates/utils/src/utils/validation.rs
+++ b/crates/utils/src/utils/validation.rs
@@ -310,6 +310,7 @@ mod tests {
       SITE_NAME_MAX_LENGTH,
     },
   };
+  use pretty_assertions::assert_eq;
   use url::Url;
 
   #[test]

--- a/src/scheduled_tasks.rs
+++ b/src/scheduled_tasks.rs
@@ -516,6 +516,7 @@ mod tests {
   #![allow(clippy::indexing_slicing)]
 
   use lemmy_routes::nodeinfo::NodeInfo;
+  use pretty_assertions::assert_eq;
   use reqwest::Client;
 
   #[tokio::test]

--- a/src/session_middleware.rs
+++ b/src/session_middleware.rs
@@ -119,6 +119,7 @@ mod tests {
     utils::build_db_pool_for_tests,
   };
   use lemmy_utils::rate_limit::RateLimitCell;
+  use pretty_assertions::assert_eq;
   use reqwest::Client;
   use reqwest_middleware::ClientBuilder;
   use serial_test::serial;


### PR DESCRIPTION
Fixes issue #4062

`pretty_assertions` was used only in test modules, only when necessary.
Most of the test modules required only `assert_eq`. Some didn't use it, so no `use`s were added. One required `assert_ne` too.