### PR TITLE
Use the Accept-Language header to set new users' language

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
+name = "accept-language"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f27d075294830fcab6f66e320dab524bc6d048f4a151698e153205559113772"
+
+[[package]]
 name = "activitypub_federation"
 version = "0.5.1-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2608,6 +2614,7 @@ dependencies = [
 name = "lemmy_api_crud"
 version = "0.19.3"
 dependencies = [
+ "accept-language",
  "activitypub_federation",
  "actix-web",
  "anyhow",

--- a/crates/api_crud/Cargo.toml
+++ b/crates/api_crud/Cargo.toml
@@ -29,6 +29,7 @@ moka.workspace = true
 once_cell.workspace = true
 anyhow.workspace = true
 webmention = "0.5.0"
+accept-language = "3.1.0"
 
 [package.metadata.cargo-machete]
 ignored = ["futures"]

--- a/crates/api_crud/src/user/create.rs
+++ b/crates/api_crud/src/user/create.rs
@@ -126,6 +126,13 @@ pub async fn register(
   // Also fixes a bug which allows users to log in when registrations are changed to closed.
   let accepted_application = Some(!require_registration_application);
 
+  // Get the user's preferred language using the Accept-Language header
+  let language_tag = req.headers().get("Accept-Language").and_then(|hdr| {
+    accept_language::parse(hdr.to_str().unwrap_or_default())
+      .get(0)
+      .map(|lang_str| lang_str.split('-').next().unwrap().to_string()) // Remove the optional region code
+  });
+
   // Create the local user
   let local_user_form = LocalUserInsertForm::builder()
     .person_id(inserted_person.id)
@@ -134,6 +141,7 @@ pub async fn register(
     .show_nsfw(Some(data.show_nsfw))
     .accepted_application(accepted_application)
     .default_listing_type(Some(local_site.default_post_listing_type))
+    .interface_language(language_tag)
     // If its the initial site setup, they are an admin
     .admin(Some(!local_site.site_setup))
     .build();


### PR DESCRIPTION
This PR uses the `Accept-Language` header to determine users' preferred language and sets that as their `interface_language` on registration, which allows Lemmy to send a properly-translated email confirmation.

This change adds a new dependency for parsing the `Accept-Language` header: https://lib.rs/crates/accept-language

Fixes #4343