### PR TITLE
Remove invalid XML characters from RSS feeds

### DIFF
--- a/crates/routes/src/feeds.rs
+++ b/crates/routes/src/feeds.rs
@@ -102,8 +102,7 @@ fn sanitize_xml(input: String) -> String {
         '\u{09}'
         | '\u{0A}'
         | '\u{0D}'
-        | '\u{20}'..='\u{FE}'
-        | '\u{00FF}'..='\u{D7FF}'
+        | '\u{20}'..='\u{D7FF}'
         | '\u{E000}'..='\u{FFFD}'
         | '\u{10000}'..='\u{10FFFF}')
     })


### PR DESCRIPTION
This PR removes any invalid XML characters from RSS strings based on the XML grammar definition for `Char`, which is located here: https://www.w3.org/TR/xml/#NT-Char.

I've tested this, and `xmllint` successfully parses the text from the post referenced in #4382 after it's sanitized by the `sanitize_xml()` function.

Fixes #4382
