### PR TITLE
Read crate version from cargo.toml (fixes #4583)

### DIFF
--- a/crates/api/src/site/leave_admin.rs
+++ b/crates/api/src/site/leave_admin.rs
@@ -13,10 +13,7 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views::structs::{CustomEmojiView, LocalUserView, SiteView};
 use lemmy_db_views_actor::structs::PersonView;
-use lemmy_utils::{
-  error::{LemmyError, LemmyErrorType},
-  version,
-};
+use lemmy_utils::{error::{LemmyError, LemmyErrorType}, VERSION};
 
 #[tracing::instrument(skip(context))]
 pub async fn leave_admin(
@@ -68,7 +65,7 @@ pub async fn leave_admin(
   Ok(Json(GetSiteResponse {
     site_view,
     admins,
-    version: version::VERSION.to_string(),
+    version: VERSION.to_string(),
     my_user: None,
     all_languages,
     discussion_languages,

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -8,12 +8,7 @@ use lemmy_db_schema::{
   newtypes::DbUrl,
   source::images::{LocalImage, LocalImageForm},
 };
-use lemmy_utils::{
-  error::{LemmyError, LemmyErrorType},
-  settings::structs::{PictrsImageMode, Settings},
-  version::VERSION,
-  REQWEST_TIMEOUT,
-};
+use lemmy_utils::{error::{LemmyError, LemmyErrorType}, settings::structs::{PictrsImageMode, Settings}, REQWEST_TIMEOUT, VERSION};
 use mime::Mime;
 use reqwest::{header::CONTENT_TYPE, Client, ClientBuilder};
 use reqwest_middleware::ClientWithMiddleware;

--- a/crates/api_crud/src/site/read.rs
+++ b/crates/api_crud/src/site/read.rs
@@ -18,10 +18,7 @@ use lemmy_db_views_actor::structs::{
   PersonBlockView,
   PersonView,
 };
-use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
-  version,
-};
+use lemmy_utils::{error::{LemmyError, LemmyErrorExt, LemmyErrorType}, VERSION};
 use moka::future::Cache;
 use once_cell::sync::Lazy;
 use std::time::Duration;
@@ -52,7 +49,7 @@ pub async fn get_site(
       Ok(GetSiteResponse {
         site_view,
         admins,
-        version: version::VERSION.to_string(),
+        version: VERSION.to_string(),
         my_user: None,
         all_languages,
         discussion_languages,

--- a/crates/routes/src/nodeinfo.rs
+++ b/crates/routes/src/nodeinfo.rs
@@ -3,11 +3,7 @@ use anyhow::anyhow;
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::RegistrationMode;
 use lemmy_db_views::structs::SiteView;
-use lemmy_utils::{
-  cache_header::{cache_1hour, cache_3days},
-  error::LemmyError,
-  version,
-};
+use lemmy_utils::{cache_header::{cache_1hour, cache_3days}, error::LemmyError, VERSION};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -56,7 +52,7 @@ async fn node_info(context: web::Data<LemmyContext>) -> Result<HttpResponse, Err
     version: Some("2.0".to_string()),
     software: Some(NodeInfoSoftware {
       name: Some("lemmy".to_string()),
-      version: Some(version::VERSION.to_string()),
+      version: Some(VERSION.to_string()),
     }),
     protocols,
     usage: Some(NodeInfoUsage {

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -10,7 +10,6 @@ cfg_if! {
     pub mod response;
     pub mod settings;
     pub mod utils;
-    pub mod version;
   }
 }
 
@@ -19,6 +18,8 @@ pub use error::LemmyErrorType;
 use std::time::Duration;
 
 pub type ConnectionId = usize;
+
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub const REQWEST_TIMEOUT: Duration = Duration::from_secs(10);
 

--- a/crates/utils/src/version.rs
+++ b/crates/utils/src/version.rs
@@ -1,1 +1,0 @@
-pub const VERSION: &str = "unknown version";

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,6 @@ COPY . ./
 # Debug build
 RUN --mount=type=cache,target=/lemmy/target set -ex; \
     if [ "${RUST_RELEASE_MODE}" = "debug" ]; then \
-        echo "pub const VERSION: &str = \"$(git describe --tag)\";" > crates/utils/src/version.rs; \
         cargo build --features "${CARGO_BUILD_FEATURES}"; \
         mv target/"${RUST_RELEASE_MODE}"/lemmy_server ./lemmy_server; \
     fi
@@ -36,7 +35,6 @@ RUN --mount=type=cache,target=/lemmy/target set -ex; \
 # Release build
 RUN --mount=type=cache,target=/lemmy/target set -ex; \
     if [ "${RUST_RELEASE_MODE}" = "release" ]; then \
-        echo "pub const VERSION: &str = \"$(git describe --tag)\";" > crates/utils/src/version.rs; \
         [ -z "$USE_RELEASE_CACHE" ] && cargo clean --release; \
         cargo build --features "${CARGO_BUILD_FEATURES}" --release; \
         mv target/"${RUST_RELEASE_MODE}"/lemmy_server ./lemmy_server; \
@@ -63,7 +61,6 @@ ENV RUST_RELEASE_MODE=${RUST_RELEASE_MODE} \
 # Debug build
 RUN --mount=type=cache,target=./target,uid=10001,gid=10001 set -ex; \
     if [ "${RUST_RELEASE_MODE}" = "debug" ]; then \
-        echo "pub const VERSION: &str = \"$(git describe --tag)\";" > crates/utils/src/version.rs; \
         cargo build --features "${CARGO_BUILD_FEATURES}"; \
         mv "./target/$CARGO_BUILD_TARGET/$RUST_RELEASE_MODE/lemmy_server" /home/lemmy/lemmy_server; \
     fi
@@ -71,7 +68,6 @@ RUN --mount=type=cache,target=./target,uid=10001,gid=10001 set -ex; \
 # Release build
 RUN --mount=type=cache,target=./target,uid=10001,gid=10001 set -ex; \
     if [ "${RUST_RELEASE_MODE}" = "release" ]; then \
-        echo "pub const VERSION: &str = \"$(git describe --tag)\";" > crates/utils/src/version.rs; \
         [ -z "$USE_RELEASE_CACHE" ] && cargo clean --release; \
         cargo build --features "${CARGO_BUILD_FEATURES}" --release; \
         mv "./target/$CARGO_BUILD_TARGET/$RUST_RELEASE_MODE/lemmy_server" /home/lemmy/lemmy_server; \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,13 +44,7 @@ use lemmy_apub::{
 use lemmy_db_schema::{source::secret::Secret, utils::build_db_pool};
 use lemmy_federate::{start_stop_federation_workers_cancellable, Opts};
 use lemmy_routes::{feeds, images, nodeinfo, webfinger};
-use lemmy_utils::{
-  error::LemmyError,
-  rate_limit::RateLimitCell,
-  response::jsonify_plain_text_errors,
-  settings::{structs::Settings, SETTINGS},
-  version,
-};
+use lemmy_utils::{error::LemmyError, rate_limit::RateLimitCell, response::jsonify_plain_text_errors, settings::{structs::Settings, SETTINGS}, VERSION};
 use prometheus::default_registry;
 use prometheus_metrics::serve_prometheus;
 use reqwest_middleware::ClientBuilder;
@@ -109,7 +103,7 @@ pub struct CmdArgs {
 /// Placing the main function in lib.rs allows other crates to import it and embed Lemmy
 pub async fn start_lemmy_server(args: CmdArgs) -> Result<(), LemmyError> {
   // Print version number to log
-  println!("Lemmy v{}", version::VERSION);
+  println!("Lemmy v{VERSION}");
 
   // return error 503 while running db migrations and startup tasks
   let mut startup_server_handle = None;


### PR DESCRIPTION
Ive tested that `cargo run` and docker version both show the version defined in Cargo.toml.