### PR TITLE
Add GDPR non-compliance warning to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
  <img width=200px height=200px src="https://raw.githubusercontent.com/LemmyNet/lemmy-ui/main/src/assets/icons/favicon.svg"></a>
 
  <h3 align="center"><a href="https://join-lemmy.org">Lemmy</a></h3>
+ <p><strong>WARNING: Lemmy is not yet compliant with the GDPR. Hosting a public instance in the EU could incur enormous fines.</strong></p>
   <p align="center">
     A link aggregator and forum for the fediverse.
     <br />


### PR DESCRIPTION
Lemmy doesn't delete uploaded images on account deletion. This is almost certainly in violation of the GDPR.

Based on the comments in LemmyNet/lemmy-ui#2384, compliance doesn't appear to be a priority, so I think a warning is justified instead because people could face potentially massive fines under the GDPR for hosting a public instance.