### PR TITLE
Add delete user field `removeData` to apub assets (fixes #4544)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2633,6 +2633,7 @@ version = "0.19.3"
 dependencies = [
  "activitypub_federation",
  "actix-web",
+ "anyhow",
  "chrono",
  "encoding",
  "enum-map",
@@ -2645,6 +2646,7 @@ dependencies = [
  "lemmy_db_views_moderator",
  "lemmy_utils",
  "mime",
+ "moka",
  "once_cell",
  "pretty_assertions",
  "regex",

--- a/crates/apub/assets/lemmy/activities/deletion/delete_user.json
+++ b/crates/apub/assets/lemmy/activities/deletion/delete_user.json
@@ -3,5 +3,6 @@
   "to": ["https://www.w3.org/ns/activitystreams#Public"],
   "object": "http://ds9.lemmy.ml/u/lemmy_alpha",
   "type": "Delete",
-  "id": "http://ds9.lemmy.ml/activities/delete/f2abee48-c7bb-41d5-9e27-8775ff32db12"
+  "id": "http://ds9.lemmy.ml/activities/delete/f2abee48-c7bb-41d5-9e27-8775ff32db12",
+  "removeData": true
 }


### PR DESCRIPTION
Unfortunately I cant think of any way to check automatically that all existing fields are documented.