### PR TITLE
Mark instance as alive after successful activity send (fixes #4039)

### DIFF
--- a/crates/db_schema/src/impls/instance.rs
+++ b/crates/db_schema/src/impls/instance.rs
@@ -64,6 +64,18 @@ impl Instance {
       e => e,
     }
   }
+  pub async fn update(
+    pool: &mut DbPool<'_>,
+    instance_id: InstanceId,
+    form: InstanceForm,
+  ) -> Result<usize, Error> {
+    let mut conn = get_conn(pool).await?;
+    diesel::update(instance::table.find(instance_id))
+      .set(form)
+      .execute(&mut conn)
+      .await
+  }
+
   pub async fn delete(pool: &mut DbPool<'_>, instance_id: InstanceId) -> Result<usize, Error> {
     let conn = &mut get_conn(pool).await?;
     diesel::delete(instance::table.find(instance_id))

--- a/crates/db_schema/src/source/instance.rs
+++ b/crates/db_schema/src/source/instance.rs
@@ -30,7 +30,6 @@ pub struct Instance {
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = instance))]
 pub struct InstanceForm {
-  #[builder(!default)]
   pub domain: String,
   pub software: Option<String>,
   pub version: Option<String>,

--- a/crates/db_schema/src/source/instance.rs
+++ b/crates/db_schema/src/source/instance.rs
@@ -30,6 +30,7 @@ pub struct Instance {
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = instance))]
 pub struct InstanceForm {
+  #[builder(!default)]
   pub domain: String,
   pub software: Option<String>,
   pub version: Option<String>,

--- a/crates/federate/src/worker.rs
+++ b/crates/federate/src/worker.rs
@@ -263,7 +263,10 @@ impl InstanceWorker {
       if updated.add(Days::new(1)) < Utc::now() {
         self.instance.updated = Some(Utc::now());
 
-        let form = InstanceForm::builder().updated(Some(naive_now())).build();
+        let form = InstanceForm::builder()
+          .domain(self.instance.domain.clone())
+          .updated(Some(naive_now()))
+          .build();
         Instance::update(pool, self.instance.id, form).await?;
       }
     }

--- a/crates/federate/src/worker.rs
+++ b/crates/federate/src/worker.rs
@@ -216,6 +216,7 @@ impl InstanceWorker {
     activity: &SentActivity,
     object: &SharedInboxActivities,
   ) -> Result<()> {
+    use lemmy_db_schema::schema::instance;
     let inbox_urls = self
       .get_inbox_urls(pool, activity)
       .await
@@ -266,7 +267,6 @@ impl InstanceWorker {
         self.instance.updated = Some(Utc::now());
 
         let form = InstanceForm::builder().updated(Some(naive_now())).build();
-        use lemmy_db_schema::schema::instance;
         let mut conn = get_conn(pool).await?;
         diesel::update(instance::table.find(self.instance.id))
           .set(form)

--- a/src/scheduled_tasks.rs
+++ b/src/scheduled_tasks.rs
@@ -477,7 +477,6 @@ async fn update_instance_software(
               let software = node_info.software.as_ref();
               Some(
                 InstanceForm::builder()
-                  .domain(instance.domain)
                   .updated(Some(naive_now()))
                   .software(software.and_then(|s| s.name.clone()))
                   .version(software.and_then(|s| s.version.clone()))

--- a/src/scheduled_tasks.rs
+++ b/src/scheduled_tasks.rs
@@ -494,10 +494,7 @@ async fn update_instance_software(
           }
         };
         if let Some(form) = form {
-          diesel::update(instance::table.find(instance.id))
-            .set(form)
-            .execute(&mut conn)
-            .await?;
+          Instance::update(pool, instance.id, form).await?;
         }
       }
       info!("Finished updating instances software and versions...");

--- a/src/scheduled_tasks.rs
+++ b/src/scheduled_tasks.rs
@@ -477,6 +477,7 @@ async fn update_instance_software(
               let software = node_info.software.as_ref();
               Some(
                 InstanceForm::builder()
+                  .domain(instance.domain)
                   .updated(Some(naive_now()))
                   .software(software.and_then(|s| s.name.clone()))
                   .version(software.and_then(|s| s.version.clone()))


### PR DESCRIPTION
This helps to ensure that instances arent marked dead if they can successfully receive activities. However it wont help for instances which are already marked as dead. Maybe we should mark all instances as alive together with this, or separately rework the update instances scheduled task.