### PR TITLE
Untangle thumbnail generation logic (ref #4604)

### DIFF
--- a/api_tests/src/image.spec.ts
+++ b/api_tests/src/image.spec.ts
@@ -30,6 +30,7 @@ import {
   getPost,
   waitUntil,
   randomString,
+  createPostWithThumbnail,
 } from "./shared";
 const downloadFileSync = require("download-file-sync");
 
@@ -264,13 +265,10 @@ test("Make regular post, and give it a custom thumbnail", async () => {
   // Use wikipedia since it has an opengraph image
   const wikipediaUrl = "https://wikipedia.org/";
 
-  let post = await createPost(
+  let post = await createPostWithThumbnail(
     alphaImage,
     community.community_view.community.id,
     wikipediaUrl,
-    randomString(10),
-    randomString(5),
-    randomString(10),
     upload1.url!,
   );
 
@@ -281,8 +279,7 @@ test("Make regular post, and give it a custom thumbnail", async () => {
   );
   expect(post.post_view.post.url).toBe(wikipediaUrl);
   expect(post.post_view.post.thumbnail_url).toBeDefined();
-
-  // Make sure the thumbnail got edited.
+  // Make sure it uses custom thumbnail
   expect(post.post_view.post.thumbnail_url).toBe(upload1.url);
 });
 
@@ -299,18 +296,19 @@ test("Create an image post, and make sure a custom thumbnail doesnt overwrite it
 
   const community = await createCommunity(alphaImage);
 
-  const post = await createPost(
+  let post = await createPostWithThumbnail(
     alphaImage,
     community.community_view.community.id,
-    upload1.url,
-    "https://example.com/",
-    randomString(10),
-    randomString(5),
+    upload1.url!,
     upload2.url!,
   );
+  post = await waitUntil(
+    () => getPost(alphaImage, post.post_view.post.id),
+    p => p.post_view.post.thumbnail_url != undefined,
+  );
   expect(post.post_view.post.url).toBe(upload1.url);
-  // Make sure the new custom thumbnail is ignored, and doesn't overwrite the image post
   expect(post.post_view.post.url).toBe(upload1.url);
+  // Make sure the custom thumbnail is ignored
   expect(post.post_view.post.thumbnail_url).toBe(
     post.post_view.post.thumbnail_url,
   );

--- a/api_tests/src/image.spec.ts
+++ b/api_tests/src/image.spec.ts
@@ -27,9 +27,9 @@ import {
   setupLogins,
   waitForPost,
   unfollows,
-  editPostThumbnail,
   getPost,
   waitUntil,
+  randomString,
 } from "./shared";
 const downloadFileSync = require("download-file-sync");
 
@@ -268,6 +268,10 @@ test("Make regular post, and give it a custom thumbnail", async () => {
     alphaImage,
     community.community_view.community.id,
     wikipediaUrl,
+    randomString(10),
+    randomString(5),
+    randomString(10),
+    upload1.url!
   );
 
   // Wait for the metadata to get fetched, since this is backgrounded now
@@ -277,14 +281,6 @@ test("Make regular post, and give it a custom thumbnail", async () => {
   );
   expect(post.post_view.post.url).toBe(wikipediaUrl);
   expect(post.post_view.post.thumbnail_url).toBeDefined();
-
-  // Edit the thumbnail
-  await editPostThumbnail(alphaImage, post.post_view.post, upload1.url!);
-
-  post = await waitUntil(
-    () => getPost(alphaImage, post.post_view.post.id),
-    p => p.post_view.post.thumbnail_url == upload1.url,
-  );
 
   // Make sure the thumbnail got edited.
   expect(post.post_view.post.thumbnail_url).toBe(upload1.url);
@@ -303,23 +299,17 @@ test("Create an image post, and make sure a custom thumbnail doesnt overwrite it
 
   const community = await createCommunity(alphaImage);
 
-  let post = await createPost(
+  const post = await createPost(
     alphaImage,
     community.community_view.community.id,
     upload1.url,
+    "https://example.com/",
+    randomString(10),
+    randomString(5),
+    upload2.url!
   );
   expect(post.post_view.post.url).toBe(upload1.url);
-
-  // Edit the post
-  await editPostThumbnail(alphaImage, post.post_view.post, upload2.url!);
-
-  // Wait for the metadata to get fetched
-  post = await waitUntil(
-    () => getPost(alphaImage, post.post_view.post.id),
-    p => p.post_view.post.thumbnail_url == upload1.url,
-  );
-
   // Make sure the new custom thumbnail is ignored, and doesn't overwrite the image post
   expect(post.post_view.post.url).toBe(upload1.url);
-  expect(post.post_view.post.thumbnail_url).toBe(upload1.url);
+  expect(post.post_view.post.thumbnail_url).toBe(post.post_view.post.thumbnail_url);
 });

--- a/api_tests/src/image.spec.ts
+++ b/api_tests/src/image.spec.ts
@@ -271,7 +271,7 @@ test("Make regular post, and give it a custom thumbnail", async () => {
     randomString(10),
     randomString(5),
     randomString(10),
-    upload1.url!
+    upload1.url!,
   );
 
   // Wait for the metadata to get fetched, since this is backgrounded now
@@ -306,10 +306,12 @@ test("Create an image post, and make sure a custom thumbnail doesnt overwrite it
     "https://example.com/",
     randomString(10),
     randomString(5),
-    upload2.url!
+    upload2.url!,
   );
   expect(post.post_view.post.url).toBe(upload1.url);
   // Make sure the new custom thumbnail is ignored, and doesn't overwrite the image post
   expect(post.post_view.post.url).toBe(upload1.url);
-  expect(post.post_view.post.thumbnail_url).toBe(post.post_view.post.thumbnail_url);
+  expect(post.post_view.post.thumbnail_url).toBe(
+    post.post_view.post.thumbnail_url,
+  );
 });

--- a/api_tests/src/image.spec.ts
+++ b/api_tests/src/image.spec.ts
@@ -278,7 +278,6 @@ test("Make regular post, and give it a custom thumbnail", async () => {
     p => p.post_view.post.thumbnail_url != undefined,
   );
   expect(post.post_view.post.url).toBe(wikipediaUrl);
-  expect(post.post_view.post.thumbnail_url).toBeDefined();
   // Make sure it uses custom thumbnail
   expect(post.post_view.post.thumbnail_url).toBe(upload1.url);
 });
@@ -307,9 +306,6 @@ test("Create an image post, and make sure a custom thumbnail doesnt overwrite it
     p => p.post_view.post.thumbnail_url != undefined,
   );
   expect(post.post_view.post.url).toBe(upload1.url);
-  expect(post.post_view.post.url).toBe(upload1.url);
   // Make sure the custom thumbnail is ignored
-  expect(post.post_view.post.thumbnail_url).toBe(
-    post.post_view.post.thumbnail_url,
-  );
+  expect(post.post_view.post.thumbnail_url == upload2.url).toBe(false);
 });

--- a/api_tests/src/shared.ts
+++ b/api_tests/src/shared.ts
@@ -228,6 +228,21 @@ export async function editPost(
   return api.editPost(form);
 }
 
+export async function createPostWithThumbnail(
+  api: LemmyHttp,
+  community_id: number,
+  url: string,
+  custom_thumbnail: string,
+): Promise<PostResponse> {
+  let form: CreatePost = {
+    name: randomString(10),
+    url,
+    community_id,
+    custom_thumbnail,
+  };
+  return api.createPost(form);
+}
+
 export async function deletePost(
   api: LemmyHttp,
   deleted: boolean,

--- a/api_tests/src/shared.ts
+++ b/api_tests/src/shared.ts
@@ -203,6 +203,7 @@ export async function createPost(
   // use example.com for consistent title and embed description
   name: string = randomString(5),
   alt_text = randomString(10),
+  custom_thumbnail: string | undefined = undefined,
 ): Promise<PostResponse> {
   let form: CreatePost = {
     name,
@@ -210,6 +211,7 @@ export async function createPost(
     body,
     alt_text,
     community_id,
+    custom_thumbnail,
   };
   return api.createPost(form);
 }
@@ -222,18 +224,6 @@ export async function editPost(
   let form: EditPost = {
     name,
     post_id: post.id,
-  };
-  return api.editPost(form);
-}
-
-export async function editPostThumbnail(
-  api: LemmyHttp,
-  post: Post,
-  customThumbnail: string,
-): Promise<PostResponse> {
-  let form: EditPost = {
-    post_id: post.id,
-    custom_thumbnail: customThumbnail,
   };
   return api.editPost(form);
 }

--- a/crates/api/src/post/get_link_metadata.rs
+++ b/crates/api/src/post/get_link_metadata.rs
@@ -11,7 +11,7 @@ pub async fn get_link_metadata(
   data: Query<GetSiteMetadata>,
   context: Data<LemmyContext>,
 ) -> LemmyResult<Json<GetSiteMetadataResponse>> {
-  let metadata = fetch_link_metadata(&data.url, false, &context).await?;
+  let metadata = fetch_link_metadata(&data.url, &context).await?;
 
   Ok(Json(GetSiteMetadataResponse { metadata }))
 }

--- a/crates/api_common/src/post.rs
+++ b/crates/api_common/src/post.rs
@@ -270,8 +270,6 @@ pub struct LinkMetadata {
   #[serde(flatten)]
   pub opengraph_data: OpenGraphData,
   pub content_type: Option<String>,
-  #[serde(skip)]
-  pub thumbnail: Option<DbUrl>,
 }
 
 #[skip_serializing_none]

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -103,12 +103,12 @@ pub fn generate_post_link_metadata(
     else if federated_thumbnail.is_some() {
       federated_thumbnail
     }
-    // Generate local thumbnail if allowed and post.url is Some
-    else if let (true, Some(url)) = (allow_generate_thumbnail, &post.url) {
-      generate_pictrs_thumbnail(url, &context)
-        .await
-        .ok()
-        .map(Into::into)
+    // Generate local thumbnail if allowed
+    else if allow_generate_thumbnail {
+      match post.url.or(metadata.opengraph_data.image) {
+        Some(url) => generate_pictrs_thumbnail(&url, &context).await.ok(),
+        None => None,
+      }
     }
     // Otherwise use opengraph preview image directly
     else {

--- a/crates/api_crud/src/post/create.rs
+++ b/crates/api_crud/src/post/create.rs
@@ -157,6 +157,7 @@ pub async fn create_post(
   generate_post_link_metadata(
     updated_post.clone(),
     custom_thumbnail,
+    None,
     |post| Some(SendActivityData::CreatePost(post)),
     Some(local_site),
     context.reset_request_count(),

--- a/crates/api_crud/src/post/update.rs
+++ b/crates/api_crud/src/post/update.rs
@@ -116,6 +116,7 @@ pub async fn update_post(
   generate_post_link_metadata(
     updated_post.clone(),
     custom_thumbnail,
+    None,
     |post| Some(SendActivityData::UpdatePost(post)),
     Some(local_site),
     context.reset_request_count(),

--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -276,6 +276,7 @@ impl Object for ApubPost {
 
     generate_post_link_metadata(
       post.clone(),
+      None,
       page.image.map(|i| i.url),
       |_| None,
       local_site,


### PR DESCRIPTION
I attempted to resolve the problem mentioned by @kroese, that the federated thumbnail was not used. While doing that I noticed that the thumbnail generation logic is really tangled, with a bool `generate_thumbnail` passed deep into `fetch_link_metadata()` when the entire logic should be directly in `generate_post_link_metadata()`. Especially because we need to know if post.url is an image to decide whether we need to generate a thumbnail. So now the whole logic is in one place.