### PR TITLE
Make SiteAggregates derive Copy and Hash

### DIFF
--- a/crates/db_schema/src/aggregates/structs.rs
+++ b/crates/db_schema/src/aggregates/structs.rs
@@ -176,7 +176,7 @@ pub struct PersonPostAggregatesForm {
   pub published: Option<DateTime<Utc>>,
 }
 
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone, Copy, Hash)]
 #[cfg_attr(
   feature = "full",
   derive(Queryable, Selectable, Associations, Identifiable, TS)


### PR DESCRIPTION
Derived some traits to make this struct easier to use with the rust api wrapper.