### PR TITLE
Forgot to add skip_serializing_none to persondetailsres.

### DIFF
--- a/crates/api_common/src/person.rs
+++ b/crates/api_common/src/person.rs
@@ -173,6 +173,7 @@ pub struct GetPersonDetails {
   pub saved_only: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "full", derive(TS))]
 #[cfg_attr(feature = "full", ts(export))]


### PR DESCRIPTION
This is necessary for lemmy-js-client generation.