### PR TITLE
Correctly synchronize collection of community featured posts 

### DIFF
--- a/crates/apub/src/objects/community.rs
+++ b/crates/apub/src/objects/community.rs
@@ -166,7 +166,7 @@ impl Object for ApubCommunity {
       moderators_url: group.attributed_to.clone().map(Into::into),
       posting_restricted_to_mods: group.posting_restricted_to_mods,
       instance_id,
-      featured_url: group.featured.map(Into::into),
+      featured_url: group.featured.clone().map(Into::into),
       ..Default::default()
     };
     let languages =
@@ -184,6 +184,9 @@ impl Object for ApubCommunity {
     spawn_try_task(async move {
       group.outbox.dereference(&community_, &context_).await?;
       group.followers.dereference(&community_, &context_).await?;
+      if let Some(featured) = group.featured {
+        featured.dereference(&community_, &context_).await?;
+      }
       if let Some(moderators) = group.attributed_to {
         moderators.dereference(&community_, &context_).await?;
       }

--- a/crates/db_schema/src/impls/community.rs
+++ b/crates/db_schema/src/impls/community.rs
@@ -14,6 +14,7 @@ use crate::{
       CommunityPersonBanForm,
       CommunityUpdateForm,
     },
+    post::Post,
   },
   traits::{ApubActor, Bannable, Crud, Followable, Joinable},
   utils::{functions::lower, get_conn, DbPool},
@@ -27,6 +28,7 @@ use diesel::{
   result::Error,
   select,
   sql_types,
+  update,
   ExpressionMethods,
   NullableExpressionMethods,
   QueryDsl,
@@ -136,6 +138,42 @@ impl Community {
       return Ok((c, Featured));
     }
     Err(diesel::NotFound)
+  }
+
+  pub async fn set_featured_posts(
+    community_id: CommunityId,
+    posts: Vec<Post>,
+    pool: &mut DbPool<'_>,
+  ) -> Result<(), Error> {
+    use crate::schema::post;
+    let conn = &mut get_conn(pool).await?;
+    for p in &posts {
+      debug_assert!(p.community_id == community_id);
+    }
+    conn
+      .build_transaction()
+      .run(|conn| {
+        Box::pin(async move {
+          update(
+            // first remove all existing featured posts
+            post::table,
+          )
+          .filter(post::dsl::community_id.eq(community_id))
+          .set(post::dsl::featured_community.eq(false))
+          .execute(conn)
+          .await?;
+
+          // then mark the given posts as featured
+          let post_ids: Vec<_> = posts.iter().map(|p| p.id).collect();
+          update(post::table)
+            .filter(post::dsl::id.eq_any(post_ids))
+            .set(post::dsl::featured_community.eq(true))
+            .execute(conn)
+            .await?;
+          Ok(())
+        }) as _
+      })
+      .await
   }
 }
 


### PR DESCRIPTION
We have a collection for synchronizing featured posts when a community gets fetched, but it turns out that was totally broken. First of all the collection wasnt fetched at all. Then the posts werent marked as featured in the db. This PR fixes it, Ive tested it manually.