### PR TITLE
On registration set show_nsfw based on site.content_warning

### DIFF
--- a/crates/api_common/src/person.rs
+++ b/crates/api_common/src/person.rs
@@ -40,7 +40,7 @@ pub struct Register {
   pub username: String,
   pub password: Sensitive<String>,
   pub password_verify: Sensitive<String>,
-  pub show_nsfw: bool,
+  pub show_nsfw: Option<bool>,
   /// email is mandatory if email verification is enabled on the server
   pub email: Option<Sensitive<String>>,
   /// The UUID of the captcha item.

--- a/crates/api_crud/src/user/create.rs
+++ b/crates/api_crud/src/user/create.rs
@@ -140,12 +140,17 @@ pub async fn register(
     .map(|lang_str| lang_str.split('-').next().unwrap_or_default().to_string())
     .collect();
 
+  // Show nsfw content if param is true, or if content_warning exists
+  let show_nsfw = data
+    .show_nsfw
+    .unwrap_or(site_view.site.content_warning.is_some());
+
   // Create the local user
   let local_user_form = LocalUserInsertForm::builder()
     .person_id(inserted_person.id)
     .email(data.email.as_deref().map(str::to_lowercase))
     .password_encrypted(data.password.to_string())
-    .show_nsfw(Some(data.show_nsfw))
+    .show_nsfw(Some(show_nsfw))
     .accepted_application(accepted_application)
     .default_listing_type(Some(local_site.default_post_listing_type))
     .post_listing_mode(Some(local_site.default_post_listing_mode))


### PR DESCRIPTION
To make this work properly, lemmy-ui during registration should send `show_nsfw = null` if the user doesnt choose a value manually. Or set the default value for show_nsfw based on `site.content_warning`.