### PR TITLE
Change defaults on user vote display mode to upvotes + downvotes

### DIFF
--- a/migrations/2024-04-05-153647_alter_vote_display_mode_defaults/down.sql
+++ b/migrations/2024-04-05-153647_alter_vote_display_mode_defaults/down.sql
@@ -1,6 +1,10 @@
 ALTER TABLE local_user_vote_display_mode
-    ALTER COLUMN upvotes SET DEFAULT FALSE,
-    ALTER COLUMN downvotes SET DEFAULT FALSE,
-    ALTER COLUMN score SET DEFAULT TRUE,
-    ALTER COLUMN upvote_percentage SET DEFAULT TRUE;
+    DROP COLUMN score,
+    ADD COLUMN score boolean DEFAULT TRUE NOT NULL,
+    DROP COLUMN upvotes,
+    ADD COLUMN upvotes boolean DEFAULT FALSE NOT NULL,
+    DROP COLUMN downvotes,
+    ADD COLUMN downvotes boolean DEFAULT FALSE NOT NULL,
+    DROP COLUMN upvote_percentage,
+    ADD COLUMN upvote_percentage boolean DEFAULT TRUE NOT NULL;
 

--- a/migrations/2024-04-05-153647_alter_vote_display_mode_defaults/down.sql
+++ b/migrations/2024-04-05-153647_alter_vote_display_mode_defaults/down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE local_user_vote_display_mode
+    ALTER COLUMN upvotes SET DEFAULT FALSE,
+    ALTER COLUMN downvotes SET DEFAULT FALSE,
+    ALTER COLUMN score SET DEFAULT TRUE,
+    ALTER COLUMN upvote_percentage SET DEFAULT TRUE;
+

--- a/migrations/2024-04-05-153647_alter_vote_display_mode_defaults/up.sql
+++ b/migrations/2024-04-05-153647_alter_vote_display_mode_defaults/up.sql
@@ -3,18 +3,12 @@
 -- Rather than
 -- Score + upvote_percentage
 ALTER TABLE local_user_vote_display_mode
-    ALTER COLUMN upvotes SET DEFAULT TRUE,
-    ALTER COLUMN downvotes SET DEFAULT TRUE,
-    ALTER COLUMN score SET DEFAULT FALSE,
-    ALTER COLUMN upvote_percentage SET DEFAULT FALSE;
-
--- Regenerate the rows with the new default
-DELETE FROM local_user_vote_display_mode;
-
--- Re-insert them
-INSERT INTO local_user_vote_display_mode (local_user_id)
-SELECT
-    id
-FROM
-    local_user;
+    DROP COLUMN score,
+    ADD COLUMN score boolean DEFAULT FALSE NOT NULL,
+    DROP COLUMN upvotes,
+    ADD COLUMN upvotes boolean DEFAULT TRUE NOT NULL,
+    DROP COLUMN downvotes,
+    ADD COLUMN downvotes boolean DEFAULT TRUE NOT NULL,
+    DROP COLUMN upvote_percentage,
+    ADD COLUMN upvote_percentage boolean DEFAULT FALSE NOT NULL;
 

--- a/migrations/2024-04-05-153647_alter_vote_display_mode_defaults/up.sql
+++ b/migrations/2024-04-05-153647_alter_vote_display_mode_defaults/up.sql
@@ -1,0 +1,10 @@
+-- Based on a poll, update the local_user_vote_display_mode defaults to:
+-- Upvotes + Downvotes
+-- Rather than
+-- Score + upvote_percentage
+ALTER TABLE local_user_vote_display_mode
+    ALTER COLUMN upvotes SET DEFAULT TRUE,
+    ALTER COLUMN downvotes SET DEFAULT TRUE,
+    ALTER COLUMN score SET DEFAULT FALSE,
+    ALTER COLUMN upvote_percentage SET DEFAULT FALSE;
+

--- a/migrations/2024-04-05-153647_alter_vote_display_mode_defaults/up.sql
+++ b/migrations/2024-04-05-153647_alter_vote_display_mode_defaults/up.sql
@@ -8,3 +8,13 @@ ALTER TABLE local_user_vote_display_mode
     ALTER COLUMN score SET DEFAULT FALSE,
     ALTER COLUMN upvote_percentage SET DEFAULT FALSE;
 
+-- Regenerate the rows with the new default
+DELETE FROM local_user_vote_display_mode;
+
+-- Re-insert them
+INSERT INTO local_user_vote_display_mode (local_user_id)
+SELECT
+    id
+FROM
+    local_user;
+


### PR DESCRIPTION
Even after a day, there's a clear consensus on this:

![Screenshot_20240405_114500_Via_1](https://github.com/LemmyNet/lemmy/assets/930215/6d3a0c8f-bb8f-452f-84d6-d52d67964694)

`Upvotes + downvotes` are the preferred display default.