### PR TITLE
Change 2FA to use hostname as issuer (fixes #4518)

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -135,11 +135,7 @@ pub(crate) fn generate_totp_2fa_secret() -> String {
   Secret::generate_secret().to_string()
 }
 
-pub(crate) fn build_totp_2fa(
-  site_name: &str,
-  username: &str,
-  secret: &str,
-) -> Result<TOTP, LemmyError> {
+fn build_totp_2fa(hostname: &str, username: &str, secret: &str) -> Result<TOTP, LemmyError> {
   let sec = Secret::Raw(secret.as_bytes().to_vec());
   let sec_bytes = sec
     .to_bytes()
@@ -151,7 +147,7 @@ pub(crate) fn build_totp_2fa(
     1,
     30,
     sec_bytes,
-    Some(site_name.to_string()),
+    Some(hostname.to_string()),
     username.to_string(),
   )
   .with_lemmy_type(LemmyErrorType::CouldntGenerateTotp)
@@ -272,7 +268,7 @@ mod tests {
   #[test]
   fn test_build_totp() {
     let generated_secret = generate_totp_2fa_secret();
-    let totp = build_totp_2fa("lemmy", "my_name", &generated_secret);
+    let totp = build_totp_2fa("lemmy.ml", "my_name", &generated_secret);
     assert!(totp.is_ok());
   }
 }

--- a/crates/api/src/local_user/login.rs
+++ b/crates/api/src/local_user/login.rs
@@ -50,7 +50,11 @@ pub async fn login(
 
   // Check the totp if enabled
   if local_user_view.local_user.totp_2fa_enabled {
-    check_totp_2fa_valid(&local_user_view, &data.totp_2fa_token, &site_view.site.name)?;
+    check_totp_2fa_valid(
+      &local_user_view,
+      &data.totp_2fa_token,
+      &context.settings().hostname,
+    )?;
   }
 
   let jwt = Claims::generate(local_user_view.local_user.id, req, &context).await?;

--- a/crates/api/src/local_user/update_totp.rs
+++ b/crates/api/src/local_user/update_totp.rs
@@ -8,7 +8,7 @@ use lemmy_db_schema::{
   source::local_user::{LocalUser, LocalUserUpdateForm},
   traits::Crud,
 };
-use lemmy_db_views::structs::{LocalUserView, SiteView};
+use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::LemmyError;
 
 /// Enable or disable two-factor-authentication. The current setting is determined from
@@ -25,12 +25,10 @@ pub async fn update_totp(
   local_user_view: LocalUserView,
   context: Data<LemmyContext>,
 ) -> Result<Json<UpdateTotpResponse>, LemmyError> {
-  let site_view = SiteView::read_local(&mut context.pool()).await?;
-
   check_totp_2fa_valid(
     &local_user_view,
     &Some(data.totp_token.clone()),
-    &site_view.site.name,
+    &context.settings().hostname,
   )?;
 
   // toggle the 2fa setting


### PR DESCRIPTION
Im not sure if this is backwards compatible with existing 2FA tokens or if this is a breaking change.