### PR TITLE
Fix broken thumbnails

### DIFF
--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -103,9 +103,13 @@ pub fn generate_post_link_metadata(
     else if federated_thumbnail.is_some() {
       federated_thumbnail
     }
-    // Generate a local thumbnail if allowed
+    // Generate local thumbnail if allowed
     else if allow_generate_thumbnail {
-      match post.url.filter(|_| is_image_post).or(metadata.opengraph_data.image) {
+      match post
+        .url
+        .filter(|_| is_image_post)
+        .or(metadata.opengraph_data.image)
+      {
         Some(url) => generate_pictrs_thumbnail(&url, &context).await.ok(),
         None => None,
       }

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -103,7 +103,7 @@ pub fn generate_post_link_metadata(
     else if federated_thumbnail.is_some() {
       federated_thumbnail
     }
-    // Generate local thumbnail if allowed
+    // Generate a local thumbnail if allowed
     else if allow_generate_thumbnail {
       match post.url.filter(|_| is_image_post).or(metadata.opengraph_data.image) {
         Some(url) => generate_pictrs_thumbnail(&url, &context).await.ok(),

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -103,13 +103,14 @@ pub fn generate_post_link_metadata(
     else if federated_thumbnail.is_some() {
       federated_thumbnail
     }
-    // Generate local thumbnail if allowed
+    // Generate local thumbnail from metadata if allowed
     else if allow_generate_thumbnail && !is_image_post {
       match metadata.opengraph_data.image {
         Some(url) => generate_pictrs_thumbnail(&url, &context).await.ok(),
         None => None,
       }
     }
+    // Generate local thumbnail from post url if allowed
     else if allow_generate_thumbnail && is_image_post {
       match post.url {
         Some(url) => generate_pictrs_thumbnail(&url, &context).await.ok(),

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -103,16 +103,9 @@ pub fn generate_post_link_metadata(
     else if federated_thumbnail.is_some() {
       federated_thumbnail
     }
-    // Generate local thumbnail from metadata if allowed
-    else if allow_generate_thumbnail && !is_image_post {
-      match metadata.opengraph_data.image {
-        Some(url) => generate_pictrs_thumbnail(&url, &context).await.ok(),
-        None => None,
-      }
-    }
-    // Generate local thumbnail from post url if allowed
-    else if allow_generate_thumbnail && is_image_post {
-      match post.url {
+    // Generate local thumbnail if allowed
+    else if allow_generate_thumbnail {
+      match post.url.filter(|_| is_image_post).or(metadata.opengraph_data.image) {
         Some(url) => generate_pictrs_thumbnail(&url, &context).await.ok(),
         None => None,
       }

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -104,8 +104,14 @@ pub fn generate_post_link_metadata(
       federated_thumbnail
     }
     // Generate local thumbnail if allowed
-    else if allow_generate_thumbnail {
-      match post.url.or(metadata.opengraph_data.image) {
+    else if allow_generate_thumbnail && !is_image_post {
+      match metadata.opengraph_data.image {
+        Some(url) => generate_pictrs_thumbnail(&url, &context).await.ok(),
+        None => None,
+      }
+    }
+    else if allow_generate_thumbnail && is_image_post {
+      match post.url {
         Some(url) => generate_pictrs_thumbnail(&url, &context).await.ok(),
         None => None,
       }


### PR DESCRIPTION
The code should never set the thumbnail to `post.url` when `is_image_post` is false.

Fixes https://github.com/LemmyNet/lemmy/issues/4660