### PR TITLE
Add secondary sort by published date for post view (fixes #4383)

### DIFF
--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -492,8 +492,14 @@ fn queries<'a>() -> Queries<
     }
 
     let sorts = [
+      // featured posts first
       Some((Ord::Desc, featured_field)),
+      // then use the main sort
       Some(main_sort),
+      // hot rank reaches zero after some days, use publish as fallback. necessary because old
+      // posts can be fetched over federation and inserted with high post id
+      Some((Ord::Desc, field!(published))),
+      // finally use unique post id as tie breaker
       Some((Ord::Desc, field!(post_id))),
     ];
     let sorts_iter = sorts.iter().flatten();


### PR DESCRIPTION
Right now there is only a secondary sort by post id, but an old post which gets fetched over federation will have a high id and be listed near the top. So sort by published date as well.