### PR TITLE
Fixing extra modlog entries when post_id or comment_id is given.

### DIFF
--- a/crates/db_views_moderator/src/admin_purge_comment_view.rs
+++ b/crates/db_views_moderator/src/admin_purge_comment_view.rs
@@ -40,6 +40,11 @@ impl AdminPurgeCommentView {
       query = query.filter(admin_purge_comment::admin_person_id.eq(admin_person_id));
     };
 
+    // If a post or comment ID is given, then don't find any results
+    if params.post_id.is_some() || params.comment_id.is_some() {
+      return Ok(vec![]);
+    }
+
     let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
     query

--- a/crates/db_views_moderator/src/admin_purge_community_view.rs
+++ b/crates/db_views_moderator/src/admin_purge_community_view.rs
@@ -38,6 +38,11 @@ impl AdminPurgeCommunityView {
       query = query.filter(admin_purge_community::admin_person_id.eq(admin_person_id));
     };
 
+    // If a post or comment ID is given, then don't find any results
+    if params.post_id.is_some() || params.comment_id.is_some() {
+      return Ok(vec![]);
+    }
+
     let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
     query

--- a/crates/db_views_moderator/src/admin_purge_person_view.rs
+++ b/crates/db_views_moderator/src/admin_purge_person_view.rs
@@ -38,6 +38,11 @@ impl AdminPurgePersonView {
       query = query.filter(admin_purge_person::admin_person_id.eq(admin_person_id));
     };
 
+    // If a post or comment ID is given, then don't find any results
+    if params.post_id.is_some() || params.comment_id.is_some() {
+      return Ok(vec![]);
+    }
+
     let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
     query

--- a/crates/db_views_moderator/src/admin_purge_post_view.rs
+++ b/crates/db_views_moderator/src/admin_purge_post_view.rs
@@ -40,6 +40,11 @@ impl AdminPurgePostView {
       query = query.filter(admin_purge_post::admin_person_id.eq(admin_person_id));
     };
 
+    // If a post or comment ID is given, then don't find any results
+    if params.post_id.is_some() || params.comment_id.is_some() {
+      return Ok(vec![]);
+    }
+
     let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
     query

--- a/crates/db_views_moderator/src/mod_add_community_view.rs
+++ b/crates/db_views_moderator/src/mod_add_community_view.rs
@@ -52,6 +52,11 @@ impl ModAddCommunityView {
       query = query.filter(person_alias_1.field(person::id).eq(other_person_id));
     };
 
+    // If a post or comment ID is given, then don't find any results
+    if params.post_id.is_some() || params.comment_id.is_some() {
+      return Ok(vec![]);
+    }
+
     let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
     query

--- a/crates/db_views_moderator/src/mod_add_view.rs
+++ b/crates/db_views_moderator/src/mod_add_view.rs
@@ -44,6 +44,11 @@ impl ModAddView {
       query = query.filter(person_alias_1.field(person::id).eq(other_person_id));
     };
 
+    // If a post or comment ID is given, then don't find any results
+    if params.post_id.is_some() || params.comment_id.is_some() {
+      return Ok(vec![]);
+    }
+
     let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
     query

--- a/crates/db_views_moderator/src/mod_ban_from_community_view.rs
+++ b/crates/db_views_moderator/src/mod_ban_from_community_view.rs
@@ -54,6 +54,11 @@ impl ModBanFromCommunityView {
       query = query.filter(mod_ban_from_community::other_person_id.eq(other_person_id));
     };
 
+    // If a post or comment ID is given, then don't find any results
+    if params.post_id.is_some() || params.comment_id.is_some() {
+      return Ok(vec![]);
+    }
+
     let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
     query

--- a/crates/db_views_moderator/src/mod_ban_view.rs
+++ b/crates/db_views_moderator/src/mod_ban_view.rs
@@ -44,6 +44,11 @@ impl ModBanView {
       query = query.filter(person_alias_1.field(person::id).eq(other_person_id));
     };
 
+    // If a post or comment ID is given, then don't find any results
+    if params.post_id.is_some() || params.comment_id.is_some() {
+      return Ok(vec![]);
+    }
+
     let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
     query

--- a/crates/db_views_moderator/src/mod_feature_post_view.rs
+++ b/crates/db_views_moderator/src/mod_feature_post_view.rs
@@ -55,6 +55,11 @@ impl ModFeaturePostView {
       query = query.filter(post::id.eq(post_id));
     }
 
+    // If a comment ID is given, then don't find any results
+    if params.comment_id.is_some() {
+      return Ok(vec![]);
+    }
+
     let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
     query

--- a/crates/db_views_moderator/src/mod_hide_community_view.rs
+++ b/crates/db_views_moderator/src/mod_hide_community_view.rs
@@ -45,6 +45,11 @@ impl ModHideCommunityView {
       query = query.filter(mod_hide_community::mod_person_id.eq(admin_id));
     };
 
+    // If a post or comment ID is given, then don't find any results
+    if params.post_id.is_some() || params.comment_id.is_some() {
+      return Ok(vec![]);
+    }
+
     let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
     query

--- a/crates/db_views_moderator/src/mod_lock_post_view.rs
+++ b/crates/db_views_moderator/src/mod_lock_post_view.rs
@@ -56,6 +56,11 @@ impl ModLockPostView {
       query = query.filter(post::id.eq(post_id));
     }
 
+    // If a comment ID is given, then don't find any results
+    if params.comment_id.is_some() {
+      return Ok(vec![]);
+    }
+
     let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
     query

--- a/crates/db_views_moderator/src/mod_remove_comment_view.rs
+++ b/crates/db_views_moderator/src/mod_remove_comment_view.rs
@@ -58,6 +58,11 @@ impl ModRemoveCommentView {
       query = query.filter(comment::id.eq(comment_id));
     }
 
+    // If a post ID is given, then don't find any results
+    if params.post_id.is_some() {
+      return Ok(vec![]);
+    }
+
     let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
     query

--- a/crates/db_views_moderator/src/mod_remove_community_view.rs
+++ b/crates/db_views_moderator/src/mod_remove_community_view.rs
@@ -39,6 +39,11 @@ impl ModRemoveCommunityView {
       query = query.filter(mod_remove_community::mod_person_id.eq(mod_person_id));
     };
 
+    // If a post or comment ID is given, then don't find any results
+    if params.post_id.is_some() || params.comment_id.is_some() {
+      return Ok(vec![]);
+    }
+
     let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
     query

--- a/crates/db_views_moderator/src/mod_remove_post_view.rs
+++ b/crates/db_views_moderator/src/mod_remove_post_view.rs
@@ -56,6 +56,11 @@ impl ModRemovePostView {
       query = query.filter(post::id.eq(post_id));
     }
 
+    // If a comment ID is given, then don't find any results
+    if params.comment_id.is_some() {
+      return Ok(vec![]);
+    }
+
     let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
     query

--- a/crates/db_views_moderator/src/mod_transfer_community_view.rs
+++ b/crates/db_views_moderator/src/mod_transfer_community_view.rs
@@ -54,6 +54,11 @@ impl ModTransferCommunityView {
       query = query.filter(person_alias_1.field(person::id).eq(other_person_id));
     };
 
+    // If a post or comment ID is given, then don't find any results
+    if params.post_id.is_some() || params.comment_id.is_some() {
+      return Ok(vec![]);
+    }
+
     let (limit, offset) = limit_and_offset(params.page, params.limit)?;
 
     query


### PR DESCRIPTION
- Previously when given a post_id, it didn't filter out any other modlog entries, such as community removals. This fixes that problem.
- Context: https://github.com/LemmyNet/lemmy-ui/pull/2437