### PR TITLE
Make it so the signed in user can see if they're banned from a community

### DIFF
--- a/crates/db_views_actor/src/community_view.rs
+++ b/crates/db_views_actor/src/community_view.rs
@@ -17,6 +17,7 @@ use lemmy_db_schema::{
     community_aggregates,
     community_block,
     community_follower,
+    community_person_ban,
     instance_block,
     local_user,
   },
@@ -58,6 +59,13 @@ fn queries<'a>() -> Queries<
             .and(community_block::person_id.eq(person_id_join)),
         ),
       )
+      .left_join(
+        community_person_ban::table.on(
+          community::id
+            .eq(community_person_ban::community_id)
+            .and(community_person_ban::person_id.eq(person_id_join)),
+        ),
+      )
   };
 
   let selection = (
@@ -65,6 +73,7 @@ fn queries<'a>() -> Queries<
     CommunityFollower::select_subscribed_type(),
     community_block::community_id.nullable().is_not_null(),
     community_aggregates::all_columns,
+    community_person_ban::person_id.nullable().is_not_null(),
   );
 
   let not_removed_or_deleted = community::removed

--- a/crates/db_views_actor/src/structs.rs
+++ b/crates/db_views_actor/src/structs.rs
@@ -80,6 +80,7 @@ pub struct CommunityView {
   pub subscribed: SubscribedType,
   pub blocked: bool,
   pub counts: CommunityAggregates,
+  pub banned: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/crates/db_views_actor/src/structs.rs
+++ b/crates/db_views_actor/src/structs.rs
@@ -80,7 +80,7 @@ pub struct CommunityView {
   pub subscribed: SubscribedType,
   pub blocked: bool,
   pub counts: CommunityAggregates,
-  pub banned: bool,
+  pub banned_from_community: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
Related to [this UI issue](https://github.com/LemmyNet/lemmy-ui/issues/2362).

Why is this change useful? To quote my comment from the linked issue:

> This will most likely require an API change to handle in a way that isn't sloppy. There are 2 ways this could be done without an API change:

> 1.  Look for one of the user's posts or comments in the community to check its creator_banned_from_community property. This could be troublesome if the banned user's posts were purged, and also introduces extra API calls.
> 2. Search the modlog for community bans. This requires making sure that they didn't receive an unban after the ban or that the ban has expired. This will require extra logic and API calls.
