### PR TITLE
fix: use docker compose v2

### DIFF
--- a/scripts/postgres_15_to_16_upgrade.sh
+++ b/scripts/postgres_15_to_16_upgrade.sh
@@ -24,7 +24,7 @@ echo "Removing the old postgres folder"
 sudo rm -rf volumes/postgres
 
 echo "Updating docker compose to use postgres version 16."
-sudo sed -i "s/image: postgres:.*/image: postgres:16-alpine/" ./docker-compose.yml
+sudo sed -i "s/image: .*postgres:.*/image: docker.io/postgres:16-alpine/" ./docker-compose.yml
 
 echo "Starting up new postgres..."
 sudo docker compose up -d postgres

--- a/scripts/postgres_15_to_16_upgrade.sh
+++ b/scripts/postgres_15_to_16_upgrade.sh
@@ -4,39 +4,39 @@ set -e
 echo "Do not stop in the middle of this upgrade, wait until you see the message: Upgrade complete."
 
 echo "Stopping lemmy and all services..."
-sudo docker-compose stop
+sudo docker compose stop
 
 echo "Make sure postgres is started..."
-sudo docker-compose up -d postgres
+sudo docker compose up -d postgres
 echo "Waiting..."
 sleep 20s
 
 echo "Exporting the Database to 15_16.dump.sql ..."
-sudo docker-compose exec -T postgres pg_dumpall -c -U lemmy > 15_16_dump.sql
+sudo docker compose exec -T postgres pg_dumpall -c -U lemmy > 15_16_dump.sql
 echo "Done."
 
 echo "Stopping postgres..."
-sudo docker-compose stop postgres
+sudo docker compose stop postgres
 echo "Waiting..."
 sleep 20s
 
 echo "Removing the old postgres folder"
 sudo rm -rf volumes/postgres
 
-echo "Updating docker-compose to use postgres version 16."
+echo "Updating docker compose to use postgres version 16."
 sed -i "s/image: postgres:.*/image: postgres:16-alpine/" ./docker-compose.yml
 
 echo "Starting up new postgres..."
-sudo docker-compose up -d postgres
+sudo docker compose up -d postgres
 echo "Waiting..."
 sleep 20s
 
 echo "Importing the database...."
-cat 15_16_dump.sql | sudo docker-compose exec -T postgres psql -U lemmy
+cat 15_16_dump.sql | sudo docker compose exec -T postgres psql -U lemmy
 echo "Done."
 
 echo "Starting up lemmy..."
-sudo docker-compose up -d
+sudo docker compose up -d
 
 echo "A copy of your old database is at 15_16.dump.sql . You can delete this file if the upgrade went smoothly."
 echo "Upgrade complete."

--- a/scripts/postgres_15_to_16_upgrade.sh
+++ b/scripts/postgres_15_to_16_upgrade.sh
@@ -12,7 +12,7 @@ echo "Waiting..."
 sleep 20s
 
 echo "Exporting the Database to 15_16.dump.sql ..."
-sudo docker compose exec -T postgres pg_dumpall -c -U lemmy > 15_16_dump.sql
+sudo docker compose exec -T postgres pg_dumpall -c -U lemmy | sudo tee 15_16_dump.sql > /dev/null
 echo "Done."
 
 echo "Stopping postgres..."
@@ -24,7 +24,7 @@ echo "Removing the old postgres folder"
 sudo rm -rf volumes/postgres
 
 echo "Updating docker compose to use postgres version 16."
-sed -i "s/image: postgres:.*/image: postgres:16-alpine/" ./docker-compose.yml
+sudo sed -i "s/image: postgres:.*/image: postgres:16-alpine/" ./docker-compose.yml
 
 echo "Starting up new postgres..."
 sudo docker compose up -d postgres
@@ -32,7 +32,7 @@ echo "Waiting..."
 sleep 20s
 
 echo "Importing the database...."
-cat 15_16_dump.sql | sudo docker compose exec -T postgres psql -U lemmy
+sudo cat 15_16_dump.sql | sudo docker compose exec -T postgres psql -U lemmy
 echo "Done."
 
 echo "Starting up lemmy..."


### PR DESCRIPTION
With Ubuntu 22.04 and Debian 12 when using v1 commands this happens:
(Ref: https://askubuntu.com/questions/1508129/docker-compose-giving-containerconfig-errors-after-update-today) 

This means your containers end up in a broken state. Updating all commands to be v2 compatible ensures they still work

Edit: Draft. Just realised there are more problems with it than I thought. (you can't `> 15_to_16` for example) 