### PR TITLE
no endless loop if queue too recent

### DIFF
--- a/crates/federate/src/worker.rs
+++ b/crates/federate/src/worker.rs
@@ -152,7 +152,15 @@ impl InstanceWorker {
       self.save_and_send_state(pool).await?;
       latest_id
     };
-    if id == latest_id {
+    if id >= latest_id {
+      if id > latest_id {
+        tracing::error!(
+          "{}: last successful id {} is higher than latest id {} in database (did the db get cleared?)",
+          self.instance.domain,
+          id.0,
+          latest_id.0
+        );
+      }
       // no more work to be done, wait before rechecking
       tokio::select! {
         () = sleep(*WORK_FINISHED_RECHECK_DELAY) => {},


### PR DESCRIPTION
If the queue has stored an id that is higher than the max id in the database, then currently the loop ends without waiting, which might cause it to pin at 100% until the next activity happens. This small change makes it wait the normal delay and log an error because I think it can only happen if someone runs `TRUNCATE sent_activities` or similar