### PR TITLE
Remove outdated comment from .woodpecker.yml

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -152,7 +152,6 @@ steps:
     environment:
       CARGO_HOME: .cargo_home
     commands:
-      # when adding new clippy lints, make sure to also add them in scripts/lint.sh
       - rustup component add clippy
       - cargo clippy --workspace --tests --all-targets --features console -- -D warnings
     when: *slow_check_paths


### PR DESCRIPTION
Lints are now only listed in Cargo.toml