### PR TITLE
Add macro assert_length!() for tests

### DIFF
--- a/crates/db_schema/src/lib.rs
+++ b/crates/db_schema/src/lib.rs
@@ -216,3 +216,12 @@ pub enum PostFeatureType {
   /// Features to the top of the community.
   Community,
 }
+
+/// Wrapper for assert_eq! macro. Checks that vec matches the given length, and prints the
+/// vec on failure.
+#[macro_export]
+macro_rules! assert_length {
+  ($len:expr, $vec:expr) => {{
+    assert_eq!($len, $vec.len(), "Vec has wrong length: {:?}", $vec)
+  }};
+}

--- a/crates/db_views/src/comment_view.rs
+++ b/crates/db_views/src/comment_view.rs
@@ -399,6 +399,7 @@ mod tests {
   };
   use lemmy_db_schema::{
     aggregates::structs::CommentAggregates,
+    assert_length,
     impls::actor_language::UNDETERMINED_ID,
     newtypes::LanguageId,
     source::{
@@ -636,7 +637,7 @@ mod tests {
     );
 
     // Make sure its 1, not showing the blocked comment
-    assert_eq!(5, read_comment_views_with_person.len());
+    assert_length!(5, read_comment_views_with_person);
 
     let read_comment_from_blocked_person = CommentView::read(
       pool,
@@ -663,7 +664,7 @@ mod tests {
       read_liked_comment_views[0]
     );
 
-    assert_eq!(1, read_liked_comment_views.len());
+    assert_length!(1, read_liked_comment_views);
 
     let read_disliked_comment_views: Vec<CommentView> = CommentQuery {
       local_user: (Some(&data.timmy_local_user_view)),
@@ -707,8 +708,8 @@ mod tests {
     .unwrap();
 
     // Make sure the comment parent-limited fetch is correct
-    assert_eq!(6, read_comment_views_top_path.len());
-    assert_eq!(4, read_comment_views_child_path.len());
+    assert_length!(6, read_comment_views_top_path);
+    assert_length!(4, read_comment_views_child_path);
 
     // Make sure it contains the parent, but not the comment from the other tree
     let child_comments = read_comment_views_child_path
@@ -732,7 +733,7 @@ mod tests {
       expected_comment_view(&data, pool).await,
       read_comment_views_top_max_depth[0]
     );
-    assert_eq!(1, read_comment_views_top_max_depth.len());
+    assert_length!(1, read_comment_views_top_max_depth);
 
     let child_path = data.inserted_comment_1.path.clone();
     let read_comment_views_parent_max_depth = CommentQuery {
@@ -751,7 +752,7 @@ mod tests {
       .comment
       .content
       .eq("Comment 3"));
-    assert_eq!(3, read_comment_views_parent_max_depth.len());
+    assert_length!(3, read_comment_views_parent_max_depth);
 
     cleanup(data, pool).await;
   }
@@ -772,7 +773,7 @@ mod tests {
     .list(pool)
     .await
     .unwrap();
-    assert_eq!(5, all_languages.len());
+    assert_length!(5, all_languages);
 
     // change user lang to finnish, should only show one post in finnish and one undetermined
     let finnish_id = Language::read_id_from_code(pool, Some("fi"))
@@ -793,7 +794,7 @@ mod tests {
     .list(pool)
     .await
     .unwrap();
-    assert_eq!(2, finnish_comments.len());
+    assert_length!(2, finnish_comments);
     let finnish_comment = finnish_comments
       .iter()
       .find(|c| c.comment.language_id == finnish_id);
@@ -818,7 +819,7 @@ mod tests {
     .list(pool)
     .await
     .unwrap();
-    assert_eq!(1, undetermined_comment.len());
+    assert_length!(1, undetermined_comment);
 
     cleanup(data, pool).await;
   }

--- a/crates/db_views/src/post_report_view.rs
+++ b/crates/db_views/src/post_report_view.rs
@@ -196,6 +196,7 @@ mod tests {
     structs::LocalUserView,
   };
   use lemmy_db_schema::{
+    assert_length,
     source::{
       community::{Community, CommunityInsertForm, CommunityModerator, CommunityModeratorForm},
       instance::Instance,
@@ -382,7 +383,7 @@ mod tests {
     .list(pool, &timmy_view)
     .await
     .unwrap();
-    assert_eq!(reports_after_resolve.len(), 1);
+    assert_length!(1, reports_after_resolve);
     assert_eq!(reports_after_resolve[0].creator.id, inserted_sara.id);
 
     // Make sure the counts are correct

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -729,6 +729,7 @@ mod tests {
   use chrono::Utc;
   use lemmy_db_schema::{
     aggregates::structs::PostAggregates,
+    assert_length,
     impls::actor_language::UNDETERMINED_ID,
     newtypes::LanguageId,
     source::{
@@ -914,7 +915,7 @@ mod tests {
     let mut expected_post_listing_with_user = expected_post_view(&data, pool).await;
 
     // Should be only one person, IE the bot post, and blocked should be missing
-    assert_eq!(1, read_post_listing.len());
+    assert_length!(1, read_post_listing);
 
     assert_eq!(expected_post_listing_with_user, read_post_listing[0]);
     expected_post_listing_with_user.my_vote = None;
@@ -943,7 +944,7 @@ mod tests {
     .await
     .unwrap();
     // should include bot post which has "undetermined" language
-    assert_eq!(2, post_listings_with_bots.len());
+    assert_length!(2, post_listings_with_bots);
 
     cleanup(data, pool).await;
   }
@@ -972,7 +973,7 @@ mod tests {
     let expected_post_listing_no_person = expected_post_view(&data, pool).await;
 
     // Should be 2 posts, with the bot post, and the blocked
-    assert_eq!(3, read_post_listing_multiple_no_person.len());
+    assert_length!(3, read_post_listing_multiple_no_person);
 
     assert_eq!(
       expected_post_listing_no_person,
@@ -1009,7 +1010,7 @@ mod tests {
     .await
     .unwrap();
     // Should be 0 posts after the community block
-    assert_eq!(0, read_post_listings_with_person_after_block.len());
+    assert_length!(0, read_post_listings_with_person_after_block);
 
     CommunityBlock::unblock(pool, &community_block)
       .await
@@ -1074,7 +1075,7 @@ mod tests {
     .list(pool)
     .await
     .unwrap();
-    assert_eq!(1, read_post_listing.len());
+    assert_length!(1, read_post_listing);
 
     assert_eq!(expected_post_with_upvote, read_post_listing[0]);
 
@@ -1199,7 +1200,7 @@ mod tests {
     .unwrap();
 
     // no language filters specified, all posts should be returned
-    assert_eq!(3, post_listings_all.len());
+    assert_length!(3, post_listings_all);
 
     let french_id = Language::read_id_from_code(pool, Some("fr"))
       .await
@@ -1219,7 +1220,7 @@ mod tests {
     .unwrap();
 
     // only one post in french and one undetermined should be returned
-    assert_eq!(2, post_listing_french.len());
+    assert_length!(2, post_listing_french);
     assert!(post_listing_french
       .iter()
       .any(|p| p.post.language_id == french_id));
@@ -1241,7 +1242,7 @@ mod tests {
     .unwrap();
 
     // french post and undetermined language post should be returned
-    assert_eq!(2, post_listings_french_und.len());
+    assert_length!(2, post_listings_french_und);
     assert_eq!(
       UNDETERMINED_ID,
       post_listings_french_und[0].post.language_id
@@ -1279,7 +1280,7 @@ mod tests {
     .list(pool)
     .await
     .unwrap();
-    assert_eq!(1, post_listings_no_admin.len());
+    assert_length!(1, post_listings_no_admin);
 
     // Removed bot post is shown to admins on its profile page
     data.local_user_view.local_user.admin = true;
@@ -1378,7 +1379,7 @@ mod tests {
     .list(pool)
     .await
     .unwrap();
-    assert_eq!(post_listings_all.len(), 3);
+    assert_length!(3, post_listings_all);
 
     // block the instance
     let block_form = InstanceBlockForm {
@@ -1395,7 +1396,7 @@ mod tests {
     .list(pool)
     .await
     .unwrap();
-    assert_eq!(post_listings_blocked.len(), 2);
+    assert_length!(2, post_listings_blocked);
     assert_ne!(
       post_listings_blocked[0].post.id,
       post_from_blocked_instance.id
@@ -1414,7 +1415,7 @@ mod tests {
     .list(pool)
     .await
     .unwrap();
-    assert_eq!(post_listings_blocked.len(), 3);
+    assert_length!(3, post_listings_blocked);
 
     Instance::delete(pool, blocked_instance.id).await.unwrap();
     cleanup(data, pool).await;
@@ -1534,7 +1535,7 @@ mod tests {
     .list(pool)
     .await
     .unwrap();
-    assert_eq!(1, post_listings_hide_read.len());
+    assert_length!(1, post_listings_hide_read);
 
     cleanup(data, pool).await;
   }

--- a/crates/db_views/src/private_message_report_view.rs
+++ b/crates/db_views/src/private_message_report_view.rs
@@ -112,6 +112,7 @@ mod tests {
 
   use crate::private_message_report_view::PrivateMessageReportQuery;
   use lemmy_db_schema::{
+    assert_length,
     source::{
       instance::Instance,
       person::{Person, PersonInsertForm},
@@ -170,7 +171,7 @@ mod tests {
       .list(pool)
       .await
       .unwrap();
-    assert_eq!(1, reports.len());
+    assert_length!(1, reports);
     assert!(!reports[0].private_message_report.resolved);
     assert_eq!(inserted_timmy.name, reports[0].private_message_creator.name);
     assert_eq!(inserted_jessica.name, reports[0].creator.name);
@@ -196,7 +197,7 @@ mod tests {
     .list(pool)
     .await
     .unwrap();
-    assert_eq!(1, reports.len());
+    assert_length!(1, reports);
     assert!(reports[0].private_message_report.resolved);
     assert!(reports[0].resolver.is_some());
     assert_eq!(

--- a/crates/db_views/src/private_message_view.rs
+++ b/crates/db_views/src/private_message_view.rs
@@ -15,7 +15,6 @@ use lemmy_db_schema::{
   schema::{person, person_block, private_message},
   utils::{get_conn, limit_and_offset, DbConn, DbPool, ListFn, Queries, ReadFn},
 };
-use std::fmt::Debug;
 use tracing::debug;
 
 fn queries<'a>() -> Queries<
@@ -252,7 +251,7 @@ mod tests {
     .await
     .unwrap();
 
-    assert_length(3, &timmy_messages);
+    assert_length!(3, &timmy_messages);
     assert_eq!(timmy_messages[0].creator.id, jess.id);
     assert_eq!(timmy_messages[0].recipient.id, timmy.id);
     assert_eq!(timmy_messages[1].creator.id, timmy.id);

--- a/crates/db_views/src/private_message_view.rs
+++ b/crates/db_views/src/private_message_view.rs
@@ -15,6 +15,7 @@ use lemmy_db_schema::{
   schema::{person, person_block, private_message},
   utils::{get_conn, limit_and_offset, DbConn, DbPool, ListFn, Queries, ReadFn},
 };
+use std::fmt::Debug;
 use tracing::debug;
 
 fn queries<'a>() -> Queries<
@@ -159,6 +160,7 @@ mod tests {
 
   use crate::{private_message_view::PrivateMessageQuery, structs::PrivateMessageView};
   use lemmy_db_schema::{
+    assert_length,
     source::{
       instance::Instance,
       person::{Person, PersonInsertForm},
@@ -250,7 +252,7 @@ mod tests {
     .await
     .unwrap();
 
-    assert_eq!(timmy_messages.len(), 3);
+    assert_length(3, &timmy_messages);
     assert_eq!(timmy_messages[0].creator.id, jess.id);
     assert_eq!(timmy_messages[0].recipient.id, timmy.id);
     assert_eq!(timmy_messages[1].creator.id, timmy.id);
@@ -267,7 +269,7 @@ mod tests {
     .await
     .unwrap();
 
-    assert_eq!(timmy_unread_messages.len(), 2);
+    assert_length!(2, &timmy_unread_messages);
     assert_eq!(timmy_unread_messages[0].creator.id, jess.id);
     assert_eq!(timmy_unread_messages[0].recipient.id, timmy.id);
     assert_eq!(timmy_unread_messages[1].creator.id, sara.id);
@@ -282,7 +284,7 @@ mod tests {
     .await
     .unwrap();
 
-    assert_eq!(timmy_sara_messages.len(), 2);
+    assert_length!(2, &timmy_sara_messages);
     assert_eq!(timmy_sara_messages[0].creator.id, timmy.id);
     assert_eq!(timmy_sara_messages[0].recipient.id, sara.id);
     assert_eq!(timmy_sara_messages[1].creator.id, sara.id);
@@ -297,7 +299,7 @@ mod tests {
     .await
     .unwrap();
 
-    assert_eq!(timmy_sara_unread_messages.len(), 1);
+    assert_length!(1, &timmy_sara_unread_messages);
     assert_eq!(timmy_sara_unread_messages[0].creator.id, sara.id);
     assert_eq!(timmy_sara_unread_messages[0].recipient.id, timmy.id);
 
@@ -327,7 +329,7 @@ mod tests {
     .await
     .unwrap();
 
-    assert_eq!(timmy_messages.len(), 1);
+    assert_length!(2, &timmy_messages);
 
     let timmy_unread_messages = PrivateMessageView::get_unread_messages(pool, timmy.id)
       .await

--- a/crates/db_views/src/private_message_view.rs
+++ b/crates/db_views/src/private_message_view.rs
@@ -328,7 +328,7 @@ mod tests {
     .await
     .unwrap();
 
-    assert_length!(2, &timmy_messages);
+    assert_length!(1, &timmy_messages);
 
     let timmy_unread_messages = PrivateMessageView::get_unread_messages(pool, timmy.id)
       .await

--- a/crates/db_views_actor/src/person_view.rs
+++ b/crates/db_views_actor/src/person_view.rs
@@ -159,6 +159,7 @@ mod tests {
   use super::*;
   use diesel::NotFound;
   use lemmy_db_schema::{
+    assert_length,
     source::{
       instance::Instance,
       local_user::{LocalUser, LocalUserInsertForm, LocalUserUpdateForm},
@@ -256,7 +257,7 @@ mod tests {
     .list(pool)
     .await
     .unwrap();
-    assert_eq!(list.len(), 1);
+    assert_length!(1, list);
     assert_eq!(list[0].person.id, data.bob.id);
 
     cleanup(data, pool).await;
@@ -281,7 +282,7 @@ mod tests {
     .unwrap();
 
     let list = PersonView::banned(pool).await.unwrap();
-    assert_eq!(list.len(), 1);
+    assert_length!(1, list);
     assert_eq!(list[0].person.id, data.alice.id);
 
     cleanup(data, pool).await;
@@ -306,7 +307,7 @@ mod tests {
     .unwrap();
 
     let list = PersonView::admins(pool).await.unwrap();
-    assert_eq!(list.len(), 1);
+    assert_length!(1, list);
     assert_eq!(list[0].person.id, data.alice.id);
 
     let is_admin = PersonView::read(pool, data.alice.id)


### PR DESCRIPTION
We have a bunch of asserts which check that a vec has the correct length. When one of these fails in CI, its impossible to tell what the problem is because the vec itself isnt being logged. [Here](https://woodpecker.join-lemmy.org/repos/129/pipeline/4828/20) is an example. This PR adds a simple wrapper macro which prints the vec itself in case the length is wrong.