### PR TITLE
Fix rate limiter

### DIFF
--- a/crates/utils/src/rate_limit/rate_limiter.rs
+++ b/crates/utils/src/rate_limit/rate_limiter.rs
@@ -158,7 +158,7 @@ impl<K: Eq + Hash, C: MapLevel> MapLevel for Map<K, C> {
 
       // Evaluated if `some_children_remaining` is false
       let total_has_refill_in_future = || {
-        group.total.into_iter().all(|(action_type, bucket)| {
+        group.total.into_iter().any(|(action_type, bucket)| {
           #[allow(clippy::indexing_slicing)]
           let config = configs[action_type];
           bucket.update(now, config).tokens != config.capacity
@@ -416,5 +416,23 @@ mod tests {
     rate_limiter.remove_full_buckets(now);
     assert!(rate_limiter.ipv4_buckets.is_empty());
     assert!(rate_limiter.ipv6_buckets.is_empty());
+
+    // `remove full buckets` should not remove empty buckets
+    let ip = "1.1.1.1".parse().unwrap();
+    // empty the bucket with 2 requests
+    assert!(rate_limiter.check(ActionType::Post, ip, now));
+    assert!(rate_limiter.check(ActionType::Post, ip, now));
+
+    rate_limiter.remove_full_buckets(now);
+    assert!(!rate_limiter.ipv4_buckets.is_empty());
+
+    // `remove full buckets` should not remove partial buckets
+    now.secs += 2;
+    let ip = "1.1.1.1".parse().unwrap();
+    // Only make one request, so bucket still has 1 token
+    assert!(rate_limiter.check(ActionType::Post, ip, now));
+
+    rate_limiter.remove_full_buckets(now);
+    assert!(!rate_limiter.ipv4_buckets.is_empty());
   }
 }


### PR DESCRIPTION
Currently, rate limiters are not working due to a bug in `remove_full_buckets` which causes **all** buckets to be removed every time it is called. This PR fixes the bug.

Includes a few additional tests for this particular case as well.