### PR TITLE
Automatically include apub hashtag with posts (fixes #3906)

### DIFF
--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -5,7 +5,7 @@ use crate::{
   objects::{read_from_string_or_source_opt, verify_is_remote_object},
   protocol::{
     objects::{
-      page::{Attachment, AttributedTo, Page, PageType},
+      page::{Attachment, AttributedTo, Hashtag, HashtagType, Page, PageType},
       LanguageTag,
     },
     ImageObject,
@@ -124,6 +124,11 @@ impl Object for ApubPost {
       })
       .into_iter()
       .collect();
+    let hashtag = Hashtag {
+      href: self.ap_id.clone().into(),
+      name: format!("#{}", &community.name),
+      kind: HashtagType::Hashtag,
+    };
 
     let page = Page {
       kind: PageType::Page,
@@ -144,6 +149,7 @@ impl Object for ApubPost {
       updated: self.updated,
       audience: Some(community.actor_id.into()),
       in_reply_to: None,
+      tag: vec![hashtag],
     };
     Ok(page)
   }

--- a/crates/apub/src/protocol/objects/page.rs
+++ b/crates/apub/src/protocol/objects/page.rs
@@ -66,6 +66,8 @@ pub struct Page {
   pub(crate) updated: Option<DateTime<Utc>>,
   pub(crate) language: Option<LanguageTag>,
   pub(crate) audience: Option<ObjectId<ApubCommunity>>,
+  #[serde(deserialize_with = "deserialize_skip_error", default)]
+  pub(crate) tag: Vec<Hashtag>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -138,6 +140,19 @@ pub(crate) struct AttributedToPeertube {
   #[serde(rename = "type")]
   pub kind: PersonOrGroupType,
   pub id: ObjectId<UserOrCommunity>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Hashtag {
+  pub(crate) href: Url,
+  pub(crate) name: String,
+  #[serde(rename = "type")]
+  pub(crate) kind: HashtagType,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum HashtagType {
+  Hashtag,
 }
 
 impl Page {


### PR DESCRIPTION
When making a post in `/c/lemmy`, automatically add the hashtag `#lemmy`. This has no effect for Lemmy but can be used for better discovery by Mastodon etc. Im not entirely sure this is a good idea, but its easy to add and can be reverted if necessary.

Here you can see it working:
https://ds9.lemmy.ml/post/9640
https://mastodon.world/@nutomic@ds9.lemmy.ml/112094731315716039