### PR TITLE
Clippy fixes for 1.77.0 nightly

### DIFF
--- a/crates/apub/src/api/search.rs
+++ b/crates/apub/src/api/search.rs
@@ -53,7 +53,8 @@ pub async fn search(
     data.community_id
   };
   let creator_id = data.creator_id;
-  let local_user = local_user_view.as_ref().map(|l| l.local_user.clone());
+  let local_user = local_user_view.as_ref().map(|luv| &luv.local_user);
+
   match search_type {
     SearchType::Posts => {
       posts = PostQuery {
@@ -90,7 +91,7 @@ pub async fn search(
         sort: (sort),
         listing_type: (listing_type),
         search_term: (Some(q)),
-        local_user: (local_user.as_ref()),
+        local_user,
         is_mod_or_admin: (is_admin),
         page: (page),
         limit: (limit),
@@ -155,7 +156,7 @@ pub async fn search(
           sort: (sort),
           listing_type: (listing_type),
           search_term: (Some(q)),
-          local_user: (local_user.as_ref()),
+          local_user,
           is_mod_or_admin: (is_admin),
           page: (page),
           limit: (limit),

--- a/crates/apub/src/api/user_settings_backup.rs
+++ b/crates/apub/src/api/user_settings_backup.rs
@@ -106,10 +106,10 @@ pub async fn import_settings(
 
   let local_user_form = LocalUserUpdateForm {
     show_nsfw: data.settings.as_ref().map(|s| s.show_nsfw),
-    theme: data.settings.as_ref().map(|s| s.theme.clone()),
+    theme: data.settings.clone().map(|s| s.theme.clone()),
     default_sort_type: data.settings.as_ref().map(|s| s.default_sort_type),
     default_listing_type: data.settings.as_ref().map(|s| s.default_listing_type),
-    interface_language: data.settings.as_ref().map(|s| s.interface_language.clone()),
+    interface_language: data.settings.clone().map(|s| s.interface_language.clone()),
     show_avatars: data.settings.as_ref().map(|s| s.show_avatars),
     send_notifications_to_email: data
       .settings

--- a/crates/apub/src/api/user_settings_backup.rs
+++ b/crates/apub/src/api/user_settings_backup.rs
@@ -109,7 +109,7 @@ pub async fn import_settings(
     theme: data.settings.clone().map(|s| s.theme.clone()),
     default_sort_type: data.settings.as_ref().map(|s| s.default_sort_type),
     default_listing_type: data.settings.as_ref().map(|s| s.default_listing_type),
-    interface_language: data.settings.clone().map(|s| s.interface_language.clone()),
+    interface_language: data.settings.clone().map(|s| s.interface_language),
     show_avatars: data.settings.as_ref().map(|s| s.show_avatars),
     send_notifications_to_email: data
       .settings

--- a/crates/apub/src/collections/community_featured.rs
+++ b/crates/apub/src/collections/community_featured.rs
@@ -15,7 +15,7 @@ use lemmy_utils::error::LemmyError;
 use url::Url;
 
 #[derive(Clone, Debug)]
-pub(crate) struct ApubCommunityFeatured(Vec<ApubPost>);
+pub(crate) struct ApubCommunityFeatured(());
 
 #[async_trait::async_trait]
 impl Collection for ApubCommunityFeatured {
@@ -86,6 +86,6 @@ impl Collection for ApubCommunityFeatured {
     .await;
 
     // This return value is unused, so just set an empty vec
-    Ok(ApubCommunityFeatured(Vec::new()))
+    Ok(ApubCommunityFeatured(()))
   }
 }

--- a/crates/apub/src/collections/community_follower.rs
+++ b/crates/apub/src/collections/community_follower.rs
@@ -15,7 +15,7 @@ use lemmy_utils::error::LemmyError;
 use url::Url;
 
 #[derive(Clone, Debug)]
-pub(crate) struct ApubCommunityFollower(Vec<()>);
+pub(crate) struct ApubCommunityFollower(());
 
 #[async_trait::async_trait]
 impl Collection for ApubCommunityFollower {
@@ -61,6 +61,6 @@ impl Collection for ApubCommunityFollower {
     )
     .await?;
 
-    Ok(ApubCommunityFollower(Vec::new()))
+    Ok(ApubCommunityFollower(()))
   }
 }

--- a/crates/apub/src/collections/community_moderators.rs
+++ b/crates/apub/src/collections/community_moderators.rs
@@ -19,7 +19,7 @@ use lemmy_utils::error::LemmyError;
 use url::Url;
 
 #[derive(Clone, Debug)]
-pub(crate) struct ApubCommunityModerators(pub(crate) Vec<CommunityModeratorView>);
+pub(crate) struct ApubCommunityModerators(());
 
 #[async_trait::async_trait]
 impl Collection for ApubCommunityModerators {
@@ -96,7 +96,7 @@ impl Collection for ApubCommunityModerators {
     }
 
     // This return value is unused, so just set an empty vec
-    Ok(ApubCommunityModerators(Vec::new()))
+    Ok(ApubCommunityModerators(()))
   }
 }
 

--- a/crates/apub/src/collections/community_outbox.rs
+++ b/crates/apub/src/collections/community_outbox.rs
@@ -27,7 +27,7 @@ use lemmy_utils::error::LemmyError;
 use url::Url;
 
 #[derive(Clone, Debug)]
-pub(crate) struct ApubCommunityOutbox(Vec<ApubPost>);
+pub(crate) struct ApubCommunityOutbox(());
 
 #[async_trait::async_trait]
 impl Collection for ApubCommunityOutbox {
@@ -111,6 +111,6 @@ impl Collection for ApubCommunityOutbox {
     .await;
 
     // This return value is unused, so just set an empty vec
-    Ok(ApubCommunityOutbox(Vec::new()))
+    Ok(ApubCommunityOutbox(()))
   }
 }

--- a/crates/federate/src/worker.rs
+++ b/crates/federate/src/worker.rs
@@ -296,7 +296,7 @@ impl InstanceWorker {
     }
     if let Some(t) = &activity.send_community_followers_of {
       if let Some(urls) = self.followed_communities.get(t) {
-        inbox_urls.extend(urls.iter().map(std::clone::Clone::clone));
+        inbox_urls.extend(urls.iter().cloned());
       }
     }
     inbox_urls.extend(

--- a/crates/routes/src/images.rs
+++ b/crates/routes/src/images.rs
@@ -58,14 +58,6 @@ struct PictrsParams {
   thumbnail: Option<i32>,
 }
 
-#[derive(Deserialize)]
-enum PictrsPurgeParams {
-  #[serde(rename = "file")]
-  File(()),
-  #[serde(rename = "alias")]
-  Alias(()),
-}
-
 fn adapt_request(
   request: &HttpRequest,
   client: &ClientWithMiddleware,

--- a/crates/routes/src/images.rs
+++ b/crates/routes/src/images.rs
@@ -61,9 +61,9 @@ struct PictrsParams {
 #[derive(Deserialize)]
 enum PictrsPurgeParams {
   #[serde(rename = "file")]
-  File(String),
+  File(()),
   #[serde(rename = "alias")]
-  Alias(String),
+  Alias(()),
 }
 
 fn adapt_request(


### PR DESCRIPTION
Check the 2nd commit, which I can revert if necessary. Clippy has some dead code warnings which seem incorrect to me.