### PR TITLE
Fix communities with broken outboxes, and use PostView. Fixes #4658

### DIFF
--- a/crates/apub/src/activities/create_or_update/post.rs
+++ b/crates/apub/src/activities/create_or_update/post.rs
@@ -38,7 +38,7 @@ use url::Url;
 
 impl CreateOrUpdatePage {
   pub(crate) async fn new(
-    post: ApubPost,
+    post: &ApubPost,
     actor: &ApubPerson,
     community: &ApubCommunity,
     kind: CreateOrUpdateType,
@@ -51,7 +51,7 @@ impl CreateOrUpdatePage {
     Ok(CreateOrUpdatePage {
       actor: actor.id().into(),
       to: vec![public()],
-      object: post.into_json(context).await?,
+      object: post.clone().into_json(context).await?,
       cc: vec![community.id()],
       kind,
       id: id.clone(),
@@ -66,7 +66,6 @@ impl CreateOrUpdatePage {
     kind: CreateOrUpdateType,
     context: Data<LemmyContext>,
   ) -> LemmyResult<()> {
-    let post = ApubPost(post);
     let community_id = post.community_id;
     let person: ApubPerson = Person::read(&mut context.pool(), person_id)
       .await?
@@ -78,7 +77,7 @@ impl CreateOrUpdatePage {
       .into();
 
     let create_or_update =
-      CreateOrUpdatePage::new(post, &person, &community, kind, &context).await?;
+      CreateOrUpdatePage::new(&post.into(), &person, &community, kind, &context).await?;
     let is_mod_action = create_or_update.object.is_mod_action(&context).await?;
     let activity = AnnouncableActivities::CreateOrUpdatePost(create_or_update);
     send_activity_in_community(

--- a/crates/apub/src/activities/create_or_update/post.rs
+++ b/crates/apub/src/activities/create_or_update/post.rs
@@ -38,7 +38,7 @@ use url::Url;
 
 impl CreateOrUpdatePage {
   pub(crate) async fn new(
-    post: &ApubPost,
+    post: ApubPost,
     actor: &ApubPerson,
     community: &ApubCommunity,
     kind: CreateOrUpdateType,
@@ -51,7 +51,7 @@ impl CreateOrUpdatePage {
     Ok(CreateOrUpdatePage {
       actor: actor.id().into(),
       to: vec![public()],
-      object: post.clone().into_json(context).await?,
+      object: post.into_json(context).await?,
       cc: vec![community.id()],
       kind,
       id: id.clone(),
@@ -77,7 +77,7 @@ impl CreateOrUpdatePage {
       .into();
 
     let create_or_update =
-      CreateOrUpdatePage::new(&post.into(), &person, &community, kind, &context).await?;
+      CreateOrUpdatePage::new(post.into(), &person, &community, kind, &context).await?;
     let is_mod_action = create_or_update.object.is_mod_action(&context).await?;
     let activity = AnnouncableActivities::CreateOrUpdatePost(create_or_update);
     send_activity_in_community(

--- a/crates/apub/src/collections/community_outbox.rs
+++ b/crates/apub/src/collections/community_outbox.rs
@@ -1,6 +1,6 @@
 use crate::{
   activity_lists::AnnouncableActivities,
-  objects::{community::ApubCommunity, post::ApubPost},
+  objects::community::ApubCommunity,
   protocol::{
     activities::{
       community::announce::AnnounceActivity,
@@ -18,11 +18,8 @@ use activitypub_federation::{
 };
 use futures::future::join_all;
 use lemmy_api_common::{context::LemmyContext, utils::generate_outbox_url};
-use lemmy_db_schema::{
-  source::{person::Person, post::Post},
-  traits::Crud,
-  utils::FETCH_LIMIT_MAX,
-};
+use lemmy_db_schema::{utils::FETCH_LIMIT_MAX, SortType};
+use lemmy_db_views::{post_view::PostQuery, structs::SiteView};
 use lemmy_utils::{
   error::{LemmyError, LemmyResult},
   LemmyErrorType,
@@ -41,19 +38,30 @@ impl Collection for ApubCommunityOutbox {
 
   #[tracing::instrument(skip_all)]
   async fn read_local(owner: &Self::Owner, data: &Data<Self::DataType>) -> LemmyResult<Self::Kind> {
-    let post_list: Vec<ApubPost> = Post::list_for_community(&mut data.pool(), owner.id)
+    let site = SiteView::read_local(&mut data.pool())
       .await?
-      .into_iter()
-      .map(Into::into)
-      .collect();
+      .ok_or(LemmyErrorType::LocalSiteNotSetup)?
+      .site;
+
+    let post_views = PostQuery {
+      community_id: Some(owner.id),
+      sort: Some(SortType::New),
+      limit: Some(FETCH_LIMIT_MAX),
+      ..Default::default()
+    }
+    .list(&site, &mut data.pool())
+    .await?;
+
     let mut ordered_items = vec![];
-    for post in post_list {
-      let person = Person::read(&mut data.pool(), post.creator_id)
-        .await?
-        .ok_or(LemmyErrorType::CouldntFindPerson)?
-        .into();
-      let create =
-        CreateOrUpdatePage::new(post, &person, owner, CreateOrUpdateType::Create, data).await?;
+    for post_view in post_views {
+      let create = CreateOrUpdatePage::new(
+        &post_view.post.into(),
+        &post_view.creator.into(),
+        owner,
+        CreateOrUpdateType::Create,
+        data,
+      )
+      .await?;
       let announcable = AnnouncableActivities::CreateOrUpdatePost(create);
       let announce = AnnounceActivity::new(announcable.try_into()?, owner, data)?;
       ordered_items.push(announce);

--- a/crates/apub/src/collections/community_outbox.rs
+++ b/crates/apub/src/collections/community_outbox.rs
@@ -55,7 +55,7 @@ impl Collection for ApubCommunityOutbox {
     let mut ordered_items = vec![];
     for post_view in post_views {
       let create = CreateOrUpdatePage::new(
-        &post_view.post.into(),
+        post_view.post.into(),
         &post_view.creator.into(),
         owner,
         CreateOrUpdateType::Create,

--- a/crates/db_schema/src/impls/post.rs
+++ b/crates/db_schema/src/impls/post.rs
@@ -84,22 +84,6 @@ impl Post {
       .await
   }
 
-  pub async fn list_for_community(
-    pool: &mut DbPool<'_>,
-    the_community_id: CommunityId,
-  ) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    post::table
-      .filter(post::community_id.eq(the_community_id))
-      .filter(post::deleted.eq(false))
-      .filter(post::removed.eq(false))
-      .then_order_by(post::featured_community.desc())
-      .then_order_by(post::published.desc())
-      .limit(FETCH_LIMIT_MAX)
-      .load::<Self>(conn)
-      .await
-  }
-
   pub async fn list_featured_for_community(
     pool: &mut DbPool<'_>,
     the_community_id: CommunityId,


### PR DESCRIPTION
Rather than looping over `Person::read`, which may include a deleted person which throws an error, use the PostView.