### PR TITLE
Avoid breaking api change, reduce api cache duration

### DIFF
--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -42,7 +42,7 @@ use lemmy_utils::{
     markdown::{markdown_check_for_blocked_urls, markdown_rewrite_image_links},
     slurs::{build_slur_regex, remove_slurs},
   },
-  CACHE_DURATION_SHORT,
+  CACHE_DURATION_FEDERATION,
 };
 use moka::future::Cache;
 use once_cell::sync::Lazy;
@@ -524,7 +524,7 @@ pub async fn get_url_blocklist(context: &LemmyContext) -> LemmyResult<RegexSet> 
   static URL_BLOCKLIST: Lazy<Cache<(), RegexSet>> = Lazy::new(|| {
     Cache::builder()
       .max_capacity(1)
-      .time_to_live(CACHE_DURATION_SHORT)
+      .time_to_live(CACHE_DURATION_FEDERATION)
       .build()
   });
 

--- a/crates/api_crud/src/site/read.rs
+++ b/crates/api_crud/src/site/read.rs
@@ -20,7 +20,7 @@ use lemmy_db_views_actor::structs::{
 };
 use lemmy_utils::{
   error::{LemmyError, LemmyErrorExt, LemmyErrorType},
-  CACHE_DURATION_SHORT,
+  CACHE_DURATION_API,
   VERSION,
 };
 use moka::future::Cache;
@@ -34,7 +34,7 @@ pub async fn get_site(
   static CACHE: Lazy<Cache<(), GetSiteResponse>> = Lazy::new(|| {
     Cache::builder()
       .max_capacity(1)
-      .time_to_live(CACHE_DURATION_SHORT)
+      .time_to_live(CACHE_DURATION_API)
       .build()
   });
 

--- a/crates/apub/src/lib.rs
+++ b/crates/apub/src/lib.rs
@@ -11,7 +11,7 @@ use lemmy_db_schema::{
 };
 use lemmy_utils::{
   error::{LemmyError, LemmyErrorType, LemmyResult},
-  CACHE_DURATION_SHORT,
+  CACHE_DURATION_FEDERATION,
 };
 use moka::future::Cache;
 use once_cell::sync::Lazy;
@@ -127,7 +127,7 @@ pub(crate) async fn local_site_data_cached(
   static CACHE: Lazy<Cache<(), Arc<LocalSiteData>>> = Lazy::new(|| {
     Cache::builder()
       .max_capacity(1)
-      .time_to_live(CACHE_DURATION_SHORT)
+      .time_to_live(CACHE_DURATION_FEDERATION)
       .build()
   });
   Ok(

--- a/crates/db_schema/src/impls/local_site.rs
+++ b/crates/db_schema/src/impls/local_site.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use diesel::{dsl::insert_into, result::Error};
 use diesel_async::RunQueryDsl;
-use lemmy_utils::{error::LemmyError, CACHE_DURATION_SHORT};
+use lemmy_utils::{error::LemmyError, CACHE_DURATION_API};
 use moka::future::Cache;
 use once_cell::sync::Lazy;
 
@@ -21,7 +21,7 @@ impl LocalSite {
     static CACHE: Lazy<Cache<(), LocalSite>> = Lazy::new(|| {
       Cache::builder()
         .max_capacity(1)
-        .time_to_live(CACHE_DURATION_SHORT)
+        .time_to_live(CACHE_DURATION_API)
         .build()
     });
     Ok(

--- a/crates/db_schema/src/source/site.rs
+++ b/crates/db_schema/src/source/site.rs
@@ -36,7 +36,7 @@ pub struct Site {
   pub inbox_url: DbUrl,
   #[serde(skip)]
   pub private_key: Option<String>,
-  #[serde(skip)]
+  // TODO: mark as `serde(skip)` in next major release as its not needed for api
   pub public_key: String,
   pub instance_id: InstanceId,
   /// If present, nsfw content is visible by default. Should be displayed by frontends/clients

--- a/crates/federate/src/util.rs
+++ b/crates/federate/src/util.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
-use lemmy_api_common::lemmy_utils::CACHE_DURATION_SHORT;
+use lemmy_api_common::lemmy_utils::CACHE_DURATION_FEDERATION;
 use lemmy_apub::{
   activity_lists::SharedInboxActivities,
   fetcher::{site_or_community_or_user::SiteOrCommunityOrUser, user_or_community::UserOrCommunity},
@@ -169,8 +169,11 @@ pub(crate) async fn get_activity_cached(
 
 /// return the most current activity id (with 1 second cache)
 pub(crate) async fn get_latest_activity_id(pool: &mut DbPool<'_>) -> Result<ActivityId> {
-  static CACHE: Lazy<Cache<(), ActivityId>> =
-    Lazy::new(|| Cache::builder().time_to_live(CACHE_DURATION_SHORT).build());
+  static CACHE: Lazy<Cache<(), ActivityId>> = Lazy::new(|| {
+    Cache::builder()
+      .time_to_live(CACHE_DURATION_FEDERATION)
+      .build()
+  });
   CACHE
     .try_get_with((), async {
       use diesel::dsl::max;

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -24,9 +24,11 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const REQWEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[cfg(debug_assertions)]
-pub const CACHE_DURATION_SHORT: Duration = Duration::from_millis(500);
+pub const CACHE_DURATION_FEDERATION: Duration = Duration::from_millis(500);
 #[cfg(not(debug_assertions))]
-pub const CACHE_DURATION_SHORT: Duration = Duration::from_secs(60);
+pub const CACHE_DURATION_FEDERATION: Duration = Duration::from_secs(60);
+
+pub const CACHE_DURATION_API: Duration = Duration::from_secs(1);
 
 #[macro_export]
 macro_rules! location_info {


### PR DESCRIPTION
- Dont mark site.public_key as `serde(skip)` to avoid breaking change
- In https://github.com/LemmyNet/lemmy/pull/4585 I changed the cache interval for `/site/v3/site` to 60s which was not intended. This changes it back to 1s.