### PR TITLE
Upgrade docker rust version to 1.75

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.6
-ARG RUST_VERSION=1.72.1
+ARG RUST_VERSION=1.75
 ARG CARGO_BUILD_FEATURES=default
 ARG RUST_RELEASE_MODE=debug
 


### PR DESCRIPTION
The dockerfile throws a build error now, seems like we are depending on some new Rust feature.