### PR TITLE
Receive & store remote site bans

### DIFF
--- a/crates/db_schema/src/schema.rs
+++ b/crates/db_schema/src/schema.rs
@@ -927,6 +927,15 @@ diesel::table! {
 }
 
 diesel::table! {
+    site_person_ban (person_id, site_id) {
+        site_id -> Int4,
+        person_id -> Int4,
+        published -> Timestamptz,
+        expires -> Nullable<Timestamptz>,
+    }
+}
+
+diesel::table! {
     tagline (id) {
         id -> Int4,
         local_site_id -> Int4,
@@ -1028,6 +1037,8 @@ diesel::joinable!(site -> instance (instance_id));
 diesel::joinable!(site_aggregates -> site (site_id));
 diesel::joinable!(site_language -> language (language_id));
 diesel::joinable!(site_language -> site (site_id));
+diesel::joinable!(site_person_ban -> person (person_id));
+diesel::joinable!(site_person_ban -> site (site_id));
 diesel::joinable!(tagline -> local_site (local_site_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
@@ -1102,5 +1113,6 @@ diesel::allow_tables_to_appear_in_same_query!(
     site,
     site_aggregates,
     site_language,
+    site_person_ban,
     tagline,
 );

--- a/crates/db_schema/src/source/site.rs
+++ b/crates/db_schema/src/source/site.rs
@@ -1,4 +1,4 @@
-use crate::newtypes::{DbUrl, InstanceId, SiteId};
+use crate::newtypes::{CommunityId, DbUrl, InstanceId, PersonId, SiteId};
 #[cfg(feature = "full")]
 use crate::schema::site;
 use chrono::{DateTime, Utc};
@@ -83,4 +83,29 @@ pub struct SiteUpdateForm {
   pub private_key: Option<Option<String>>,
   pub public_key: Option<String>,
   pub content_warning: Option<Option<String>>,
+}
+
+#[derive(PartialEq, Eq, Debug)]
+#[cfg_attr(
+  feature = "full",
+  derive(Identifiable, Queryable, Selectable, Associations)
+)]
+#[cfg_attr(feature = "full", diesel(belongs_to(crate::source::site::Site)))]
+#[cfg_attr(feature = "full", diesel(table_name = site_person_ban))]
+#[cfg_attr(feature = "full", diesel(primary_key(person_id, site_id)))]
+#[cfg_attr(feature = "full", diesel(check_for_backend(diesel::pg::Pg)))]
+pub struct SitePersonBan {
+  pub site_id: SiteId,
+  pub person_id: PersonId,
+  pub published: DateTime<Utc>,
+  pub expires: Option<DateTime<Utc>>,
+}
+
+#[derive(Clone)]
+#[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
+#[cfg_attr(feature = "full", diesel(table_name = site_person_ban))]
+pub struct SitePersonBanForm {
+  pub site_id: SiteId,
+  pub person_id: PersonId,
+  pub expires: Option<Option<DateTime<Utc>>>,
 }

--- a/crates/db_views_actor/src/lib.rs
+++ b/crates/db_views_actor/src/lib.rs
@@ -18,4 +18,6 @@ pub mod person_block_view;
 pub mod person_mention_view;
 #[cfg(feature = "full")]
 pub mod person_view;
+#[cfg(feature = "full")]
+pub mod site_person_ban_view;
 pub mod structs;

--- a/crates/db_views_actor/src/site_person_ban_view.rs
+++ b/crates/db_views_actor/src/site_person_ban_view.rs
@@ -1,0 +1,25 @@
+use crate::structs::SitePersonBanView;
+use diesel::{dsl::exists, result::Error, select, ExpressionMethods, QueryDsl};
+use diesel_async::RunQueryDsl;
+use lemmy_db_schema::{
+  newtypes::{PersonId, SiteId},
+  schema::site_person_ban,
+  utils::{get_conn, DbPool},
+};
+
+impl SitePersonBanView {
+  pub async fn get(
+    pool: &mut DbPool<'_>,
+    from_person_id: PersonId,
+    from_site_id: SiteId,
+  ) -> Result<bool, Error> {
+    let conn = &mut get_conn(pool).await?;
+    select(exists(
+      site_person_ban::table
+        .filter(site_person_ban::site_id.eq(from_site_id))
+        .filter(site_person_ban::person_id.eq(from_person_id)),
+    ))
+    .get_result::<bool>(conn)
+    .await
+  }
+}

--- a/crates/db_views_actor/src/structs.rs
+++ b/crates/db_views_actor/src/structs.rs
@@ -149,3 +149,12 @@ pub struct PersonView {
   pub counts: PersonAggregates,
   pub is_admin: bool,
 }
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "full", derive(Queryable))]
+#[cfg_attr(feature = "full", diesel(check_for_backend(diesel::pg::Pg)))]
+/// A site person ban.
+pub struct SitePersonBanView {
+  pub site: Site,
+  pub person: Person,
+}

--- a/migrations/2024-03-26-131042_site_person_ban/down.sql
+++ b/migrations/2024-03-26-131042_site_person_ban/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE site_person_ban;

--- a/migrations/2024-03-26-131042_site_person_ban/up.sql
+++ b/migrations/2024-03-26-131042_site_person_ban/up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE site_person_ban
+(
+    site_id   INTEGER                                NOT NULL
+        REFERENCES site
+            ON UPDATE CASCADE ON DELETE CASCADE,
+    person_id INTEGER                                NOT NULL
+        REFERENCES person
+            ON UPDATE CASCADE ON DELETE CASCADE,
+    published TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    expires   TIMESTAMP WITH TIME ZONE,
+    PRIMARY KEY (person_id, site_id)
+);
+

--- a/src/scheduled_tasks.rs
+++ b/src/scheduled_tasks.rs
@@ -21,6 +21,7 @@ use lemmy_db_schema::{
     post,
     received_activity,
     sent_activity,
+    site_person_ban,
   },
   source::{
     instance::{Instance, InstanceForm},
@@ -441,8 +442,14 @@ async fn update_banned_when_expired(pool: &mut DbPool<'_>) {
       )
       .execute(&mut conn)
       .await
-      .inspect_err(|e| error!("Failed to remove community_ban expired rows: {e}"))
+      .inspect_err(|e| error!("Failed to remove community_person_ban expired rows: {e}"))
       .ok();
+
+      diesel::delete(site_person_ban::table.filter(site_person_ban::expires.lt(now().nullable())))
+        .execute(&mut conn)
+        .await
+        .inspect_err(|e| error!("Failed to remove site_person_ban expired rows: {e}"))
+        .ok();
     }
     Err(e) => {
       error!("Failed to get connection from pool: {e}");


### PR DESCRIPTION
Currently, remote site bans are only received if they originate from the user's home instance. This has some downsides:
1. Instances can't check if their users are site banned from remote communities, meaning that local users can post completely unmoderated content in their local views of remote communities. https://github.com/LemmyNet/lemmy/issues/3399
2. Remote instance admins can completely negate bans against their users on any instance, by simply banning & unbanning them locally (as this overwrites existing bans on all instances!)

This PR adds a new `site_person_ban` table, which stores data about all incoming federated bans. Additionally, this PR adds logic to prevent participating in communities if the user is banned on the host instance.

TODO:
* Need to add logic to the API to reflect if a user is banned on their home instance, as we no longer use the `person.banned` column for remote bans (that column is now exclusively reserved for local bans and should never be overwritten by federation)
* I want to do some proper testing for this in the next few days, as it's quite an important feature