### PR TITLE
Removing scheme from block urls. Fixes #4656

### DIFF
--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -536,17 +536,8 @@ pub async fn get_url_blocklist(context: &LemmyContext) -> LemmyResult<RegexSet> 
       .try_get_with::<_, LemmyError>((), async {
         let urls = LocalSiteUrlBlocklist::get_all(&mut context.pool()).await?;
 
-        let regexes = urls.iter().map(|url| {
-          // The scheme is removed in the saving,
-          // so fake it here to build the url.
-          let url = &format!("https://{}", url.url);
-          let parsed = Url::parse(url).expect("Couldn't parse URL.");
-          format!(
-            "{}{}",
-            escape(parsed.host_str().expect("No domain.")),
-            escape(parsed.path())
-          )
-        });
+        // The urls are already validated on saving, so just escape them.
+        let regexes = urls.iter().map(|url| escape(&url.url));
 
         let set = RegexSet::new(regexes)?;
         Ok(set)

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -537,23 +537,15 @@ pub async fn get_url_blocklist(context: &LemmyContext) -> LemmyResult<RegexSet> 
         let urls = LocalSiteUrlBlocklist::get_all(&mut context.pool()).await?;
 
         let regexes = urls.iter().map(|url| {
-          let url = &url.url;
-          let parsed = Url::parse(url).expect("Coundln't parse URL.");
-          if url.ends_with('/') {
-            format!(
-              "({}://)?{}{}?",
-              parsed.scheme(),
-              escape(parsed.domain().expect("No domain.")),
-              escape(parsed.path())
-            )
-          } else {
-            format!(
-              "({}://)?{}{}",
-              parsed.scheme(),
-              escape(parsed.domain().expect("No domain.")),
-              escape(parsed.path())
-            )
-          }
+          // The scheme is removed in the saving,
+          // so fake it here to build the url.
+          let url = &format!("https://{}", url.url);
+          let parsed = Url::parse(url).expect("Couldn't parse URL.");
+          format!(
+            "{}{}",
+            escape(parsed.host_str().expect("No domain.")),
+            escape(parsed.path())
+          )
         });
 
         let set = RegexSet::new(regexes)?;

--- a/crates/utils/src/utils/validation.rs
+++ b/crates/utils/src/utils/validation.rs
@@ -330,7 +330,7 @@ pub fn build_url_str_without_scheme(url_str: &str) -> LemmyResult<String> {
     }
   })?;
 
-  // Set the scheme to https, then remove the http:// part
+  // Set the scheme to http, then remove the http:// part
   url
     .set_scheme("http")
     .map_err(|_| LemmyErrorType::InvalidUrl)?;

--- a/crates/utils/src/utils/validation.rs
+++ b/crates/utils/src/utils/validation.rs
@@ -624,12 +624,12 @@ mod tests {
         "example.com".to_string(),
         "http://example.com".to_string(),
         "https://example.com".to_string(),
-        "https://example.blog/test?q=test2&q2=test3#test4".to_string(),
+        "https://example.com/test?q=test2&q2=test3#test4".to_string(),
       ])
       .unwrap(),
       &vec![
         "example.com/".to_string(),
-        "example.blog/test?q=test2&q2=test3#test4".to_string()
+        "example.com/test?q=test2&q2=test3#test4".to_string()
       ],
     );
 

--- a/crates/utils/src/utils/validation.rs
+++ b/crates/utils/src/utils/validation.rs
@@ -335,13 +335,18 @@ pub fn build_url_str_without_scheme(url_str: &str) -> LemmyResult<String> {
     .set_scheme("http")
     .map_err(|_| LemmyErrorType::InvalidUrl)?;
 
-  Ok(
-    url
-      .to_string()
-      .get(7..)
-      .ok_or(LemmyErrorType::InvalidUrl)?
-      .to_string(),
-  )
+  let mut out = url
+    .to_string()
+    .get(7..)
+    .ok_or(LemmyErrorType::InvalidUrl)?
+    .to_string();
+
+  // Remove trailing / if necessary
+  if out.ends_with('/') {
+    out.pop();
+  }
+
+  Ok(out)
 }
 
 #[cfg(test)]
@@ -628,7 +633,7 @@ mod tests {
       ])
       .unwrap(),
       &vec![
-        "example.com/".to_string(),
+        "example.com".to_string(),
         "example.com/test?q=test2&q2=test3#test4".to_string()
       ],
     );


### PR DESCRIPTION
See linked issue for discussion, but when saving blocked domains, this removes the scheme, and uniques.