### PR TITLE
Add `media:content` thumbnail to RSS feed

### DIFF
--- a/crates/routes/src/feeds.rs
+++ b/crates/routes/src/feeds.rs
@@ -85,6 +85,10 @@ static RSS_NAMESPACE: Lazy<BTreeMap<String, String>> = Lazy::new(|| {
     "dc".to_string(),
     rss::extension::dublincore::NAMESPACE.to_string(),
   );
+  h.insert(
+    "media".to_string(),
+    "http://search.yahoo.com/mrss/".to_string(),
+  );
   h
 });
 

--- a/crates/routes/src/feeds.rs
+++ b/crates/routes/src/feeds.rs
@@ -520,6 +520,8 @@ fn create_post_items(
 
     let mut extensions = ExtensionMap::new();
 
+    // If there's a thumbnail URL, add a media:content tag to display it.
+    // See https://www.rssboard.org/media-rss#media-content for details.
     if let Some(url) = p.post.thumbnail_url {
       let mut thumbnail_ext = ExtensionBuilder::default();
       thumbnail_ext.name("media:content".to_string());

--- a/crates/routes/src/feeds.rs
+++ b/crates/routes/src/feeds.rs
@@ -6,7 +6,10 @@ use lemmy_api_common::{context::LemmyContext, utils::check_private_instance};
 use lemmy_db_schema::{
   source::{community::Community, person::Person},
   traits::ApubActor,
-  CommentSortType, CommunityVisibility, ListingType, SortType,
+  CommentSortType,
+  CommunityVisibility,
+  ListingType,
+  SortType,
 };
 use lemmy_db_views::{
   post_view::PostQuery,
@@ -24,9 +27,10 @@ use lemmy_utils::{
 };
 use once_cell::sync::Lazy;
 use rss::{
-  extension::dublincore::DublinCoreExtension,
-  extension::{ExtensionBuilder, ExtensionMap},
-  Channel, Guid, Item,
+  extension::{dublincore::DublinCoreExtension, ExtensionBuilder, ExtensionMap},
+  Channel,
+  Guid,
+  Item,
 };
 use serde::Deserialize;
 use std::{collections::BTreeMap, str::FromStr};


### PR DESCRIPTION
This PR adds a `<media:content>` tag to RSS feed items by using `ExtensionBuilder` to build a custom extension for the `rss` crate.

Fixes #581 