### PR TITLE
Fix for PictrsImageMode::None

### DIFF
--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -302,11 +302,13 @@ async fn generate_pictrs_thumbnail(
 ) -> Result<Url, LemmyError> {
   let pictrs_config = context.settings().pictrs_config()?;
 
-    match pictrs_config.image_mode() {
-        PictrsImageMode::None => return Ok(image_url.clone()),
-        PictrsImageMode::ProxyAllImages => return Ok(proxy_image_link(image_url.clone(), context).await?.into()),
-        _ => {}
-    };
+  match pictrs_config.image_mode() {
+    PictrsImageMode::None => return Ok(image_url.clone()),
+    PictrsImageMode::ProxyAllImages => {
+      return Ok(proxy_image_link(image_url.clone(), context).await?.into())
+    }
+    _ => {}
+  };
 
   // fetch remote non-pictrs images for persistent thumbnail link
   // TODO: should limit size once supported by pictrs

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -302,6 +302,10 @@ async fn generate_pictrs_thumbnail(
 ) -> Result<Url, LemmyError> {
   let pictrs_config = context.settings().pictrs_config()?;
 
+  if pictrs_config.image_mode() == PictrsImageMode::None {
+    return Ok(image_url.clone());
+  }
+
   if pictrs_config.image_mode() == PictrsImageMode::ProxyAllImages {
     return Ok(proxy_image_link(image_url.clone(), context).await?.into());
   }

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -302,13 +302,11 @@ async fn generate_pictrs_thumbnail(
 ) -> Result<Url, LemmyError> {
   let pictrs_config = context.settings().pictrs_config()?;
 
-  if pictrs_config.image_mode() == PictrsImageMode::None {
-    return Ok(image_url.clone());
-  }
-
-  if pictrs_config.image_mode() == PictrsImageMode::ProxyAllImages {
-    return Ok(proxy_image_link(image_url.clone(), context).await?.into());
-  }
+    match pictrs_config.image_mode() {
+        PictrsImageMode::None => return Ok(image_url.clone()),
+        PictrsImageMode::ProxyAllImages => return Ok(proxy_image_link(image_url.clone(), context).await?.into()),
+        _ => {}
+    };
 
   // fetch remote non-pictrs images for persistent thumbnail link
   // TODO: should limit size once supported by pictrs


### PR DESCRIPTION
Currently the option PictrsImageMode::None is not working since it is totally ignored. This pull fixes that.