### PR TITLE
When purging a federated user, federate local community removals.

### DIFF
--- a/crates/api/src/site/purge/person.rs
+++ b/crates/api/src/site/purge/person.rs
@@ -1,3 +1,4 @@
+use crate::ban_nonlocal_user_from_local_communities;
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
@@ -28,7 +29,7 @@ pub async fn purge_person(
   // Only let admin purge an item
   is_admin(&local_user_view)?;
 
-  // Read the person to get their images
+  // Read the local user to get their images, and delete them
   if let Ok(local_user) = LocalUserView::read_person(&mut context.pool(), data.person_id).await {
     let pictrs_uploads =
       LocalImage::get_all_by_local_user_id(&mut context.pool(), &local_user.local_user.id).await?;
@@ -39,6 +40,18 @@ pub async fn purge_person(
         .ok();
     }
   }
+
+  let person = Person::read(&mut context.pool(), data.person_id).await?;
+  ban_nonlocal_user_from_local_communities(
+    &local_user_view,
+    &person,
+    true,
+    &data.reason,
+    &Some(true),
+    &None,
+    &context,
+  )
+  .await?;
 
   // Clear profile data.
   Person::delete_account(&mut context.pool(), data.person_id).await?;


### PR DESCRIPTION
We recently merged this for site user bans, but it also needs to be done for user purges.

Context: #4118