### PR TITLE
Update contact section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,12 @@ When working on an issue or pull request, you can comment with any questions you
 
 - If you want to help with translating, take a look at [Weblate](https://weblate.join-lemmy.org/projects/lemmy/). You can also help by [translating the documentation](https://github.com/LemmyNet/lemmy-docs#adding-a-new-language).
 
-## Contact
+## Discussions
 
+- [Matrix Space](https://matrix.to/#/#lemmy-space:matrix.org)
+- [Lemmy Community](https://lemmy.ml/c/lemmy)
+- [Lemmy Support Community](https://lemmy.ml/c/lemmy_support)
 - [Mastodon](https://mastodon.social/@LemmyDev)
-- [Lemmy Support Forum](https://lemmy.ml/c/lemmy_support)
 
 ## Code Mirrors
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,6 @@ When working on an issue or pull request, you can comment with any questions you
 - [Matrix Space](https://matrix.to/#/#lemmy-space:matrix.org)
 - [Lemmy Forum](https://lemmy.ml/c/lemmy)
 - [Lemmy Support Forum](https://lemmy.ml/c/lemmy_support)
-- [Mastodon](https://mastodon.social/@LemmyDev)
 
 ## Code Mirrors
 

--- a/README.md
+++ b/README.md
@@ -149,11 +149,11 @@ When working on an issue or pull request, you can comment with any questions you
 
 - If you want to help with translating, take a look at [Weblate](https://weblate.join-lemmy.org/projects/lemmy/). You can also help by [translating the documentation](https://github.com/LemmyNet/lemmy-docs#adding-a-new-language).
 
-## Discussions
+## Community
 
 - [Matrix Space](https://matrix.to/#/#lemmy-space:matrix.org)
-- [Lemmy Community](https://lemmy.ml/c/lemmy)
-- [Lemmy Support Community](https://lemmy.ml/c/lemmy_support)
+- [Lemmy Forum](https://lemmy.ml/c/lemmy)
+- [Lemmy Support Forum](https://lemmy.ml/c/lemmy_support)
 - [Mastodon](https://mastodon.social/@LemmyDev)
 
 ## Code Mirrors


### PR DESCRIPTION
Community seems like a better title, as these are mainly for talking with other Lemmy users and not only with devs. Not sure how its possible that the Matrix link was completely missing. I also removed the Mastodon link as we rarely use that.