### PR TITLE
Avoid overwriting local objects via federation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,9 +16,8 @@ checksum = "8f27d075294830fcab6f66e320dab524bc6d048f4a151698e153205559113772"
 
 [[package]]
 name = "activitypub_federation"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a028034c642d3ed16b535f98f48b3df30397833c183d68852d79de16650d5ed5"
+version = "0.5.3"
+source = "git+https://github.com/LemmyNet/activitypub-federation-rust.git?branch=object-id-is-local#579319e75595a7d9ffbc616854fefc7aa9dadc67"
 dependencies = [
  "activitystreams-kinds",
  "actix-web",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,8 +16,9 @@ checksum = "8f27d075294830fcab6f66e320dab524bc6d048f4a151698e153205559113772"
 
 [[package]]
 name = "activitypub_federation"
-version = "0.5.3"
-source = "git+https://github.com/LemmyNet/activitypub-federation-rust.git?branch=object-id-is-local#579319e75595a7d9ffbc616854fefc7aa9dadc67"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e16130d5914e6483f99bde5a9bb97ca62e1f359e0b9791c8ebd5c7abd50fe8e"
 dependencies = [
  "activitystreams-kinds",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ lemmy_db_views = { version = "=0.19.4-beta.2", path = "./crates/db_views" }
 lemmy_db_views_actor = { version = "=0.19.4-beta.2", path = "./crates/db_views_actor" }
 lemmy_db_views_moderator = { version = "=0.19.4-beta.2", path = "./crates/db_views_moderator" }
 lemmy_federate = { version = "=0.19.4-beta.2", path = "./crates/federate" }
-activitypub_federation = { git = "https://github.com/LemmyNet/activitypub-federation-rust.git", branch = "object-id-is-local", default-features = false, features = [
+activitypub_federation = { version = "0.5.4", default-features = false, features = [
   "actix-web",
 ] }
 diesel = "2.1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ lemmy_db_views = { version = "=0.19.4-beta.2", path = "./crates/db_views" }
 lemmy_db_views_actor = { version = "=0.19.4-beta.2", path = "./crates/db_views_actor" }
 lemmy_db_views_moderator = { version = "=0.19.4-beta.2", path = "./crates/db_views_moderator" }
 lemmy_federate = { version = "=0.19.4-beta.2", path = "./crates/federate" }
-activitypub_federation = { version = "0.5.2", default-features = false, features = [
+activitypub_federation = { git = "https://github.com/LemmyNet/activitypub-federation-rust.git", branch = "object-id-is-local", default-features = false, features = [
   "actix-web",
 ] }
 diesel = "2.1.4"

--- a/crates/apub/src/objects/comment.rs
+++ b/crates/apub/src/objects/comment.rs
@@ -139,7 +139,7 @@ impl Object for ApubComment {
     let community = note.community(context).await?;
 
     check_apub_id_valid_with_strictness(note.id.inner(), community.local, context).await?;
-    verify_is_remote_object(note.id.inner(), context.settings())?;
+    verify_is_remote_object(&note.id, context)?;
     verify_person_in_community(&note.attributed_to, &community, context).await?;
     let (post, _) = note.get_parents(context).await?;
     let creator = note.attributed_to.dereference(context).await?;
@@ -158,8 +158,8 @@ impl Object for ApubComment {
   /// If the parent community, post and comment(s) are not known locally, these are also fetched.
   #[tracing::instrument(skip_all)]
   async fn from_json(note: Note, context: &Data<LemmyContext>) -> Result<ApubComment, LemmyError> {
-    // Dont allow overwriting local object
-    if note.id.inner().domain() == Some(context.domain()) {
+    // Avoid overwriting local object
+    if note.id.is_local(context) {
       return note.id.dereference_local(context).await;
     }
 

--- a/crates/apub/src/objects/comment.rs
+++ b/crates/apub/src/objects/comment.rs
@@ -158,6 +158,11 @@ impl Object for ApubComment {
   /// If the parent community, post and comment(s) are not known locally, these are also fetched.
   #[tracing::instrument(skip_all)]
   async fn from_json(note: Note, context: &Data<LemmyContext>) -> Result<ApubComment, LemmyError> {
+    // Dont allow overwriting local object
+    if note.id.inner().domain() == Some(context.domain()) {
+      return note.id.dereference_local(context).await;
+    }
+
     let creator = note.attributed_to.dereference(context).await?;
     let (post, parent_comment) = note.get_parents(context).await?;
 

--- a/crates/apub/src/objects/comment.rs
+++ b/crates/apub/src/objects/comment.rs
@@ -158,11 +158,6 @@ impl Object for ApubComment {
   /// If the parent community, post and comment(s) are not known locally, these are also fetched.
   #[tracing::instrument(skip_all)]
   async fn from_json(note: Note, context: &Data<LemmyContext>) -> Result<ApubComment, LemmyError> {
-    // Avoid overwriting local object
-    if note.id.is_local(context) {
-      return note.id.dereference_local(context).await;
-    }
-
     let creator = note.attributed_to.dereference(context).await?;
     let (post, parent_comment) = note.get_parents(context).await?;
 

--- a/crates/apub/src/objects/community.rs
+++ b/crates/apub/src/objects/community.rs
@@ -138,11 +138,6 @@ impl Object for ApubCommunity {
     group: Group,
     context: &Data<Self::DataType>,
   ) -> Result<ApubCommunity, LemmyError> {
-    // Avoid overwriting local object
-    if group.id.is_local(context) {
-      return group.id.dereference_local(context).await;
-    }
-
     let instance_id = fetch_instance_actor_for_object(&group.id, context).await?;
 
     let local_site = LocalSite::read(&mut context.pool()).await.ok();

--- a/crates/apub/src/objects/community.rs
+++ b/crates/apub/src/objects/community.rs
@@ -138,8 +138,8 @@ impl Object for ApubCommunity {
     group: Group,
     context: &Data<Self::DataType>,
   ) -> Result<ApubCommunity, LemmyError> {
-    // Dont allow overwriting local object
-    if group.id.inner().domain() == Some(context.domain()) {
+    // Avoid overwriting local object
+    if group.id.is_local(context) {
       return group.id.dereference_local(context).await;
     }
 

--- a/crates/apub/src/objects/community.rs
+++ b/crates/apub/src/objects/community.rs
@@ -138,6 +138,11 @@ impl Object for ApubCommunity {
     group: Group,
     context: &Data<Self::DataType>,
   ) -> Result<ApubCommunity, LemmyError> {
+    // Dont allow overwriting local object
+    if group.id.inner().domain() == Some(context.domain()) {
+      return group.id.dereference_local(context).await;
+    }
+
     let instance_id = fetch_instance_actor_for_object(&group.id, context).await?;
 
     let local_site = LocalSite::read(&mut context.pool()).await.ok();

--- a/crates/apub/src/objects/instance.rs
+++ b/crates/apub/src/objects/instance.rs
@@ -138,6 +138,10 @@ impl Object for ApubSite {
 
   #[tracing::instrument(skip_all)]
   async fn from_json(apub: Self::Kind, context: &Data<Self::DataType>) -> Result<Self, LemmyError> {
+    // Dont allow overwriting local object
+    if apub.id.inner().domain() == Some(context.domain()) {
+      return apub.id.dereference_local(context).await;
+    }
     let domain = apub.id.inner().domain().expect("group id has domain");
     let instance = DbInstance::read_or_create(&mut context.pool(), domain.to_string()).await?;
 

--- a/crates/apub/src/objects/instance.rs
+++ b/crates/apub/src/objects/instance.rs
@@ -138,8 +138,8 @@ impl Object for ApubSite {
 
   #[tracing::instrument(skip_all)]
   async fn from_json(apub: Self::Kind, context: &Data<Self::DataType>) -> Result<Self, LemmyError> {
-    // Dont allow overwriting local object
-    if apub.id.inner().domain() == Some(context.domain()) {
+    // Avoid overwriting local object
+    if apub.id.is_local(context) {
       return apub.id.dereference_local(context).await;
     }
     let domain = apub.id.inner().domain().expect("group id has domain");

--- a/crates/apub/src/objects/mod.rs
+++ b/crates/apub/src/objects/mod.rs
@@ -1,9 +1,14 @@
 use crate::protocol::Source;
-use activitypub_federation::protocol::values::MediaTypeMarkdownOrHtml;
+use activitypub_federation::{
+  config::Data,
+  fetch::object_id::ObjectId,
+  protocol::values::MediaTypeMarkdownOrHtml,
+};
 use anyhow::anyhow;
 use html2md::parse_html;
-use lemmy_utils::{error::LemmyError, settings::structs::Settings};
-use url::Url;
+use lemmy_api_common::context::LemmyContext;
+use lemmy_utils::error::LemmyError;
+use std::fmt::Debug;
 
 pub mod comment;
 pub mod community;
@@ -43,9 +48,15 @@ pub(crate) fn read_from_string_or_source_opt(
 /// wrapped in Announce. If we simply receive this like any other federated object, overwrite the
 /// existing, local Post. In particular, it will set the field local = false, so that the object
 /// can't be fetched from the Activitypub HTTP endpoint anymore (which only serves local objects).
-pub(crate) fn verify_is_remote_object(id: &Url, settings: &Settings) -> Result<(), LemmyError> {
-  let local_domain = settings.get_hostname_without_port()?;
-  if id.domain() == Some(&local_domain) {
+pub(crate) fn verify_is_remote_object<T>(
+  id: &ObjectId<T>,
+  context: &Data<LemmyContext>,
+) -> Result<(), LemmyError>
+where
+  T: activitypub_federation::traits::Object<DataType = LemmyContext> + Debug + Send + 'static,
+  for<'de2> <T as activitypub_federation::traits::Object>::Kind: serde::Deserialize<'de2>,
+{
+  if !id.is_local(context) {
     Err(anyhow!("cant accept local object from remote instance").into())
   } else {
     Ok(())

--- a/crates/apub/src/objects/mod.rs
+++ b/crates/apub/src/objects/mod.rs
@@ -3,11 +3,13 @@ use activitypub_federation::{
   config::Data,
   fetch::object_id::ObjectId,
   protocol::values::MediaTypeMarkdownOrHtml,
+  traits::Object,
 };
 use anyhow::anyhow;
 use html2md::parse_html;
 use lemmy_api_common::context::LemmyContext;
 use lemmy_utils::error::LemmyError;
+use serde::Deserialize;
 use std::fmt::Debug;
 
 pub mod comment;
@@ -53,8 +55,8 @@ pub(crate) fn verify_is_remote_object<T>(
   context: &Data<LemmyContext>,
 ) -> Result<(), LemmyError>
 where
-  T: activitypub_federation::traits::Object<DataType = LemmyContext> + Debug + Send + 'static,
-  for<'de2> <T as activitypub_federation::traits::Object>::Kind: serde::Deserialize<'de2>,
+  T: Object<DataType = LemmyContext> + Debug + Send + 'static,
+  for<'de2> <T as Object>::Kind: Deserialize<'de2>,
 {
   if !id.is_local(context) {
     Err(anyhow!("cant accept local object from remote instance").into())

--- a/crates/apub/src/objects/mod.rs
+++ b/crates/apub/src/objects/mod.rs
@@ -58,7 +58,7 @@ where
   T: Object<DataType = LemmyContext> + Debug + Send + 'static,
   for<'de2> <T as Object>::Kind: Deserialize<'de2>,
 {
-  if !id.is_local(context) {
+  if id.is_local(context) {
     Err(anyhow!("cant accept local object from remote instance").into())
   } else {
     Ok(())

--- a/crates/apub/src/objects/person.rs
+++ b/crates/apub/src/objects/person.rs
@@ -149,6 +149,10 @@ impl Object for ApubPerson {
     person: Person,
     context: &Data<Self::DataType>,
   ) -> Result<ApubPerson, LemmyError> {
+    // Dont allow overwriting local object
+    if person.id.inner().domain() == Some(context.domain()) {
+      return person.id.dereference_local(context).await;
+    }
     let instance_id = fetch_instance_actor_for_object(&person.id, context).await?;
 
     let local_site = LocalSite::read(&mut context.pool()).await.ok();

--- a/crates/apub/src/objects/person.rs
+++ b/crates/apub/src/objects/person.rs
@@ -1,3 +1,4 @@
+use super::verify_is_remote_object;
 use crate::{
   activities::GetActorType,
   check_apub_id_valid_with_strictness,
@@ -137,6 +138,7 @@ impl Object for ApubPerson {
     check_slurs_opt(&person.name, slur_regex)?;
 
     verify_domains_match(person.id.inner(), expected_domain)?;
+    verify_is_remote_object(&person.id, context)?;
     check_apub_id_valid_with_strictness(person.id.inner(), false, context).await?;
 
     let bio = read_from_string_or_source_opt(&person.summary, &None, &person.source);
@@ -149,10 +151,6 @@ impl Object for ApubPerson {
     person: Person,
     context: &Data<Self::DataType>,
   ) -> Result<ApubPerson, LemmyError> {
-    // Avoid overwriting local object
-    if person.id.is_local(context) {
-      return person.id.dereference_local(context).await;
-    }
     let instance_id = fetch_instance_actor_for_object(&person.id, context).await?;
 
     let local_site = LocalSite::read(&mut context.pool()).await.ok();

--- a/crates/apub/src/objects/person.rs
+++ b/crates/apub/src/objects/person.rs
@@ -149,8 +149,8 @@ impl Object for ApubPerson {
     person: Person,
     context: &Data<Self::DataType>,
   ) -> Result<ApubPerson, LemmyError> {
-    // Dont allow overwriting local object
-    if person.id.inner().domain() == Some(context.domain()) {
+    // Avoid overwriting local object
+    if person.id.is_local(context) {
       return person.id.dereference_local(context).await;
     }
     let instance_id = fetch_instance_actor_for_object(&person.id, context).await?;

--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -182,6 +182,11 @@ impl Object for ApubPost {
 
   #[tracing::instrument(skip_all)]
   async fn from_json(page: Page, context: &Data<Self::DataType>) -> Result<ApubPost, LemmyError> {
+    // Dont allow overwriting local object
+    if page.id.inner().domain() == Some(context.domain()) {
+      return page.id.dereference_local(context).await;
+    }
+
     let creator = page.creator()?.dereference(context).await?;
     let community = page.community(context).await?;
     if community.posting_restricted_to_mods {

--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -164,7 +164,7 @@ impl Object for ApubPost {
     // instance from the post author.
     if !page.is_mod_action(context).await? {
       verify_domains_match(page.id.inner(), expected_domain)?;
-      verify_is_remote_object(page.id.inner(), context.settings())?;
+      verify_is_remote_object(&page.id, context)?;
     };
 
     let community = page.community(context).await?;
@@ -182,8 +182,8 @@ impl Object for ApubPost {
 
   #[tracing::instrument(skip_all)]
   async fn from_json(page: Page, context: &Data<Self::DataType>) -> Result<ApubPost, LemmyError> {
-    // Dont allow overwriting local object
-    if page.id.inner().domain() == Some(context.domain()) {
+    // Avoid overwriting local object
+    if page.id.is_local(context) {
       return page.id.dereference_local(context).await;
     }
 

--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -182,11 +182,6 @@ impl Object for ApubPost {
 
   #[tracing::instrument(skip_all)]
   async fn from_json(page: Page, context: &Data<Self::DataType>) -> Result<ApubPost, LemmyError> {
-    // Avoid overwriting local object
-    if page.id.is_local(context) {
-      return page.id.dereference_local(context).await;
-    }
-
     let creator = page.creator()?.dereference(context).await?;
     let community = page.community(context).await?;
     if community.posting_restricted_to_mods {

--- a/crates/apub/src/objects/private_message.rs
+++ b/crates/apub/src/objects/private_message.rs
@@ -121,8 +121,8 @@ impl Object for ApubPrivateMessage {
     note: ChatMessage,
     context: &Data<Self::DataType>,
   ) -> Result<ApubPrivateMessage, LemmyError> {
-    // Dont allow overwriting local object
-    if note.id.inner().domain() == Some(context.domain()) {
+    // Avoid overwriting local object
+    if note.id.is_local(context) {
       return note.id.dereference_local(context).await;
     }
 

--- a/crates/apub/src/objects/private_message.rs
+++ b/crates/apub/src/objects/private_message.rs
@@ -121,6 +121,11 @@ impl Object for ApubPrivateMessage {
     note: ChatMessage,
     context: &Data<Self::DataType>,
   ) -> Result<ApubPrivateMessage, LemmyError> {
+    // Dont allow overwriting local object
+    if note.id.inner().domain() == Some(context.domain()) {
+      return note.id.dereference_local(context).await;
+    }
+
     let creator = note.attributed_to.dereference(context).await?;
     let recipient = note.to[0].dereference(context).await?;
     check_person_block(creator.id, recipient.id, &mut context.pool()).await?;


### PR DESCRIPTION
Its possible that we receive an activity like `Announce/Create/Post` which might overwrite a locally created post. This can cause issues such as https://github.com/LemmyNet/lemmy/issues/3060. Better to have a check to avoid this.