### PR TITLE
Update aarch64-lemmy-linux-gnu to v0.3.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ ARG RUST_RELEASE_MODE=debug
 
 ARG AMD_BUILDER_IMAGE=rust:${RUST_VERSION}
 # Repo: https://github.com/raskyld/lemmy-cross-toolchains
-ARG ARM_BUILDER_IMAGE="ghcr.io/raskyld/aarch64-lemmy-linux-gnu:v0.2.0"
+ARG ARM_BUILDER_IMAGE="ghcr.io/raskyld/aarch64-lemmy-linux-gnu:v0.3.0"
 
 ARG AMD_RUNNER_IMAGE=debian:bookworm-slim
 ARG ARM_RUNNER_IMAGE=debian:bookworm-slim


### PR DESCRIPTION
Updates aarch64-lemmy-linux-gnu to v0.3.0, which has Rust 1.77 instead of 1.75