### PR TITLE
Ensure rustfmt is installed in cargo fmt CI job

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -60,7 +60,7 @@ steps:
       # store cargo data in repo folder so that it gets cached between steps
       CARGO_HOME: .cargo_home
     commands:
-      # need make existing toolchain available
+      - rustup component add rustfmt
       - cargo +nightly fmt -- --check
 
   cargo_machete:


### PR DESCRIPTION
There seems to be a difference between the `rustlang/rust:nightly` image used by the join-lemmy woodpecker environment vs what is currently published to docker hub:

```
# docker pull rustlang/rust:nightly
nightly: Pulling from rustlang/rust
Digest: sha256:afb97dbf266be5ffc6641446a794c6dc6a0b5c3cc350454d3ab3c66c8b1fdd5f
Status: Image is up to date for rustlang/rust:nightly
docker.io/rustlang/rust:nightly
# docker run --rm -it rustlang/rust:nightly
root@d255613d5c06:/# cargo +nightly fmt -- --check
error: 'cargo-fmt' is not installed for the toolchain 'nightly-x86_64-unknown-linux-gnu'
To install, run `rustup component add rustfmt`
```

I'm not sure what is meant by the toolchain comment, whether that is related to this?

This is the current outcome of attempting to run the latest commit on `main`, f56b84615c78a0ca9942e7a82c8d7ce4255ec5cb, through my own woodpecker instance: https://wpci.lem.rocks/repos/1/pipeline/4/8

With this change it will no longer fail to run `cargo fmt`: https://wpci.lem.rocks/repos/1/pipeline/11/8

Running `rustup component add rustfmt` multiple times does not cause any issues, so it should not cause any issues when it's already available:
```
# docker run --rm -it rustlang/rust:nightly
root@727062619cd1:/# rustup component add rustfmt
info: downloading component 'rustfmt'
info: installing component 'rustfmt'
root@727062619cd1:/# rustup component add rustfmt
info: component 'rustfmt' for target 'x86_64-unknown-linux-gnu' is up to date
root@727062619cd1:/# echo $?
0
```