### PR TITLE
Removing group from woodpecker, as its deprecated.

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -78,33 +78,6 @@ steps:
       - IGNORED=$(git ls-files --cached -i --exclude-standard)
       - if [[ "$IGNORED" ]]; then echo "Ignored files present:\n$IGNORED\n"; exit 1; fi
 
-  restore-cache:
-    image: meltwater/drone-cache:v1
-    pull: true
-    settings:
-      restore: true
-      endpoint:
-        from_secret: MINIO_ENDPOINT
-      access-key:
-        from_secret: MINIO_WRITE_USER
-      secret-key:
-        from_secret: MINIO_WRITE_PASSWORD
-      bucket:
-        from_secret: MINIO_BUCKET
-      region: us-east-1
-      cache_key: "rust-cache"
-      path-style: true
-      backend_operation_timeout: 30m
-      compression_level: 0
-      exit_code: true
-      mount:
-        - ".cargo_home"
-        - "target"
-        - "api_tests/node_modules"
-    secrets:
-      [MINIO_ENDPOINT, MINIO_WRITE_USER, MINIO_WRITE_PASSWORD, MINIO_BUCKET]
-    when: *slow_check_paths
-
   # make sure api builds with default features (used by other crates relying on lemmy api)
   check_api_common_default_features:
     image: *rust_image
@@ -204,35 +177,6 @@ steps:
       - yarn
       - yarn api-test
     when: *slow_check_paths
-
-  rebuild-cache:
-    image: meltwater/drone-cache:v1
-    pull: true
-    settings:
-      rebuild: true
-      endpoint:
-        from_secret: MINIO_ENDPOINT
-      access-key:
-        from_secret: MINIO_WRITE_USER
-      secret-key:
-        from_secret: MINIO_WRITE_PASSWORD
-      bucket:
-        from_secret: MINIO_BUCKET
-      cache_key: "rust-cache"
-      region: us-east-1
-      path-style: true
-      backend_operation_timeout: 60m
-      compression_level: 0
-      exit_code: true
-      mount:
-        - ".cargo_home"
-        - "target"
-        - "api_tests/node_modules"
-    secrets:
-      [MINIO_ENDPOINT, MINIO_WRITE_USER, MINIO_WRITE_PASSWORD, MINIO_BUCKET]
-    when:
-      - event: push
-        branch: main
 
   publish_release_docker:
     image: woodpeckerci/plugin-docker-buildx

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -39,25 +39,21 @@ steps:
       - git submodule update
 
   prettier_check:
-    group: format
     image: tmknom/prettier:3.0.0
     commands:
       - prettier -c . '!**/volumes' '!**/dist' '!target' '!**/translations'
 
   toml_fmt:
-    group: format
     image: tamasfe/taplo:0.8.1
     commands:
       - taplo format --check
 
   sql_fmt:
-    group: format
     image: backplane/pgformatter:latest
     commands:
       - ./scripts/sql_format_check.sh
 
   cargo_fmt:
-    group: format
     image: rustlang/rust:nightly
     environment:
       # store cargo data in repo folder so that it gets cached between steps
@@ -67,7 +63,6 @@ steps:
       - cargo +nightly fmt -- --check
 
   cargo_machete:
-    group: format
     image: rustlang/rust:nightly
     commands:
       - wget https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz
@@ -77,7 +72,6 @@ steps:
       - cargo machete
 
   ignored_files:
-    group: format
     image: alpine:3
     commands:
       - apk add git
@@ -188,7 +182,6 @@ steps:
     when: *slow_check_paths
 
   cargo_test:
-    group: tests
     image: *rust_image
     environment:
       LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
@@ -200,7 +193,6 @@ steps:
     when: *slow_check_paths
 
   run_federation_tests:
-    group: tests
     image: node:20-bookworm-slim
     environment:
       LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432


### PR DESCRIPTION
Also removing the drone meltwater cache. Half our builds fail because of its unreliability, and it probably doesn't save that much time anyway.