### PR TITLE
When uploading new avatar/banner, delete old one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2577,6 +2577,7 @@ version = "0.19.3"
 dependencies = [
  "activitypub_federation",
  "actix-web",
+ "anyhow",
  "chrono",
  "encoding",
  "enum-map",
@@ -2589,6 +2590,7 @@ dependencies = [
  "lemmy_db_views_moderator",
  "lemmy_utils",
  "mime",
+ "moka",
  "once_cell",
  "pretty_assertions",
  "regex",

--- a/api_tests/run-federation-test.sh
+++ b/api_tests/run-federation-test.sh
@@ -11,7 +11,7 @@ killall -s1 lemmy_server || true
 popd
 
 pnpm i
-pnpm api-test-user || true
+pnpm api-test || true
 
 killall -s1 lemmy_server || true
 killall -s1 pict-rs || true

--- a/api_tests/run-federation-test.sh
+++ b/api_tests/run-federation-test.sh
@@ -11,7 +11,7 @@ killall -s1 lemmy_server || true
 popd
 
 pnpm i
-pnpm api-test || true
+pnpm api-test-user || true
 
 killall -s1 lemmy_server || true
 killall -s1 pict-rs || true

--- a/api_tests/src/user.spec.ts
+++ b/api_tests/src/user.spec.ts
@@ -19,8 +19,9 @@ import {
   getPost,
   getComments,
   fetchFunction,
+  alphaImage,
 } from "./shared";
-import { LemmyHttp, SaveUserSettings } from "lemmy-js-client";
+import { LemmyHttp, SaveUserSettings, UploadImage } from "lemmy-js-client";
 import { GetPosts } from "lemmy-js-client/dist/types/GetPosts";
 
 beforeAll(setupLogins);
@@ -138,4 +139,37 @@ test("Create user with Arabic name", async () => {
 
   let alphaPerson = (await resolvePerson(alpha, apShortname)).person;
   expect(alphaPerson).toBeDefined();
+});
+
+test.only("Set a new avatar, old avatar is deleted", async () => {
+  const listMediaRes = await alphaImage.listMedia();
+  expect(listMediaRes.images.length).toBe(0);
+  const upload_form1: UploadImage = {
+    image: Buffer.from("test1"),
+  };
+  const upload1 = await alphaImage.uploadImage(upload_form1);
+  expect(upload1.url).toBeDefined();
+  console.log(upload1);
+
+  let form1 = {
+    avatar: upload1.url
+  };
+  await saveUserSettings(alpha, form1);
+  const listMediaRes1 = await alphaImage.listMedia();
+  expect(listMediaRes1.images.length).toBe(1);
+  console.log(listMediaRes1);
+
+  const upload_form2: UploadImage = {
+    image: Buffer.from("test2"),
+  };
+  const upload2 = await alphaImage.uploadImage(upload_form2);
+  expect(upload2.url).toBeDefined();
+
+  let form2 = {
+    avatar: upload1.url
+  };
+  await saveUserSettings(alpha, form2);
+  // make sure only the new avatar is kept
+  const listMediaRes2 = await alphaImage.listMedia();
+  expect(listMediaRes2.images.length).toBe(1);
 });

--- a/api_tests/src/user.spec.ts
+++ b/api_tests/src/user.spec.ts
@@ -141,7 +141,7 @@ test("Create user with Arabic name", async () => {
   expect(alphaPerson).toBeDefined();
 });
 
-test.only("Set a new avatar, old avatar is deleted", async () => {
+test("Set a new avatar, old avatar is deleted", async () => {
   const listMediaRes = await alphaImage.listMedia();
   expect(listMediaRes.images.length).toBe(0);
   const upload_form1: UploadImage = {
@@ -149,15 +149,13 @@ test.only("Set a new avatar, old avatar is deleted", async () => {
   };
   const upload1 = await alphaImage.uploadImage(upload_form1);
   expect(upload1.url).toBeDefined();
-  console.log(upload1);
 
   let form1 = {
-    avatar: upload1.url
+    avatar: upload1.url,
   };
   await saveUserSettings(alpha, form1);
   const listMediaRes1 = await alphaImage.listMedia();
   expect(listMediaRes1.images.length).toBe(1);
-  console.log(listMediaRes1);
 
   const upload_form2: UploadImage = {
     image: Buffer.from("test2"),
@@ -166,7 +164,7 @@ test.only("Set a new avatar, old avatar is deleted", async () => {
   expect(upload2.url).toBeDefined();
 
   let form2 = {
-    avatar: upload1.url
+    avatar: upload1.url,
   };
   await saveUserSettings(alpha, form2);
   // make sure only the new avatar is kept

--- a/crates/api/src/local_user/save_settings.rs
+++ b/crates/api/src/local_user/save_settings.rs
@@ -2,6 +2,7 @@ use actix_web::web::{Data, Json};
 use lemmy_api_common::{
   context::LemmyContext,
   person::SaveUserSettings,
+  request::delete_image_from_pictrs,
   utils::{
     get_url_blocklist,
     local_site_to_slur_regex,
@@ -14,6 +15,7 @@ use lemmy_api_common::{
 use lemmy_db_schema::{
   source::{
     actor_language::LocalUserLanguage,
+    images::LocalImage,
     local_user::{LocalUser, LocalUserUpdateForm},
     local_user_vote_display_mode::{LocalUserVoteDisplayMode, LocalUserVoteDisplayModeUpdateForm},
     person::{Person, PersonUpdateForm},
@@ -40,6 +42,17 @@ pub async fn save_user_settings(
   let bio = diesel_option_overwrite(
     process_markdown_opt(&data.bio, &slur_regex, &url_blocklist, &context).await?,
   );
+  if data.avatar.is_some() {
+    // Ignore errors because image may be stored externally.
+    if let Some(avatar) = &local_user_view.person.avatar {
+      let image = LocalImage::delete_by_url(&mut context.pool(), &avatar)
+        .await
+        .ok();
+      if let Some(image) = image {
+        delete_image_from_pictrs(&image.pictrs_alias, &image.pictrs_delete_token, &context).await?;
+      }
+    }
+  }
 
   let avatar = proxy_image_link_opt_api(&data.avatar, &context).await?;
   let banner = proxy_image_link_opt_api(&data.banner, &context).await?;

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -322,11 +322,11 @@ pub async fn replace_image(
   if new_image.is_some() {
     // Ignore errors because image may be stored externally.
     if let Some(avatar) = &old_image {
-      let image = LocalImage::delete_by_url(&mut context.pool(), &avatar)
+      let image = LocalImage::delete_by_url(&mut context.pool(), avatar)
         .await
         .ok();
       if let Some(image) = image {
-        delete_image_from_pictrs(&image.pictrs_alias, &image.pictrs_delete_token, &context).await?;
+        delete_image_from_pictrs(&image.pictrs_alias, &image.pictrs_delete_token, context).await?;
       }
     }
   }

--- a/crates/api_crud/src/community/update.rs
+++ b/crates/api_crud/src/community/update.rs
@@ -4,6 +4,7 @@ use lemmy_api_common::{
   build_response::build_community_response,
   community::{CommunityResponse, EditCommunity},
   context::LemmyContext,
+  request::replace_image,
   send_activity::{ActivityChannel, SendActivityData},
   utils::{
     check_community_mod_action,
@@ -42,6 +43,9 @@ pub async fn update_community(
   let description =
     process_markdown_opt(&data.description, &slur_regex, &url_blocklist, &context).await?;
   is_valid_body_field(&data.description, false)?;
+  let old_community = Community::read(&mut context.pool(), data.community_id).await?;
+  replace_image(&data.icon, &old_community.icon, &context).await?;
+  replace_image(&data.banner, &old_community.banner, &context).await?;
 
   let description = diesel_option_overwrite(description);
   let icon = proxy_image_link_opt_api(&data.icon, &context).await?;

--- a/crates/api_crud/src/site/update.rs
+++ b/crates/api_crud/src/site/update.rs
@@ -1,7 +1,9 @@
 use crate::site::{application_question_check, site_default_post_listing_type_check};
-use actix_web::web::{Data, Json};
+use activitypub_federation::config::Data;
+use actix_web::web::Json;
 use lemmy_api_common::{
   context::LemmyContext,
+  request::replace_image,
   site::{EditSite, SiteResponse},
   utils::{
     get_url_blocklist,
@@ -62,6 +64,9 @@ pub async fn update_site(
   if let Some(discussion_languages) = data.discussion_languages.clone() {
     SiteLanguage::update(&mut context.pool(), discussion_languages.clone(), &site).await?;
   }
+
+  replace_image(&data.icon, &site.icon, &context).await?;
+  replace_image(&data.banner, &site.banner, &context).await?;
 
   let slur_regex = local_site_to_slur_regex(&local_site);
   let url_blocklist = get_url_blocklist(&context).await?;

--- a/crates/db_schema/src/impls/images.rs
+++ b/crates/db_schema/src/impls/images.rs
@@ -74,19 +74,16 @@ impl LocalImage {
     query.load::<LocalImage>(conn).await
   }
 
-  pub async fn delete_by_alias(pool: &mut DbPool<'_>, alias: &str) -> Result<usize, Error> {
+  pub async fn delete_by_alias(pool: &mut DbPool<'_>, alias: &str) -> Result<Self, Error> {
     let conn = &mut get_conn(pool).await?;
     diesel::delete(local_image::table.filter(local_image::pictrs_alias.eq(alias)))
-      .execute(conn)
+      .get_result(conn)
       .await
   }
 
   pub async fn delete_by_url(pool: &mut DbPool<'_>, url: &DbUrl) -> Result<Self, Error> {
-    let conn = &mut get_conn(pool).await?;
     let alias = url.as_str().split('/').last().ok_or(NotFound)?;
-    diesel::delete(local_image::table.filter(local_image::pictrs_alias.eq(alias)))
-      .get_result(conn)
-      .await
+    Self::delete_by_alias(pool, alias).await
   }
 }
 

--- a/crates/db_schema/src/impls/images.rs
+++ b/crates/db_schema/src/impls/images.rs
@@ -14,8 +14,6 @@ use diesel::{
   QueryDsl,
 };
 use diesel_async::RunQueryDsl;
-use once_cell::sync::Lazy;
-use regex::Regex;
 use url::Url;
 
 impl LocalImage {
@@ -85,10 +83,7 @@ impl LocalImage {
 
   pub async fn delete_by_url(pool: &mut DbPool<'_>, url: &DbUrl) -> Result<Self, Error> {
     let conn = &mut get_conn(pool).await?;
-    static IMAGE_REGEX: Lazy<Regex> =
-      Lazy::new(|| Regex::new(r"^.*/pictrs/image/([a-z0-9-]+\.[a-z]+)$").expect("compile regex"));
-    let captures = IMAGE_REGEX.captures(url.as_str()).unwrap();
-    let alias = &captures[1];
+    let alias = url.as_str().split('/').last().ok_or(NotFound)?;
     diesel::delete(local_image::table.filter(local_image::pictrs_alias.eq(alias)))
       .get_result(conn)
       .await


### PR DESCRIPTION
We currently keep old avatars, banners etc around forever. It makes sense to delete them when a new one is uploaded. For now I implemented it only for user avatar change, but will do the same for user banner, community icon etc if it looks good.

Depends on https://github.com/LemmyNet/lemmy/pull/4509