### PR TITLE
Convert all Result<..., LemmyError> into LemmyResult<...> Fixes #4613

### DIFF
--- a/crates/api/src/comment/distinguish.rs
+++ b/crates/api/src/comment/distinguish.rs
@@ -9,14 +9,14 @@ use lemmy_db_schema::{
   traits::Crud,
 };
 use lemmy_db_views::structs::{CommentView, LocalUserView};
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn distinguish_comment(
   data: Json<DistinguishComment>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<CommentResponse>, LemmyError> {
+) -> LemmyResult<Json<CommentResponse>> {
   let orig_comment = CommentView::read(&mut context.pool(), data.comment_id, None).await?;
 
   check_community_user_action(

--- a/crates/api/src/comment/like.rs
+++ b/crates/api/src/comment/like.rs
@@ -17,7 +17,7 @@ use lemmy_db_schema::{
   traits::Likeable,
 };
 use lemmy_db_views::structs::{CommentView, LocalUserView};
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 use std::ops::Deref;
 
 #[tracing::instrument(skip(context))]
@@ -25,7 +25,7 @@ pub async fn like_comment(
   data: Json<CreateCommentLike>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<CommentResponse>, LemmyError> {
+) -> LemmyResult<Json<CommentResponse>> {
   let local_site = LocalSite::read(&mut context.pool()).await?;
 
   let mut recipient_ids = Vec::<LocalUserId>::new();

--- a/crates/api/src/comment/list_comment_likes.rs
+++ b/crates/api/src/comment/list_comment_likes.rs
@@ -5,7 +5,7 @@ use lemmy_api_common::{
   utils::is_mod_or_admin,
 };
 use lemmy_db_views::structs::{CommentView, LocalUserView, VoteView};
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 /// Lists likes for a comment
 #[tracing::instrument(skip(context))]
@@ -13,7 +13,7 @@ pub async fn list_comment_likes(
   data: Query<ListCommentLikes>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<ListCommentLikesResponse>, LemmyError> {
+) -> LemmyResult<Json<ListCommentLikesResponse>> {
   let comment_view = CommentView::read(
     &mut context.pool(),
     data.comment_id,

--- a/crates/api/src/comment/save.rs
+++ b/crates/api/src/comment/save.rs
@@ -8,14 +8,14 @@ use lemmy_db_schema::{
   traits::Saveable,
 };
 use lemmy_db_views::structs::{CommentView, LocalUserView};
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn save_comment(
   data: Json<SaveComment>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<CommentResponse>, LemmyError> {
+) -> LemmyResult<Json<CommentResponse>> {
   let comment_saved_form = CommentSavedForm {
     comment_id: data.comment_id,
     person_id: local_user_view.person.id,

--- a/crates/api/src/comment_report/create.rs
+++ b/crates/api/src/comment_report/create.rs
@@ -19,7 +19,7 @@ use lemmy_db_schema::{
   traits::Reportable,
 };
 use lemmy_db_views::structs::{CommentReportView, CommentView, LocalUserView};
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 /// Creates a comment report and notifies the moderators of the community
 #[tracing::instrument(skip(context))]
@@ -27,7 +27,7 @@ pub async fn create_comment_report(
   data: Json<CreateCommentReport>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<CommentReportResponse>, LemmyError> {
+) -> LemmyResult<Json<CommentReportResponse>> {
   let local_site = LocalSite::read(&mut context.pool()).await?;
 
   let reason = data.reason.trim().to_string();

--- a/crates/api/src/comment_report/list.rs
+++ b/crates/api/src/comment_report/list.rs
@@ -5,7 +5,7 @@ use lemmy_api_common::{
   utils::check_community_mod_of_any_or_admin_action,
 };
 use lemmy_db_views::{comment_report_view::CommentReportQuery, structs::LocalUserView};
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 /// Lists comment reports for a community if an id is supplied
 /// or returns all comment reports for communities a user moderates
@@ -14,7 +14,7 @@ pub async fn list_comment_reports(
   data: Query<ListCommentReports>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<ListCommentReportsResponse>, LemmyError> {
+) -> LemmyResult<Json<ListCommentReportsResponse>> {
   let community_id = data.community_id;
   let comment_id = data.comment_id;
   let unresolved_only = data.unresolved_only.unwrap_or_default();

--- a/crates/api/src/comment_report/resolve.rs
+++ b/crates/api/src/comment_report/resolve.rs
@@ -6,7 +6,7 @@ use lemmy_api_common::{
 };
 use lemmy_db_schema::{source::comment_report::CommentReport, traits::Reportable};
 use lemmy_db_views::structs::{CommentReportView, LocalUserView};
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 /// Resolves or unresolves a comment report and notifies the moderators of the community
 #[tracing::instrument(skip(context))]
@@ -14,7 +14,7 @@ pub async fn resolve_comment_report(
   data: Json<ResolveCommentReport>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<CommentReportResponse>, LemmyError> {
+) -> LemmyResult<Json<CommentReportResponse>> {
   let report_id = data.report_id;
   let person_id = local_user_view.person.id;
   let report = CommentReportView::read(&mut context.pool(), report_id, person_id).await?;

--- a/crates/api/src/community/add_mod.rs
+++ b/crates/api/src/community/add_mod.rs
@@ -15,14 +15,14 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_db_views_actor::structs::CommunityModeratorView;
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn add_mod_to_community(
   data: Json<AddModToCommunity>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<AddModToCommunityResponse>, LemmyError> {
+) -> LemmyResult<Json<AddModToCommunityResponse>> {
   let community_id = data.community_id;
 
   // Verify that only mods or admins can add mod

--- a/crates/api/src/community/ban.rs
+++ b/crates/api/src/community/ban.rs
@@ -21,7 +21,7 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_db_views_actor::structs::PersonView;
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+  error::{LemmyErrorExt, LemmyErrorType, LemmyResult},
   utils::validation::is_valid_body_field,
 };
 
@@ -30,7 +30,7 @@ pub async fn ban_from_community(
   data: Json<BanFromCommunity>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<BanFromCommunityResponse>, LemmyError> {
+) -> LemmyResult<Json<BanFromCommunityResponse>> {
   let banned_person_id = data.person_id;
   let remove_data = data.remove_data.unwrap_or(false);
   let expires = check_expire_time(data.expires)?;

--- a/crates/api/src/community/block.rs
+++ b/crates/api/src/community/block.rs
@@ -14,14 +14,14 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_db_views_actor::structs::CommunityView;
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn block_community(
   data: Json<BlockCommunity>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<BlockCommunityResponse>, LemmyError> {
+) -> LemmyResult<Json<BlockCommunityResponse>> {
   let community_id = data.community_id;
   let person_id = local_user_view.person.id;
   let community_block_form = CommunityBlockForm {

--- a/crates/api/src/community/follow.rs
+++ b/crates/api/src/community/follow.rs
@@ -15,14 +15,14 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_db_views_actor::structs::CommunityView;
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn follow_community(
   data: Json<FollowCommunity>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<CommunityResponse>, LemmyError> {
+) -> LemmyResult<Json<CommunityResponse>> {
   let community = Community::read(&mut context.pool(), data.community_id).await?;
   let mut community_follower_form = CommunityFollowerForm {
     community_id: community.id,

--- a/crates/api/src/community/hide.rs
+++ b/crates/api/src/community/hide.rs
@@ -15,14 +15,14 @@ use lemmy_db_schema::{
   traits::Crud,
 };
 use lemmy_db_views::structs::LocalUserView;
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn hide_community(
   data: Json<HideCommunity>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<SuccessResponse>, LemmyError> {
+) -> LemmyResult<Json<SuccessResponse>> {
   // Verify its a admin (only admin can hide or unhide it)
   is_admin(&local_user_view)?;
 

--- a/crates/api/src/community/transfer.rs
+++ b/crates/api/src/community/transfer.rs
@@ -15,7 +15,7 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_db_views_actor::structs::{CommunityModeratorView, CommunityView};
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+  error::{LemmyErrorExt, LemmyErrorType, LemmyResult},
   location_info,
 };
 
@@ -26,7 +26,7 @@ pub async fn transfer_community(
   data: Json<TransferCommunity>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<GetCommunityResponse>, LemmyError> {
+) -> LemmyResult<Json<GetCommunityResponse>> {
   let community_id = data.community_id;
   let mut community_mods =
     CommunityModeratorView::for_community(&mut context.pool(), community_id).await?;

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -26,7 +26,7 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorExt2, LemmyErrorType, LemmyResult},
+  error::{LemmyErrorExt, LemmyErrorExt2, LemmyErrorType, LemmyResult},
   utils::slurs::check_slurs,
 };
 use std::io::Cursor;
@@ -44,7 +44,7 @@ pub mod site;
 pub mod sitemap;
 
 /// Converts the captcha to a base64 encoded wav audio file
-pub(crate) fn captcha_as_wav_base64(captcha: &Captcha) -> Result<String, LemmyError> {
+pub(crate) fn captcha_as_wav_base64(captcha: &Captcha) -> LemmyResult<String> {
   let letters = captcha.as_wav();
 
   // Decode each wav file, concatenate the samples
@@ -78,7 +78,7 @@ pub(crate) fn captcha_as_wav_base64(captcha: &Captcha) -> Result<String, LemmyEr
 }
 
 /// Check size of report
-pub(crate) fn check_report_reason(reason: &str, local_site: &LocalSite) -> Result<(), LemmyError> {
+pub(crate) fn check_report_reason(reason: &str, local_site: &LocalSite) -> LemmyResult<()> {
   let slur_regex = &local_site_to_slur_regex(local_site);
 
   check_slurs(reason, slur_regex)?;
@@ -91,7 +91,7 @@ pub(crate) fn check_report_reason(reason: &str, local_site: &LocalSite) -> Resul
   }
 }
 
-pub fn read_auth_token(req: &HttpRequest) -> Result<Option<String>, LemmyError> {
+pub fn read_auth_token(req: &HttpRequest) -> LemmyResult<Option<String>> {
   // Try reading jwt from auth header
   if let Ok(header) = Authorization::<Bearer>::parse(req) {
     Ok(Some(header.as_ref().token().to_string()))
@@ -135,7 +135,7 @@ pub(crate) fn generate_totp_2fa_secret() -> String {
   Secret::generate_secret().to_string()
 }
 
-fn build_totp_2fa(hostname: &str, username: &str, secret: &str) -> Result<TOTP, LemmyError> {
+fn build_totp_2fa(hostname: &str, username: &str, secret: &str) -> LemmyResult<TOTP> {
   let sec = Secret::Raw(secret.as_bytes().to_vec());
   let sec_bytes = sec
     .to_bytes()
@@ -248,7 +248,7 @@ pub(crate) async fn ban_nonlocal_user_from_local_communities(
 pub async fn local_user_view_from_jwt(
   jwt: &str,
   context: &LemmyContext,
-) -> Result<LocalUserView, LemmyError> {
+) -> LemmyResult<LocalUserView> {
   let local_user_id = Claims::validate(jwt, context)
     .await
     .with_lemmy_type(LemmyErrorType::NotLoggedIn)?;

--- a/crates/api/src/local_user/add_admin.rs
+++ b/crates/api/src/local_user/add_admin.rs
@@ -13,14 +13,14 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_db_views_actor::structs::PersonView;
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn add_admin(
   data: Json<AddAdmin>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<AddAdminResponse>, LemmyError> {
+) -> LemmyResult<Json<AddAdminResponse>> {
   // Make sure user is an admin
   is_admin(&local_user_view)?;
 

--- a/crates/api/src/local_user/ban_person.rs
+++ b/crates/api/src/local_user/ban_person.rs
@@ -18,7 +18,7 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_db_views_actor::structs::PersonView;
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+  error::{LemmyErrorExt, LemmyErrorType, LemmyResult},
   utils::validation::is_valid_body_field,
 };
 
@@ -27,7 +27,7 @@ pub async fn ban_from_site(
   data: Json<BanPerson>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<BanPersonResponse>, LemmyError> {
+) -> LemmyResult<Json<BanPersonResponse>> {
   // Make sure user is an admin
   is_admin(&local_user_view)?;
 

--- a/crates/api/src/local_user/block.rs
+++ b/crates/api/src/local_user/block.rs
@@ -9,14 +9,14 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_db_views_actor::structs::PersonView;
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn block_person(
   data: Json<BlockPerson>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<BlockPersonResponse>, LemmyError> {
+) -> LemmyResult<Json<BlockPersonResponse>> {
   let target_id = data.person_id;
   let person_id = local_user_view.person.id;
 

--- a/crates/api/src/local_user/change_password.rs
+++ b/crates/api/src/local_user/change_password.rs
@@ -11,7 +11,7 @@ use lemmy_api_common::{
 };
 use lemmy_db_schema::source::{local_user::LocalUser, login_token::LoginToken};
 use lemmy_db_views::structs::LocalUserView;
-use lemmy_utils::error::{LemmyError, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn change_password(
@@ -19,7 +19,7 @@ pub async fn change_password(
   req: HttpRequest,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<LoginResponse>, LemmyError> {
+) -> LemmyResult<Json<LoginResponse>> {
   password_length_check(&data.new_password)?;
 
   // Make sure passwords match

--- a/crates/api/src/local_user/change_password_after_reset.rs
+++ b/crates/api/src/local_user/change_password_after_reset.rs
@@ -10,13 +10,13 @@ use lemmy_db_schema::source::{
   login_token::LoginToken,
   password_reset_request::PasswordResetRequest,
 };
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn change_password_after_reset(
   data: Json<PasswordChangeAfterReset>,
   context: Data<LemmyContext>,
-) -> Result<Json<SuccessResponse>, LemmyError> {
+) -> LemmyResult<Json<SuccessResponse>> {
   // Fetch the user_id from the token
   let token = data.token.clone();
   let local_user_id = PasswordResetRequest::read_from_token(&mut context.pool(), &token)

--- a/crates/api/src/local_user/generate_totp_secret.rs
+++ b/crates/api/src/local_user/generate_totp_secret.rs
@@ -8,7 +8,7 @@ use lemmy_api_common::{
 };
 use lemmy_db_schema::source::local_user::{LocalUser, LocalUserUpdateForm};
 use lemmy_db_views::structs::{LocalUserView, SiteView};
-use lemmy_utils::error::{LemmyError, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorType, LemmyResult};
 
 /// Generate a new secret for two-factor-authentication. Afterwards you need to call [toggle_totp]
 /// to enable it. This can only be called if 2FA is currently disabled.
@@ -16,7 +16,7 @@ use lemmy_utils::error::{LemmyError, LemmyErrorType};
 pub async fn generate_totp_secret(
   local_user_view: LocalUserView,
   context: Data<LemmyContext>,
-) -> Result<Json<GenerateTotpSecretResponse>, LemmyError> {
+) -> LemmyResult<Json<GenerateTotpSecretResponse>> {
   let site_view = SiteView::read_local(&mut context.pool()).await?;
 
   if local_user_view.local_user.totp_2fa_enabled {

--- a/crates/api/src/local_user/get_captcha.rs
+++ b/crates/api/src/local_user/get_captcha.rs
@@ -17,10 +17,10 @@ use lemmy_db_schema::source::{
   captcha_answer::{CaptchaAnswer, CaptchaAnswerForm},
   local_site::LocalSite,
 };
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 #[tracing::instrument(skip(context))]
-pub async fn get_captcha(context: Data<LemmyContext>) -> Result<HttpResponse, LemmyError> {
+pub async fn get_captcha(context: Data<LemmyContext>) -> LemmyResult<HttpResponse> {
   let local_site = LocalSite::read(&mut context.pool()).await?;
   let mut res = HttpResponseBuilder::new(StatusCode::OK);
   res.insert_header(CacheControl(vec![CacheDirective::NoStore]));

--- a/crates/api/src/local_user/list_banned.rs
+++ b/crates/api/src/local_user/list_banned.rs
@@ -2,12 +2,12 @@ use actix_web::web::{Data, Json};
 use lemmy_api_common::{context::LemmyContext, person::BannedPersonsResponse, utils::is_admin};
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_db_views_actor::structs::PersonView;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 pub async fn list_banned_users(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<BannedPersonsResponse>, LemmyError> {
+) -> LemmyResult<Json<BannedPersonsResponse>> {
   // Make sure user is an admin
   is_admin(&local_user_view)?;
 

--- a/crates/api/src/local_user/list_logins.rs
+++ b/crates/api/src/local_user/list_logins.rs
@@ -2,12 +2,12 @@ use actix_web::web::{Data, Json};
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::source::login_token::LoginToken;
 use lemmy_db_views::structs::LocalUserView;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 pub async fn list_logins(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<Vec<LoginToken>>, LemmyError> {
+) -> LemmyResult<Json<Vec<LoginToken>>> {
   let logins = LoginToken::list(&mut context.pool(), local_user_view.local_user.id).await?;
 
   Ok(Json(logins))

--- a/crates/api/src/local_user/list_media.rs
+++ b/crates/api/src/local_user/list_media.rs
@@ -5,14 +5,14 @@ use lemmy_api_common::{
 };
 use lemmy_db_schema::source::images::LocalImage;
 use lemmy_db_views::structs::LocalUserView;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 #[tracing::instrument(skip(context))]
 pub async fn list_media(
   data: Query<ListMedia>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<ListMediaResponse>, LemmyError> {
+) -> LemmyResult<Json<ListMediaResponse>> {
   let page = data.page;
   let limit = data.limit;
   let images = LocalImage::get_all_paged_by_local_user_id(

--- a/crates/api/src/local_user/login.rs
+++ b/crates/api/src/local_user/login.rs
@@ -16,14 +16,14 @@ use lemmy_db_schema::{
   RegistrationMode,
 };
 use lemmy_db_views::structs::{LocalUserView, SiteView};
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn login(
   data: Json<Login>,
   req: HttpRequest,
   context: Data<LemmyContext>,
-) -> Result<Json<LoginResponse>, LemmyError> {
+) -> LemmyResult<Json<LoginResponse>> {
   let site_view = SiteView::read_local(&mut context.pool()).await?;
 
   // Fetch that username / email
@@ -70,7 +70,7 @@ async fn check_registration_application(
   local_user_view: &LocalUserView,
   local_site: &LocalSite,
   pool: &mut DbPool<'_>,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   if (local_site.registration_mode == RegistrationMode::RequireApplication
     || local_site.registration_mode == RegistrationMode::Closed)
     && !local_user_view.local_user.accepted_application

--- a/crates/api/src/local_user/notifications/list_mentions.rs
+++ b/crates/api/src/local_user/notifications/list_mentions.rs
@@ -5,14 +5,14 @@ use lemmy_api_common::{
 };
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_db_views_actor::person_mention_view::PersonMentionQuery;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 #[tracing::instrument(skip(context))]
 pub async fn list_mentions(
   data: Query<GetPersonMentions>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<GetPersonMentionsResponse>, LemmyError> {
+) -> LemmyResult<Json<GetPersonMentionsResponse>> {
   let sort = data.sort;
   let page = data.page;
   let limit = data.limit;

--- a/crates/api/src/local_user/notifications/list_replies.rs
+++ b/crates/api/src/local_user/notifications/list_replies.rs
@@ -5,14 +5,14 @@ use lemmy_api_common::{
 };
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_db_views_actor::comment_reply_view::CommentReplyQuery;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 #[tracing::instrument(skip(context))]
 pub async fn list_replies(
   data: Query<GetReplies>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<GetRepliesResponse>, LemmyError> {
+) -> LemmyResult<Json<GetRepliesResponse>> {
   let sort = data.sort;
   let page = data.page;
   let limit = data.limit;

--- a/crates/api/src/local_user/notifications/mark_all_read.rs
+++ b/crates/api/src/local_user/notifications/mark_all_read.rs
@@ -6,13 +6,13 @@ use lemmy_db_schema::source::{
   private_message::PrivateMessage,
 };
 use lemmy_db_views::structs::LocalUserView;
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn mark_all_notifications_read(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<GetRepliesResponse>, LemmyError> {
+) -> LemmyResult<Json<GetRepliesResponse>> {
   let person_id = local_user_view.person.id;
 
   // Mark all comment_replies as read

--- a/crates/api/src/local_user/notifications/mark_mention_read.rs
+++ b/crates/api/src/local_user/notifications/mark_mention_read.rs
@@ -9,14 +9,14 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_db_views_actor::structs::PersonMentionView;
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn mark_person_mention_as_read(
   data: Json<MarkPersonMentionAsRead>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<PersonMentionResponse>, LemmyError> {
+) -> LemmyResult<Json<PersonMentionResponse>> {
   let person_mention_id = data.person_mention_id;
   let read_person_mention = PersonMention::read(&mut context.pool(), person_mention_id).await?;
 

--- a/crates/api/src/local_user/notifications/mark_reply_read.rs
+++ b/crates/api/src/local_user/notifications/mark_reply_read.rs
@@ -9,14 +9,14 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_db_views_actor::structs::CommentReplyView;
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn mark_reply_as_read(
   data: Json<MarkCommentReplyAsRead>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<CommentReplyResponse>, LemmyError> {
+) -> LemmyResult<Json<CommentReplyResponse>> {
   let comment_reply_id = data.comment_reply_id;
   let read_comment_reply = CommentReply::read(&mut context.pool(), comment_reply_id).await?;
 

--- a/crates/api/src/local_user/notifications/unread_count.rs
+++ b/crates/api/src/local_user/notifications/unread_count.rs
@@ -2,13 +2,13 @@ use actix_web::web::{Data, Json};
 use lemmy_api_common::{context::LemmyContext, person::GetUnreadCountResponse};
 use lemmy_db_views::structs::{LocalUserView, PrivateMessageView};
 use lemmy_db_views_actor::structs::{CommentReplyView, PersonMentionView};
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 #[tracing::instrument(skip(context))]
 pub async fn unread_count(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<GetUnreadCountResponse>, LemmyError> {
+) -> LemmyResult<Json<GetUnreadCountResponse>> {
   let person_id = local_user_view.person.id;
 
   let replies = CommentReplyView::get_unread_replies(&mut context.pool(), person_id).await?;

--- a/crates/api/src/local_user/report_count.rs
+++ b/crates/api/src/local_user/report_count.rs
@@ -10,14 +10,14 @@ use lemmy_db_views::structs::{
   PostReportView,
   PrivateMessageReportView,
 };
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 #[tracing::instrument(skip(context))]
 pub async fn report_count(
   data: Query<GetReportCount>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<GetReportCountResponse>, LemmyError> {
+) -> LemmyResult<Json<GetReportCountResponse>> {
   let person_id = local_user_view.person.id;
   let admin = local_user_view.local_user.admin;
   let community_id = data.community_id;

--- a/crates/api/src/local_user/save_settings.rs
+++ b/crates/api/src/local_user/save_settings.rs
@@ -25,7 +25,7 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views::structs::{LocalUserView, SiteView};
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorType},
+  error::{LemmyErrorType, LemmyResult},
   utils::validation::{is_valid_bio_field, is_valid_display_name, is_valid_matrix_id},
 };
 
@@ -34,7 +34,7 @@ pub async fn save_user_settings(
   data: Json<SaveUserSettings>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<SuccessResponse>, LemmyError> {
+) -> LemmyResult<Json<SuccessResponse>> {
   let site_view = SiteView::read_local(&mut context.pool()).await?;
 
   let slur_regex = local_site_to_slur_regex(&site_view.local_site);

--- a/crates/api/src/local_user/update_totp.rs
+++ b/crates/api/src/local_user/update_totp.rs
@@ -6,7 +6,7 @@ use lemmy_api_common::{
 };
 use lemmy_db_schema::source::local_user::{LocalUser, LocalUserUpdateForm};
 use lemmy_db_views::structs::LocalUserView;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 /// Enable or disable two-factor-authentication. The current setting is determined from
 /// [LocalUser.totp_2fa_enabled].
@@ -21,7 +21,7 @@ pub async fn update_totp(
   data: Json<UpdateTotp>,
   local_user_view: LocalUserView,
   context: Data<LemmyContext>,
-) -> Result<Json<UpdateTotpResponse>, LemmyError> {
+) -> LemmyResult<Json<UpdateTotpResponse>> {
   check_totp_2fa_valid(
     &local_user_view,
     &Some(data.totp_token.clone()),

--- a/crates/api/src/local_user/validate_auth.rs
+++ b/crates/api/src/local_user/validate_auth.rs
@@ -4,7 +4,7 @@ use actix_web::{
   HttpRequest,
 };
 use lemmy_api_common::{context::LemmyContext, SuccessResponse};
-use lemmy_utils::error::{LemmyError, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorType, LemmyResult};
 
 /// Returns an error message if the auth token is invalid for any reason. Necessary because other
 /// endpoints silently treat any call with invalid auth as unauthenticated.
@@ -12,7 +12,7 @@ use lemmy_utils::error::{LemmyError, LemmyErrorType};
 pub async fn validate_auth(
   req: HttpRequest,
   context: Data<LemmyContext>,
-) -> Result<Json<SuccessResponse>, LemmyError> {
+) -> LemmyResult<Json<SuccessResponse>> {
   let jwt = read_auth_token(&req)?;
   if let Some(jwt) = jwt {
     local_user_view_from_jwt(&jwt, &context).await?;

--- a/crates/api/src/post/feature.rs
+++ b/crates/api/src/post/feature.rs
@@ -16,14 +16,14 @@ use lemmy_db_schema::{
   PostFeatureType,
 };
 use lemmy_db_views::structs::LocalUserView;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 #[tracing::instrument(skip(context))]
 pub async fn feature_post(
   data: Json<FeaturePost>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<PostResponse>, LemmyError> {
+) -> LemmyResult<Json<PostResponse>> {
   let post_id = data.post_id;
   let orig_post = Post::read(&mut context.pool(), post_id).await?;
 

--- a/crates/api/src/post/get_link_metadata.rs
+++ b/crates/api/src/post/get_link_metadata.rs
@@ -4,13 +4,13 @@ use lemmy_api_common::{
   post::{GetSiteMetadata, GetSiteMetadataResponse},
   request::fetch_link_metadata,
 };
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 #[tracing::instrument(skip(context))]
 pub async fn get_link_metadata(
   data: Query<GetSiteMetadata>,
   context: Data<LemmyContext>,
-) -> Result<Json<GetSiteMetadataResponse>, LemmyError> {
+) -> LemmyResult<Json<GetSiteMetadataResponse>> {
   let metadata = fetch_link_metadata(&data.url, false, &context).await?;
 
   Ok(Json(GetSiteMetadataResponse { metadata }))

--- a/crates/api/src/post/hide.rs
+++ b/crates/api/src/post/hide.rs
@@ -2,7 +2,7 @@ use actix_web::web::{Data, Json};
 use lemmy_api_common::{context::LemmyContext, post::HidePost, SuccessResponse};
 use lemmy_db_schema::source::post::PostHide;
 use lemmy_db_views::structs::LocalUserView;
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType, MAX_API_PARAM_ELEMENTS};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult, MAX_API_PARAM_ELEMENTS};
 use std::collections::HashSet;
 
 #[tracing::instrument(skip(context))]
@@ -10,7 +10,7 @@ pub async fn hide_post(
   data: Json<HidePost>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<SuccessResponse>, LemmyError> {
+) -> LemmyResult<Json<SuccessResponse>> {
   let post_ids = HashSet::from_iter(data.post_ids.clone());
 
   if post_ids.len() > MAX_API_PARAM_ELEMENTS {

--- a/crates/api/src/post/like.rs
+++ b/crates/api/src/post/like.rs
@@ -21,7 +21,7 @@ use lemmy_db_schema::{
   traits::{Crud, Likeable},
 };
 use lemmy_db_views::structs::LocalUserView;
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 use std::ops::Deref;
 
 #[tracing::instrument(skip(context))]
@@ -29,7 +29,7 @@ pub async fn like_post(
   data: Json<CreatePostLike>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<PostResponse>, LemmyError> {
+) -> LemmyResult<Json<PostResponse>> {
   let local_site = LocalSite::read(&mut context.pool()).await?;
 
   // Don't do a downvote if site has downvotes disabled

--- a/crates/api/src/post/list_post_likes.rs
+++ b/crates/api/src/post/list_post_likes.rs
@@ -6,7 +6,7 @@ use lemmy_api_common::{
 };
 use lemmy_db_schema::{source::post::Post, traits::Crud};
 use lemmy_db_views::structs::{LocalUserView, VoteView};
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 /// Lists likes for a post
 #[tracing::instrument(skip(context))]
@@ -14,7 +14,7 @@ pub async fn list_post_likes(
   data: Query<ListPostLikes>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<ListPostLikesResponse>, LemmyError> {
+) -> LemmyResult<Json<ListPostLikesResponse>> {
   let post = Post::read(&mut context.pool(), data.post_id).await?;
   is_mod_or_admin(
     &mut context.pool(),

--- a/crates/api/src/post/lock.rs
+++ b/crates/api/src/post/lock.rs
@@ -15,14 +15,14 @@ use lemmy_db_schema::{
   traits::Crud,
 };
 use lemmy_db_views::structs::LocalUserView;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 #[tracing::instrument(skip(context))]
 pub async fn lock_post(
   data: Json<LockPost>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<PostResponse>, LemmyError> {
+) -> LemmyResult<Json<PostResponse>> {
   let post_id = data.post_id;
   let orig_post = Post::read(&mut context.pool(), post_id).await?;
 

--- a/crates/api/src/post/mark_read.rs
+++ b/crates/api/src/post/mark_read.rs
@@ -2,7 +2,7 @@ use actix_web::web::{Data, Json};
 use lemmy_api_common::{context::LemmyContext, post::MarkPostAsRead, SuccessResponse};
 use lemmy_db_schema::source::post::PostRead;
 use lemmy_db_views::structs::LocalUserView;
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType, MAX_API_PARAM_ELEMENTS};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult, MAX_API_PARAM_ELEMENTS};
 use std::collections::HashSet;
 
 #[tracing::instrument(skip(context))]
@@ -10,7 +10,7 @@ pub async fn mark_post_as_read(
   data: Json<MarkPostAsRead>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<SuccessResponse>, LemmyError> {
+) -> LemmyResult<Json<SuccessResponse>> {
   let post_ids = HashSet::from_iter(data.post_ids.clone());
 
   if post_ids.len() > MAX_API_PARAM_ELEMENTS {

--- a/crates/api/src/post/save.rs
+++ b/crates/api/src/post/save.rs
@@ -9,14 +9,14 @@ use lemmy_db_schema::{
   traits::Saveable,
 };
 use lemmy_db_views::structs::{LocalUserView, PostView};
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn save_post(
   data: Json<SavePost>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<PostResponse>, LemmyError> {
+) -> LemmyResult<Json<PostResponse>> {
   let post_saved_form = PostSavedForm {
     post_id: data.post_id,
     person_id: local_user_view.person.id,

--- a/crates/api/src/post_report/create.rs
+++ b/crates/api/src/post_report/create.rs
@@ -19,7 +19,7 @@ use lemmy_db_schema::{
   traits::Reportable,
 };
 use lemmy_db_views::structs::{LocalUserView, PostReportView, PostView};
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 /// Creates a post report and notifies the moderators of the community
 #[tracing::instrument(skip(context))]
@@ -27,7 +27,7 @@ pub async fn create_post_report(
   data: Json<CreatePostReport>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<PostReportResponse>, LemmyError> {
+) -> LemmyResult<Json<PostReportResponse>> {
   let local_site = LocalSite::read(&mut context.pool()).await?;
 
   let reason = data.reason.trim().to_string();

--- a/crates/api/src/post_report/list.rs
+++ b/crates/api/src/post_report/list.rs
@@ -5,7 +5,7 @@ use lemmy_api_common::{
   utils::check_community_mod_of_any_or_admin_action,
 };
 use lemmy_db_views::{post_report_view::PostReportQuery, structs::LocalUserView};
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 /// Lists post reports for a community if an id is supplied
 /// or returns all post reports for communities a user moderates
@@ -14,7 +14,7 @@ pub async fn list_post_reports(
   data: Query<ListPostReports>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<ListPostReportsResponse>, LemmyError> {
+) -> LemmyResult<Json<ListPostReportsResponse>> {
   let community_id = data.community_id;
   let post_id = data.post_id;
   let unresolved_only = data.unresolved_only.unwrap_or_default();

--- a/crates/api/src/post_report/resolve.rs
+++ b/crates/api/src/post_report/resolve.rs
@@ -6,7 +6,7 @@ use lemmy_api_common::{
 };
 use lemmy_db_schema::{source::post_report::PostReport, traits::Reportable};
 use lemmy_db_views::structs::{LocalUserView, PostReportView};
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 /// Resolves or unresolves a post report and notifies the moderators of the community
 #[tracing::instrument(skip(context))]
@@ -14,7 +14,7 @@ pub async fn resolve_post_report(
   data: Json<ResolvePostReport>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<PostReportResponse>, LemmyError> {
+) -> LemmyResult<Json<PostReportResponse>> {
   let report_id = data.report_id;
   let person_id = local_user_view.person.id;
   let report = PostReportView::read(&mut context.pool(), report_id, person_id).await?;

--- a/crates/api/src/private_message/mark_read.rs
+++ b/crates/api/src/private_message/mark_read.rs
@@ -8,14 +8,14 @@ use lemmy_db_schema::{
   traits::Crud,
 };
 use lemmy_db_views::structs::{LocalUserView, PrivateMessageView};
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn mark_pm_as_read(
   data: Json<MarkPrivateMessageAsRead>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<PrivateMessageResponse>, LemmyError> {
+) -> LemmyResult<Json<PrivateMessageResponse>> {
   // Checking permissions
   let private_message_id = data.private_message_id;
   let orig_private_message = PrivateMessage::read(&mut context.pool(), private_message_id).await?;

--- a/crates/api/src/private_message_report/create.rs
+++ b/crates/api/src/private_message_report/create.rs
@@ -14,14 +14,14 @@ use lemmy_db_schema::{
   traits::{Crud, Reportable},
 };
 use lemmy_db_views::structs::{LocalUserView, PrivateMessageReportView};
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn create_pm_report(
   data: Json<CreatePrivateMessageReport>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<PrivateMessageReportResponse>, LemmyError> {
+) -> LemmyResult<Json<PrivateMessageReportResponse>> {
   let local_site = LocalSite::read(&mut context.pool()).await?;
 
   let reason = data.reason.trim().to_string();

--- a/crates/api/src/private_message_report/list.rs
+++ b/crates/api/src/private_message_report/list.rs
@@ -8,14 +8,14 @@ use lemmy_db_views::{
   private_message_report_view::PrivateMessageReportQuery,
   structs::LocalUserView,
 };
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 #[tracing::instrument(skip(context))]
 pub async fn list_pm_reports(
   data: Query<ListPrivateMessageReports>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<ListPrivateMessageReportsResponse>, LemmyError> {
+) -> LemmyResult<Json<ListPrivateMessageReportsResponse>> {
   is_admin(&local_user_view)?;
 
   let unresolved_only = data.unresolved_only.unwrap_or_default();

--- a/crates/api/src/private_message_report/resolve.rs
+++ b/crates/api/src/private_message_report/resolve.rs
@@ -6,14 +6,14 @@ use lemmy_api_common::{
 };
 use lemmy_db_schema::{source::private_message_report::PrivateMessageReport, traits::Reportable};
 use lemmy_db_views::structs::{LocalUserView, PrivateMessageReportView};
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn resolve_pm_report(
   data: Json<ResolvePrivateMessageReport>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<PrivateMessageReportResponse>, LemmyError> {
+) -> LemmyResult<Json<PrivateMessageReportResponse>> {
   is_admin(&local_user_view)?;
 
   let report_id = data.report_id;

--- a/crates/api/src/site/block.rs
+++ b/crates/api/src/site/block.rs
@@ -9,14 +9,14 @@ use lemmy_db_schema::{
   traits::Blockable,
 };
 use lemmy_db_views::structs::LocalUserView;
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn block_instance(
   data: Json<BlockInstance>,
   local_user_view: LocalUserView,
   context: Data<LemmyContext>,
-) -> Result<Json<BlockInstanceResponse>, LemmyError> {
+) -> LemmyResult<Json<BlockInstanceResponse>> {
   let instance_id = data.instance_id;
   let person_id = local_user_view.person.id;
   if local_user_view.person.instance_id == instance_id {

--- a/crates/api/src/site/federated_instances.rs
+++ b/crates/api/src/site/federated_instances.rs
@@ -5,12 +5,12 @@ use lemmy_api_common::{
   utils::build_federated_instances,
 };
 use lemmy_db_views::structs::SiteView;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 #[tracing::instrument(skip(context))]
 pub async fn get_federated_instances(
   context: Data<LemmyContext>,
-) -> Result<Json<GetFederatedInstancesResponse>, LemmyError> {
+) -> LemmyResult<Json<GetFederatedInstancesResponse>> {
   let site_view = SiteView::read_local(&mut context.pool()).await?;
   let federated_instances =
     build_federated_instances(&site_view.local_site, &mut context.pool()).await?;

--- a/crates/api/src/site/leave_admin.rs
+++ b/crates/api/src/site/leave_admin.rs
@@ -14,7 +14,7 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::{CustomEmojiView, LocalUserView, SiteView};
 use lemmy_db_views_actor::structs::PersonView;
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorType},
+  error::{LemmyErrorType, LemmyResult},
   VERSION,
 };
 
@@ -22,7 +22,7 @@ use lemmy_utils::{
 pub async fn leave_admin(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<GetSiteResponse>, LemmyError> {
+) -> LemmyResult<Json<GetSiteResponse>> {
   is_admin(&local_user_view)?;
 
   // Make sure there isn't just one admin (so if one leaves, there will still be one left)

--- a/crates/api/src/site/list_all_media.rs
+++ b/crates/api/src/site/list_all_media.rs
@@ -6,14 +6,14 @@ use lemmy_api_common::{
 };
 use lemmy_db_schema::source::images::LocalImage;
 use lemmy_db_views::structs::LocalUserView;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 #[tracing::instrument(skip(context))]
 pub async fn list_all_media(
   data: Query<ListMedia>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<ListMediaResponse>, LemmyError> {
+) -> LemmyResult<Json<ListMediaResponse>> {
   // Only let admins view all media
   is_admin(&local_user_view)?;
 

--- a/crates/api/src/site/mod_log.rs
+++ b/crates/api/src/site/mod_log.rs
@@ -24,7 +24,7 @@ use lemmy_db_views_moderator::structs::{
   ModTransferCommunityView,
   ModlogListParams,
 };
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 use ModlogActionType::*;
 
 #[tracing::instrument(skip(context))]
@@ -32,7 +32,7 @@ pub async fn get_mod_log(
   data: Query<GetModlog>,
   context: Data<LemmyContext>,
   local_user_view: Option<LocalUserView>,
-) -> Result<Json<GetModlogResponse>, LemmyError> {
+) -> LemmyResult<Json<GetModlogResponse>> {
   let local_site = LocalSite::read(&mut context.pool()).await?;
 
   check_private_instance(&local_user_view, &local_site)?;

--- a/crates/api/src/site/purge/comment.rs
+++ b/crates/api/src/site/purge/comment.rs
@@ -15,14 +15,14 @@ use lemmy_db_schema::{
   traits::Crud,
 };
 use lemmy_db_views::structs::{CommentView, LocalUserView};
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 #[tracing::instrument(skip(context))]
 pub async fn purge_comment(
   data: Json<PurgeComment>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<SuccessResponse>, LemmyError> {
+) -> LemmyResult<Json<SuccessResponse>> {
   // Only let admin purge an item
   is_admin(&local_user_view)?;
 

--- a/crates/api/src/site/purge/community.rs
+++ b/crates/api/src/site/purge/community.rs
@@ -16,14 +16,14 @@ use lemmy_db_schema::{
   traits::Crud,
 };
 use lemmy_db_views::structs::LocalUserView;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 #[tracing::instrument(skip(context))]
 pub async fn purge_community(
   data: Json<PurgeCommunity>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<SuccessResponse>, LemmyError> {
+) -> LemmyResult<Json<SuccessResponse>> {
   // Only let admin purge an item
   is_admin(&local_user_view)?;
 

--- a/crates/api/src/site/purge/person.rs
+++ b/crates/api/src/site/purge/person.rs
@@ -16,14 +16,14 @@ use lemmy_db_schema::{
   traits::Crud,
 };
 use lemmy_db_views::structs::LocalUserView;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 #[tracing::instrument(skip(context))]
 pub async fn purge_person(
   data: Json<PurgePerson>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<SuccessResponse>, LemmyError> {
+) -> LemmyResult<Json<SuccessResponse>> {
   // Only let admin purge an item
   is_admin(&local_user_view)?;
 

--- a/crates/api/src/site/purge/post.rs
+++ b/crates/api/src/site/purge/post.rs
@@ -16,14 +16,14 @@ use lemmy_db_schema::{
   traits::Crud,
 };
 use lemmy_db_views::structs::LocalUserView;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 #[tracing::instrument(skip(context))]
 pub async fn purge_post(
   data: Json<PurgePost>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<SuccessResponse>, LemmyError> {
+) -> LemmyResult<Json<SuccessResponse>> {
   // Only let admin purge an item
   is_admin(&local_user_view)?;
 

--- a/crates/api/src/site/registration_applications/approve.rs
+++ b/crates/api/src/site/registration_applications/approve.rs
@@ -13,13 +13,13 @@ use lemmy_db_schema::{
   utils::diesel_option_overwrite,
 };
 use lemmy_db_views::structs::{LocalUserView, RegistrationApplicationView};
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 pub async fn approve_registration_application(
   data: Json<ApproveRegistrationApplication>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<RegistrationApplicationResponse>, LemmyError> {
+) -> LemmyResult<Json<RegistrationApplicationResponse>> {
   let app_id = data.id;
 
   // Only let admins do this

--- a/crates/api/src/site/registration_applications/list.rs
+++ b/crates/api/src/site/registration_applications/list.rs
@@ -9,14 +9,14 @@ use lemmy_db_views::{
   registration_application_view::RegistrationApplicationQuery,
   structs::LocalUserView,
 };
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 /// Lists registration applications, filterable by undenied only.
 pub async fn list_registration_applications(
   data: Query<ListRegistrationApplications>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<ListRegistrationApplicationsResponse>, LemmyError> {
+) -> LemmyResult<Json<ListRegistrationApplicationsResponse>> {
   let local_site = LocalSite::read(&mut context.pool()).await?;
 
   // Make sure user is an admin

--- a/crates/api/src/site/registration_applications/unread_count.rs
+++ b/crates/api/src/site/registration_applications/unread_count.rs
@@ -6,12 +6,12 @@ use lemmy_api_common::{
 };
 use lemmy_db_schema::source::local_site::LocalSite;
 use lemmy_db_views::structs::{LocalUserView, RegistrationApplicationView};
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 pub async fn get_unread_registration_application_count(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<GetUnreadRegistrationApplicationCountResponse>, LemmyError> {
+) -> LemmyResult<Json<GetUnreadRegistrationApplicationCountResponse>> {
   let local_site = LocalSite::read(&mut context.pool()).await?;
 
   // Only let admins do this

--- a/crates/api_common/src/build_response.rs
+++ b/crates/api_common/src/build_response.rs
@@ -25,7 +25,7 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::{CommentView, LocalUserView, PostView};
 use lemmy_db_views_actor::structs::CommunityView;
 use lemmy_utils::{
-  error::LemmyError,
+  error::LemmyResult,
   utils::{markdown::markdown_to_html, mention::MentionData},
 };
 
@@ -34,7 +34,7 @@ pub async fn build_comment_response(
   comment_id: CommentId,
   local_user_view: Option<LocalUserView>,
   recipient_ids: Vec<LocalUserId>,
-) -> Result<CommentResponse, LemmyError> {
+) -> LemmyResult<CommentResponse> {
   let person_id = local_user_view.map(|l| l.person.id);
   let comment_view = CommentView::read(&mut context.pool(), comment_id, person_id).await?;
   Ok(CommentResponse {
@@ -47,7 +47,7 @@ pub async fn build_community_response(
   context: &LemmyContext,
   local_user_view: LocalUserView,
   community_id: CommunityId,
-) -> Result<Json<CommunityResponse>, LemmyError> {
+) -> LemmyResult<Json<CommunityResponse>> {
   let is_mod_or_admin = is_mod_or_admin(&mut context.pool(), &local_user_view.person, community_id)
     .await
     .is_ok();
@@ -72,7 +72,7 @@ pub async fn build_post_response(
   community_id: CommunityId,
   person: &Person,
   post_id: PostId,
-) -> Result<Json<PostResponse>, LemmyError> {
+) -> LemmyResult<Json<PostResponse>> {
   let is_mod_or_admin = is_mod_or_admin(&mut context.pool(), person, community_id)
     .await
     .is_ok();
@@ -94,7 +94,7 @@ pub async fn send_local_notifs(
   person: &Person,
   do_send_email: bool,
   context: &LemmyContext,
-) -> Result<Vec<LocalUserId>, LemmyError> {
+) -> LemmyResult<Vec<LocalUserId>> {
   let mut recipient_ids = Vec::new();
   let inbox_link = format!("{}/inbox", context.settings().get_protocol_and_hostname());
 

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -16,7 +16,7 @@ use lemmy_db_schema::{
   },
 };
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorType},
+  error::{LemmyError, LemmyErrorType, LemmyResult},
   settings::structs::{PictrsImageMode, Settings},
   spawn_try_task,
   REQWEST_TIMEOUT,
@@ -46,7 +46,7 @@ pub async fn fetch_link_metadata(
   url: &Url,
   generate_thumbnail: bool,
   context: &LemmyContext,
-) -> Result<LinkMetadata, LemmyError> {
+) -> LemmyResult<LinkMetadata> {
   info!("Fetching site metadata for url: {}", url);
   let response = context.client().get(url.as_str()).send().await?;
 
@@ -132,7 +132,7 @@ pub fn generate_post_link_metadata(
 }
 
 /// Extract site metadata from HTML Opengraph attributes.
-fn extract_opengraph_data(html_bytes: &[u8], url: &Url) -> Result<OpenGraphData, LemmyError> {
+fn extract_opengraph_data(html_bytes: &[u8], url: &Url) -> LemmyResult<OpenGraphData> {
   let html = String::from_utf8_lossy(html_bytes);
 
   // Make sure the first line is doctype html
@@ -240,10 +240,7 @@ struct PictrsPurgeResponse {
 /// - It might fail due to image being not local
 /// - It might not be an image
 /// - Pictrs might not be set up
-pub async fn purge_image_from_pictrs(
-  image_url: &Url,
-  context: &LemmyContext,
-) -> Result<(), LemmyError> {
+pub async fn purge_image_from_pictrs(image_url: &Url, context: &LemmyContext) -> LemmyResult<()> {
   is_image_content_type(context.client(), image_url).await?;
 
   let alias = image_url
@@ -278,7 +275,7 @@ pub async fn delete_image_from_pictrs(
   alias: &str,
   delete_token: &str,
   context: &LemmyContext,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   let pictrs_config = context.settings().pictrs_config()?;
   let url = format!(
     "{}image/delete/{}/{}",
@@ -296,10 +293,7 @@ pub async fn delete_image_from_pictrs(
 
 /// Retrieves the image with local pict-rs and generates a thumbnail. Returns the thumbnail url.
 #[tracing::instrument(skip_all)]
-async fn generate_pictrs_thumbnail(
-  image_url: &Url,
-  context: &LemmyContext,
-) -> Result<Url, LemmyError> {
+async fn generate_pictrs_thumbnail(image_url: &Url, context: &LemmyContext) -> LemmyResult<Url> {
   let pictrs_config = context.settings().pictrs_config()?;
 
   if pictrs_config.image_mode() == PictrsImageMode::ProxyAllImages {
@@ -345,7 +339,7 @@ async fn generate_pictrs_thumbnail(
 
 // TODO: get rid of this by reading content type from db
 #[tracing::instrument(skip_all)]
-async fn is_image_content_type(client: &ClientWithMiddleware, url: &Url) -> Result<(), LemmyError> {
+async fn is_image_content_type(client: &ClientWithMiddleware, url: &Url) -> LemmyResult<()> {
   let response = client.get(url.as_str()).send().await?;
   if response
     .headers()
@@ -365,7 +359,7 @@ pub async fn replace_image(
   new_image: &Option<String>,
   old_image: &Option<DbUrl>,
   context: &Data<LemmyContext>,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   if new_image.is_some() {
     // Ignore errors because image may be stored externally.
     if let Some(avatar) = &old_image {

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -60,7 +60,7 @@ pub async fn is_mod_or_admin(
   pool: &mut DbPool<'_>,
   person: &Person,
   community_id: CommunityId,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   check_user_valid(person)?;
 
   let is_mod_or_admin = CommunityView::is_mod_or_admin(pool, person.id, community_id).await?;
@@ -76,7 +76,7 @@ pub async fn is_mod_or_admin_opt(
   pool: &mut DbPool<'_>,
   local_user_view: Option<&LocalUserView>,
   community_id: Option<CommunityId>,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   if let Some(local_user_view) = local_user_view {
     if let Some(community_id) = community_id {
       is_mod_or_admin(pool, &local_user_view.person, community_id).await
@@ -108,7 +108,7 @@ pub async fn check_community_mod_of_any_or_admin_action(
   }
 }
 
-pub fn is_admin(local_user_view: &LocalUserView) -> Result<(), LemmyError> {
+pub fn is_admin(local_user_view: &LocalUserView) -> LemmyResult<()> {
   check_user_valid(&local_user_view.person)?;
   if !local_user_view.local_user.admin {
     Err(LemmyErrorType::NotAnAdmin)?
@@ -122,7 +122,7 @@ pub fn is_admin(local_user_view: &LocalUserView) -> Result<(), LemmyError> {
 pub fn is_top_mod(
   local_user_view: &LocalUserView,
   community_mods: &[CommunityModeratorView],
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   check_user_valid(&local_user_view.person)?;
   if local_user_view.person.id
     != community_mods
@@ -137,7 +137,7 @@ pub fn is_top_mod(
 }
 
 #[tracing::instrument(skip_all)]
-pub async fn get_post(post_id: PostId, pool: &mut DbPool<'_>) -> Result<Post, LemmyError> {
+pub async fn get_post(post_id: PostId, pool: &mut DbPool<'_>) -> LemmyResult<Post> {
   Post::read(pool, post_id)
     .await
     .with_lemmy_type(LemmyErrorType::CouldntFindPost)
@@ -148,14 +148,14 @@ pub async fn mark_post_as_read(
   person_id: PersonId,
   post_id: PostId,
   pool: &mut DbPool<'_>,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   PostRead::mark_as_read(pool, HashSet::from([post_id]), person_id)
     .await
     .with_lemmy_type(LemmyErrorType::CouldntMarkPostAsRead)?;
   Ok(())
 }
 
-pub fn check_user_valid(person: &Person) -> Result<(), LemmyError> {
+pub fn check_user_valid(person: &Person) -> LemmyResult<()> {
   // Check for a site ban
   if person.banned {
     Err(LemmyErrorType::SiteBan)?
@@ -230,7 +230,7 @@ pub async fn check_community_mod_action(
 }
 
 /// Don't allow creating reports for removed / deleted posts
-pub fn check_post_deleted_or_removed(post: &Post) -> Result<(), LemmyError> {
+pub fn check_post_deleted_or_removed(post: &Post) -> LemmyResult<()> {
   if post.deleted || post.removed {
     Err(LemmyErrorType::Deleted)?
   } else {
@@ -238,7 +238,7 @@ pub fn check_post_deleted_or_removed(post: &Post) -> Result<(), LemmyError> {
   }
 }
 
-pub fn check_comment_deleted_or_removed(comment: &Comment) -> Result<(), LemmyError> {
+pub fn check_comment_deleted_or_removed(comment: &Comment) -> LemmyResult<()> {
   if comment.deleted || comment.removed {
     Err(LemmyErrorType::Deleted)?
   } else {
@@ -252,7 +252,7 @@ pub async fn check_person_block(
   my_id: PersonId,
   potential_blocker_id: PersonId,
   pool: &mut DbPool<'_>,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   let is_blocked = PersonBlock::read(pool, potential_blocker_id, my_id).await?;
   if is_blocked {
     Err(LemmyErrorType::PersonIsBlocked)?
@@ -267,7 +267,7 @@ async fn check_community_block(
   community_id: CommunityId,
   person_id: PersonId,
   pool: &mut DbPool<'_>,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   let is_blocked = CommunityBlock::read(pool, person_id, community_id).await?;
   if is_blocked {
     Err(LemmyErrorType::CommunityIsBlocked)?
@@ -282,7 +282,7 @@ async fn check_instance_block(
   instance_id: InstanceId,
   person_id: PersonId,
   pool: &mut DbPool<'_>,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   let is_blocked = InstanceBlock::read(pool, person_id, instance_id).await?;
   if is_blocked {
     Err(LemmyErrorType::InstanceIsBlocked)?
@@ -298,7 +298,7 @@ pub async fn check_person_instance_community_block(
   community_instance_id: InstanceId,
   community_id: CommunityId,
   pool: &mut DbPool<'_>,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   check_person_block(my_id, potential_blocker_id, pool).await?;
   check_instance_block(community_instance_id, potential_blocker_id, pool).await?;
   check_community_block(community_id, potential_blocker_id, pool).await?;
@@ -306,7 +306,7 @@ pub async fn check_person_instance_community_block(
 }
 
 #[tracing::instrument(skip_all)]
-pub fn check_downvotes_enabled(score: i16, local_site: &LocalSite) -> Result<(), LemmyError> {
+pub fn check_downvotes_enabled(score: i16, local_site: &LocalSite) -> LemmyResult<()> {
   if score == -1 && !local_site.enable_downvotes {
     Err(LemmyErrorType::DownvotesAreDisabled)?
   } else {
@@ -316,7 +316,7 @@ pub fn check_downvotes_enabled(score: i16, local_site: &LocalSite) -> Result<(),
 
 /// Dont allow bots to do certain actions, like voting
 #[tracing::instrument(skip_all)]
-pub fn check_bot_account(person: &Person) -> Result<(), LemmyError> {
+pub fn check_bot_account(person: &Person) -> LemmyResult<()> {
   if person.bot_account {
     Err(LemmyErrorType::InvalidBotAction)?
   } else {
@@ -328,7 +328,7 @@ pub fn check_bot_account(person: &Person) -> Result<(), LemmyError> {
 pub fn check_private_instance(
   local_user_view: &Option<LocalUserView>,
   local_site: &LocalSite,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   if local_user_view.is_none() && local_site.private_instance {
     Err(LemmyErrorType::InstanceIsPrivate)?
   } else {
@@ -340,7 +340,7 @@ pub fn check_private_instance(
 pub async fn build_federated_instances(
   local_site: &LocalSite,
   pool: &mut DbPool<'_>,
-) -> Result<Option<FederatedInstances>, LemmyError> {
+) -> LemmyResult<Option<FederatedInstances>> {
   if local_site.federation_enabled {
     let mut linked = Vec::new();
     let mut allowed = Vec::new();
@@ -375,7 +375,7 @@ pub async fn build_federated_instances(
 }
 
 /// Checks the password length
-pub fn password_length_check(pass: &str) -> Result<(), LemmyError> {
+pub fn password_length_check(pass: &str) -> LemmyResult<()> {
   if !(10..=60).contains(&pass.chars().count()) {
     Err(LemmyErrorType::InvalidPassword)?
   } else {
@@ -384,7 +384,7 @@ pub fn password_length_check(pass: &str) -> Result<(), LemmyError> {
 }
 
 /// Checks for a honeypot. If this field is filled, fail the rest of the function
-pub fn honeypot_check(honeypot: &Option<String>) -> Result<(), LemmyError> {
+pub fn honeypot_check(honeypot: &Option<String>) -> LemmyResult<()> {
   if honeypot.is_some() && honeypot != &Some(String::new()) {
     Err(LemmyErrorType::HoneypotFailed)?
   } else {
@@ -422,7 +422,7 @@ pub async fn send_password_reset_email(
   user: &LocalUserView,
   pool: &mut DbPool<'_>,
   settings: &Settings,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   // Generate a random token
   let token = uuid::Uuid::new_v4().to_string();
 
@@ -447,7 +447,7 @@ pub async fn send_verification_email(
   new_email: &str,
   pool: &mut DbPool<'_>,
   settings: &Settings,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   let form = EmailVerificationForm {
     local_user_id: user.local_user.id,
     email: new_email.to_string(),
@@ -564,7 +564,7 @@ pub async fn get_url_blocklist(context: &LemmyContext) -> LemmyResult<RegexSet> 
 pub async fn send_application_approved_email(
   user: &LocalUserView,
   settings: &Settings,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   let email = &user.local_user.email.clone().expect("email");
   let lang = get_interface_language(user);
   let subject = lang.registration_approved_subject(&user.person.actor_id);
@@ -577,7 +577,7 @@ pub async fn send_new_applicant_email_to_admins(
   applicant_username: &str,
   pool: &mut DbPool<'_>,
   settings: &Settings,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   // Collect the admins with emails
   let admins = LocalUserView::list_admins_with_emails(pool).await?;
 
@@ -602,7 +602,7 @@ pub async fn send_new_report_email_to_admins(
   reported_username: &str,
   pool: &mut DbPool<'_>,
   settings: &Settings,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   // Collect the admins with emails
   let admins = LocalUserView::list_admins_with_emails(pool).await?;
 
@@ -618,9 +618,7 @@ pub async fn send_new_report_email_to_admins(
   Ok(())
 }
 
-pub fn check_private_instance_and_federation_enabled(
-  local_site: &LocalSite,
-) -> Result<(), LemmyError> {
+pub fn check_private_instance_and_federation_enabled(local_site: &LocalSite) -> LemmyResult<()> {
   if local_site.private_instance && local_site.federation_enabled {
     Err(LemmyErrorType::CantEnablePrivateInstanceAndFederationTogether)?
   } else {
@@ -634,7 +632,7 @@ pub fn check_private_instance_and_federation_enabled(
 pub async fn read_site_for_actor(
   actor_id: DbUrl,
   context: &LemmyContext,
-) -> Result<Option<Site>, LemmyError> {
+) -> LemmyResult<Option<Site>> {
   let site_id = Site::instance_actor_id_from_url(actor_id.clone().into());
   let site = Site::read_from_apub_id(&mut context.pool(), &site_id.into()).await?;
   Ok(site)
@@ -643,7 +641,7 @@ pub async fn read_site_for_actor(
 pub async fn purge_image_posts_for_person(
   banned_person_id: PersonId,
   context: &LemmyContext,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   let pool = &mut context.pool();
   let posts = Post::fetch_pictrs_posts_for_creator(pool, banned_person_id).await?;
   for post in posts {
@@ -661,10 +659,7 @@ pub async fn purge_image_posts_for_person(
 }
 
 /// Delete a local_user's images
-async fn delete_local_user_images(
-  person_id: PersonId,
-  context: &LemmyContext,
-) -> Result<(), LemmyError> {
+async fn delete_local_user_images(person_id: PersonId, context: &LemmyContext) -> LemmyResult<()> {
   if let Ok(local_user) = LocalUserView::read_person(&mut context.pool(), person_id).await {
     let pictrs_uploads =
       LocalImage::get_all_by_local_user_id(&mut context.pool(), local_user.local_user.id).await?;
@@ -682,7 +677,7 @@ async fn delete_local_user_images(
 pub async fn purge_image_posts_for_community(
   banned_community_id: CommunityId,
   context: &LemmyContext,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   let pool = &mut context.pool();
   let posts = Post::fetch_pictrs_posts_for_community(pool, banned_community_id).await?;
   for post in posts {
@@ -702,7 +697,7 @@ pub async fn purge_image_posts_for_community(
 pub async fn remove_user_data(
   banned_person_id: PersonId,
   context: &LemmyContext,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   let pool = &mut context.pool();
   // Purge user images
   let person = Person::read(pool, banned_person_id).await?;
@@ -785,7 +780,7 @@ pub async fn remove_user_data_in_community(
   community_id: CommunityId,
   banned_person_id: PersonId,
   pool: &mut DbPool<'_>,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   // Posts
   Post::update_removed_for_creator(pool, banned_person_id, Some(community_id), true).await?;
 
@@ -815,10 +810,7 @@ pub async fn remove_user_data_in_community(
   Ok(())
 }
 
-pub async fn purge_user_account(
-  person_id: PersonId,
-  context: &LemmyContext,
-) -> Result<(), LemmyError> {
+pub async fn purge_user_account(person_id: PersonId, context: &LemmyContext) -> LemmyResult<()> {
   let pool = &mut context.pool();
 
   let person = Person::read(pool, person_id).await?;
@@ -888,7 +880,7 @@ pub fn generate_inbox_url(actor_id: &DbUrl) -> Result<DbUrl, ParseError> {
   Ok(Url::parse(&format!("{actor_id}/inbox"))?.into())
 }
 
-pub fn generate_shared_inbox_url(settings: &Settings) -> Result<DbUrl, LemmyError> {
+pub fn generate_shared_inbox_url(settings: &Settings) -> LemmyResult<DbUrl> {
   let url = format!("{}/inbox", settings.get_protocol_and_hostname());
   Ok(Url::parse(&url)?.into())
 }
@@ -901,7 +893,7 @@ pub fn generate_featured_url(actor_id: &DbUrl) -> Result<DbUrl, ParseError> {
   Ok(Url::parse(&format!("{actor_id}/featured"))?.into())
 }
 
-pub fn generate_moderators_url(community_id: &DbUrl) -> Result<DbUrl, LemmyError> {
+pub fn generate_moderators_url(community_id: &DbUrl) -> LemmyResult<DbUrl> {
   Ok(Url::parse(&format!("{community_id}/moderators"))?.into())
 }
 

--- a/crates/api_crud/src/comment/create.rs
+++ b/crates/api_crud/src/comment/create.rs
@@ -30,7 +30,7 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+  error::{LemmyErrorExt, LemmyErrorType, LemmyResult},
   utils::{mention::scrape_text_for_mentions, validation::is_valid_body_field},
 };
 
@@ -41,7 +41,7 @@ pub async fn create_comment(
   data: Json<CreateComment>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<CommentResponse>, LemmyError> {
+) -> LemmyResult<Json<CommentResponse>> {
   let local_site = LocalSite::read(&mut context.pool()).await?;
 
   let slur_regex = local_site_to_slur_regex(&local_site);
@@ -207,7 +207,7 @@ pub async fn create_comment(
   ))
 }
 
-pub fn check_comment_depth(comment: &Comment) -> Result<(), LemmyError> {
+pub fn check_comment_depth(comment: &Comment) -> LemmyResult<()> {
   let path = &comment.path.0;
   let length = path.split('.').count();
   if length > MAX_COMMENT_DEPTH_LIMIT {

--- a/crates/api_crud/src/comment/delete.rs
+++ b/crates/api_crud/src/comment/delete.rs
@@ -12,14 +12,14 @@ use lemmy_db_schema::{
   traits::Crud,
 };
 use lemmy_db_views::structs::{CommentView, LocalUserView};
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn delete_comment(
   data: Json<DeleteComment>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<CommentResponse>, LemmyError> {
+) -> LemmyResult<Json<CommentResponse>> {
   let comment_id = data.comment_id;
   let orig_comment = CommentView::read(&mut context.pool(), comment_id, None).await?;
 

--- a/crates/api_crud/src/comment/read.rs
+++ b/crates/api_crud/src/comment/read.rs
@@ -7,14 +7,14 @@ use lemmy_api_common::{
 };
 use lemmy_db_schema::source::local_site::LocalSite;
 use lemmy_db_views::structs::LocalUserView;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 #[tracing::instrument(skip(context))]
 pub async fn get_comment(
   data: Query<GetComment>,
   context: Data<LemmyContext>,
   local_user_view: Option<LocalUserView>,
-) -> Result<Json<CommentResponse>, LemmyError> {
+) -> LemmyResult<Json<CommentResponse>> {
   let local_site = LocalSite::read(&mut context.pool()).await?;
 
   check_private_instance(&local_user_view, &local_site)?;

--- a/crates/api_crud/src/comment/remove.rs
+++ b/crates/api_crud/src/comment/remove.rs
@@ -16,14 +16,14 @@ use lemmy_db_schema::{
   traits::{Crud, Reportable},
 };
 use lemmy_db_views::structs::{CommentView, LocalUserView};
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn remove_comment(
   data: Json<RemoveComment>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<CommentResponse>, LemmyError> {
+) -> LemmyResult<Json<CommentResponse>> {
   let comment_id = data.comment_id;
   let orig_comment = CommentView::read(&mut context.pool(), comment_id, None).await?;
 

--- a/crates/api_crud/src/comment/update.rs
+++ b/crates/api_crud/src/comment/update.rs
@@ -23,7 +23,7 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views::structs::{CommentView, LocalUserView};
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+  error::{LemmyErrorExt, LemmyErrorType, LemmyResult},
   utils::{mention::scrape_text_for_mentions, validation::is_valid_body_field},
 };
 
@@ -32,7 +32,7 @@ pub async fn update_comment(
   data: Json<EditComment>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<CommentResponse>, LemmyError> {
+) -> LemmyResult<Json<CommentResponse>> {
   let local_site = LocalSite::read(&mut context.pool()).await?;
 
   let comment_id = data.comment_id;

--- a/crates/api_crud/src/community/create.rs
+++ b/crates/api_crud/src/community/create.rs
@@ -33,7 +33,7 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views::structs::{LocalUserView, SiteView};
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+  error::{LemmyErrorExt, LemmyErrorType, LemmyResult},
   utils::{
     slurs::check_slurs,
     validation::{is_valid_actor_name, is_valid_body_field},
@@ -45,7 +45,7 @@ pub async fn create_community(
   data: Json<CreateCommunity>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<CommunityResponse>, LemmyError> {
+) -> LemmyResult<Json<CommunityResponse>> {
   let site_view = SiteView::read_local(&mut context.pool()).await?;
   let local_site = site_view.local_site;
 

--- a/crates/api_crud/src/community/delete.rs
+++ b/crates/api_crud/src/community/delete.rs
@@ -13,14 +13,14 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_db_views_actor::structs::CommunityModeratorView;
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn delete_community(
   data: Json<DeleteCommunity>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<CommunityResponse>, LemmyError> {
+) -> LemmyResult<Json<CommunityResponse>> {
   // Fetch the community mods
   let community_id = data.community_id;
   let community_mods =

--- a/crates/api_crud/src/community/list.rs
+++ b/crates/api_crud/src/community/list.rs
@@ -6,14 +6,14 @@ use lemmy_api_common::{
 };
 use lemmy_db_views::structs::{LocalUserView, SiteView};
 use lemmy_db_views_actor::community_view::CommunityQuery;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 #[tracing::instrument(skip(context))]
 pub async fn list_communities(
   data: Query<ListCommunities>,
   context: Data<LemmyContext>,
   local_user_view: Option<LocalUserView>,
-) -> Result<Json<ListCommunitiesResponse>, LemmyError> {
+) -> LemmyResult<Json<ListCommunitiesResponse>> {
   let local_site = SiteView::read_local(&mut context.pool()).await?;
   let is_admin = local_user_view
     .as_ref()

--- a/crates/api_crud/src/community/remove.rs
+++ b/crates/api_crud/src/community/remove.rs
@@ -15,14 +15,14 @@ use lemmy_db_schema::{
   traits::Crud,
 };
 use lemmy_db_views::structs::LocalUserView;
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn remove_community(
   data: Json<RemoveCommunity>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<CommunityResponse>, LemmyError> {
+) -> LemmyResult<Json<CommunityResponse>> {
   check_community_mod_action(
     &local_user_view.person,
     data.community_id,

--- a/crates/api_crud/src/community/update.rs
+++ b/crates/api_crud/src/community/update.rs
@@ -25,7 +25,7 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+  error::{LemmyErrorExt, LemmyErrorType, LemmyResult},
   utils::{slurs::check_slurs_opt, validation::is_valid_body_field},
 };
 
@@ -34,7 +34,7 @@ pub async fn update_community(
   data: Json<EditCommunity>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<CommunityResponse>, LemmyError> {
+) -> LemmyResult<Json<CommunityResponse>> {
   let local_site = LocalSite::read(&mut context.pool()).await?;
 
   let slur_regex = local_site_to_slur_regex(&local_site);

--- a/crates/api_crud/src/custom_emoji/create.rs
+++ b/crates/api_crud/src/custom_emoji/create.rs
@@ -11,14 +11,14 @@ use lemmy_db_schema::source::{
   local_site::LocalSite,
 };
 use lemmy_db_views::structs::{CustomEmojiView, LocalUserView};
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 #[tracing::instrument(skip(context))]
 pub async fn create_custom_emoji(
   data: Json<CreateCustomEmoji>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<CustomEmojiResponse>, LemmyError> {
+) -> LemmyResult<Json<CustomEmojiResponse>> {
   let local_site = LocalSite::read(&mut context.pool()).await?;
   // Make sure user is an admin
   is_admin(&local_user_view)?;

--- a/crates/api_crud/src/custom_emoji/delete.rs
+++ b/crates/api_crud/src/custom_emoji/delete.rs
@@ -8,14 +8,14 @@ use lemmy_api_common::{
 };
 use lemmy_db_schema::source::custom_emoji::CustomEmoji;
 use lemmy_db_views::structs::LocalUserView;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 #[tracing::instrument(skip(context))]
 pub async fn delete_custom_emoji(
   data: Json<DeleteCustomEmoji>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<SuccessResponse>, LemmyError> {
+) -> LemmyResult<Json<SuccessResponse>> {
   // Make sure user is an admin
   is_admin(&local_user_view)?;
 

--- a/crates/api_crud/src/custom_emoji/update.rs
+++ b/crates/api_crud/src/custom_emoji/update.rs
@@ -11,14 +11,14 @@ use lemmy_db_schema::source::{
   local_site::LocalSite,
 };
 use lemmy_db_views::structs::{CustomEmojiView, LocalUserView};
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 #[tracing::instrument(skip(context))]
 pub async fn update_custom_emoji(
   data: Json<EditCustomEmoji>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<CustomEmojiResponse>, LemmyError> {
+) -> LemmyResult<Json<CustomEmojiResponse>> {
   let local_site = LocalSite::read(&mut context.pool()).await?;
   // Make sure user is an admin
   is_admin(&local_user_view)?;

--- a/crates/api_crud/src/post/create.rs
+++ b/crates/api_crud/src/post/create.rs
@@ -32,7 +32,7 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_db_views_actor::structs::CommunityModeratorView;
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+  error::{LemmyErrorExt, LemmyErrorType, LemmyResult},
   spawn_try_task,
   utils::{
     slurs::check_slurs,
@@ -55,7 +55,7 @@ pub async fn create_post(
   data: Json<CreatePost>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<PostResponse>, LemmyError> {
+) -> LemmyResult<Json<PostResponse>> {
   let local_site = LocalSite::read(&mut context.pool()).await?;
 
   honeypot_check(&data.honeypot)?;

--- a/crates/api_crud/src/post/delete.rs
+++ b/crates/api_crud/src/post/delete.rs
@@ -12,14 +12,14 @@ use lemmy_db_schema::{
   traits::Crud,
 };
 use lemmy_db_views::structs::LocalUserView;
-use lemmy_utils::error::{LemmyError, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn delete_post(
   data: Json<DeletePost>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<PostResponse>, LemmyError> {
+) -> LemmyResult<Json<PostResponse>> {
   let post_id = data.post_id;
   let orig_post = Post::read(&mut context.pool(), post_id).await?;
 

--- a/crates/api_crud/src/post/read.rs
+++ b/crates/api_crud/src/post/read.rs
@@ -14,14 +14,14 @@ use lemmy_db_views::{
   structs::{LocalUserView, PostView, SiteView},
 };
 use lemmy_db_views_actor::structs::{CommunityModeratorView, CommunityView};
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn get_post(
   data: Query<GetPost>,
   context: Data<LemmyContext>,
   local_user_view: Option<LocalUserView>,
-) -> Result<Json<GetPostResponse>, LemmyError> {
+) -> LemmyResult<Json<GetPostResponse>> {
   let local_site = SiteView::read_local(&mut context.pool()).await?;
 
   check_private_instance(&local_user_view, &local_site.local_site)?;

--- a/crates/api_crud/src/post/remove.rs
+++ b/crates/api_crud/src/post/remove.rs
@@ -16,14 +16,14 @@ use lemmy_db_schema::{
   traits::{Crud, Reportable},
 };
 use lemmy_db_views::structs::LocalUserView;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 #[tracing::instrument(skip(context))]
 pub async fn remove_post(
   data: Json<RemovePost>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<PostResponse>, LemmyError> {
+) -> LemmyResult<Json<PostResponse>> {
   let post_id = data.post_id;
   let orig_post = Post::read(&mut context.pool(), post_id).await?;
 

--- a/crates/api_crud/src/post/update.rs
+++ b/crates/api_crud/src/post/update.rs
@@ -25,7 +25,7 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+  error::{LemmyErrorExt, LemmyErrorType, LemmyResult},
   utils::{
     slurs::check_slurs_opt,
     validation::{
@@ -45,7 +45,7 @@ pub async fn update_post(
   data: Json<EditPost>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<PostResponse>, LemmyError> {
+) -> LemmyResult<Json<PostResponse>> {
   let local_site = LocalSite::read(&mut context.pool()).await?;
 
   // TODO No good way to handle a clear.

--- a/crates/api_crud/src/private_message/create.rs
+++ b/crates/api_crud/src/private_message/create.rs
@@ -24,7 +24,7 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views::structs::{LocalUserView, PrivateMessageView};
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+  error::{LemmyErrorExt, LemmyErrorType, LemmyResult},
   utils::{markdown::markdown_to_html, validation::is_valid_body_field},
 };
 
@@ -33,7 +33,7 @@ pub async fn create_private_message(
   data: Json<CreatePrivateMessage>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<PrivateMessageResponse>, LemmyError> {
+) -> LemmyResult<Json<PrivateMessageResponse>> {
   let local_site = LocalSite::read(&mut context.pool()).await?;
 
   let slur_regex = local_site_to_slur_regex(&local_site);

--- a/crates/api_crud/src/private_message/delete.rs
+++ b/crates/api_crud/src/private_message/delete.rs
@@ -10,14 +10,14 @@ use lemmy_db_schema::{
   traits::Crud,
 };
 use lemmy_db_views::structs::{LocalUserView, PrivateMessageView};
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn delete_private_message(
   data: Json<DeletePrivateMessage>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<PrivateMessageResponse>, LemmyError> {
+) -> LemmyResult<Json<PrivateMessageResponse>> {
   // Checking permissions
   let private_message_id = data.private_message_id;
   let orig_private_message = PrivateMessage::read(&mut context.pool(), private_message_id).await?;

--- a/crates/api_crud/src/private_message/read.rs
+++ b/crates/api_crud/src/private_message/read.rs
@@ -4,14 +4,14 @@ use lemmy_api_common::{
   private_message::{GetPrivateMessages, PrivateMessagesResponse},
 };
 use lemmy_db_views::{private_message_view::PrivateMessageQuery, structs::LocalUserView};
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 #[tracing::instrument(skip(context))]
 pub async fn get_private_message(
   data: Query<GetPrivateMessages>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<PrivateMessagesResponse>, LemmyError> {
+) -> LemmyResult<Json<PrivateMessagesResponse>> {
   let person_id = local_user_view.person.id;
 
   let page = data.page;

--- a/crates/api_crud/src/private_message/update.rs
+++ b/crates/api_crud/src/private_message/update.rs
@@ -16,7 +16,7 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views::structs::{LocalUserView, PrivateMessageView};
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+  error::{LemmyErrorExt, LemmyErrorType, LemmyResult},
   utils::validation::is_valid_body_field,
 };
 
@@ -25,7 +25,7 @@ pub async fn update_private_message(
   data: Json<EditPrivateMessage>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<PrivateMessageResponse>, LemmyError> {
+) -> LemmyResult<Json<PrivateMessageResponse>> {
   let local_site = LocalSite::read(&mut context.pool()).await?;
 
   // Checking permissions

--- a/crates/api_crud/src/site/create.rs
+++ b/crates/api_crud/src/site/create.rs
@@ -27,7 +27,7 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views::structs::{LocalUserView, SiteView};
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorType, LemmyResult},
+  error::{LemmyErrorType, LemmyResult},
   utils::{
     slurs::{check_slurs, check_slurs_opt},
     validation::{
@@ -46,7 +46,7 @@ pub async fn create_site(
   data: Json<CreateSite>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<SiteResponse>, LemmyError> {
+) -> LemmyResult<Json<SiteResponse>> {
   let local_site = LocalSite::read(&mut context.pool()).await?;
 
   // Make sure user is an admin; other types of users should not create site data...

--- a/crates/api_crud/src/site/read.rs
+++ b/crates/api_crud/src/site/read.rs
@@ -19,7 +19,7 @@ use lemmy_db_views_actor::structs::{
   PersonView,
 };
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+  error::{LemmyError, LemmyErrorExt, LemmyErrorType, LemmyResult},
   CACHE_DURATION_API,
   VERSION,
 };
@@ -30,7 +30,7 @@ use once_cell::sync::Lazy;
 pub async fn get_site(
   local_user_view: Option<LocalUserView>,
   context: Data<LemmyContext>,
-) -> Result<Json<GetSiteResponse>, LemmyError> {
+) -> LemmyResult<Json<GetSiteResponse>> {
   static CACHE: Lazy<Cache<(), GetSiteResponse>> = Lazy::new(|| {
     Cache::builder()
       .max_capacity(1)

--- a/crates/api_crud/src/site/update.rs
+++ b/crates/api_crud/src/site/update.rs
@@ -32,7 +32,7 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views::structs::{LocalUserView, SiteView};
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType, LemmyResult},
+  error::{LemmyErrorExt, LemmyErrorType, LemmyResult},
   utils::{
     slurs::check_slurs_opt,
     validation::{
@@ -51,7 +51,7 @@ pub async fn update_site(
   data: Json<EditSite>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> Result<Json<SiteResponse>, LemmyError> {
+) -> LemmyResult<Json<SiteResponse>> {
   let site_view = SiteView::read_local(&mut context.pool()).await?;
   let local_site = site_view.local_site;
   let site = site_view.site;

--- a/crates/api_crud/src/user/create.rs
+++ b/crates/api_crud/src/user/create.rs
@@ -31,7 +31,7 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views::structs::{LocalUserView, SiteView};
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+  error::{LemmyErrorExt, LemmyErrorType, LemmyResult},
   utils::{
     slurs::{check_slurs, check_slurs_opt},
     validation::is_valid_actor_name,
@@ -44,7 +44,7 @@ pub async fn register(
   data: Json<Register>,
   req: HttpRequest,
   context: Data<LemmyContext>,
-) -> Result<Json<LoginResponse>, LemmyError> {
+) -> LemmyResult<Json<LoginResponse>> {
   let site_view = SiteView::read_local(&mut context.pool()).await?;
   let local_site = site_view.local_site;
   let require_registration_application =

--- a/crates/apub/src/activities/block/block_user.rs
+++ b/crates/apub/src/activities/block/block_user.rs
@@ -39,7 +39,7 @@ use lemmy_db_schema::{
   },
   traits::{Bannable, Crud, Followable},
 };
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::{LemmyError, LemmyResult};
 use url::Url;
 
 impl BlockUser {
@@ -51,7 +51,7 @@ impl BlockUser {
     reason: Option<String>,
     expires: Option<DateTime<Utc>>,
     context: &Data<LemmyContext>,
-  ) -> Result<BlockUser, LemmyError> {
+  ) -> LemmyResult<BlockUser> {
     let audience = if let SiteOrCommunity::Community(c) = target {
       Some(c.id().into())
     } else {
@@ -85,7 +85,7 @@ impl BlockUser {
     reason: Option<String>,
     expires: Option<DateTime<Utc>>,
     context: &Data<LemmyContext>,
-  ) -> Result<(), LemmyError> {
+  ) -> LemmyResult<()> {
     let block = BlockUser::new(
       target,
       user,
@@ -125,7 +125,7 @@ impl ActivityHandler for BlockUser {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+  async fn verify(&self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     verify_is_public(&self.to, &self.cc)?;
     match self.target.dereference(context).await? {
       SiteOrCommunity::Site(site) => {
@@ -148,7 +148,7 @@ impl ActivityHandler for BlockUser {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+  async fn receive(self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     let expires = self.expires.or(self.end_time).map(Into::into);
     let mod_person = self.actor.dereference(context).await?;

--- a/crates/apub/src/activities/block/mod.rs
+++ b/crates/apub/src/activities/block/mod.rs
@@ -58,10 +58,7 @@ impl Object for SiteOrCommunity {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn read_from_id(
-    object_id: Url,
-    data: &Data<Self::DataType>,
-  ) -> Result<Option<Self>, LemmyError>
+  async fn read_from_id(object_id: Url, data: &Data<Self::DataType>) -> LemmyResult<Option<Self>>
   where
     Self: Sized,
   {
@@ -74,11 +71,11 @@ impl Object for SiteOrCommunity {
     })
   }
 
-  async fn delete(self, _data: &Data<Self::DataType>) -> Result<(), LemmyError> {
+  async fn delete(self, _data: &Data<Self::DataType>) -> LemmyResult<()> {
     unimplemented!()
   }
 
-  async fn into_json(self, _data: &Data<Self::DataType>) -> Result<Self::Kind, LemmyError> {
+  async fn into_json(self, _data: &Data<Self::DataType>) -> LemmyResult<Self::Kind> {
     unimplemented!()
   }
 
@@ -87,7 +84,7 @@ impl Object for SiteOrCommunity {
     apub: &Self::Kind,
     expected_domain: &Url,
     data: &Data<Self::DataType>,
-  ) -> Result<(), LemmyError> {
+  ) -> LemmyResult<()> {
     match apub {
       InstanceOrGroup::Instance(i) => ApubSite::verify(i, expected_domain, data).await,
       InstanceOrGroup::Group(g) => ApubCommunity::verify(g, expected_domain, data).await,
@@ -95,7 +92,7 @@ impl Object for SiteOrCommunity {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn from_json(apub: Self::Kind, data: &Data<Self::DataType>) -> Result<Self, LemmyError>
+  async fn from_json(apub: Self::Kind, data: &Data<Self::DataType>) -> LemmyResult<Self>
   where
     Self: Sized,
   {
@@ -117,10 +114,7 @@ impl SiteOrCommunity {
   }
 }
 
-async fn generate_cc(
-  target: &SiteOrCommunity,
-  pool: &mut DbPool<'_>,
-) -> Result<Vec<Url>, LemmyError> {
+async fn generate_cc(target: &SiteOrCommunity, pool: &mut DbPool<'_>) -> LemmyResult<Vec<Url>> {
   Ok(match target {
     SiteOrCommunity::Site(_) => Site::read_remote_sites(pool)
       .await?
@@ -139,7 +133,7 @@ pub(crate) async fn send_ban_from_site(
   ban: bool,
   expires: Option<i64>,
   context: Data<LemmyContext>,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   let site = SiteOrCommunity::Site(SiteView::read_local(&mut context.pool()).await?.site.into());
   let expires = check_expire_time(expires)?;
 

--- a/crates/apub/src/activities/block/undo_block_user.rs
+++ b/crates/apub/src/activities/block/undo_block_user.rs
@@ -27,7 +27,7 @@ use lemmy_db_schema::{
   },
   traits::{Bannable, Crud},
 };
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::{LemmyError, LemmyResult};
 use url::Url;
 
 impl UndoBlockUser {
@@ -38,7 +38,7 @@ impl UndoBlockUser {
     mod_: &ApubPerson,
     reason: Option<String>,
     context: &Data<LemmyContext>,
-  ) -> Result<(), LemmyError> {
+  ) -> LemmyResult<()> {
     let block = BlockUser::new(target, user, mod_, None, reason, None, context).await?;
     let audience = if let SiteOrCommunity::Community(c) = target {
       Some(c.id().into())
@@ -88,7 +88,7 @@ impl ActivityHandler for UndoBlockUser {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+  async fn verify(&self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     verify_is_public(&self.to, &self.cc)?;
     verify_domains_match(self.actor.inner(), self.object.actor.inner())?;
     self.object.verify(context).await?;
@@ -96,7 +96,7 @@ impl ActivityHandler for UndoBlockUser {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+  async fn receive(self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     let expires = self.object.expires.or(self.object.end_time).map(Into::into);
     let mod_person = self.actor.dereference(context).await?;

--- a/crates/apub/src/activities/community/announce.rs
+++ b/crates/apub/src/activities/community/announce.rs
@@ -82,7 +82,7 @@ impl AnnounceActivity {
     object: RawAnnouncableActivities,
     community: &ApubCommunity,
     context: &Data<LemmyContext>,
-  ) -> Result<AnnounceActivity, LemmyError> {
+  ) -> LemmyResult<AnnounceActivity> {
     let inner_kind = object
       .other
       .get("type")
@@ -105,7 +105,7 @@ impl AnnounceActivity {
     object: RawAnnouncableActivities,
     community: &ApubCommunity,
     context: &Data<LemmyContext>,
-  ) -> Result<(), LemmyError> {
+  ) -> LemmyResult<()> {
     let announce = AnnounceActivity::new(object.clone(), community, context)?;
     let inboxes = ActivitySendTargets::to_local_community_followers(community.id);
     send_lemmy_activity(context, announce, community, inboxes.clone(), false).await?;
@@ -148,13 +148,13 @@ impl ActivityHandler for AnnounceActivity {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn verify(&self, _context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+  async fn verify(&self, _context: &Data<Self::DataType>) -> LemmyResult<()> {
     verify_is_public(&self.to, &self.cc)?;
     Ok(())
   }
 
   #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+  async fn receive(self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     let object: AnnouncableActivities = self.object.object(context).await?.try_into()?;
 

--- a/crates/apub/src/activities/community/collection_add.rs
+++ b/crates/apub/src/activities/community/collection_add.rs
@@ -36,7 +36,7 @@ use lemmy_db_schema::{
   },
   traits::{Crud, Joinable},
 };
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::{LemmyError, LemmyResult};
 use url::Url;
 
 impl CollectionAdd {
@@ -46,7 +46,7 @@ impl CollectionAdd {
     added_mod: &ApubPerson,
     actor: &ApubPerson,
     context: &Data<LemmyContext>,
-  ) -> Result<(), LemmyError> {
+  ) -> LemmyResult<()> {
     let id = generate_activity_id(
       AddType::Add,
       &context.settings().get_protocol_and_hostname(),
@@ -72,7 +72,7 @@ impl CollectionAdd {
     featured_post: &ApubPost,
     actor: &ApubPerson,
     context: &Data<LemmyContext>,
-  ) -> Result<(), LemmyError> {
+  ) -> LemmyResult<()> {
     let id = generate_activity_id(
       AddType::Add,
       &context.settings().get_protocol_and_hostname(),
@@ -114,7 +114,7 @@ impl ActivityHandler for CollectionAdd {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+  async fn verify(&self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     verify_is_public(&self.to, &self.cc)?;
     let community = self.community(context).await?;
     verify_person_in_community(&self.actor, &community, context).await?;
@@ -123,7 +123,7 @@ impl ActivityHandler for CollectionAdd {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+  async fn receive(self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     let (community, collection_type) =
       Community::get_by_collection_url(&mut context.pool(), &self.target.into()).await?;
@@ -179,7 +179,7 @@ pub(crate) async fn send_add_mod_to_community(
   updated_mod_id: PersonId,
   added: bool,
   context: Data<LemmyContext>,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   let actor: ApubPerson = actor.into();
   let community: ApubCommunity = Community::read(&mut context.pool(), community_id)
     .await?
@@ -199,7 +199,7 @@ pub(crate) async fn send_feature_post(
   actor: Person,
   featured: bool,
   context: Data<LemmyContext>,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   let actor: ApubPerson = actor.into();
   let post: ApubPost = post.into();
   let community = Community::read(&mut context.pool(), post.community_id)

--- a/crates/apub/src/activities/community/collection_remove.rs
+++ b/crates/apub/src/activities/community/collection_remove.rs
@@ -31,7 +31,7 @@ use lemmy_db_schema::{
   },
   traits::{Crud, Joinable},
 };
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::{LemmyError, LemmyResult};
 use url::Url;
 
 impl CollectionRemove {
@@ -41,7 +41,7 @@ impl CollectionRemove {
     removed_mod: &ApubPerson,
     actor: &ApubPerson,
     context: &Data<LemmyContext>,
-  ) -> Result<(), LemmyError> {
+  ) -> LemmyResult<()> {
     let id = generate_activity_id(
       RemoveType::Remove,
       &context.settings().get_protocol_and_hostname(),
@@ -67,7 +67,7 @@ impl CollectionRemove {
     featured_post: &ApubPost,
     actor: &ApubPerson,
     context: &Data<LemmyContext>,
-  ) -> Result<(), LemmyError> {
+  ) -> LemmyResult<()> {
     let id = generate_activity_id(
       RemoveType::Remove,
       &context.settings().get_protocol_and_hostname(),
@@ -109,7 +109,7 @@ impl ActivityHandler for CollectionRemove {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+  async fn verify(&self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     verify_is_public(&self.to, &self.cc)?;
     let community = self.community(context).await?;
     verify_person_in_community(&self.actor, &community, context).await?;
@@ -118,7 +118,7 @@ impl ActivityHandler for CollectionRemove {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+  async fn receive(self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     let (community, collection_type) =
       Community::get_by_collection_url(&mut context.pool(), &self.target.into()).await?;

--- a/crates/apub/src/activities/community/lock_page.rs
+++ b/crates/apub/src/activities/community/lock_page.rs
@@ -31,7 +31,7 @@ use lemmy_db_schema::{
   },
   traits::Crud,
 };
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::{LemmyError, LemmyResult};
 use url::Url;
 
 #[async_trait::async_trait]
@@ -106,7 +106,7 @@ pub(crate) async fn send_lock_post(
   actor: Person,
   locked: bool,
   context: Data<LemmyContext>,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   let community: ApubCommunity = Community::read(&mut context.pool(), post.community_id)
     .await?
     .into();

--- a/crates/apub/src/activities/community/mod.rs
+++ b/crates/apub/src/activities/community/mod.rs
@@ -10,7 +10,7 @@ use lemmy_db_schema::{
   source::{activity::ActivitySendTargets, person::PersonFollower},
   CommunityVisibility,
 };
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 pub mod announce;
 pub mod collection_add;
@@ -39,7 +39,7 @@ pub(crate) async fn send_activity_in_community(
   extra_inboxes: ActivitySendTargets,
   is_mod_action: bool,
   context: &Data<LemmyContext>,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   // If community is local only, don't send anything out
   if community.visibility != CommunityVisibility::Public {
     return Ok(());

--- a/crates/apub/src/activities/community/report.rs
+++ b/crates/apub/src/activities/community/report.rs
@@ -29,7 +29,7 @@ use lemmy_db_schema::{
   },
   traits::{Crud, Reportable},
 };
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::{LemmyError, LemmyResult};
 use url::Url;
 
 impl Report {
@@ -40,7 +40,7 @@ impl Report {
     community: Community,
     reason: String,
     context: Data<LemmyContext>,
-  ) -> Result<(), LemmyError> {
+  ) -> LemmyResult<()> {
     let actor: ApubPerson = actor.into();
     let community: ApubCommunity = community.into();
     let kind = FlagType::Flag;
@@ -94,14 +94,14 @@ impl ActivityHandler for Report {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+  async fn verify(&self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     let community = self.community(context).await?;
     verify_person_in_community(&self.actor, &community, context).await?;
     Ok(())
   }
 
   #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+  async fn receive(self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     let actor = self.actor.dereference(context).await?;
     let reason = self.reason()?;

--- a/crates/apub/src/activities/community/update.rs
+++ b/crates/apub/src/activities/community/update.rs
@@ -26,14 +26,14 @@ use lemmy_db_schema::{
   traits::Crud,
   utils::naive_now,
 };
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::{LemmyError, LemmyResult};
 use url::Url;
 
 pub(crate) async fn send_update_community(
   community: Community,
   actor: Person,
   context: Data<LemmyContext>,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   let community: ApubCommunity = community.into();
   let actor: ApubPerson = actor.into();
   let id = generate_activity_id(
@@ -76,7 +76,7 @@ impl ActivityHandler for UpdateCommunity {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+  async fn verify(&self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     verify_is_public(&self.to, &self.cc)?;
     let community = self.community(context).await?;
     verify_person_in_community(&self.actor, &community, context).await?;
@@ -86,7 +86,7 @@ impl ActivityHandler for UpdateCommunity {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+  async fn receive(self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     let community = self.community(context).await?;
 

--- a/crates/apub/src/activities/create_or_update/comment.rs
+++ b/crates/apub/src/activities/create_or_update/comment.rs
@@ -39,7 +39,10 @@ use lemmy_db_schema::{
   },
   traits::{Crud, Likeable},
 };
-use lemmy_utils::{error::LemmyError, utils::mention::scrape_text_for_mentions};
+use lemmy_utils::{
+  error::{LemmyError, LemmyResult},
+  utils::mention::scrape_text_for_mentions,
+};
 use url::Url;
 
 impl CreateOrUpdateNote {
@@ -49,7 +52,7 @@ impl CreateOrUpdateNote {
     person_id: PersonId,
     kind: CreateOrUpdateType,
     context: Data<LemmyContext>,
-  ) -> Result<(), LemmyError> {
+  ) -> LemmyResult<()> {
     // TODO: might be helpful to add a comment method to retrieve community directly
     let post_id = comment.post_id;
     let post = Post::read(&mut context.pool(), post_id).await?;
@@ -114,7 +117,7 @@ impl ActivityHandler for CreateOrUpdateNote {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+  async fn verify(&self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     verify_is_public(&self.to, &self.cc)?;
     let post = self.object.get_parents(context).await?.0;
     let community = self.community(context).await?;
@@ -129,7 +132,7 @@ impl ActivityHandler for CreateOrUpdateNote {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+  async fn receive(self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     // Need to do this check here instead of Note::from_json because we need the person who
     // send the activity, not the comment author.

--- a/crates/apub/src/activities/create_or_update/post.rs
+++ b/crates/apub/src/activities/create_or_update/post.rs
@@ -33,7 +33,7 @@ use lemmy_db_schema::{
   },
   traits::{Crud, Likeable},
 };
-use lemmy_utils::error::{LemmyError, LemmyErrorType};
+use lemmy_utils::error::{LemmyError, LemmyErrorType, LemmyResult};
 use url::Url;
 
 impl CreateOrUpdatePage {
@@ -43,7 +43,7 @@ impl CreateOrUpdatePage {
     community: &ApubCommunity,
     kind: CreateOrUpdateType,
     context: &Data<LemmyContext>,
-  ) -> Result<CreateOrUpdatePage, LemmyError> {
+  ) -> LemmyResult<CreateOrUpdatePage> {
     let id = generate_activity_id(
       kind.clone(),
       &context.settings().get_protocol_and_hostname(),
@@ -65,7 +65,7 @@ impl CreateOrUpdatePage {
     person_id: PersonId,
     kind: CreateOrUpdateType,
     context: Data<LemmyContext>,
-  ) -> Result<(), LemmyError> {
+  ) -> LemmyResult<()> {
     let post = ApubPost(post);
     let community_id = post.community_id;
     let person: ApubPerson = Person::read(&mut context.pool(), person_id).await?.into();
@@ -104,7 +104,7 @@ impl ActivityHandler for CreateOrUpdatePage {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+  async fn verify(&self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     verify_is_public(&self.to, &self.cc)?;
     let community = self.community(context).await?;
     verify_person_in_community(&self.actor, &community, context).await?;
@@ -138,7 +138,7 @@ impl ActivityHandler for CreateOrUpdatePage {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+  async fn receive(self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     let post = ApubPost::from_json(self.object, context).await?;
 

--- a/crates/apub/src/activities/create_or_update/private_message.rs
+++ b/crates/apub/src/activities/create_or_update/private_message.rs
@@ -15,14 +15,14 @@ use activitypub_federation::{
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::source::activity::ActivitySendTargets;
 use lemmy_db_views::structs::PrivateMessageView;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::{LemmyError, LemmyResult};
 use url::Url;
 
 pub(crate) async fn send_create_or_update_pm(
   pm_view: PrivateMessageView,
   kind: CreateOrUpdateType,
   context: Data<LemmyContext>,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   let actor: ApubPerson = pm_view.creator.into();
   let recipient: ApubPerson = pm_view.recipient.into();
 
@@ -57,7 +57,7 @@ impl ActivityHandler for CreateOrUpdateChatMessage {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+  async fn verify(&self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     verify_person(&self.actor, context).await?;
     verify_domains_match(self.actor.inner(), self.object.id.inner())?;
     verify_domains_match(self.to[0].inner(), self.object.to[0].inner())?;
@@ -66,7 +66,7 @@ impl ActivityHandler for CreateOrUpdateChatMessage {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+  async fn receive(self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     ApubPrivateMessage::from_json(self.object, context).await?;
     Ok(())

--- a/crates/apub/src/activities/deletion/undo_delete.rs
+++ b/crates/apub/src/activities/deletion/undo_delete.rs
@@ -25,7 +25,7 @@ use lemmy_db_schema::{
   },
   traits::Crud,
 };
-use lemmy_utils::error::{LemmyError, LemmyErrorType};
+use lemmy_utils::error::{LemmyError, LemmyErrorType, LemmyResult};
 use url::Url;
 
 #[async_trait::async_trait]
@@ -48,7 +48,7 @@ impl ActivityHandler for UndoDelete {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+  async fn receive(self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     if self.object.summary.is_some() {
       UndoDelete::receive_undo_remove_action(
@@ -72,7 +72,7 @@ impl UndoDelete {
     community: Option<&Community>,
     summary: Option<String>,
     context: &Data<LemmyContext>,
-  ) -> Result<UndoDelete, LemmyError> {
+  ) -> LemmyResult<UndoDelete> {
     let object = Delete::new(actor, object, to.clone(), community, summary, context)?;
 
     let id = generate_activity_id(
@@ -96,7 +96,7 @@ impl UndoDelete {
     actor: &ApubPerson,
     object: &Url,
     context: &Data<LemmyContext>,
-  ) -> Result<(), LemmyError> {
+  ) -> LemmyResult<()> {
     match DeletableObjects::read_from_db(object, context).await? {
       DeletableObjects::Community(community) => {
         if community.local {

--- a/crates/apub/src/activities/following/accept.rs
+++ b/crates/apub/src/activities/following/accept.rs
@@ -14,12 +14,12 @@ use lemmy_db_schema::{
   source::{activity::ActivitySendTargets, community::CommunityFollower},
   traits::Followable,
 };
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::{LemmyError, LemmyResult};
 use url::Url;
 
 impl AcceptFollow {
   #[tracing::instrument(skip_all)]
-  pub async fn send(follow: Follow, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+  pub async fn send(follow: Follow, context: &Data<LemmyContext>) -> LemmyResult<()> {
     let user_or_community = follow.object.dereference_local(context).await?;
     let person = follow.actor.clone().dereference(context).await?;
     let accept = AcceptFollow {
@@ -52,7 +52,7 @@ impl ActivityHandler for AcceptFollow {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+  async fn verify(&self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     verify_urls_match(self.actor.inner(), self.object.object.inner())?;
     self.object.verify(context).await?;
     if let Some(to) = &self.to {
@@ -62,7 +62,7 @@ impl ActivityHandler for AcceptFollow {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+  async fn receive(self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     let community = self.actor.dereference(context).await?;
     let person = self.object.actor.dereference(context).await?;

--- a/crates/apub/src/activities/following/follow.rs
+++ b/crates/apub/src/activities/following/follow.rs
@@ -26,7 +26,7 @@ use lemmy_db_schema::{
   traits::Followable,
   CommunityVisibility,
 };
-use lemmy_utils::error::{LemmyError, LemmyErrorType};
+use lemmy_utils::error::{LemmyError, LemmyErrorType, LemmyResult};
 use url::Url;
 
 impl Follow {
@@ -34,7 +34,7 @@ impl Follow {
     actor: &ApubPerson,
     community: &ApubCommunity,
     context: &Data<LemmyContext>,
-  ) -> Result<Follow, LemmyError> {
+  ) -> LemmyResult<Follow> {
     Ok(Follow {
       actor: actor.id().into(),
       object: community.id().into(),
@@ -52,7 +52,7 @@ impl Follow {
     actor: &ApubPerson,
     community: &ApubCommunity,
     context: &Data<LemmyContext>,
-  ) -> Result<(), LemmyError> {
+  ) -> LemmyResult<()> {
     let follow = Follow::new(actor, community, context)?;
     let inbox = if community.local {
       ActivitySendTargets::empty()
@@ -77,7 +77,7 @@ impl ActivityHandler for Follow {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+  async fn verify(&self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     verify_person(&self.actor, context).await?;
     let object = self.object.dereference(context).await?;
     if let UserOrCommunity::Community(c) = object {
@@ -90,7 +90,7 @@ impl ActivityHandler for Follow {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+  async fn receive(self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     let actor = self.actor.dereference(context).await?;
     let object = self.object.dereference(context).await?;

--- a/crates/apub/src/activities/following/mod.rs
+++ b/crates/apub/src/activities/following/mod.rs
@@ -5,7 +5,7 @@ use crate::{
 use activitypub_federation::config::Data;
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::source::{community::Community, person::Person};
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 pub mod accept;
 pub mod follow;
@@ -16,7 +16,7 @@ pub async fn send_follow_community(
   person: Person,
   follow: bool,
   context: &Data<LemmyContext>,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   let community: ApubCommunity = community.into();
   let actor: ApubPerson = person.into();
   if follow {

--- a/crates/apub/src/activities/following/undo_follow.rs
+++ b/crates/apub/src/activities/following/undo_follow.rs
@@ -20,7 +20,7 @@ use lemmy_db_schema::{
   },
   traits::Followable,
 };
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::{LemmyError, LemmyResult};
 use url::Url;
 
 impl UndoFollow {
@@ -29,7 +29,7 @@ impl UndoFollow {
     actor: &ApubPerson,
     community: &ApubCommunity,
     context: &Data<LemmyContext>,
-  ) -> Result<(), LemmyError> {
+  ) -> LemmyResult<()> {
     let object = Follow::new(actor, community, context)?;
     let undo = UndoFollow {
       actor: actor.id().into(),
@@ -64,7 +64,7 @@ impl ActivityHandler for UndoFollow {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+  async fn verify(&self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     verify_urls_match(self.actor.inner(), self.object.actor.inner())?;
     verify_person(&self.actor, context).await?;
     self.object.verify(context).await?;
@@ -75,7 +75,7 @@ impl ActivityHandler for UndoFollow {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+  async fn receive(self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     let person = self.actor.dereference(context).await?;
     let object = self.object.object.dereference(context).await?;

--- a/crates/apub/src/activities/mod.rs
+++ b/crates/apub/src/activities/mod.rs
@@ -61,7 +61,7 @@ pub mod voting;
 async fn verify_person(
   person_id: &ObjectId<ApubPerson>,
   context: &Data<LemmyContext>,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   let person = person_id.dereference(context).await?;
   if person.banned {
     Err(anyhow!("Person {} is banned", person_id))
@@ -78,7 +78,7 @@ pub(crate) async fn verify_person_in_community(
   person_id: &ObjectId<ApubPerson>,
   community: &ApubCommunity,
   context: &Data<LemmyContext>,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   let person = person_id.dereference(context).await?;
   if person.banned {
     Err(LemmyErrorType::PersonIsBannedFromSite(
@@ -105,7 +105,7 @@ pub(crate) async fn verify_mod_action(
   mod_id: &ObjectId<ApubPerson>,
   community: &Community,
   context: &Data<LemmyContext>,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   let mod_ = mod_id.dereference(context).await?;
 
   let is_mod_or_admin =
@@ -124,7 +124,7 @@ pub(crate) async fn verify_mod_action(
   Err(LemmyErrorType::NotAModerator)?
 }
 
-pub(crate) fn verify_is_public(to: &[Url], cc: &[Url]) -> Result<(), LemmyError> {
+pub(crate) fn verify_is_public(to: &[Url], cc: &[Url]) -> LemmyResult<()> {
   if ![to, cc].iter().any(|set| set.contains(&public())) {
     Err(LemmyErrorType::ObjectIsNotPublic)?
   } else {
@@ -132,10 +132,7 @@ pub(crate) fn verify_is_public(to: &[Url], cc: &[Url]) -> Result<(), LemmyError>
   }
 }
 
-pub(crate) fn verify_community_matches<T>(
-  a: &ObjectId<ApubCommunity>,
-  b: T,
-) -> Result<(), LemmyError>
+pub(crate) fn verify_community_matches<T>(a: &ObjectId<ApubCommunity>, b: T) -> LemmyResult<()>
 where
   T: Into<ObjectId<ApubCommunity>>,
 {
@@ -147,7 +144,7 @@ where
   }
 }
 
-pub(crate) fn check_community_deleted_or_removed(community: &Community) -> Result<(), LemmyError> {
+pub(crate) fn check_community_deleted_or_removed(community: &Community) -> LemmyResult<()> {
   if community.deleted || community.removed {
     Err(LemmyErrorType::CannotCreatePostOrCommentInDeletedOrRemovedCommunity)?
   } else {
@@ -196,7 +193,7 @@ async fn send_lemmy_activity<Activity, ActorT>(
   actor: &ActorT,
   send_targets: ActivitySendTargets,
   sensitive: bool,
-) -> Result<(), LemmyError>
+) -> LemmyResult<()>
 where
   Activity: ActivityHandler + Serialize + Send + Sync + Clone,
   ActorT: Actor + GetActorType,

--- a/crates/apub/src/activities/voting/mod.rs
+++ b/crates/apub/src/activities/voting/mod.rs
@@ -21,7 +21,7 @@ use lemmy_db_schema::{
   },
   traits::Likeable,
 };
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 pub mod undo_vote;
 pub mod vote;
@@ -32,7 +32,7 @@ pub(crate) async fn send_like_activity(
   community: Community,
   score: i16,
   context: Data<LemmyContext>,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   let object_id: ObjectId<PostOrComment> = object_id.into();
   let actor: ApubPerson = actor.into();
   let community: ApubCommunity = community.into();
@@ -58,7 +58,7 @@ async fn vote_comment(
   actor: ApubPerson,
   comment: &ApubComment,
   context: &Data<LemmyContext>,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   let comment_id = comment.id;
   let like_form = CommentLikeForm {
     comment_id,
@@ -78,7 +78,7 @@ async fn vote_post(
   actor: ApubPerson,
   post: &ApubPost,
   context: &Data<LemmyContext>,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   let post_id = post.id;
   let like_form = PostLikeForm {
     post_id: post.id,
@@ -96,7 +96,7 @@ async fn undo_vote_comment(
   actor: ApubPerson,
   comment: &ApubComment,
   context: &Data<LemmyContext>,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   let comment_id = comment.id;
   let person_id = actor.id;
   CommentLike::remove(&mut context.pool(), person_id, comment_id).await?;
@@ -108,7 +108,7 @@ async fn undo_vote_post(
   actor: ApubPerson,
   post: &ApubPost,
   context: &Data<LemmyContext>,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   let post_id = post.id;
   let person_id = actor.id;
   PostLike::remove(&mut context.pool(), person_id, post_id).await?;

--- a/crates/apub/src/activities/voting/undo_vote.rs
+++ b/crates/apub/src/activities/voting/undo_vote.rs
@@ -19,7 +19,7 @@ use activitypub_federation::{
   traits::{ActivityHandler, Actor},
 };
 use lemmy_api_common::context::LemmyContext;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::{LemmyError, LemmyResult};
 use url::Url;
 
 impl UndoVote {
@@ -28,7 +28,7 @@ impl UndoVote {
     actor: &ApubPerson,
     community: &ApubCommunity,
     context: &Data<LemmyContext>,
-  ) -> Result<Self, LemmyError> {
+  ) -> LemmyResult<Self> {
     Ok(UndoVote {
       actor: actor.id().into(),
       object: vote,
@@ -56,7 +56,7 @@ impl ActivityHandler for UndoVote {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+  async fn verify(&self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     let community = self.community(context).await?;
     verify_person_in_community(&self.actor, &community, context).await?;
     verify_urls_match(self.actor.inner(), self.object.actor.inner())?;
@@ -65,7 +65,7 @@ impl ActivityHandler for UndoVote {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+  async fn receive(self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     let actor = self.actor.dereference(context).await?;
     let object = self.object.object.dereference(context).await?;

--- a/crates/apub/src/activities/voting/vote.rs
+++ b/crates/apub/src/activities/voting/vote.rs
@@ -19,7 +19,7 @@ use activitypub_federation::{
 };
 use lemmy_api_common::{context::LemmyContext, utils::check_bot_account};
 use lemmy_db_schema::source::local_site::LocalSite;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::{LemmyError, LemmyResult};
 use url::Url;
 
 impl Vote {
@@ -29,7 +29,7 @@ impl Vote {
     community: &ApubCommunity,
     kind: VoteType,
     context: &Data<LemmyContext>,
-  ) -> Result<Vote, LemmyError> {
+  ) -> LemmyResult<Vote> {
     Ok(Vote {
       actor: actor.id().into(),
       object: object_id,
@@ -54,14 +54,14 @@ impl ActivityHandler for Vote {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn verify(&self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+  async fn verify(&self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     let community = self.community(context).await?;
     verify_person_in_community(&self.actor, &community, context).await?;
     Ok(())
   }
 
   #[tracing::instrument(skip_all)]
-  async fn receive(self, context: &Data<LemmyContext>) -> Result<(), LemmyError> {
+  async fn receive(self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     let actor = self.actor.dereference(context).await?;
     let object = self.object.dereference(context).await?;

--- a/crates/apub/src/activity_lists.rs
+++ b/crates/apub/src/activity_lists.rs
@@ -26,7 +26,7 @@ use crate::{
 };
 use activitypub_federation::{config::Data, traits::ActivityHandler};
 use lemmy_api_common::context::LemmyContext;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -101,7 +101,7 @@ pub enum AnnouncableActivities {
 #[async_trait::async_trait]
 impl InCommunity for AnnouncableActivities {
   #[tracing::instrument(skip(self, context))]
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+  async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     use AnnouncableActivities::*;
     match self {
       CreateOrUpdateComment(a) => a.community(context).await,

--- a/crates/apub/src/api/list_comments.rs
+++ b/crates/apub/src/api/list_comments.rs
@@ -15,14 +15,14 @@ use lemmy_db_schema::{
   traits::Crud,
 };
 use lemmy_db_views::{comment_view::CommentQuery, structs::LocalUserView};
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn list_comments(
   data: Query<GetComments>,
   context: Data<LemmyContext>,
   local_user_view: Option<LocalUserView>,
-) -> Result<Json<GetCommentsResponse>, LemmyError> {
+) -> LemmyResult<Json<GetCommentsResponse>> {
   let local_site = LocalSite::read(&mut context.pool()).await?;
   check_private_instance(&local_user_view, &local_site)?;
 

--- a/crates/apub/src/api/list_posts.rs
+++ b/crates/apub/src/api/list_posts.rs
@@ -15,14 +15,14 @@ use lemmy_db_views::{
   post_view::PostQuery,
   structs::{LocalUserView, PaginationCursor, SiteView},
 };
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn list_posts(
   data: Query<GetPosts>,
   context: Data<LemmyContext>,
   local_user_view: Option<LocalUserView>,
-) -> Result<Json<GetPostsResponse>, LemmyError> {
+) -> LemmyResult<Json<GetPostsResponse>> {
   let local_site = SiteView::read_local(&mut context.pool()).await?;
 
   check_private_instance(&local_user_view, &local_site.local_site)?;

--- a/crates/apub/src/api/read_community.rs
+++ b/crates/apub/src/api/read_community.rs
@@ -13,14 +13,14 @@ use lemmy_db_schema::source::{
 };
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_db_views_actor::structs::{CommunityModeratorView, CommunityView};
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorExt2, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorExt2, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn get_community(
   data: Query<GetCommunity>,
   context: Data<LemmyContext>,
   local_user_view: Option<LocalUserView>,
-) -> Result<Json<GetCommunityResponse>, LemmyError> {
+) -> LemmyResult<Json<GetCommunityResponse>> {
   let local_site = LocalSite::read(&mut context.pool()).await?;
 
   if data.name.is_none() && data.id.is_none() {

--- a/crates/apub/src/api/read_person.rs
+++ b/crates/apub/src/api/read_person.rs
@@ -13,14 +13,14 @@ use lemmy_db_views::{
   structs::{LocalUserView, SiteView},
 };
 use lemmy_db_views_actor::structs::{CommunityModeratorView, PersonView};
-use lemmy_utils::error::{LemmyError, LemmyErrorExt2, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt2, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn read_person(
   data: Query<GetPersonDetails>,
   context: Data<LemmyContext>,
   local_user_view: Option<LocalUserView>,
-) -> Result<Json<GetPersonDetailsResponse>, LemmyError> {
+) -> LemmyResult<Json<GetPersonDetailsResponse>> {
   // Check to make sure a person name or an id is given
   if data.username.is_none() && data.person_id.is_none() {
     Err(LemmyErrorType::NoIdGiven)?

--- a/crates/apub/src/api/resolve_object.rs
+++ b/crates/apub/src/api/resolve_object.rs
@@ -13,14 +13,14 @@ use lemmy_api_common::{
 use lemmy_db_schema::{newtypes::PersonId, source::local_site::LocalSite, utils::DbPool};
 use lemmy_db_views::structs::{CommentView, LocalUserView, PostView};
 use lemmy_db_views_actor::structs::{CommunityView, PersonView};
-use lemmy_utils::error::{LemmyError, LemmyErrorExt2, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorExt2, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
 pub async fn resolve_object(
   data: Query<ResolveObject>,
   context: Data<LemmyContext>,
   local_user_view: Option<LocalUserView>,
-) -> Result<Json<ResolveObjectResponse>, LemmyError> {
+) -> LemmyResult<Json<ResolveObjectResponse>> {
   let local_site = LocalSite::read(&mut context.pool()).await?;
   check_private_instance(&local_user_view, &local_site)?;
   let person_id = local_user_view.map(|v| v.person.id);
@@ -46,7 +46,7 @@ async fn convert_response(
   object: SearchableObjects,
   user_id: Option<PersonId>,
   pool: &mut DbPool<'_>,
-) -> Result<Json<ResolveObjectResponse>, LemmyError> {
+) -> LemmyResult<Json<ResolveObjectResponse>> {
   use SearchableObjects::*;
   let removed_or_deleted;
   let mut res = ResolveObjectResponse::default();

--- a/crates/apub/src/api/search.rs
+++ b/crates/apub/src/api/search.rs
@@ -13,14 +13,14 @@ use lemmy_db_views::{
   structs::{LocalUserView, SiteView},
 };
 use lemmy_db_views_actor::{community_view::CommunityQuery, person_view::PersonQuery};
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 #[tracing::instrument(skip(context))]
 pub async fn search(
   data: Query<Search>,
   context: Data<LemmyContext>,
   local_user_view: Option<LocalUserView>,
-) -> Result<Json<SearchResponse>, LemmyError> {
+) -> LemmyResult<Json<SearchResponse>> {
   let local_site = SiteView::read_local(&mut context.pool()).await?;
 
   check_private_instance(&local_user_view, &local_site.local_site)?;

--- a/crates/apub/src/api/user_settings_backup.rs
+++ b/crates/apub/src/api/user_settings_backup.rs
@@ -26,7 +26,7 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorType, LemmyResult, MAX_API_PARAM_ELEMENTS},
+  error::{LemmyErrorType, LemmyResult, MAX_API_PARAM_ELEMENTS},
   spawn_try_task,
 };
 use serde::{Deserialize, Serialize};
@@ -70,7 +70,7 @@ pub struct UserSettingsBackup {
 pub async fn export_settings(
   local_user_view: LocalUserView,
   context: Data<LemmyContext>,
-) -> Result<Json<UserSettingsBackup>, LemmyError> {
+) -> LemmyResult<Json<UserSettingsBackup>> {
   let lists = LocalUser::export_backup(&mut context.pool(), local_user_view.person.id).await?;
 
   let vec_into = |vec: Vec<_>| vec.into_iter().map(Into::into).collect();
@@ -97,7 +97,7 @@ pub async fn import_settings(
   data: Json<UserSettingsBackup>,
   local_user_view: LocalUserView,
   context: Data<LemmyContext>,
-) -> Result<Json<SuccessResponse>, LemmyError> {
+) -> LemmyResult<Json<SuccessResponse>> {
   let person_form = PersonUpdateForm {
     display_name: Some(data.display_name.clone()),
     bio: Some(data.bio.clone()),

--- a/crates/apub/src/collections/community_moderators.rs
+++ b/crates/apub/src/collections/community_moderators.rs
@@ -15,7 +15,7 @@ use lemmy_db_schema::{
   traits::Joinable,
 };
 use lemmy_db_views_actor::structs::CommunityModeratorView;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::{LemmyError, LemmyResult};
 use url::Url;
 
 #[derive(Clone, Debug)]
@@ -29,10 +29,7 @@ impl Collection for ApubCommunityModerators {
   type Error = LemmyError;
 
   #[tracing::instrument(skip_all)]
-  async fn read_local(
-    owner: &Self::Owner,
-    data: &Data<Self::DataType>,
-  ) -> Result<Self::Kind, LemmyError> {
+  async fn read_local(owner: &Self::Owner, data: &Data<Self::DataType>) -> LemmyResult<Self::Kind> {
     let moderators = CommunityModeratorView::for_community(&mut data.pool(), owner.id).await?;
     let ordered_items = moderators
       .into_iter()
@@ -50,7 +47,7 @@ impl Collection for ApubCommunityModerators {
     group_moderators: &GroupModerators,
     expected_domain: &Url,
     _data: &Data<Self::DataType>,
-  ) -> Result<(), LemmyError> {
+  ) -> LemmyResult<()> {
     verify_domains_match(&group_moderators.id, expected_domain)?;
     Ok(())
   }
@@ -60,7 +57,7 @@ impl Collection for ApubCommunityModerators {
     apub: Self::Kind,
     owner: &Self::Owner,
     data: &Data<Self::DataType>,
-  ) -> Result<Self, LemmyError> {
+  ) -> LemmyResult<Self> {
     let community_id = owner.id;
     let current_moderators =
       CommunityModeratorView::for_community(&mut data.pool(), community_id).await?;
@@ -118,7 +115,6 @@ mod tests {
     },
     traits::Crud,
   };
-  use lemmy_utils::error::LemmyResult;
   use pretty_assertions::assert_eq;
   use serial_test::serial;
 

--- a/crates/apub/src/collections/community_outbox.rs
+++ b/crates/apub/src/collections/community_outbox.rs
@@ -23,7 +23,7 @@ use lemmy_db_schema::{
   traits::Crud,
   utils::FETCH_LIMIT_MAX,
 };
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::{LemmyError, LemmyResult};
 use url::Url;
 
 #[derive(Clone, Debug)]
@@ -37,10 +37,7 @@ impl Collection for ApubCommunityOutbox {
   type Error = LemmyError;
 
   #[tracing::instrument(skip_all)]
-  async fn read_local(
-    owner: &Self::Owner,
-    data: &Data<Self::DataType>,
-  ) -> Result<Self::Kind, LemmyError> {
+  async fn read_local(owner: &Self::Owner, data: &Data<Self::DataType>) -> LemmyResult<Self::Kind> {
     let post_list: Vec<ApubPost> = Post::list_for_community(&mut data.pool(), owner.id)
       .await?
       .into_iter()
@@ -71,7 +68,7 @@ impl Collection for ApubCommunityOutbox {
     group_outbox: &GroupOutbox,
     expected_domain: &Url,
     _data: &Data<Self::DataType>,
-  ) -> Result<(), LemmyError> {
+  ) -> LemmyResult<()> {
     verify_domains_match(expected_domain, &group_outbox.id)?;
     Ok(())
   }
@@ -81,7 +78,7 @@ impl Collection for ApubCommunityOutbox {
     apub: Self::Kind,
     _owner: &Self::Owner,
     data: &Data<Self::DataType>,
-  ) -> Result<Self, LemmyError> {
+  ) -> LemmyResult<Self> {
     let mut outbox_activities = apub.ordered_items;
     if outbox_activities.len() as i64 > FETCH_LIMIT_MAX {
       outbox_activities = outbox_activities

--- a/crates/apub/src/fetcher/mod.rs
+++ b/crates/apub/src/fetcher/mod.rs
@@ -8,7 +8,7 @@ use itertools::Itertools;
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::traits::ApubActor;
 use lemmy_db_views::structs::LocalUserView;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::{LemmyError, LemmyResult};
 
 pub mod post_or_comment;
 pub mod search;
@@ -25,7 +25,7 @@ pub async fn resolve_actor_identifier<ActorType, DbActor>(
   context: &Data<LemmyContext>,
   local_user_view: &Option<LocalUserView>,
   include_deleted: bool,
-) -> Result<ActorType, LemmyError>
+) -> LemmyResult<ActorType>
 where
   ActorType: Object<DataType = LemmyContext, Error = LemmyError>
     + Object

--- a/crates/apub/src/fetcher/search.rs
+++ b/crates/apub/src/fetcher/search.rs
@@ -10,7 +10,7 @@ use activitypub_federation::{
 };
 use chrono::{DateTime, Utc};
 use lemmy_api_common::context::LemmyContext;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::{LemmyError, LemmyResult};
 use serde::Deserialize;
 use url::Url;
 
@@ -21,7 +21,7 @@ use url::Url;
 pub(crate) async fn search_query_to_object_id(
   mut query: String,
   context: &Data<LemmyContext>,
-) -> Result<SearchableObjects, LemmyError> {
+) -> LemmyResult<SearchableObjects> {
   Ok(match Url::parse(&query) {
     Ok(url) => {
       // its already an url, just go with it
@@ -46,7 +46,7 @@ pub(crate) async fn search_query_to_object_id(
 pub(crate) async fn search_query_to_object_id_local(
   query: &str,
   context: &Data<LemmyContext>,
-) -> Result<SearchableObjects, LemmyError> {
+) -> LemmyResult<SearchableObjects> {
   let url = Url::parse(query)?;
   ObjectId::from(url).dereference_local(context).await
 }
@@ -90,7 +90,7 @@ impl Object for SearchableObjects {
   async fn read_from_id(
     object_id: Url,
     context: &Data<Self::DataType>,
-  ) -> Result<Option<Self>, LemmyError> {
+  ) -> LemmyResult<Option<Self>> {
     let uc = UserOrCommunity::read_from_id(object_id.clone(), context).await?;
     if let Some(uc) = uc {
       return Ok(Some(SearchableObjects::PersonOrCommunity(Box::new(uc))));
@@ -107,7 +107,7 @@ impl Object for SearchableObjects {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn delete(self, data: &Data<Self::DataType>) -> Result<(), LemmyError> {
+  async fn delete(self, data: &Data<Self::DataType>) -> LemmyResult<()> {
     match self {
       SearchableObjects::Post(p) => p.delete(data).await,
       SearchableObjects::Comment(c) => c.delete(data).await,
@@ -118,7 +118,7 @@ impl Object for SearchableObjects {
     }
   }
 
-  async fn into_json(self, _data: &Data<Self::DataType>) -> Result<Self::Kind, LemmyError> {
+  async fn into_json(self, _data: &Data<Self::DataType>) -> LemmyResult<Self::Kind> {
     unimplemented!()
   }
 
@@ -127,7 +127,7 @@ impl Object for SearchableObjects {
     apub: &Self::Kind,
     expected_domain: &Url,
     data: &Data<Self::DataType>,
-  ) -> Result<(), LemmyError> {
+  ) -> LemmyResult<()> {
     match apub {
       SearchableKinds::Page(a) => ApubPost::verify(a, expected_domain, data).await,
       SearchableKinds::Note(a) => ApubComment::verify(a, expected_domain, data).await,
@@ -139,7 +139,7 @@ impl Object for SearchableObjects {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn from_json(apub: Self::Kind, context: &Data<LemmyContext>) -> Result<Self, LemmyError> {
+  async fn from_json(apub: Self::Kind, context: &Data<LemmyContext>) -> LemmyResult<Self> {
     use SearchableKinds as SAT;
     use SearchableObjects as SO;
     Ok(match apub {

--- a/crates/apub/src/fetcher/site_or_community_or_user.rs
+++ b/crates/apub/src/fetcher/site_or_community_or_user.rs
@@ -9,7 +9,7 @@ use activitypub_federation::{
 };
 use chrono::{DateTime, Utc};
 use lemmy_api_common::context::LemmyContext;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::{LemmyError, LemmyResult};
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 
@@ -44,19 +44,19 @@ impl Object for SiteOrCommunityOrUser {
   async fn read_from_id(
     _object_id: Url,
     _data: &Data<Self::DataType>,
-  ) -> Result<Option<Self>, LemmyError> {
+  ) -> LemmyResult<Option<Self>> {
     unimplemented!();
   }
 
   #[tracing::instrument(skip_all)]
-  async fn delete(self, data: &Data<Self::DataType>) -> Result<(), LemmyError> {
+  async fn delete(self, data: &Data<Self::DataType>) -> LemmyResult<()> {
     match self {
       SiteOrCommunityOrUser::Site(p) => p.delete(data).await,
       SiteOrCommunityOrUser::UserOrCommunity(p) => p.delete(data).await,
     }
   }
 
-  async fn into_json(self, _data: &Data<Self::DataType>) -> Result<Self::Kind, LemmyError> {
+  async fn into_json(self, _data: &Data<Self::DataType>) -> LemmyResult<Self::Kind> {
     unimplemented!()
   }
 
@@ -65,7 +65,7 @@ impl Object for SiteOrCommunityOrUser {
     apub: &Self::Kind,
     expected_domain: &Url,
     data: &Data<Self::DataType>,
-  ) -> Result<(), LemmyError> {
+  ) -> LemmyResult<()> {
     match apub {
       SiteOrPersonOrGroup::Instance(a) => ApubSite::verify(a, expected_domain, data).await,
       SiteOrPersonOrGroup::PersonOrGroup(a) => {
@@ -75,7 +75,7 @@ impl Object for SiteOrCommunityOrUser {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn from_json(_apub: Self::Kind, _data: &Data<Self::DataType>) -> Result<Self, LemmyError> {
+  async fn from_json(_apub: Self::Kind, _data: &Data<Self::DataType>) -> LemmyResult<Self> {
     unimplemented!();
   }
 }

--- a/crates/apub/src/http/comment.rs
+++ b/crates/apub/src/http/comment.rs
@@ -15,7 +15,7 @@ use lemmy_db_schema::{
   source::{comment::Comment, community::Community, post::Post},
   traits::Crud,
 };
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -28,7 +28,7 @@ pub(crate) struct CommentQuery {
 pub(crate) async fn get_apub_comment(
   info: Path<CommentQuery>,
   context: Data<LemmyContext>,
-) -> Result<HttpResponse, LemmyError> {
+) -> LemmyResult<HttpResponse> {
   let id = CommentId(info.comment_id.parse::<i32>()?);
   // Can't use CommentView here because it excludes deleted/removed/local-only items
   let comment: ApubComment = Comment::read(&mut context.pool(), id).await?.into();

--- a/crates/apub/src/http/mod.rs
+++ b/crates/apub/src/http/mod.rs
@@ -18,7 +18,7 @@ use lemmy_db_schema::{
   source::{activity::SentActivity, community::Community},
   CommunityVisibility,
 };
-use lemmy_utils::error::{LemmyError, LemmyErrorType, LemmyResult};
+use lemmy_utils::error::{LemmyErrorType, LemmyResult};
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
 use url::Url;
@@ -88,7 +88,7 @@ pub struct ActivityQuery {
 pub(crate) async fn get_activity(
   info: web::Path<ActivityQuery>,
   context: web::Data<LemmyContext>,
-) -> Result<HttpResponse, LemmyError> {
+) -> LemmyResult<HttpResponse> {
   let settings = context.settings();
   let activity_id = Url::parse(&format!(
     "{}/activities/{}/{}",

--- a/crates/apub/src/http/person.rs
+++ b/crates/apub/src/http/person.rs
@@ -14,7 +14,7 @@ use activitypub_federation::{
 use actix_web::{web, web::Bytes, HttpRequest, HttpResponse};
 use lemmy_api_common::{context::LemmyContext, utils::generate_outbox_url};
 use lemmy_db_schema::{source::person::Person, traits::ApubActor};
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -27,7 +27,7 @@ pub struct PersonQuery {
 pub(crate) async fn get_apub_person_http(
   info: web::Path<PersonQuery>,
   context: Data<LemmyContext>,
-) -> Result<HttpResponse, LemmyError> {
+) -> LemmyResult<HttpResponse> {
   let user_name = info.into_inner().user_name;
   // TODO: this needs to be able to read deleted persons, so that it can send tombstones
   let person: ApubPerson = Person::read_from_name(&mut context.pool(), &user_name, true)
@@ -48,7 +48,7 @@ pub async fn person_inbox(
   request: HttpRequest,
   body: Bytes,
   data: Data<LemmyContext>,
-) -> Result<HttpResponse, LemmyError> {
+) -> LemmyResult<HttpResponse> {
   receive_activity::<WithContext<PersonInboxActivities>, UserOrCommunity, LemmyContext>(
     request, body, &data,
   )
@@ -59,7 +59,7 @@ pub async fn person_inbox(
 pub(crate) async fn get_apub_person_outbox(
   info: web::Path<PersonQuery>,
   context: Data<LemmyContext>,
-) -> Result<HttpResponse, LemmyError> {
+) -> LemmyResult<HttpResponse> {
   let person = Person::read_from_name(&mut context.pool(), &info.user_name, false).await?;
   let outbox_id = generate_outbox_url(&person.actor_id)?.into();
   let outbox = EmptyOutbox::new(outbox_id)?;

--- a/crates/apub/src/http/post.rs
+++ b/crates/apub/src/http/post.rs
@@ -15,7 +15,7 @@ use lemmy_db_schema::{
   source::{community::Community, post::Post},
   traits::Crud,
 };
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -28,7 +28,7 @@ pub(crate) struct PostQuery {
 pub(crate) async fn get_apub_post(
   info: web::Path<PostQuery>,
   context: Data<LemmyContext>,
-) -> Result<HttpResponse, LemmyError> {
+) -> LemmyResult<HttpResponse> {
   let id = PostId(info.post_id.parse::<i32>()?);
   // Can't use PostView here because it excludes deleted/removed/local-only items
   let post: ApubPost = Post::read(&mut context.pool(), id).await?.into();

--- a/crates/apub/src/http/site.rs
+++ b/crates/apub/src/http/site.rs
@@ -7,12 +7,10 @@ use activitypub_federation::{config::Data, traits::Object};
 use actix_web::HttpResponse;
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_views::structs::SiteView;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 use url::Url;
 
-pub(crate) async fn get_apub_site_http(
-  context: Data<LemmyContext>,
-) -> Result<HttpResponse, LemmyError> {
+pub(crate) async fn get_apub_site_http(context: Data<LemmyContext>) -> LemmyResult<HttpResponse> {
   let site: ApubSite = SiteView::read_local(&mut context.pool()).await?.site.into();
 
   let apub = site.into_json(&context).await?;
@@ -20,9 +18,7 @@ pub(crate) async fn get_apub_site_http(
 }
 
 #[tracing::instrument(skip_all)]
-pub(crate) async fn get_apub_site_outbox(
-  context: Data<LemmyContext>,
-) -> Result<HttpResponse, LemmyError> {
+pub(crate) async fn get_apub_site_outbox(context: Data<LemmyContext>) -> LemmyResult<HttpResponse> {
   let outbox_id = format!(
     "{}/site_outbox",
     context.settings().get_protocol_and_hostname()

--- a/crates/apub/src/lib.rs
+++ b/crates/apub/src/lib.rs
@@ -77,7 +77,7 @@ impl UrlVerifier for VerifyUrlData {
 /// - URL being in the allowlist (if it is active)
 /// - URL not being in the blocklist (if it is active)
 #[tracing::instrument(skip(local_site_data))]
-fn check_apub_id_valid(apub_id: &Url, local_site_data: &LocalSiteData) -> Result<(), LemmyError> {
+fn check_apub_id_valid(apub_id: &Url, local_site_data: &LocalSiteData) -> LemmyResult<()> {
   let domain = apub_id.domain().expect("apud id has domain").to_string();
 
   if !local_site_data
@@ -157,7 +157,7 @@ pub(crate) async fn check_apub_id_valid_with_strictness(
   apub_id: &Url,
   is_strict: bool,
   context: &LemmyContext,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   let domain = apub_id.domain().expect("apud id has domain").to_string();
   let local_instance = context
     .settings()
@@ -198,10 +198,7 @@ pub(crate) async fn check_apub_id_valid_with_strictness(
 /// This ensures that the same activity doesnt get received and processed more than once, which
 /// would be a waste of resources.
 #[tracing::instrument(skip(data))]
-async fn insert_received_activity(
-  ap_id: &Url,
-  data: &Data<LemmyContext>,
-) -> Result<(), LemmyError> {
+async fn insert_received_activity(ap_id: &Url, data: &Data<LemmyContext>) -> LemmyResult<()> {
   ReceivedActivity::create(&mut data.pool(), &ap_id.clone().into()).await?;
   Ok(())
 }

--- a/crates/apub/src/mentions.rs
+++ b/crates/apub/src/mentions.rs
@@ -11,7 +11,7 @@ use lemmy_db_schema::{
   traits::Crud,
   utils::DbPool,
 };
-use lemmy_utils::{error::LemmyError, utils::mention::scrape_text_for_mentions};
+use lemmy_utils::{error::LemmyResult, utils::mention::scrape_text_for_mentions};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use url::Url;
@@ -44,7 +44,7 @@ pub async fn collect_non_local_mentions(
   comment: &ApubComment,
   community_id: ObjectId<ApubCommunity>,
   context: &Data<LemmyContext>,
-) -> Result<MentionsAndAddresses, LemmyError> {
+) -> LemmyResult<MentionsAndAddresses> {
   let parent_creator = get_comment_parent_creator(&mut context.pool(), comment).await?;
   let mut addressed_ccs: Vec<Url> = vec![community_id.into(), parent_creator.id()];
 
@@ -94,7 +94,7 @@ pub async fn collect_non_local_mentions(
 async fn get_comment_parent_creator(
   pool: &mut DbPool<'_>,
   comment: &Comment,
-) -> Result<ApubPerson, LemmyError> {
+) -> LemmyResult<ApubPerson> {
   let parent_creator_id = if let Some(parent_comment_id) = comment.parent_comment_id() {
     let parent_comment = Comment::read(pool, parent_comment_id).await?;
     parent_comment.creator_id

--- a/crates/apub/src/objects/community.rs
+++ b/crates/apub/src/objects/community.rs
@@ -38,7 +38,11 @@ use lemmy_db_schema::{
   utils::naive_now,
 };
 use lemmy_db_views_actor::structs::CommunityFollowerView;
-use lemmy_utils::{error::LemmyError, spawn_try_task, utils::markdown::markdown_to_html};
+use lemmy_utils::{
+  error::{LemmyError, LemmyResult},
+  spawn_try_task,
+  utils::markdown::markdown_to_html,
+};
 use std::ops::Deref;
 use url::Url;
 
@@ -72,7 +76,7 @@ impl Object for ApubCommunity {
   async fn read_from_id(
     object_id: Url,
     context: &Data<Self::DataType>,
-  ) -> Result<Option<Self>, LemmyError> {
+  ) -> LemmyResult<Option<Self>> {
     Ok(
       Community::read_from_apub_id(&mut context.pool(), &object_id.into())
         .await?
@@ -81,7 +85,7 @@ impl Object for ApubCommunity {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn delete(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+  async fn delete(self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     let form = CommunityUpdateForm {
       deleted: Some(true),
       ..Default::default()
@@ -91,7 +95,7 @@ impl Object for ApubCommunity {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn into_json(self, data: &Data<Self::DataType>) -> Result<Group, LemmyError> {
+  async fn into_json(self, data: &Data<Self::DataType>) -> LemmyResult<Group> {
     let community_id = self.id;
     let langs = CommunityLanguage::read(&mut data.pool(), community_id).await?;
     let language = LanguageTag::new_multiple(langs, &mut data.pool()).await?;
@@ -128,16 +132,13 @@ impl Object for ApubCommunity {
     group: &Group,
     expected_domain: &Url,
     context: &Data<Self::DataType>,
-  ) -> Result<(), LemmyError> {
+  ) -> LemmyResult<()> {
     group.verify(expected_domain, context).await
   }
 
   /// Converts a `Group` to `Community`, inserts it into the database and updates moderators.
   #[tracing::instrument(skip_all)]
-  async fn from_json(
-    group: Group,
-    context: &Data<Self::DataType>,
-  ) -> Result<ApubCommunity, LemmyError> {
+  async fn from_json(group: Group, context: &Data<Self::DataType>) -> LemmyResult<ApubCommunity> {
     let instance_id = fetch_instance_actor_for_object(&group.id, context).await?;
 
     let local_site = LocalSite::read(&mut context.pool()).await.ok();
@@ -234,10 +235,7 @@ impl GetActorType for ApubCommunity {
 impl ApubCommunity {
   /// For a given community, returns the inboxes of all followers.
   #[tracing::instrument(skip_all)]
-  pub(crate) async fn get_follower_inboxes(
-    &self,
-    context: &LemmyContext,
-  ) -> Result<Vec<Url>, LemmyError> {
+  pub(crate) async fn get_follower_inboxes(&self, context: &LemmyContext) -> LemmyResult<Vec<Url>> {
     let id = self.id;
 
     let local_site_data = local_site_data_cached(&mut context.pool()).await?;
@@ -264,7 +262,6 @@ pub(crate) mod tests {
   };
   use activitypub_federation::fetch::collection_id::CollectionId;
   use lemmy_db_schema::source::site::Site;
-  use lemmy_utils::error::LemmyResult;
   use pretty_assertions::assert_eq;
   use serial_test::serial;
 

--- a/crates/apub/src/objects/instance.rs
+++ b/crates/apub/src/objects/instance.rs
@@ -39,7 +39,7 @@ use lemmy_db_schema::{
   utils::naive_now,
 };
 use lemmy_utils::{
-  error::LemmyError,
+  error::{LemmyError, LemmyResult},
   utils::{
     markdown::markdown_to_html,
     slurs::{check_slurs, check_slurs_opt},
@@ -76,10 +76,7 @@ impl Object for ApubSite {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn read_from_id(
-    object_id: Url,
-    data: &Data<Self::DataType>,
-  ) -> Result<Option<Self>, LemmyError> {
+  async fn read_from_id(object_id: Url, data: &Data<Self::DataType>) -> LemmyResult<Option<Self>> {
     Ok(
       Site::read_from_apub_id(&mut data.pool(), &object_id.into())
         .await?
@@ -87,12 +84,12 @@ impl Object for ApubSite {
     )
   }
 
-  async fn delete(self, _data: &Data<Self::DataType>) -> Result<(), LemmyError> {
+  async fn delete(self, _data: &Data<Self::DataType>) -> LemmyResult<()> {
     unimplemented!()
   }
 
   #[tracing::instrument(skip_all)]
-  async fn into_json(self, data: &Data<Self::DataType>) -> Result<Self::Kind, LemmyError> {
+  async fn into_json(self, data: &Data<Self::DataType>) -> LemmyResult<Self::Kind> {
     let site_id = self.id;
     let langs = SiteLanguage::read(&mut data.pool(), site_id).await?;
     let language = LanguageTag::new_multiple(langs, &mut data.pool()).await?;
@@ -124,7 +121,7 @@ impl Object for ApubSite {
     apub: &Self::Kind,
     expected_domain: &Url,
     data: &Data<Self::DataType>,
-  ) -> Result<(), LemmyError> {
+  ) -> LemmyResult<()> {
     check_apub_id_valid_with_strictness(apub.id.inner(), true, data).await?;
     verify_domains_match(expected_domain, apub.id.inner())?;
 
@@ -137,7 +134,7 @@ impl Object for ApubSite {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn from_json(apub: Self::Kind, context: &Data<Self::DataType>) -> Result<Self, LemmyError> {
+  async fn from_json(apub: Self::Kind, context: &Data<Self::DataType>) -> LemmyResult<Self> {
     let domain = apub.id.inner().domain().expect("group id has domain");
     let instance = DbInstance::read_or_create(&mut context.pool(), domain.to_string()).await?;
 
@@ -200,7 +197,7 @@ impl GetActorType for ApubSite {
 pub(in crate::objects) async fn fetch_instance_actor_for_object<T: Into<Url> + Clone>(
   object_id: &T,
   context: &Data<LemmyContext>,
-) -> Result<InstanceId, LemmyError> {
+) -> LemmyResult<InstanceId> {
   let object_id: Url = object_id.clone().into();
   let instance_id = Site::instance_actor_id_from_url(object_id);
   let site = ObjectId::<ApubSite>::from(instance_id.clone())
@@ -225,7 +222,6 @@ pub(in crate::objects) async fn fetch_instance_actor_for_object<T: Into<Url> + C
 pub(crate) mod tests {
   use super::*;
   use crate::protocol::tests::file_to_json_object;
-  use lemmy_utils::error::LemmyResult;
   use pretty_assertions::assert_eq;
   use serial_test::serial;
 

--- a/crates/apub/src/objects/mod.rs
+++ b/crates/apub/src/objects/mod.rs
@@ -2,7 +2,7 @@ use crate::protocol::Source;
 use activitypub_federation::protocol::values::MediaTypeMarkdownOrHtml;
 use anyhow::anyhow;
 use html2md::parse_html;
-use lemmy_utils::{error::LemmyError, settings::structs::Settings};
+use lemmy_utils::{error::LemmyResult, settings::structs::Settings};
 use url::Url;
 
 pub mod comment;
@@ -43,7 +43,7 @@ pub(crate) fn read_from_string_or_source_opt(
 /// wrapped in Announce. If we simply receive this like any other federated object, overwrite the
 /// existing, local Post. In particular, it will set the field local = false, so that the object
 /// can't be fetched from the Activitypub HTTP endpoint anymore (which only serves local objects).
-pub(crate) fn verify_is_remote_object(id: &Url, settings: &Settings) -> Result<(), LemmyError> {
+pub(crate) fn verify_is_remote_object(id: &Url, settings: &Settings) -> LemmyResult<()> {
   let local_domain = settings.get_hostname_without_port()?;
   if id.domain() == Some(&local_domain) {
     Err(anyhow!("cant accept local object from remote instance").into())

--- a/crates/apub/src/objects/person.rs
+++ b/crates/apub/src/objects/person.rs
@@ -38,7 +38,7 @@ use lemmy_db_schema::{
   utils::naive_now,
 };
 use lemmy_utils::{
-  error::LemmyError,
+  error::{LemmyError, LemmyResult},
   utils::{
     markdown::markdown_to_html,
     slurs::{check_slurs, check_slurs_opt},
@@ -77,7 +77,7 @@ impl Object for ApubPerson {
   async fn read_from_id(
     object_id: Url,
     context: &Data<Self::DataType>,
-  ) -> Result<Option<Self>, LemmyError> {
+  ) -> LemmyResult<Option<Self>> {
     Ok(
       DbPerson::read_from_apub_id(&mut context.pool(), &object_id.into())
         .await?
@@ -86,7 +86,7 @@ impl Object for ApubPerson {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn delete(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+  async fn delete(self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     let form = PersonUpdateForm {
       deleted: Some(true),
       ..Default::default()
@@ -96,7 +96,7 @@ impl Object for ApubPerson {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn into_json(self, _context: &Data<Self::DataType>) -> Result<Person, LemmyError> {
+  async fn into_json(self, _context: &Data<Self::DataType>) -> LemmyResult<Person> {
     let kind = if self.bot_account {
       UserTypes::Service
     } else {
@@ -130,7 +130,7 @@ impl Object for ApubPerson {
     person: &Person,
     expected_domain: &Url,
     context: &Data<Self::DataType>,
-  ) -> Result<(), LemmyError> {
+  ) -> LemmyResult<()> {
     let local_site_data = local_site_data_cached(&mut context.pool()).await?;
     let slur_regex = &local_site_opt_to_slur_regex(&local_site_data.local_site);
     check_slurs(&person.preferred_username, slur_regex)?;
@@ -145,10 +145,7 @@ impl Object for ApubPerson {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn from_json(
-    person: Person,
-    context: &Data<Self::DataType>,
-  ) -> Result<ApubPerson, LemmyError> {
+  async fn from_json(person: Person, context: &Data<Self::DataType>) -> LemmyResult<ApubPerson> {
     let instance_id = fetch_instance_actor_for_object(&person.id, context).await?;
 
     let local_site = LocalSite::read(&mut context.pool()).await.ok();
@@ -228,7 +225,6 @@ pub(crate) mod tests {
   };
   use activitypub_federation::fetch::object_id::ObjectId;
   use lemmy_db_schema::source::site::Site;
-  use lemmy_utils::error::LemmyResult;
   use pretty_assertions::assert_eq;
   use serial_test::serial;
 

--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -44,7 +44,7 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views_actor::structs::CommunityModeratorView;
 use lemmy_utils::{
-  error::LemmyError,
+  error::{LemmyError, LemmyResult},
   utils::{markdown::markdown_to_html, slurs::check_slurs_opt, validation::check_url_scheme},
 };
 use std::ops::Deref;
@@ -83,7 +83,7 @@ impl Object for ApubPost {
   async fn read_from_id(
     object_id: Url,
     context: &Data<Self::DataType>,
-  ) -> Result<Option<Self>, LemmyError> {
+  ) -> LemmyResult<Option<Self>> {
     Ok(
       Post::read_from_apub_id(&mut context.pool(), object_id)
         .await?
@@ -92,7 +92,7 @@ impl Object for ApubPost {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn delete(self, context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+  async fn delete(self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     if !self.deleted {
       let form = PostUpdateForm {
         deleted: Some(true),
@@ -105,7 +105,7 @@ impl Object for ApubPost {
 
   // Turn a Lemmy post into an ActivityPub page that can be sent out over the network.
   #[tracing::instrument(skip_all)]
-  async fn into_json(self, context: &Data<Self::DataType>) -> Result<Page, LemmyError> {
+  async fn into_json(self, context: &Data<Self::DataType>) -> LemmyResult<Page> {
     let creator_id = self.creator_id;
     let creator = Person::read(&mut context.pool(), creator_id).await?;
     let community_id = self.community_id;
@@ -159,7 +159,7 @@ impl Object for ApubPost {
     page: &Page,
     expected_domain: &Url,
     context: &Data<Self::DataType>,
-  ) -> Result<(), LemmyError> {
+  ) -> LemmyResult<()> {
     // We can't verify the domain in case of mod action, because the mod may be on a different
     // instance from the post author.
     if !page.is_mod_action(context).await? {
@@ -181,7 +181,7 @@ impl Object for ApubPost {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn from_json(page: Page, context: &Data<Self::DataType>) -> Result<ApubPost, LemmyError> {
+  async fn from_json(page: Page, context: &Data<Self::DataType>) -> LemmyResult<ApubPost> {
     let creator = page.creator()?.dereference(context).await?;
     let community = page.community(context).await?;
     if community.posting_restricted_to_mods {
@@ -305,7 +305,6 @@ mod tests {
     protocol::tests::file_to_json_object,
   };
   use lemmy_db_schema::source::site::Site;
-  use lemmy_utils::error::LemmyResult;
   use pretty_assertions::assert_eq;
   use serial_test::serial;
 

--- a/crates/apub/src/objects/private_message.rs
+++ b/crates/apub/src/objects/private_message.rs
@@ -25,7 +25,7 @@ use lemmy_db_schema::{
   traits::Crud,
 };
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorType},
+  error::{LemmyError, LemmyErrorType, LemmyResult},
   utils::markdown::markdown_to_html,
 };
 use std::ops::Deref;
@@ -61,7 +61,7 @@ impl Object for ApubPrivateMessage {
   async fn read_from_id(
     object_id: Url,
     context: &Data<Self::DataType>,
-  ) -> Result<Option<Self>, LemmyError> {
+  ) -> LemmyResult<Option<Self>> {
     Ok(
       PrivateMessage::read_from_apub_id(&mut context.pool(), object_id)
         .await?
@@ -69,13 +69,13 @@ impl Object for ApubPrivateMessage {
     )
   }
 
-  async fn delete(self, _context: &Data<Self::DataType>) -> Result<(), LemmyError> {
+  async fn delete(self, _context: &Data<Self::DataType>) -> LemmyResult<()> {
     // do nothing, because pm can't be fetched over http
     unimplemented!()
   }
 
   #[tracing::instrument(skip_all)]
-  async fn into_json(self, context: &Data<Self::DataType>) -> Result<ChatMessage, LemmyError> {
+  async fn into_json(self, context: &Data<Self::DataType>) -> LemmyResult<ChatMessage> {
     let creator_id = self.creator_id;
     let creator = Person::read(&mut context.pool(), creator_id).await?;
 
@@ -101,7 +101,7 @@ impl Object for ApubPrivateMessage {
     note: &ChatMessage,
     expected_domain: &Url,
     context: &Data<Self::DataType>,
-  ) -> Result<(), LemmyError> {
+  ) -> LemmyResult<()> {
     verify_domains_match(note.id.inner(), expected_domain)?;
     verify_domains_match(note.attributed_to.inner(), note.id.inner())?;
 
@@ -120,7 +120,7 @@ impl Object for ApubPrivateMessage {
   async fn from_json(
     note: ChatMessage,
     context: &Data<Self::DataType>,
-  ) -> Result<ApubPrivateMessage, LemmyError> {
+  ) -> LemmyResult<ApubPrivateMessage> {
     let creator = note.attributed_to.dereference(context).await?;
     let recipient = note.to[0].dereference(context).await?;
     check_person_block(creator.id, recipient.id, &mut context.pool()).await?;
@@ -159,7 +159,6 @@ mod tests {
   };
   use assert_json_diff::assert_json_include;
   use lemmy_db_schema::source::site::Site;
-  use lemmy_utils::error::LemmyResult;
   use pretty_assertions::assert_eq;
   use serial_test::serial;
 

--- a/crates/apub/src/protocol/activities/block/block_user.rs
+++ b/crates/apub/src/protocol/activities/block/block_user.rs
@@ -12,7 +12,7 @@ use activitypub_federation::{
 use anyhow::anyhow;
 use chrono::{DateTime, Utc};
 use lemmy_api_common::context::LemmyContext;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use url::Url;
@@ -45,7 +45,7 @@ pub struct BlockUser {
 
 #[async_trait::async_trait]
 impl InCommunity for BlockUser {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+  async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let target = self.target.dereference(context).await?;
     let community = match target {
       SiteOrCommunity::Community(c) => c,

--- a/crates/apub/src/protocol/activities/block/undo_block_user.rs
+++ b/crates/apub/src/protocol/activities/block/undo_block_user.rs
@@ -10,7 +10,7 @@ use activitypub_federation::{
   protocol::helpers::deserialize_one_or_many,
 };
 use lemmy_api_common::context::LemmyContext;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use url::Url;
@@ -33,7 +33,7 @@ pub struct UndoBlockUser {
 
 #[async_trait::async_trait]
 impl InCommunity for UndoBlockUser {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+  async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let community = self.object.community(context).await?;
     if let Some(audience) = &self.audience {
       verify_community_matches(audience, community.actor_id.clone())?;

--- a/crates/apub/src/protocol/activities/community/collection_add.rs
+++ b/crates/apub/src/protocol/activities/community/collection_add.rs
@@ -11,7 +11,7 @@ use activitypub_federation::{
 };
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::source::community::Community;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -33,7 +33,7 @@ pub struct CollectionAdd {
 
 #[async_trait::async_trait]
 impl InCommunity for CollectionAdd {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+  async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let (community, _) =
       Community::get_by_collection_url(&mut context.pool(), &self.clone().target.into()).await?;
     if let Some(audience) = &self.audience {

--- a/crates/apub/src/protocol/activities/community/collection_remove.rs
+++ b/crates/apub/src/protocol/activities/community/collection_remove.rs
@@ -11,7 +11,7 @@ use activitypub_federation::{
 };
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::source::community::Community;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -33,7 +33,7 @@ pub struct CollectionRemove {
 
 #[async_trait::async_trait]
 impl InCommunity for CollectionRemove {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+  async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let (community, _) =
       Community::get_by_collection_url(&mut context.pool(), &self.clone().target.into()).await?;
     if let Some(audience) = &self.audience {

--- a/crates/apub/src/protocol/activities/community/lock_page.rs
+++ b/crates/apub/src/protocol/activities/community/lock_page.rs
@@ -11,7 +11,7 @@ use activitypub_federation::{
 };
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::{source::community::Community, traits::Crud};
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 use serde::{Deserialize, Serialize};
 use strum_macros::Display;
 use url::Url;
@@ -53,7 +53,7 @@ pub struct UndoLockPage {
 
 #[async_trait::async_trait]
 impl InCommunity for LockPage {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+  async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let post = self.object.dereference(context).await?;
     let community = Community::read(&mut context.pool(), post.community_id).await?;
     if let Some(audience) = &self.audience {
@@ -65,7 +65,7 @@ impl InCommunity for LockPage {
 
 #[async_trait::async_trait]
 impl InCommunity for UndoLockPage {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+  async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let community = self.object.community(context).await?;
     if let Some(audience) = &self.audience {
       verify_community_matches(audience, community.actor_id.clone())?;

--- a/crates/apub/src/protocol/activities/community/report.rs
+++ b/crates/apub/src/protocol/activities/community/report.rs
@@ -11,7 +11,7 @@ use activitypub_federation::{
   protocol::helpers::deserialize_one,
 };
 use lemmy_api_common::context::LemmyContext;
-use lemmy_utils::error::{LemmyError, LemmyErrorType, LemmyResult};
+use lemmy_utils::error::{LemmyErrorType, LemmyResult};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -71,7 +71,7 @@ impl ReportObject {
 
 #[async_trait::async_trait]
 impl InCommunity for Report {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+  async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let community = self.to[0].dereference(context).await?;
     if let Some(audience) = &self.audience {
       verify_community_matches(audience, community.actor_id.clone())?;

--- a/crates/apub/src/protocol/activities/community/update.rs
+++ b/crates/apub/src/protocol/activities/community/update.rs
@@ -10,7 +10,7 @@ use activitypub_federation::{
   protocol::helpers::deserialize_one_or_many,
 };
 use lemmy_api_common::context::LemmyContext;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -34,7 +34,7 @@ pub struct UpdateCommunity {
 
 #[async_trait::async_trait]
 impl InCommunity for UpdateCommunity {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+  async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let community: ApubCommunity = self.object.id.clone().dereference(context).await?;
     if let Some(audience) = &self.audience {
       verify_community_matches(audience, community.actor_id.clone())?;

--- a/crates/apub/src/protocol/activities/create_or_update/note.rs
+++ b/crates/apub/src/protocol/activities/create_or_update/note.rs
@@ -11,7 +11,7 @@ use activitypub_federation::{
 };
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::{source::community::Community, traits::Crud};
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -34,7 +34,7 @@ pub struct CreateOrUpdateNote {
 
 #[async_trait::async_trait]
 impl InCommunity for CreateOrUpdateNote {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+  async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let post = self.object.get_parents(context).await?.0;
     let community = Community::read(&mut context.pool(), post.community_id).await?;
     if let Some(audience) = &self.audience {

--- a/crates/apub/src/protocol/activities/create_or_update/page.rs
+++ b/crates/apub/src/protocol/activities/create_or_update/page.rs
@@ -9,7 +9,7 @@ use activitypub_federation::{
   protocol::helpers::deserialize_one_or_many,
 };
 use lemmy_api_common::context::LemmyContext;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -30,7 +30,7 @@ pub struct CreateOrUpdatePage {
 
 #[async_trait::async_trait]
 impl InCommunity for CreateOrUpdatePage {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+  async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let community = self.object.community(context).await?;
     if let Some(audience) = &self.audience {
       verify_community_matches(audience, community.actor_id.clone())?;

--- a/crates/apub/src/protocol/activities/deletion/delete.rs
+++ b/crates/apub/src/protocol/activities/deletion/delete.rs
@@ -15,7 +15,7 @@ use lemmy_db_schema::{
   source::{community::Community, post::Post},
   traits::Crud,
 };
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use url::Url;
@@ -47,7 +47,7 @@ pub struct Delete {
 
 #[async_trait::async_trait]
 impl InCommunity for Delete {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+  async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let community_id = match DeletableObjects::read_from_db(self.object.id(), context).await? {
       DeletableObjects::Community(c) => c.id,
       DeletableObjects::Comment(c) => {

--- a/crates/apub/src/protocol/activities/deletion/undo_delete.rs
+++ b/crates/apub/src/protocol/activities/deletion/undo_delete.rs
@@ -10,7 +10,7 @@ use activitypub_federation::{
   protocol::helpers::deserialize_one_or_many,
 };
 use lemmy_api_common::context::LemmyContext;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use url::Url;
@@ -35,7 +35,7 @@ pub struct UndoDelete {
 
 #[async_trait::async_trait]
 impl InCommunity for UndoDelete {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+  async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let community = self.object.community(context).await?;
     if let Some(audience) = &self.audience {
       verify_community_matches(audience, community.actor_id.clone())?;

--- a/crates/apub/src/protocol/activities/voting/undo_vote.rs
+++ b/crates/apub/src/protocol/activities/voting/undo_vote.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use activitypub_federation::{config::Data, fetch::object_id::ObjectId, kinds::activity::UndoType};
 use lemmy_api_common::context::LemmyContext;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -22,7 +22,7 @@ pub struct UndoVote {
 
 #[async_trait::async_trait]
 impl InCommunity for UndoVote {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+  async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let community = self.object.community(context).await?;
     if let Some(audience) = &self.audience {
       verify_community_matches(audience, community.actor_id.clone())?;

--- a/crates/apub/src/protocol/activities/voting/vote.rs
+++ b/crates/apub/src/protocol/activities/voting/vote.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use activitypub_federation::{config::Data, fetch::object_id::ObjectId};
 use lemmy_api_common::context::LemmyContext;
-use lemmy_utils::error::{LemmyError, LemmyErrorType};
+use lemmy_utils::error::{LemmyError, LemmyErrorType, LemmyResult};
 use serde::{Deserialize, Serialize};
 use strum_macros::Display;
 use url::Url;
@@ -51,7 +51,7 @@ impl From<&VoteType> for i16 {
 
 #[async_trait::async_trait]
 impl InCommunity for Vote {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+  async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let community = self
       .object
       .dereference(context)

--- a/crates/apub/src/protocol/collections/empty_outbox.rs
+++ b/crates/apub/src/protocol/collections/empty_outbox.rs
@@ -1,5 +1,5 @@
 use activitypub_federation::kinds::collection::OrderedCollectionType;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -14,7 +14,7 @@ pub(crate) struct EmptyOutbox {
 }
 
 impl EmptyOutbox {
-  pub(crate) fn new(outbox_id: Url) -> Result<EmptyOutbox, LemmyError> {
+  pub(crate) fn new(outbox_id: Url) -> LemmyResult<EmptyOutbox> {
     Ok(EmptyOutbox {
       r#type: OrderedCollectionType::OrderedCollection,
       id: outbox_id,

--- a/crates/apub/src/protocol/objects/group.rs
+++ b/crates/apub/src/protocol/objects/group.rs
@@ -26,7 +26,7 @@ use activitypub_federation::{
 use chrono::{DateTime, Utc};
 use lemmy_api_common::{context::LemmyContext, utils::local_site_opt_to_slur_regex};
 use lemmy_utils::{
-  error::LemmyError,
+  error::LemmyResult,
   utils::slurs::{check_slurs, check_slurs_opt},
 };
 use serde::{Deserialize, Serialize};
@@ -76,7 +76,7 @@ impl Group {
     &self,
     expected_domain: &Url,
     context: &LemmyContext,
-  ) -> Result<(), LemmyError> {
+  ) -> LemmyResult<()> {
     check_apub_id_valid_with_strictness(self.id.inner(), true, context).await?;
     verify_domains_match(expected_domain, self.id.inner())?;
 

--- a/crates/apub/src/protocol/objects/mod.rs
+++ b/crates/apub/src/protocol/objects/mod.rs
@@ -4,7 +4,7 @@ use lemmy_db_schema::{
   source::language::Language,
   utils::DbPool,
 };
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -34,7 +34,7 @@ impl LanguageTag {
   pub(crate) async fn new_single(
     lang: LanguageId,
     pool: &mut DbPool<'_>,
-  ) -> Result<Option<LanguageTag>, LemmyError> {
+  ) -> LemmyResult<Option<LanguageTag>> {
     let lang = Language::read_from_id(pool, lang).await?;
 
     // undetermined
@@ -51,7 +51,7 @@ impl LanguageTag {
   pub(crate) async fn new_multiple(
     lang_ids: Vec<LanguageId>,
     pool: &mut DbPool<'_>,
-  ) -> Result<Vec<LanguageTag>, LemmyError> {
+  ) -> LemmyResult<Vec<LanguageTag>> {
     let mut langs = Vec::<Language>::new();
 
     for l in lang_ids {
@@ -71,7 +71,7 @@ impl LanguageTag {
   pub(crate) async fn to_language_id_single(
     lang: Option<Self>,
     pool: &mut DbPool<'_>,
-  ) -> Result<Option<LanguageId>, LemmyError> {
+  ) -> LemmyResult<Option<LanguageId>> {
     let identifier = lang.map(|l| l.identifier);
     let language = Language::read_id_from_code(pool, identifier.as_deref()).await?;
 
@@ -81,7 +81,7 @@ impl LanguageTag {
   pub(crate) async fn to_language_id_multiple(
     langs: Vec<Self>,
     pool: &mut DbPool<'_>,
-  ) -> Result<Vec<LanguageId>, LemmyError> {
+  ) -> LemmyResult<Vec<LanguageId>> {
     let mut language_ids = Vec::new();
 
     for l in langs {

--- a/crates/apub/src/protocol/objects/note.rs
+++ b/crates/apub/src/protocol/objects/note.rs
@@ -20,7 +20,7 @@ use lemmy_db_schema::{
   source::{community::Community, post::Post},
   traits::Crud,
 };
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use std::ops::Deref;
@@ -57,7 +57,7 @@ impl Note {
   pub(crate) async fn get_parents(
     &self,
     context: &Data<LemmyContext>,
-  ) -> Result<(ApubPost, Option<ApubComment>), LemmyError> {
+  ) -> LemmyResult<(ApubPost, Option<ApubComment>)> {
     // Fetch parent comment chain in a box, otherwise it can cause a stack overflow.
     let parent = Box::pin(self.in_reply_to.dereference(context).await?);
     match parent.deref() {
@@ -73,7 +73,7 @@ impl Note {
 
 #[async_trait::async_trait]
 impl InCommunity for Note {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+  async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let (post, _) = self.get_parents(context).await?;
     let community = Community::read(&mut context.pool(), post.community_id).await?;
     if let Some(audience) = &self.audience {

--- a/crates/apub/src/protocol/objects/page.rs
+++ b/crates/apub/src/protocol/objects/page.rs
@@ -20,7 +20,7 @@ use activitypub_federation::{
 use chrono::{DateTime, Utc};
 use itertools::Itertools;
 use lemmy_api_common::context::LemmyContext;
-use lemmy_utils::error::{LemmyError, LemmyErrorType};
+use lemmy_utils::error::{LemmyError, LemmyErrorType, LemmyResult};
 use serde::{de::Error, Deserialize, Deserializer, Serialize};
 use serde_with::skip_serializing_none;
 use url::Url;
@@ -160,10 +160,7 @@ impl Page {
   /// it is a mod action and needs to be verified as such.
   ///
   /// Locked needs to be false on a newly created post (verified in [[CreatePost]].
-  pub(crate) async fn is_mod_action(
-    &self,
-    context: &Data<LemmyContext>,
-  ) -> Result<bool, LemmyError> {
+  pub(crate) async fn is_mod_action(&self, context: &Data<LemmyContext>) -> LemmyResult<bool> {
     let old_post = self.id.clone().dereference_local(context).await;
     Ok(Page::is_locked_changed(&old_post, &self.comments_enabled))
   }
@@ -181,7 +178,7 @@ impl Page {
     false
   }
 
-  pub(crate) fn creator(&self) -> Result<ObjectId<ApubPerson>, LemmyError> {
+  pub(crate) fn creator(&self) -> LemmyResult<ObjectId<ApubPerson>> {
     match &self.attributed_to {
       AttributedTo::Lemmy(l) => Ok(l.clone()),
       AttributedTo::Peertube(p) => p
@@ -224,10 +221,10 @@ impl ActivityHandler for Page {
   fn actor(&self) -> &Url {
     unimplemented!()
   }
-  async fn verify(&self, data: &Data<Self::DataType>) -> Result<(), LemmyError> {
+  async fn verify(&self, data: &Data<Self::DataType>) -> LemmyResult<()> {
     ApubPost::verify(self, self.id.inner(), data).await
   }
-  async fn receive(self, data: &Data<Self::DataType>) -> Result<(), LemmyError> {
+  async fn receive(self, data: &Data<Self::DataType>) -> LemmyResult<()> {
     ApubPost::from_json(self, data).await?;
     Ok(())
   }
@@ -235,7 +232,7 @@ impl ActivityHandler for Page {
 
 #[async_trait::async_trait]
 impl InCommunity for Page {
-  async fn community(&self, context: &Data<LemmyContext>) -> Result<ApubCommunity, LemmyError> {
+  async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let community = match &self.attributed_to {
       AttributedTo::Lemmy(_) => {
         let mut iter = self.to.iter().merge(self.cc.iter());

--- a/crates/db_schema/src/impls/actor_language.rs
+++ b/crates/db_schema/src/impls/actor_language.rs
@@ -26,7 +26,7 @@ use diesel::{
   QueryDsl,
 };
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
-use lemmy_utils::error::{LemmyError, LemmyErrorType};
+use lemmy_utils::error::{LemmyErrorType, LemmyResult};
 use tokio::sync::OnceCell;
 
 pub const UNDETERMINED_ID: LanguageId = LanguageId(0);
@@ -194,7 +194,7 @@ impl CommunityLanguage {
     pool: &mut DbPool<'_>,
     for_language_id: Option<LanguageId>,
     for_community_id: CommunityId,
-  ) -> Result<(), LemmyError> {
+  ) -> LemmyResult<()> {
     use crate::schema::community_language::dsl::community_language;
     let conn = &mut get_conn(pool).await?;
 

--- a/crates/db_schema/src/impls/local_site.rs
+++ b/crates/db_schema/src/impls/local_site.rs
@@ -1,23 +1,23 @@
 use crate::{
-  schema::local_site::dsl::local_site,
+  schema::local_site,
   source::local_site::{LocalSite, LocalSiteInsertForm, LocalSiteUpdateForm},
   utils::{get_conn, DbPool},
 };
 use diesel::{dsl::insert_into, result::Error};
 use diesel_async::RunQueryDsl;
-use lemmy_utils::{error::LemmyError, CACHE_DURATION_API};
+use lemmy_utils::{error::LemmyResult, CACHE_DURATION_API};
 use moka::future::Cache;
 use once_cell::sync::Lazy;
 
 impl LocalSite {
   pub async fn create(pool: &mut DbPool<'_>, form: &LocalSiteInsertForm) -> Result<Self, Error> {
     let conn = &mut get_conn(pool).await?;
-    insert_into(local_site)
+    insert_into(local_site::table)
       .values(form)
       .get_result::<Self>(conn)
       .await
   }
-  pub async fn read(pool: &mut DbPool<'_>) -> Result<Self, LemmyError> {
+  pub async fn read(pool: &mut DbPool<'_>) -> LemmyResult<Self> {
     static CACHE: Lazy<Cache<(), LocalSite>> = Lazy::new(|| {
       Cache::builder()
         .max_capacity(1)
@@ -28,20 +28,20 @@ impl LocalSite {
       CACHE
         .try_get_with((), async {
           let conn = &mut get_conn(pool).await?;
-          local_site.first::<Self>(conn).await
+          local_site::table.first::<Self>(conn).await
         })
         .await?,
     )
   }
   pub async fn update(pool: &mut DbPool<'_>, form: &LocalSiteUpdateForm) -> Result<Self, Error> {
     let conn = &mut get_conn(pool).await?;
-    diesel::update(local_site)
+    diesel::update(local_site::table)
       .set(form)
       .get_result::<Self>(conn)
       .await
   }
   pub async fn delete(pool: &mut DbPool<'_>) -> Result<usize, Error> {
     let conn = &mut get_conn(pool).await?;
-    diesel::delete(local_site).execute(conn).await
+    diesel::delete(local_site::table).execute(conn).await
   }
 }

--- a/crates/db_schema/src/impls/private_message.rs
+++ b/crates/db_schema/src/impls/private_message.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use diesel::{dsl::insert_into, result::Error, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 use url::Url;
 
 #[async_trait]
@@ -59,7 +59,7 @@ impl PrivateMessage {
   pub async fn read_from_apub_id(
     pool: &mut DbPool<'_>,
     object_id: Url,
-  ) -> Result<Option<Self>, LemmyError> {
+  ) -> LemmyResult<Option<Self>> {
     let conn = &mut get_conn(pool).await?;
     let object_id: DbUrl = object_id.into();
     Ok(

--- a/crates/db_schema/src/utils.rs
+++ b/crates/db_schema/src/utils.rs
@@ -31,7 +31,7 @@ use diesel_migrations::EmbeddedMigrations;
 use futures_util::{future::BoxFuture, Future, FutureExt};
 use i_love_jesus::CursorKey;
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+  error::{LemmyErrorExt, LemmyErrorType, LemmyResult},
   settings::SETTINGS,
 };
 use once_cell::sync::Lazy;
@@ -292,9 +292,7 @@ pub fn diesel_option_overwrite(opt: Option<String>) -> Option<Option<String>> {
   }
 }
 
-pub fn diesel_option_overwrite_to_url(
-  opt: &Option<String>,
-) -> Result<Option<Option<DbUrl>>, LemmyError> {
+pub fn diesel_option_overwrite_to_url(opt: &Option<String>) -> LemmyResult<Option<Option<DbUrl>>> {
   match opt.as_ref().map(String::as_str) {
     // An empty string is an erase
     Some("") => Ok(Some(None)),
@@ -305,9 +303,7 @@ pub fn diesel_option_overwrite_to_url(
   }
 }
 
-pub fn diesel_option_overwrite_to_url_create(
-  opt: &Option<String>,
-) -> Result<Option<DbUrl>, LemmyError> {
+pub fn diesel_option_overwrite_to_url_create(opt: &Option<String>) -> LemmyResult<Option<DbUrl>> {
   match opt.as_ref().map(String::as_str) {
     // An empty string is nothing
     Some("") => Ok(None),
@@ -365,7 +361,7 @@ impl ServerCertVerifier for NoCertVerifier {
 
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
 
-fn run_migrations(db_url: &str) -> Result<(), LemmyError> {
+fn run_migrations(db_url: &str) -> LemmyResult<()> {
   // Needs to be a sync connection
   let mut conn = PgConnection::establish(db_url).with_context(|| "Error connecting to database")?;
 
@@ -378,7 +374,7 @@ fn run_migrations(db_url: &str) -> Result<(), LemmyError> {
   Ok(())
 }
 
-pub async fn build_db_pool() -> Result<ActualDbPool, LemmyError> {
+pub async fn build_db_pool() -> LemmyResult<ActualDbPool> {
   let db_url = SETTINGS.get_database_url();
   // We only support TLS with sslmode=require currently
   let tls_enabled = db_url.contains("sslmode=require");

--- a/crates/routes/src/feeds.rs
+++ b/crates/routes/src/feeds.rs
@@ -22,7 +22,7 @@ use lemmy_db_views_actor::{
 };
 use lemmy_utils::{
   cache_header::cache_1hour,
-  error::{LemmyError, LemmyErrorType},
+  error::{LemmyError, LemmyErrorType, LemmyResult},
   utils::markdown::{markdown_to_html, sanitize_html},
 };
 use once_cell::sync::Lazy;
@@ -151,7 +151,7 @@ async fn get_feed_data(
   sort_type: SortType,
   limit: i64,
   page: i64,
-) -> Result<HttpResponse, LemmyError> {
+) -> LemmyResult<HttpResponse> {
   let site_view = SiteView::read_local(&mut context.pool()).await?;
 
   check_private_instance(&None, &site_view.local_site)?;
@@ -256,7 +256,7 @@ async fn get_feed_user(
   limit: &i64,
   page: &i64,
   user_name: &str,
-) -> Result<Channel, LemmyError> {
+) -> LemmyResult<Channel> {
   let site_view = SiteView::read_local(&mut context.pool()).await?;
   let person = Person::read_from_name(&mut context.pool(), user_name, false).await?;
 
@@ -292,7 +292,7 @@ async fn get_feed_community(
   limit: &i64,
   page: &i64,
   community_name: &str,
-) -> Result<Channel, LemmyError> {
+) -> LemmyResult<Channel> {
   let site_view = SiteView::read_local(&mut context.pool()).await?;
   let community = Community::read_from_name(&mut context.pool(), community_name, false).await?;
   if community.visibility != CommunityVisibility::Public {
@@ -335,7 +335,7 @@ async fn get_feed_front(
   limit: &i64,
   page: &i64,
   jwt: &str,
-) -> Result<Channel, LemmyError> {
+) -> LemmyResult<Channel> {
   let site_view = SiteView::read_local(&mut context.pool()).await?;
   let local_user = local_user_view_from_jwt(jwt, context).await?;
 
@@ -370,7 +370,7 @@ async fn get_feed_front(
 }
 
 #[tracing::instrument(skip_all)]
-async fn get_feed_inbox(context: &LemmyContext, jwt: &str) -> Result<Channel, LemmyError> {
+async fn get_feed_inbox(context: &LemmyContext, jwt: &str) -> LemmyResult<Channel> {
   let site_view = SiteView::read_local(&mut context.pool()).await?;
   let local_user = local_user_view_from_jwt(jwt, context).await?;
   let person_id = local_user.local_user.person_id;
@@ -425,7 +425,7 @@ fn create_reply_and_mention_items(
   replies: Vec<CommentReplyView>,
   mentions: Vec<PersonMentionView>,
   protocol_and_hostname: &str,
-) -> Result<Vec<Item>, LemmyError> {
+) -> LemmyResult<Vec<Item>> {
   let mut reply_items: Vec<Item> = replies
     .iter()
     .map(|r| {
@@ -438,7 +438,7 @@ fn create_reply_and_mention_items(
         protocol_and_hostname,
       )
     })
-    .collect::<Result<Vec<Item>, LemmyError>>()?;
+    .collect::<LemmyResult<Vec<Item>>>()?;
 
   let mut mention_items: Vec<Item> = mentions
     .iter()
@@ -452,7 +452,7 @@ fn create_reply_and_mention_items(
         protocol_and_hostname,
       )
     })
-    .collect::<Result<Vec<Item>, LemmyError>>()?;
+    .collect::<LemmyResult<Vec<Item>>>()?;
 
   reply_items.append(&mut mention_items);
   Ok(reply_items)
@@ -465,7 +465,7 @@ fn build_item(
   url: &str,
   content: &str,
   protocol_and_hostname: &str,
-) -> Result<Item, LemmyError> {
+) -> LemmyResult<Item> {
   // TODO add images
   let author_url = format!("{protocol_and_hostname}/u/{creator_name}");
   let guid = Some(Guid {
@@ -489,10 +489,7 @@ fn build_item(
 }
 
 #[tracing::instrument(skip_all)]
-fn create_post_items(
-  posts: Vec<PostView>,
-  protocol_and_hostname: &str,
-) -> Result<Vec<Item>, LemmyError> {
+fn create_post_items(posts: Vec<PostView>, protocol_and_hostname: &str) -> LemmyResult<Vec<Item>> {
   let mut items: Vec<Item> = Vec::new();
 
   for p in posts {

--- a/crates/routes/src/lib.rs
+++ b/crates/routes/src/lib.rs
@@ -1,6 +1,6 @@
 use lemmy_api_common::{claims::Claims, context::LemmyContext, utils::check_user_valid};
 use lemmy_db_views::structs::LocalUserView;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 
 pub mod feeds;
 pub mod images;
@@ -8,10 +8,7 @@ pub mod nodeinfo;
 pub mod webfinger;
 
 #[tracing::instrument(skip_all)]
-async fn local_user_view_from_jwt(
-  jwt: &str,
-  context: &LemmyContext,
-) -> Result<LocalUserView, LemmyError> {
+async fn local_user_view_from_jwt(jwt: &str, context: &LemmyContext) -> LemmyResult<LocalUserView> {
   let local_user_id = Claims::validate(jwt, context).await?;
   let local_user_view = LocalUserView::read(&mut context.pool(), local_user_id).await?;
   check_user_valid(&local_user_view.person)?;

--- a/crates/routes/src/nodeinfo.rs
+++ b/crates/routes/src/nodeinfo.rs
@@ -5,7 +5,7 @@ use lemmy_db_schema::RegistrationMode;
 use lemmy_db_views::structs::SiteView;
 use lemmy_utils::{
   cache_header::{cache_1hour, cache_3days},
-  error::LemmyError,
+  error::{LemmyError, LemmyResult},
   VERSION,
 };
 use serde::{Deserialize, Serialize};
@@ -24,9 +24,7 @@ pub fn config(cfg: &mut web::ServiceConfig) {
     );
 }
 
-async fn node_info_well_known(
-  context: web::Data<LemmyContext>,
-) -> Result<HttpResponse, LemmyError> {
+async fn node_info_well_known(context: web::Data<LemmyContext>) -> LemmyResult<HttpResponse> {
   let node_info = NodeInfoWellKnown {
     links: vec![NodeInfoWellKnownLinks {
       rel: Url::parse("http://nodeinfo.diaspora.software/ns/schema/2.0")?,

--- a/crates/routes/src/webfinger.rs
+++ b/crates/routes/src/webfinger.rs
@@ -9,7 +9,7 @@ use lemmy_db_schema::{
   traits::ApubActor,
   CommunityVisibility,
 };
-use lemmy_utils::{cache_header::cache_3days, error::LemmyError};
+use lemmy_utils::{cache_header::cache_3days, error::LemmyResult};
 use serde::Deserialize;
 use std::collections::HashMap;
 use url::Url;
@@ -35,7 +35,7 @@ pub fn config(cfg: &mut web::ServiceConfig) {
 async fn get_webfinger_response(
   info: Query<Params>,
   context: Data<LemmyContext>,
-) -> Result<HttpResponse, LemmyError> {
+) -> LemmyResult<HttpResponse> {
   let name = extract_webfinger_name(&info.resource, &context)?;
 
   let links = if name == context.settings().hostname {

--- a/crates/utils/src/email.rs
+++ b/crates/utils/src/email.rs
@@ -1,5 +1,5 @@
 use crate::{
-  error::{LemmyError, LemmyErrorExt, LemmyErrorType},
+  error::{LemmyErrorExt, LemmyErrorType, LemmyResult},
   settings::structs::Settings,
 };
 use html2text;
@@ -25,7 +25,7 @@ pub async fn send_email(
   to_username: &str,
   html: &str,
   settings: &Settings,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   let email_config = settings.email.clone().ok_or(LemmyErrorType::NoEmailSetup)?;
   let domain = settings.hostname.clone();
 

--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -244,11 +244,11 @@ cfg_if! {
     }
 
     pub trait LemmyErrorExt<T, E: Into<anyhow::Error>> {
-      fn with_lemmy_type(self, error_type: LemmyErrorType) -> Result<T, LemmyError>;
+      fn with_lemmy_type(self, error_type: LemmyErrorType) -> LemmyResult<T>;
     }
 
     impl<T, E: Into<anyhow::Error>> LemmyErrorExt<T, E> for Result<T, E> {
-      fn with_lemmy_type(self, error_type: LemmyErrorType) -> Result<T, LemmyError> {
+      fn with_lemmy_type(self, error_type: LemmyErrorType) -> LemmyResult<T> {
         self.map_err(|error| LemmyError {
           error_type,
           inner: error.into(),
@@ -257,12 +257,12 @@ cfg_if! {
       }
     }
     pub trait LemmyErrorExt2<T> {
-      fn with_lemmy_type(self, error_type: LemmyErrorType) -> Result<T, LemmyError>;
+      fn with_lemmy_type(self, error_type: LemmyErrorType) -> LemmyResult<T>;
       fn into_anyhow(self) -> Result<T, anyhow::Error>;
     }
 
-    impl<T> LemmyErrorExt2<T> for Result<T, LemmyError> {
-      fn with_lemmy_type(self, error_type: LemmyErrorType) -> Result<T, LemmyError> {
+    impl<T> LemmyErrorExt2<T> for LemmyResult<T> {
+      fn with_lemmy_type(self, error_type: LemmyErrorType) -> LemmyResult<T> {
         self.map_err(|mut e| {
           e.error_type = error_type;
           e

--- a/crates/utils/src/settings/mod.rs
+++ b/crates/utils/src/settings/mod.rs
@@ -1,4 +1,4 @@
-use crate::{error::LemmyError, location_info};
+use crate::{error::LemmyResult, location_info};
 use anyhow::{anyhow, Context};
 use deser_hjson::from_str;
 use once_cell::sync::Lazy;
@@ -38,7 +38,7 @@ impl Settings {
   /// Note: The env var `LEMMY_DATABASE_URL` is parsed in
   /// `lemmy_db_schema/src/lib.rs::get_database_url_from_env()`
   /// Warning: Only call this once.
-  pub(crate) fn init() -> Result<Self, LemmyError> {
+  pub(crate) fn init() -> LemmyResult<Self> {
     let config = from_str::<Settings>(&Self::read_config_file()?)?;
     if config.hostname == "unset" {
       Err(anyhow!("Hostname variable is not set!").into())
@@ -108,7 +108,7 @@ impl Settings {
     WEBFINGER_REGEX.clone()
   }
 
-  pub fn pictrs_config(&self) -> Result<PictrsConfig, LemmyError> {
+  pub fn pictrs_config(&self) -> LemmyResult<PictrsConfig> {
     self
       .pictrs
       .clone()

--- a/crates/utils/src/utils/slurs.rs
+++ b/crates/utils/src/utils/slurs.rs
@@ -1,4 +1,4 @@
-use crate::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
+use crate::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 use regex::{Regex, RegexBuilder};
 
 pub fn remove_slurs(test: &str, slur_regex: &Option<Regex>) -> String {
@@ -39,7 +39,7 @@ pub fn build_slur_regex(regex_str: Option<&str>) -> Option<Regex> {
   })
 }
 
-pub fn check_slurs(text: &str, slur_regex: &Option<Regex>) -> Result<(), LemmyError> {
+pub fn check_slurs(text: &str, slur_regex: &Option<Regex>) -> LemmyResult<()> {
   if let Err(slurs) = slur_check(text, slur_regex) {
     Err(anyhow::anyhow!("{}", slurs_vec_to_str(&slurs))).with_lemmy_type(LemmyErrorType::Slurs)
   } else {
@@ -47,10 +47,7 @@ pub fn check_slurs(text: &str, slur_regex: &Option<Regex>) -> Result<(), LemmyEr
   }
 }
 
-pub fn check_slurs_opt(
-  text: &Option<String>,
-  slur_regex: &Option<Regex>,
-) -> Result<(), LemmyError> {
+pub fn check_slurs_opt(text: &Option<String>, slur_regex: &Option<Regex>) -> LemmyResult<()> {
   match text {
     Some(t) => check_slurs(t, slur_regex),
     None => Ok(()),

--- a/src/code_migrations.rs
+++ b/src/code_migrations.rs
@@ -34,14 +34,14 @@ use lemmy_db_schema::{
   traits::Crud,
   utils::{get_conn, naive_now, DbPool},
 };
-use lemmy_utils::{error::LemmyError, settings::structs::Settings};
+use lemmy_utils::{error::LemmyResult, settings::structs::Settings};
 use tracing::info;
 use url::Url;
 
 pub async fn run_advanced_migrations(
   pool: &mut DbPool<'_>,
   settings: &Settings,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   let protocol_and_hostname = &settings.get_protocol_and_hostname();
   user_updates_2020_04_02(pool, protocol_and_hostname).await?;
   community_updates_2020_04_02(pool, protocol_and_hostname).await?;
@@ -60,7 +60,7 @@ pub async fn run_advanced_migrations(
 async fn user_updates_2020_04_02(
   pool: &mut DbPool<'_>,
   protocol_and_hostname: &str,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   use lemmy_db_schema::schema::person::dsl::{actor_id, local, person};
   let conn = &mut get_conn(pool).await?;
 
@@ -99,7 +99,7 @@ async fn user_updates_2020_04_02(
 async fn community_updates_2020_04_02(
   pool: &mut DbPool<'_>,
   protocol_and_hostname: &str,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   use lemmy_db_schema::schema::community::dsl::{actor_id, community, local};
   let conn = &mut get_conn(pool).await?;
 
@@ -139,7 +139,7 @@ async fn community_updates_2020_04_02(
 async fn post_updates_2020_04_03(
   pool: &mut DbPool<'_>,
   protocol_and_hostname: &str,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   use lemmy_db_schema::schema::post::dsl::{ap_id, local, post};
   let conn = &mut get_conn(pool).await?;
 
@@ -177,7 +177,7 @@ async fn post_updates_2020_04_03(
 async fn comment_updates_2020_04_03(
   pool: &mut DbPool<'_>,
   protocol_and_hostname: &str,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   use lemmy_db_schema::schema::comment::dsl::{ap_id, comment, local};
   let conn = &mut get_conn(pool).await?;
 
@@ -215,7 +215,7 @@ async fn comment_updates_2020_04_03(
 async fn private_message_updates_2020_05_05(
   pool: &mut DbPool<'_>,
   protocol_and_hostname: &str,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   use lemmy_db_schema::schema::private_message::dsl::{ap_id, local, private_message};
   let conn = &mut get_conn(pool).await?;
 
@@ -253,7 +253,7 @@ async fn private_message_updates_2020_05_05(
 async fn post_thumbnail_url_updates_2020_07_27(
   pool: &mut DbPool<'_>,
   protocol_and_hostname: &str,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   use lemmy_db_schema::schema::post::dsl::{post, thumbnail_url};
   let conn = &mut get_conn(pool).await?;
 
@@ -282,10 +282,7 @@ async fn post_thumbnail_url_updates_2020_07_27(
 
 /// We are setting inbox and follower URLs for local and remote actors alike, because for now
 /// all federated instances are also Lemmy and use the same URL scheme.
-async fn apub_columns_2021_02_02(
-  pool: &mut DbPool<'_>,
-  settings: &Settings,
-) -> Result<(), LemmyError> {
+async fn apub_columns_2021_02_02(pool: &mut DbPool<'_>, settings: &Settings) -> LemmyResult<()> {
   let conn = &mut get_conn(pool).await?;
   info!("Running apub_columns_2021_02_02");
   {
@@ -346,7 +343,7 @@ async fn instance_actor_2022_01_28(
   pool: &mut DbPool<'_>,
   protocol_and_hostname: &str,
   settings: &Settings,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   info!("Running instance_actor_2021_09_29");
   if let Ok(site_view) = SiteView::read_local(pool).await {
     let site = site_view.site;
@@ -374,7 +371,7 @@ async fn instance_actor_2022_01_28(
 /// key field is empty, generate a new keypair. It would be possible to regenerate only the pubkey,
 /// but thats more complicated and has no benefit, as federation is already broken for these actors.
 /// https://github.com/LemmyNet/lemmy/issues/2347
-async fn regenerate_public_keys_2022_07_05(pool: &mut DbPool<'_>) -> Result<(), LemmyError> {
+async fn regenerate_public_keys_2022_07_05(pool: &mut DbPool<'_>) -> LemmyResult<()> {
   let conn = &mut get_conn(pool).await?;
   info!("Running regenerate_public_keys_2022_07_05");
 
@@ -433,7 +430,7 @@ async fn regenerate_public_keys_2022_07_05(pool: &mut DbPool<'_>) -> Result<(), 
 async fn initialize_local_site_2022_10_10(
   pool: &mut DbPool<'_>,
   settings: &Settings,
-) -> Result<(), LemmyError> {
+) -> LemmyResult<()> {
   info!("Running initialize_local_site_2022_10_10");
 
   // Check to see if local_site exists

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@ use actix_web::{
   App,
   HttpResponse,
   HttpServer,
-  Result,
 };
 use actix_web_prom::PrometheusMetricsBuilder;
 use clap::Parser;
@@ -45,7 +44,7 @@ use lemmy_db_schema::{source::secret::Secret, utils::build_db_pool};
 use lemmy_federate::{start_stop_federation_workers_cancellable, Opts};
 use lemmy_routes::{feeds, images, nodeinfo, webfinger};
 use lemmy_utils::{
-  error::LemmyError,
+  error::LemmyResult,
   rate_limit::RateLimitCell,
   response::jsonify_plain_text_errors,
   settings::{structs::Settings, SETTINGS},
@@ -107,7 +106,7 @@ pub struct CmdArgs {
 }
 
 /// Placing the main function in lib.rs allows other crates to import it and embed Lemmy
-pub async fn start_lemmy_server(args: CmdArgs) -> Result<(), LemmyError> {
+pub async fn start_lemmy_server(args: CmdArgs) -> LemmyResult<()> {
   // Print version number to log
   println!("Lemmy v{VERSION}");
 
@@ -244,7 +243,7 @@ pub async fn start_lemmy_server(args: CmdArgs) -> Result<(), LemmyError> {
 }
 
 /// Creates temporary HTTP server which returns status 503 for all requests.
-fn create_startup_server() -> Result<ServerHandle, LemmyError> {
+fn create_startup_server() -> LemmyResult<ServerHandle> {
   let startup_server = HttpServer::new(move || {
     App::new().wrap(ErrorHandlers::new().default_handler(move |req| {
       let (req, _) = req.into_parts();
@@ -267,7 +266,7 @@ fn create_http_server(
   federation_config: FederationConfig<LemmyContext>,
   settings: Settings,
   federation_enabled: bool,
-) -> Result<ServerHandle, LemmyError> {
+) -> LemmyResult<ServerHandle> {
   // this must come before the HttpServer creation
   // creates a middleware that populates http metrics for each path, method, and status code
   let prom_api_metrics = PrometheusMetricsBuilder::new("lemmy_api")
@@ -349,7 +348,7 @@ fn cors_config(settings: &Settings) -> Cors {
   }
 }
 
-pub fn init_logging(opentelemetry_url: &Option<Url>) -> Result<(), LemmyError> {
+pub fn init_logging(opentelemetry_url: &Option<Url>) -> LemmyResult<()> {
   LogTracer::init()?;
 
   let log_description = env::var("RUST_LOG").unwrap_or_else(|_| "info".into());

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 use clap::Parser;
 use lemmy_server::{init_logging, start_lemmy_server, CmdArgs};
-use lemmy_utils::{error::LemmyError, settings::SETTINGS};
+use lemmy_utils::{error::LemmyResult, settings::SETTINGS};
 
 #[tokio::main]
-pub async fn main() -> Result<(), LemmyError> {
+pub async fn main() -> LemmyResult<()> {
   init_logging(&SETTINGS.opentelemetry_url)?;
   let args = CmdArgs::parse();
 

--- a/src/scheduled_tasks.rs
+++ b/src/scheduled_tasks.rs
@@ -29,13 +29,13 @@ use lemmy_db_schema::{
   utils::{get_conn, naive_now, now, DbPool, DELETED_REPLACEMENT_TEXT},
 };
 use lemmy_routes::nodeinfo::NodeInfo;
-use lemmy_utils::error::{LemmyError, LemmyResult};
+use lemmy_utils::error::LemmyResult;
 use reqwest_middleware::ClientWithMiddleware;
 use std::time::Duration;
 use tracing::{error, info, warn};
 
 /// Schedules various cleanup tasks for lemmy in a background thread
-pub async fn setup(context: LemmyContext) -> Result<(), LemmyError> {
+pub async fn setup(context: LemmyContext) -> LemmyResult<()> {
   // Setup the connections
   let mut scheduler = AsyncScheduler::new();
   startup_jobs(&mut context.pool()).await;

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -8,11 +8,7 @@ use opentelemetry_otlp::WithExportConfig;
 use tracing::{subscriber::set_global_default, Subscriber};
 use tracing_subscriber::{filter::Targets, layer::SubscriberExt, registry::LookupSpan, Layer};
 
-pub fn init_tracing<S>(
-  opentelemetry_url: &str,
-  subscriber: S,
-  targets: Targets,
-) -> Result<(), LemmyError>
+pub fn init_tracing<S>(opentelemetry_url: &str, subscriber: S, targets: Targets) -> LemmyResult<()>
 where
   S: Subscriber + for<'a> LookupSpan<'a> + Send + Sync + 'static,
 {

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,5 +1,5 @@
 use console_subscriber::ConsoleLayer;
-use lemmy_utils::error::LemmyError;
+use lemmy_utils::error::LemmyResult;
 use opentelemetry::{
   sdk::{propagation::TraceContextPropagator, Resource},
   KeyValue,


### PR DESCRIPTION
Cleanup task to remove all `Result<.., LemmyError>` into `LemmyResult<...>`