### PR TITLE
Move `publish = false` to correct place in lemmy_server (fixes #4359)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [workspace.package]
 version = "0.19.2-rc.5"
-publish = false
 edition = "2021"
 description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
@@ -17,6 +16,7 @@ license.workspace = true
 homepage.workspace = true
 documentation.workspace = true
 repository.workspace = true
+publish = false
 
 [lib]
 doctest = false


### PR DESCRIPTION
```
You may press ctrl-c to skip waiting; the crate should be available shortly.
   Published lemmy_api_common v0.19.2-rc.5 at registry `crates-io`
info published lemmy_api_common v0.19.2-rc.5
    Updating crates.io index
   Packaging lemmy_server v0.19.2-rc.5 (/woodpecker/src/github.com/LemmyNet/lemmy)
    Updating crates.io index
    Updating crates.io index
error: failed to prepare local package for uploading
```

It was trying to publish the `lemmy_server` package because `publish = false` was in the wrong place.