### PR TITLE
Fix community add mod check (fixes #4624)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2588,7 +2588,7 @@ dependencies = [
  "actix-web",
  "actix-web-httpauth",
  "anyhow",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bcrypt",
  "captcha",
  "chrono",

--- a/crates/api/src/community/add_mod.rs
+++ b/crates/api/src/community/add_mod.rs
@@ -36,8 +36,20 @@ pub async fn add_mod_to_community(
   let community = Community::read(&mut context.pool(), community_id)
     .await?
     .ok_or(LemmyErrorType::CouldntFindCommunity)?;
+
+  // If user is admin and community is remote, explicitly check that he is a
+  // moderator. This is necessary because otherwise the action would be rejected
+  // by the community's home instance.
   if local_user_view.local_user.admin && !community.local {
-    Err(LemmyErrorType::NotAModerator)?
+    let is_mod = CommunityModeratorView::is_community_moderator(
+      &mut context.pool(),
+      community.id,
+      local_user_view.person.id,
+    )
+    .await?;
+    if !is_mod {
+      Err(LemmyErrorType::NotAModerator)?
+    }
   }
 
   // Update in local database


### PR DESCRIPTION
That check was working incorrectly in case the user is both admin and also mod of remote community.