### PR TITLE
Adding ability to hide posts.

### DIFF
--- a/crates/api/src/post/hide.rs
+++ b/crates/api/src/post/hide.rs
@@ -1,13 +1,13 @@
 use actix_web::web::{Data, Json};
-use lemmy_api_common::{context::LemmyContext, post::MarkPostAsRead, SuccessResponse};
-use lemmy_db_schema::source::post::PostRead;
+use lemmy_api_common::{context::LemmyContext, post::HidePost, SuccessResponse};
+use lemmy_db_schema::source::post::PostHide;
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType, MAX_API_PARAM_ELEMENTS};
 use std::collections::HashSet;
 
 #[tracing::instrument(skip(context))]
-pub async fn mark_post_as_read(
-  data: Json<MarkPostAsRead>,
+pub async fn hide_post(
+  data: Json<HidePost>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> Result<Json<SuccessResponse>, LemmyError> {
@@ -19,15 +19,15 @@ pub async fn mark_post_as_read(
 
   let person_id = local_user_view.person.id;
 
-  // Mark the post as read / unread
-  if data.read {
-    PostRead::mark_as_read(&mut context.pool(), post_ids, person_id)
+  // Mark the post as hidden / unhidden
+  if data.hide {
+    PostHide::hide(&mut context.pool(), post_ids, person_id)
       .await
-      .with_lemmy_type(LemmyErrorType::CouldntMarkPostAsRead)?;
+      .with_lemmy_type(LemmyErrorType::CouldntHidePost)?;
   } else {
-    PostRead::mark_as_unread(&mut context.pool(), post_ids, person_id)
+    PostHide::unhide(&mut context.pool(), post_ids, person_id)
       .await
-      .with_lemmy_type(LemmyErrorType::CouldntMarkPostAsRead)?;
+      .with_lemmy_type(LemmyErrorType::CouldntHidePost)?;
   }
 
   Ok(Json(SuccessResponse::default()))

--- a/crates/api/src/post/mod.rs
+++ b/crates/api/src/post/mod.rs
@@ -1,5 +1,6 @@
 pub mod feature;
 pub mod get_link_metadata;
+pub mod hide;
 pub mod like;
 pub mod list_post_likes;
 pub mod lock;

--- a/crates/api_common/src/post.rs
+++ b/crates/api_common/src/post.rs
@@ -79,6 +79,7 @@ pub struct GetPosts {
   pub saved_only: Option<bool>,
   pub liked_only: Option<bool>,
   pub disliked_only: Option<bool>,
+  pub show_hidden: Option<bool>,
   pub page_cursor: Option<PaginationCursor>,
 }
 
@@ -148,10 +149,18 @@ pub struct RemovePost {
 #[cfg_attr(feature = "full", ts(export))]
 /// Mark a post as read.
 pub struct MarkPostAsRead {
-  /// TODO: deprecated, send `post_ids` instead
-  pub post_id: Option<PostId>,
-  pub post_ids: Option<Vec<PostId>>,
+  pub post_ids: Vec<PostId>,
   pub read: bool,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "full", derive(TS))]
+#[cfg_attr(feature = "full", ts(export))]
+/// Hide a post from list views
+pub struct HidePost {
+  pub post_ids: Vec<PostId>,
+  pub hide: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, Default, PartialEq, Eq, Hash)]

--- a/crates/apub/src/api/list_posts.rs
+++ b/crates/apub/src/api/list_posts.rs
@@ -36,6 +36,7 @@ pub async fn list_posts(
     data.community_id
   };
   let saved_only = data.saved_only.unwrap_or_default();
+  let show_hidden = data.show_hidden.unwrap_or_default();
 
   let liked_only = data.liked_only.unwrap_or_default();
   let disliked_only = data.disliked_only.unwrap_or_default();
@@ -75,6 +76,7 @@ pub async fn list_posts(
     page,
     page_after,
     limit,
+    show_hidden,
     ..Default::default()
   }
   .list(&local_site.site, &mut context.pool())

--- a/crates/db_schema/src/impls/post.rs
+++ b/crates/db_schema/src/impls/post.rs
@@ -1,23 +1,10 @@
 use crate::{
   newtypes::{CommunityId, DbUrl, PersonId, PostId},
-  schema::post::dsl::{
-    ap_id,
-    body,
-    community_id,
-    creator_id,
-    deleted,
-    featured_community,
-    local,
-    name,
-    post,
-    published,
-    removed,
-    thumbnail_url,
-    updated,
-    url,
-  },
+  schema::{post, post_hide, post_like, post_read, post_saved},
   source::post::{
     Post,
+    PostHide,
+    PostHideForm,
     PostInsertForm,
     PostLike,
     PostLikeForm,
@@ -53,9 +40,9 @@ impl Crud for Post {
 
   async fn create(pool: &mut DbPool<'_>, form: &Self::InsertForm) -> Result<Self, Error> {
     let conn = &mut get_conn(pool).await?;
-    insert_into(post)
+    insert_into(post::table)
       .values(form)
-      .on_conflict(ap_id)
+      .on_conflict(post::ap_id)
       .do_update()
       .set(form)
       .get_result::<Self>(conn)
@@ -68,7 +55,7 @@ impl Crud for Post {
     new_post: &Self::UpdateForm,
   ) -> Result<Self, Error> {
     let conn = &mut get_conn(pool).await?;
-    diesel::update(post.find(post_id))
+    diesel::update(post::table.find(post_id))
       .set(new_post)
       .get_result::<Self>(conn)
       .await
@@ -81,12 +68,12 @@ impl Post {
     the_community_id: CommunityId,
   ) -> Result<Vec<Self>, Error> {
     let conn = &mut get_conn(pool).await?;
-    post
-      .filter(community_id.eq(the_community_id))
-      .filter(deleted.eq(false))
-      .filter(removed.eq(false))
-      .then_order_by(featured_community.desc())
-      .then_order_by(published.desc())
+    post::table
+      .filter(post::community_id.eq(the_community_id))
+      .filter(post::deleted.eq(false))
+      .filter(post::removed.eq(false))
+      .then_order_by(post::featured_community.desc())
+      .then_order_by(post::published.desc())
       .limit(FETCH_LIMIT_MAX)
       .load::<Self>(conn)
       .await
@@ -97,12 +84,12 @@ impl Post {
     the_community_id: CommunityId,
   ) -> Result<Vec<Self>, Error> {
     let conn = &mut get_conn(pool).await?;
-    post
-      .filter(community_id.eq(the_community_id))
-      .filter(deleted.eq(false))
-      .filter(removed.eq(false))
-      .filter(featured_community.eq(true))
-      .then_order_by(published.desc())
+    post::table
+      .filter(post::community_id.eq(the_community_id))
+      .filter(post::deleted.eq(false))
+      .filter(post::removed.eq(false))
+      .filter(post::featured_community.eq(true))
+      .then_order_by(post::published.desc())
       .limit(FETCH_LIMIT_MAX)
       .load::<Self>(conn)
       .await
@@ -112,13 +99,13 @@ impl Post {
     pool: &mut DbPool<'_>,
   ) -> Result<Vec<(DbUrl, chrono::DateTime<Utc>)>, Error> {
     let conn = &mut get_conn(pool).await?;
-    post
-      .select((ap_id, coalesce(updated, published)))
-      .filter(local.eq(true))
-      .filter(deleted.eq(false))
-      .filter(removed.eq(false))
-      .filter(published.ge(Utc::now().naive_utc() - Duration::days(SITEMAP_DAYS)))
-      .order(published.desc())
+    post::table
+      .select((post::ap_id, coalesce(post::updated, post::published)))
+      .filter(post::local.eq(true))
+      .filter(post::deleted.eq(false))
+      .filter(post::removed.eq(false))
+      .filter(post::published.ge(Utc::now().naive_utc() - Duration::days(SITEMAP_DAYS)))
+      .order(post::published.desc())
       .limit(SITEMAP_LIMIT)
       .load::<(DbUrl, chrono::DateTime<Utc>)>(conn)
       .await
@@ -130,13 +117,13 @@ impl Post {
   ) -> Result<Vec<Self>, Error> {
     let conn = &mut get_conn(pool).await?;
 
-    diesel::update(post.filter(creator_id.eq(for_creator_id)))
+    diesel::update(post::table.filter(post::creator_id.eq(for_creator_id)))
       .set((
-        name.eq(DELETED_REPLACEMENT_TEXT),
-        url.eq(Option::<&str>::None),
-        body.eq(DELETED_REPLACEMENT_TEXT),
-        deleted.eq(true),
-        updated.eq(naive_now()),
+        post::name.eq(DELETED_REPLACEMENT_TEXT),
+        post::url.eq(Option::<&str>::None),
+        post::body.eq(DELETED_REPLACEMENT_TEXT),
+        post::deleted.eq(true),
+        post::updated.eq(naive_now()),
       ))
       .get_results::<Self>(conn)
       .await
@@ -150,15 +137,15 @@ impl Post {
   ) -> Result<Vec<Self>, Error> {
     let conn = &mut get_conn(pool).await?;
 
-    let mut update = diesel::update(post).into_boxed();
-    update = update.filter(creator_id.eq(for_creator_id));
+    let mut update = diesel::update(post::table).into_boxed();
+    update = update.filter(post::creator_id.eq(for_creator_id));
 
     if let Some(for_community_id) = for_community_id {
-      update = update.filter(community_id.eq(for_community_id));
+      update = update.filter(post::community_id.eq(for_community_id));
     }
 
     update
-      .set((removed.eq(new_removed), updated.eq(naive_now())))
+      .set((post::removed.eq(new_removed), post::updated.eq(naive_now())))
       .get_results::<Self>(conn)
       .await
   }
@@ -174,8 +161,8 @@ impl Post {
     let conn = &mut get_conn(pool).await?;
     let object_id: DbUrl = object_id.into();
     Ok(
-      post
-        .filter(ap_id.eq(object_id))
+      post::table
+        .filter(post::ap_id.eq(object_id))
         .first::<Post>(conn)
         .await
         .ok()
@@ -190,9 +177,9 @@ impl Post {
     let conn = &mut get_conn(pool).await?;
     let pictrs_search = "%pictrs/image%";
 
-    post
-      .filter(creator_id.eq(for_creator_id))
-      .filter(url.like(pictrs_search))
+    post::table
+      .filter(post::creator_id.eq(for_creator_id))
+      .filter(post::url.like(pictrs_search))
       .load::<Self>(conn)
       .await
   }
@@ -206,13 +193,13 @@ impl Post {
     let pictrs_search = "%pictrs/image%";
 
     diesel::update(
-      post
-        .filter(creator_id.eq(for_creator_id))
-        .filter(url.like(pictrs_search)),
+      post::table
+        .filter(post::creator_id.eq(for_creator_id))
+        .filter(post::url.like(pictrs_search)),
     )
     .set((
-      url.eq::<Option<String>>(None),
-      thumbnail_url.eq::<Option<String>>(None),
+      post::url.eq::<Option<String>>(None),
+      post::thumbnail_url.eq::<Option<String>>(None),
     ))
     .get_results::<Self>(conn)
     .await
@@ -224,9 +211,9 @@ impl Post {
   ) -> Result<Vec<Self>, Error> {
     let conn = &mut get_conn(pool).await?;
     let pictrs_search = "%pictrs/image%";
-    post
-      .filter(community_id.eq(for_community_id))
-      .filter(url.like(pictrs_search))
+    post::table
+      .filter(post::community_id.eq(for_community_id))
+      .filter(post::url.like(pictrs_search))
       .load::<Self>(conn)
       .await
   }
@@ -240,13 +227,13 @@ impl Post {
     let pictrs_search = "%pictrs/image%";
 
     diesel::update(
-      post
-        .filter(community_id.eq(for_community_id))
-        .filter(url.like(pictrs_search)),
+      post::table
+        .filter(post::community_id.eq(for_community_id))
+        .filter(post::url.like(pictrs_search)),
     )
     .set((
-      url.eq::<Option<String>>(None),
-      thumbnail_url.eq::<Option<String>>(None),
+      post::url.eq::<Option<String>>(None),
+      post::thumbnail_url.eq::<Option<String>>(None),
     ))
     .get_results::<Self>(conn)
     .await
@@ -258,11 +245,10 @@ impl Likeable for PostLike {
   type Form = PostLikeForm;
   type IdType = PostId;
   async fn like(pool: &mut DbPool<'_>, post_like_form: &PostLikeForm) -> Result<Self, Error> {
-    use crate::schema::post_like::dsl::{person_id, post_id, post_like};
     let conn = &mut get_conn(pool).await?;
-    insert_into(post_like)
+    insert_into(post_like::table)
       .values(post_like_form)
-      .on_conflict((post_id, person_id))
+      .on_conflict((post_like::post_id, post_like::person_id))
       .do_update()
       .set(post_like_form)
       .get_result::<Self>(conn)
@@ -273,9 +259,8 @@ impl Likeable for PostLike {
     person_id: PersonId,
     post_id: PostId,
   ) -> Result<usize, Error> {
-    use crate::schema::post_like::dsl;
     let conn = &mut get_conn(pool).await?;
-    diesel::delete(dsl::post_like.find((person_id, post_id)))
+    diesel::delete(post_like::table.find((person_id, post_id)))
       .execute(conn)
       .await
   }
@@ -285,20 +270,18 @@ impl Likeable for PostLike {
 impl Saveable for PostSaved {
   type Form = PostSavedForm;
   async fn save(pool: &mut DbPool<'_>, post_saved_form: &PostSavedForm) -> Result<Self, Error> {
-    use crate::schema::post_saved::dsl::{person_id, post_id, post_saved};
     let conn = &mut get_conn(pool).await?;
-    insert_into(post_saved)
+    insert_into(post_saved::table)
       .values(post_saved_form)
-      .on_conflict((post_id, person_id))
+      .on_conflict((post_saved::post_id, post_saved::person_id))
       .do_update()
       .set(post_saved_form)
       .get_result::<Self>(conn)
       .await
   }
   async fn unsave(pool: &mut DbPool<'_>, post_saved_form: &PostSavedForm) -> Result<usize, Error> {
-    use crate::schema::post_saved::dsl::post_saved;
     let conn = &mut get_conn(pool).await?;
-    diesel::delete(post_saved.find((post_saved_form.person_id, post_saved_form.post_id)))
+    diesel::delete(post_saved::table.find((post_saved_form.person_id, post_saved_form.post_id)))
       .execute(conn)
       .await
   }
@@ -310,14 +293,13 @@ impl PostRead {
     post_ids: HashSet<PostId>,
     person_id: PersonId,
   ) -> Result<usize, Error> {
-    use crate::schema::post_read::dsl::post_read;
     let conn = &mut get_conn(pool).await?;
 
     let forms = post_ids
       .into_iter()
       .map(|post_id| PostReadForm { post_id, person_id })
       .collect::<Vec<PostReadForm>>();
-    insert_into(post_read)
+    insert_into(post_read::table)
       .values(forms)
       .on_conflict_do_nothing()
       .execute(conn)
@@ -329,13 +311,48 @@ impl PostRead {
     post_id_: HashSet<PostId>,
     person_id_: PersonId,
   ) -> Result<usize, Error> {
-    use crate::schema::post_read::dsl::{person_id, post_id, post_read};
     let conn = &mut get_conn(pool).await?;
 
     diesel::delete(
-      post_read
-        .filter(post_id.eq_any(post_id_))
-        .filter(person_id.eq(person_id_)),
+      post_read::table
+        .filter(post_read::post_id.eq_any(post_id_))
+        .filter(post_read::person_id.eq(person_id_)),
+    )
+    .execute(conn)
+    .await
+  }
+}
+
+impl PostHide {
+  pub async fn hide(
+    pool: &mut DbPool<'_>,
+    post_ids: HashSet<PostId>,
+    person_id: PersonId,
+  ) -> Result<usize, Error> {
+    let conn = &mut get_conn(pool).await?;
+
+    let forms = post_ids
+      .into_iter()
+      .map(|post_id| PostHideForm { post_id, person_id })
+      .collect::<Vec<PostHideForm>>();
+    insert_into(post_hide::table)
+      .values(forms)
+      .on_conflict_do_nothing()
+      .execute(conn)
+      .await
+  }
+
+  pub async fn unhide(
+    pool: &mut DbPool<'_>,
+    post_id_: HashSet<PostId>,
+    person_id_: PersonId,
+  ) -> Result<usize, Error> {
+    let conn = &mut get_conn(pool).await?;
+
+    diesel::delete(
+      post_hide::table
+        .filter(post_hide::post_id.eq_any(post_id_))
+        .filter(post_hide::person_id.eq(person_id_)),
     )
     .execute(conn)
     .await

--- a/crates/db_schema/src/schema.rs
+++ b/crates/db_schema/src/schema.rs
@@ -731,6 +731,14 @@ diesel::table! {
 }
 
 diesel::table! {
+    post_hide (person_id, post_id) {
+        post_id -> Int4,
+        person_id -> Int4,
+        published -> Timestamptz,
+    }
+}
+
+diesel::table! {
     post_like (person_id, post_id) {
         post_id -> Int4,
         person_id -> Int4,
@@ -983,6 +991,8 @@ diesel::joinable!(post_aggregates -> community (community_id));
 diesel::joinable!(post_aggregates -> instance (instance_id));
 diesel::joinable!(post_aggregates -> person (creator_id));
 diesel::joinable!(post_aggregates -> post (post_id));
+diesel::joinable!(post_hide -> person (person_id));
+diesel::joinable!(post_hide -> post (post_id));
 diesel::joinable!(post_like -> person (person_id));
 diesel::joinable!(post_like -> post (post_id));
 diesel::joinable!(post_read -> person (person_id));
@@ -1054,6 +1064,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     person_post_aggregates,
     post,
     post_aggregates,
+    post_hide,
     post_like,
     post_read,
     post_report,

--- a/crates/db_schema/src/source/post.rs
+++ b/crates/db_schema/src/source/post.rs
@@ -1,6 +1,6 @@
 use crate::newtypes::{CommunityId, DbUrl, LanguageId, PersonId, PostId};
 #[cfg(feature = "full")]
-use crate::schema::{post, post_like, post_read, post_saved};
+use crate::schema::{post, post_hide, post_like, post_read, post_saved};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -179,6 +179,28 @@ pub struct PostRead {
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = post_read))]
 pub(crate) struct PostReadForm {
+  pub post_id: PostId,
+  pub person_id: PersonId,
+}
+
+#[derive(PartialEq, Eq, Debug)]
+#[cfg_attr(
+  feature = "full",
+  derive(Identifiable, Queryable, Selectable, Associations)
+)]
+#[cfg_attr(feature = "full", diesel(belongs_to(crate::source::post::Post)))]
+#[cfg_attr(feature = "full", diesel(table_name = post_hide))]
+#[cfg_attr(feature = "full", diesel(primary_key(post_id, person_id)))]
+#[cfg_attr(feature = "full", diesel(check_for_backend(diesel::pg::Pg)))]
+pub struct PostHide {
+  pub post_id: PostId,
+  pub person_id: PersonId,
+  pub published: DateTime<Utc>,
+}
+
+#[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
+#[cfg_attr(feature = "full", diesel(table_name = post_hide))]
+pub(crate) struct PostHideForm {
   pub post_id: PostId,
   pub person_id: PersonId,
 }

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -421,7 +421,7 @@ fn queries<'a>() -> Queries<
       // Do not hide read posts when it is a user profile view
       // Or, only hide read posts on non-profile views
       if let (None, Some(person_id)) = (options.creator_id, my_person_id) {
-        query = query.filter(not(is_read(person_id)))
+        query = query.filter(not(is_read(person_id)));
       }
     }
 

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -1521,7 +1521,12 @@ mod tests {
     assert_eq!(vec![POST_BY_BOT, POST], names(&post_listings_show_hidden));
 
     // Make sure that hidden field is true.
-    assert!(&post_listings_show_hidden[0].hidden);
+    assert!(
+      &post_listings_show_hidden
+        .first()
+        .expect("first post should exist")
+        .hidden
+    );
 
     cleanup(data, pool).await
   }

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -35,6 +35,7 @@ use lemmy_db_schema::{
     person_post_aggregates,
     post,
     post_aggregates,
+    post_hide,
     post_like,
     post_read,
     post_saved,
@@ -107,6 +108,16 @@ fn queries<'a>() -> Queries<
     )
   };
 
+  let is_hidden = |person_id| {
+    exists(
+      post_hide::table.filter(
+        post_aggregates::post_id
+          .eq(post_hide::post_id)
+          .and(post_hide::person_id.eq(person_id)),
+      ),
+    )
+  };
+
   let is_creator_blocked = |person_id| {
     exists(
       person_block::table.filter(
@@ -143,6 +154,13 @@ fn queries<'a>() -> Queries<
     let is_read_selection: Box<dyn BoxableExpression<_, Pg, SqlType = sql_types::Bool>> =
       if let Some(person_id) = my_person_id {
         Box::new(is_read(person_id))
+      } else {
+        Box::new(false.into_sql::<sql_types::Bool>())
+      };
+
+    let is_hidden_selection: Box<dyn BoxableExpression<_, Pg, SqlType = sql_types::Bool>> =
+      if let Some(person_id) = my_person_id {
+        Box::new(is_hidden(person_id))
       } else {
         Box::new(false.into_sql::<sql_types::Bool>())
       };
@@ -211,6 +229,7 @@ fn queries<'a>() -> Queries<
         subscribed_type_selection,
         is_saved_selection,
         is_read_selection,
+        is_hidden_selection,
         is_creator_blocked_selection,
         score_selection,
         coalesce(
@@ -402,7 +421,14 @@ fn queries<'a>() -> Queries<
       // Do not hide read posts when it is a user profile view
       // Or, only hide read posts on non-profile views
       if let (None, Some(person_id)) = (options.creator_id, my_person_id) {
-        query = query.filter(not(is_read(person_id)));
+        query = query.filter(not(is_read(person_id)))
+      }
+    }
+
+    if !options.show_hidden {
+      // If a creator id isn't given (IE its on home or community pages), hide the hidden posts
+      if let (None, Some(person_id)) = (options.creator_id, my_person_id) {
+        query = query.filter(not(is_hidden(person_id)));
       }
     }
 
@@ -593,6 +619,7 @@ pub struct PostQuery<'a> {
   pub page_after: Option<PaginationCursorData>,
   pub page_before_or_equal: Option<PaginationCursorData>,
   pub page_back: bool,
+  pub show_hidden: bool,
 }
 
 impl<'a> PostQuery<'a> {
@@ -726,7 +753,7 @@ mod tests {
       local_user::{LocalUser, LocalUserInsertForm, LocalUserUpdateForm},
       person::{Person, PersonInsertForm},
       person_block::{PersonBlock, PersonBlockForm},
-      post::{Post, PostInsertForm, PostLike, PostLikeForm, PostRead, PostUpdateForm},
+      post::{Post, PostHide, PostInsertForm, PostLike, PostLikeForm, PostRead, PostUpdateForm},
       site::Site,
     },
     traits::{Blockable, Crud, Joinable, Likeable},
@@ -1463,6 +1490,39 @@ mod tests {
     cleanup(data, pool).await
   }
 
+  #[tokio::test]
+  #[serial]
+  async fn post_listings_hide_hidden() -> LemmyResult<()> {
+    let pool = &build_db_pool().await?;
+    let pool = &mut pool.into();
+    let data = init_data(pool).await?;
+
+    // Mark a post as hidden
+    PostHide::hide(
+      pool,
+      HashSet::from([data.inserted_bot_post.id]),
+      data.local_user_view.person.id,
+    )
+    .await?;
+
+    // Make sure you don't see the hidden post in the results
+    let post_listings_hide_hidden = data.default_post_query().list(&data.site, pool).await?;
+    assert_eq!(vec![POST], names(&post_listings_hide_hidden));
+
+    // Make sure it does come back with the show_hidden option
+    let post_listings_show_hidden = PostQuery {
+      sort: Some(SortType::New),
+      local_user: Some(&data.local_user_view),
+      show_hidden: true,
+      ..Default::default()
+    }
+    .list(&data.site, pool)
+    .await?;
+    assert_eq!(vec![POST_BY_BOT, POST], names(&post_listings_show_hidden));
+
+    cleanup(data, pool).await
+  }
+
   async fn cleanup(data: Data, pool: &mut DbPool<'_>) -> LemmyResult<()> {
     let num_deleted = Post::delete(pool, data.inserted_post.id).await?;
     Community::delete(pool, data.inserted_community.id).await?;
@@ -1584,6 +1644,7 @@ mod tests {
       },
       subscribed: SubscribedType::NotSubscribed,
       read: false,
+      hidden: false,
       saved: false,
       creator_blocked: false,
     })

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -1520,6 +1520,9 @@ mod tests {
     .await?;
     assert_eq!(vec![POST_BY_BOT, POST], names(&post_listings_show_hidden));
 
+    // Make sure that hidden field is true.
+    assert!(&post_listings_show_hidden[0].hidden);
+
     cleanup(data, pool).await
   }
 

--- a/crates/db_views/src/structs.rs
+++ b/crates/db_views/src/structs.rs
@@ -120,6 +120,7 @@ pub struct PostView {
   pub subscribed: SubscribedType,
   pub saved: bool,
   pub read: bool,
+  pub hidden: bool,
   pub creator_blocked: bool,
   pub my_vote: Option<i16>,
   pub unread_comments: i64,

--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -122,6 +122,7 @@ pub enum LemmyErrorType {
   CouldntLikePost,
   CouldntSavePost,
   CouldntMarkPostAsRead,
+  CouldntHidePost,
   CouldntUpdateCommunity,
   CouldntUpdateReplies,
   CouldntUpdatePersonMentions,

--- a/migrations/2024-02-28-144211_hide_posts/down.sql
+++ b/migrations/2024-02-28-144211_hide_posts/down.sql
@@ -1,0 +1,2 @@
+DROP TABLE post_hide;
+

--- a/migrations/2024-02-28-144211_hide_posts/up.sql
+++ b/migrations/2024-02-28-144211_hide_posts/up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE post_hide (
+    post_id int REFERENCES post ON UPDATE CASCADE ON DELETE CASCADE NOT NULL,
+    person_id int REFERENCES person ON UPDATE CASCADE ON DELETE CASCADE NOT NULL,
+    published timestamp with time zone NOT NULL DEFAULT now(),
+    PRIMARY KEY (person_id, post_id)
+);
+

--- a/src/api_routes_http.rs
+++ b/src/api_routes_http.rs
@@ -49,6 +49,7 @@ use lemmy_api::{
   post::{
     feature::feature_post,
     get_link_metadata::get_link_metadata,
+    hide::hide_post,
     like::like_post,
     list_post_likes::list_post_likes,
     lock::lock_post,
@@ -206,6 +207,7 @@ pub fn config(cfg: &mut web::ServiceConfig, rate_limit: &RateLimitCell) {
           .route("/delete", web::post().to(delete_post))
           .route("/remove", web::post().to(remove_post))
           .route("/mark_as_read", web::post().to(mark_post_as_read))
+          .route("/hide", web::post().to(hide_post))
           .route("/lock", web::post().to(lock_post))
           .route("/feature", web::post().to(feature_post))
           .route("/list", web::get().to(list_posts))


### PR DESCRIPTION
- Adds an post/hide API route.
- Adds a `show_hidden` (default false) to `GetPosts`.
- Adds a `hidden` field to `PostView`.
- Removes the single `post_id` from MarkPostAsRead.
- Fixes #1403