### PR TITLE
Dont require leading ! or @ for webfinger resolve

### DIFF
--- a/api_tests/src/user.spec.ts
+++ b/api_tests/src/user.spec.ts
@@ -45,7 +45,7 @@ test("Create user", async () => {
   if (!site.my_user) {
     throw "Missing site user";
   }
-  apShortname = `@${site.my_user.local_user_view.person.name}@lemmy-alpha:8541`;
+  apShortname = `${site.my_user.local_user_view.person.name}@lemmy-alpha:8541`;
 });
 
 test("Set some user settings, check that they are federated", async () => {
@@ -68,7 +68,7 @@ test("Delete user", async () => {
   let user = await registerUser(alpha, alphaUrl);
 
   // make a local post and comment
-  let alphaCommunity = (await resolveCommunity(user, "!main@lemmy-alpha:8541"))
+  let alphaCommunity = (await resolveCommunity(user, "main@lemmy-alpha:8541"))
     .community;
   if (!alphaCommunity) {
     throw "Missing alpha community";
@@ -134,7 +134,7 @@ test("Create user with Arabic name", async () => {
   if (!site.my_user) {
     throw "Missing site user";
   }
-  apShortname = `@${site.my_user.local_user_view.person.name}@lemmy-alpha:8541`;
+  apShortname = `${site.my_user.local_user_view.person.name}@lemmy-alpha:8541`;
 
   let alphaPerson = (await resolvePerson(alpha, apShortname)).person;
   expect(alphaPerson).toBeDefined();

--- a/crates/apub/src/api/resolve_object.rs
+++ b/crates/apub/src/api/resolve_object.rs
@@ -59,7 +59,7 @@ async fn convert_response(
       removed_or_deleted = c.deleted || c.removed;
       res.comment = Some(CommentView::read(pool, c.id, user_id).await?)
     }
-    PersonOrCommunity(p) => match p {
+    PersonOrCommunity(p) => match *p {
       UserOrCommunity::User(u) => {
         removed_or_deleted = u.deleted;
         res.person = Some(PersonView::read(pool, u.id).await?)

--- a/crates/apub/src/fetcher/search.rs
+++ b/crates/apub/src/fetcher/search.rs
@@ -1,45 +1,40 @@
 use crate::{
   objects::{comment::ApubComment, community::ApubCommunity, person::ApubPerson, post::ApubPost},
-  protocol::objects::{group::Group, note::Note, page::Page, person::Person},
+  protocol::objects::{note::Note, page::Page},
 };
 use activitypub_federation::{
   config::Data,
   fetch::{object_id::ObjectId, webfinger::webfinger_resolve_actor},
   traits::Object,
 };
+
 use chrono::{DateTime, Utc};
 use lemmy_api_common::context::LemmyContext;
-use lemmy_utils::error::{LemmyError, LemmyErrorType};
+use lemmy_utils::error::{LemmyError};
 use serde::Deserialize;
 use url::Url;
+
+use crate::fetcher::user_or_community::{PersonOrGroup, UserOrCommunity};
 
 /// Converts search query to object id. The query can either be an URL, which will be treated as
 /// ObjectId directly, or a webfinger identifier (@user@example.com or !community@example.com)
 /// which gets resolved to an URL.
 #[tracing::instrument(skip_all)]
 pub(crate) async fn search_query_to_object_id(
-  query: &str,
+  mut query: String,
   context: &Data<LemmyContext>,
 ) -> Result<SearchableObjects, LemmyError> {
-  Ok(match Url::parse(query) {
+  Ok(match Url::parse(&query) {
     Ok(url) => {
       // its already an url, just go with it
       ObjectId::from(url).dereference(context).await?
     }
     Err(_) => {
       // not an url, try to resolve via webfinger
-      let mut chars = query.chars();
-      let kind = chars.next();
-      let identifier = chars.as_str();
-      match kind {
-        Some('@') => SearchableObjects::Person(
-          webfinger_resolve_actor::<LemmyContext, ApubPerson>(identifier, context).await?,
-        ),
-        Some('!') => SearchableObjects::Community(
-          webfinger_resolve_actor::<LemmyContext, ApubCommunity>(identifier, context).await?,
-        ),
-        _ => return Err(LemmyErrorType::InvalidQuery)?,
+      if query.starts_with("!") || query.starts_with("@") {
+        query.remove(0);
       }
+        SearchableObjects::PersonOrCommunity(webfinger_resolve_actor::<LemmyContext, UserOrCommunity>(&query, context).await?)
     }
   })
 }
@@ -59,19 +54,17 @@ pub(crate) async fn search_query_to_object_id_local(
 /// The types of ActivityPub objects that can be fetched directly by searching for their ID.
 #[derive(Debug)]
 pub(crate) enum SearchableObjects {
-  Person(ApubPerson),
-  Community(ApubCommunity),
   Post(ApubPost),
   Comment(ApubComment),
+  PersonOrCommunity(UserOrCommunity)
 }
 
 #[derive(Deserialize)]
 #[serde(untagged)]
 pub(crate) enum SearchableKinds {
-  Group(Group),
-  Person(Person),
   Page(Page),
   Note(Note),
+  PersonOrGroup(PersonOrGroup)
 }
 
 #[async_trait::async_trait]
@@ -82,10 +75,9 @@ impl Object for SearchableObjects {
 
   fn last_refreshed_at(&self) -> Option<DateTime<Utc>> {
     match self {
-      SearchableObjects::Person(p) => p.last_refreshed_at(),
-      SearchableObjects::Community(c) => c.last_refreshed_at(),
       SearchableObjects::Post(p) => p.last_refreshed_at(),
       SearchableObjects::Comment(c) => c.last_refreshed_at(),
+      SearchableObjects::PersonOrCommunity(p) => p.last_refreshed_at(),
     }
   }
 
@@ -99,13 +91,9 @@ impl Object for SearchableObjects {
     object_id: Url,
     context: &Data<Self::DataType>,
   ) -> Result<Option<Self>, LemmyError> {
-    let c = ApubCommunity::read_from_id(object_id.clone(), context).await?;
-    if let Some(c) = c {
-      return Ok(Some(SearchableObjects::Community(c)));
-    }
-    let p = ApubPerson::read_from_id(object_id.clone(), context).await?;
-    if let Some(p) = p {
-      return Ok(Some(SearchableObjects::Person(p)));
+    let uc = UserOrCommunity::read_from_id(object_id.clone(), context).await?;
+    if let Some(uc) = uc {
+      return Ok(Some(SearchableObjects::PersonOrCommunity(uc)));
     }
     let p = ApubPost::read_from_id(object_id.clone(), context).await?;
     if let Some(p) = p {
@@ -121,10 +109,14 @@ impl Object for SearchableObjects {
   #[tracing::instrument(skip_all)]
   async fn delete(self, data: &Data<Self::DataType>) -> Result<(), LemmyError> {
     match self {
-      SearchableObjects::Person(p) => p.delete(data).await,
-      SearchableObjects::Community(c) => c.delete(data).await,
       SearchableObjects::Post(p) => p.delete(data).await,
       SearchableObjects::Comment(c) => c.delete(data).await,
+      SearchableObjects::PersonOrCommunity(pc) => {
+        match pc {
+          UserOrCommunity::User(p) => p.delete(data).await,
+          UserOrCommunity::Community(c) => c.delete(data).await,
+        }
+      }
     }
   }
 
@@ -139,10 +131,14 @@ impl Object for SearchableObjects {
     data: &Data<Self::DataType>,
   ) -> Result<(), LemmyError> {
     match apub {
-      SearchableKinds::Group(a) => ApubCommunity::verify(a, expected_domain, data).await,
-      SearchableKinds::Person(a) => ApubPerson::verify(a, expected_domain, data).await,
       SearchableKinds::Page(a) => ApubPost::verify(a, expected_domain, data).await,
       SearchableKinds::Note(a) => ApubComment::verify(a, expected_domain, data).await,
+      SearchableKinds::PersonOrGroup(pg) => {
+        match pg {
+          PersonOrGroup::Person(a) => ApubPerson::verify(a, expected_domain, data).await,
+          PersonOrGroup::Group(a) => ApubCommunity::verify(a, expected_domain, data).await,
+        }
+      }
     }
   }
 
@@ -151,10 +147,11 @@ impl Object for SearchableObjects {
     use SearchableKinds as SAT;
     use SearchableObjects as SO;
     Ok(match apub {
-      SAT::Group(g) => SO::Community(ApubCommunity::from_json(g, context).await?),
-      SAT::Person(p) => SO::Person(ApubPerson::from_json(p, context).await?),
       SAT::Page(p) => SO::Post(ApubPost::from_json(p, context).await?),
       SAT::Note(n) => SO::Comment(ApubComment::from_json(n, context).await?),
+      SAT::PersonOrGroup(pg) => {
+        SO::PersonOrCommunity(UserOrCommunity::from_json(pg, context).await?)
+      }
     })
   }
 }


### PR DESCRIPTION
I noticed that this requirement is totally unnecessary as we can determine the type from the response. Only limitation is if there is a community and user with the same name, then it may be necessary to fetch by url.