### PR TITLE
Change exponential backoff algorithm for federation send

### DIFF
--- a/crates/api_common/src/lib.rs
+++ b/crates/api_common/src/lib.rs
@@ -51,7 +51,7 @@ const HOUR: Duration = Duration::from_secs(3600);
 /// retries have already happened. Uses exponential backoff with maximum of one hour.
 pub fn federate_retry_sleep_duration(retry_count: i32) -> Duration {
   let pow = 2.0_f64.powf(retry_count.into());
-  let pow = Duration::from_secs_f64(pow);
+  let pow = Duration::try_from_secs_f64(pow).unwrap_or(HOUR);
   min(HOUR, pow)
 }
 
@@ -68,6 +68,6 @@ pub(crate) mod tests {
     assert_eq!(s(8), federate_retry_sleep_duration(3));
     assert_eq!(s(16), federate_retry_sleep_duration(4));
     assert_eq!(s(1024), federate_retry_sleep_duration(10));
-    assert_eq!(s(3600), federate_retry_sleep_duration(20));
+    assert_eq!(s(3600), federate_retry_sleep_duration(100));
   }
 }

--- a/crates/api_common/src/lib.rs
+++ b/crates/api_common/src/lib.rs
@@ -43,9 +43,9 @@ impl Default for SuccessResponse {
   }
 }
 
-// TODO: use from_hours once stabilized
+// TODO: use from_days once stabilized
 // https://github.com/rust-lang/rust/issues/120301
-const DAY: Duration = Duration::from_secs(3600);
+const DAY: Duration = Duration::from_secs(24 * 60 * 60);
 
 /// Calculate how long to sleep until next federation send based on how many
 /// retries have already happened. Uses exponential backoff with maximum of one day. The first

--- a/crates/api_common/src/lib.rs
+++ b/crates/api_common/src/lib.rs
@@ -48,8 +48,14 @@ impl Default for SuccessResponse {
 const DAY: Duration = Duration::from_secs(3600);
 
 /// Calculate how long to sleep until next federation send based on how many
-/// retries have already happened. Uses exponential backoff with maximum of one day.
+/// retries have already happened. Uses exponential backoff with maximum of one day. The first
+/// error is ignored.
 pub fn federate_retry_sleep_duration(retry_count: i32) -> Duration {
+  debug_assert!(retry_count != 0);
+  if retry_count == 1 {
+    return Duration::from_secs(0);
+  }
+  let retry_count = retry_count - 1;
   let pow = 1.25_f64.powf(retry_count.into());
   let pow = Duration::try_from_secs_f64(pow).unwrap_or(DAY);
   min(DAY, pow)
@@ -61,10 +67,15 @@ pub(crate) mod tests {
 
   #[test]
   fn test_federate_retry_sleep_duration() {
-    let s = |s,m: u32| Duration::new(s, m * 1000);
-    assert_eq!(s(1, 0), federate_retry_sleep_duration(0));
-    assert_eq!(s(1, 250000), federate_retry_sleep_duration(1));
-    assert_eq!(s(1, 562500), federate_retry_sleep_duration(2));
+    assert_eq!(Duration::from_secs(0), federate_retry_sleep_duration(1));
+    assert_eq!(
+      Duration::new(1, 250000000),
+      federate_retry_sleep_duration(2)
+    );
+    assert_eq!(
+      Duration::new(2, 441406250),
+      federate_retry_sleep_duration(5)
+    );
     assert_eq!(DAY, federate_retry_sleep_duration(100));
   }
 }

--- a/crates/api_common/src/lib.rs
+++ b/crates/api_common/src/lib.rs
@@ -61,7 +61,7 @@ pub(crate) mod tests {
 
   #[test]
   fn test_federate_retry_sleep_duration() {
-    let s = |secs| Duration::from_secs(secs);
+    let s = Duration::from_secs;
     assert_eq!(s(1), federate_retry_sleep_duration(0));
     assert_eq!(s(2), federate_retry_sleep_duration(1));
     assert_eq!(s(4), federate_retry_sleep_duration(2));

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.6
-ARG RUST_VERSION=1.77
+ARG RUST_VERSION=1.76
 ARG CARGO_BUILD_FEATURES=default
 ARG RUST_RELEASE_MODE=debug
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.6
-ARG RUST_VERSION=1.76
+ARG RUST_VERSION=1.77
 ARG CARGO_BUILD_FEATURES=default
 ARG RUST_RELEASE_MODE=debug
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,7 +6,7 @@ CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 cd $CWD/../
 
 PACKAGE="$1"
-echo "$PACKAGE"
+TEST="$2"
 
 source scripts/start_dev_db.sh
 
@@ -17,7 +17,7 @@ export RUST_BACKTRACE=1
 
 if [ -n "$PACKAGE" ];
 then
-  cargo test -p $PACKAGE --all-features --no-fail-fast
+  cargo test -p $PACKAGE --all-features --no-fail-fast $TEST
 else
   cargo test --workspace --no-fail-fast
 fi


### PR DESCRIPTION
Lemmy.world had a problem with incoming federation where `/inbox` requests were failing, so `FederationQueueState::fail_count` kept increasing. On lemmy.ml the value reached 16, which results in a sleep of 18 hours before the next activity send would be attempted. This is way too long so that it was necessary to reset the count manually.

This shouldnt be necessary, Lemmy shouldnt wait such a long time so Ive added a limit of one hour. Alternatively it may be possible to calculate the sleep interval differently instead of `2^n` but I didnt find any resources for exponential backoff which match our use case.

@phiresky I noticed another problem with the outgoing federation workers. It looks like the list of dead and alive instances is never reloaded after starting. So if an instance is marked dead when Lemmy starts, it will never attempt to send any activities until Lemmy is restarted. Similarly, if an instance is alive at the start and marked as dead later, Lemmy will still attempt to send activities forever, according to the sleep interval. Am I missing anything, or do you have an idea how to fix this?