### PR TITLE
Increase CI timeout for restore cache

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -100,7 +100,7 @@ steps:
       region: us-east-1
       cache_key: "rust-cache"
       path-style: true
-      backend_operation_timeout: 15m
+      backend_operation_timeout: 30m
       compression_level: 0
       exit_code: true
       mount:


### PR DESCRIPTION
Sometimes it takes longer than 15 minutes and causes the build to fail, eg [here](https://woodpecker.join-lemmy.org/repos/129/pipeline/4990/11). 