### PR TITLE
Dont show deleted / removed posts when searching. Fixes #4576

### DIFF
--- a/crates/db_views/src/comment_view.rs
+++ b/crates/db_views/src/comment_view.rs
@@ -220,8 +220,7 @@ fn queries<'a>() -> Queries<
       query = query.filter(
         comment::content
           .ilike(fuzzy_search(&search_term))
-          .and(comment::removed.eq(false))
-          .and(comment::deleted.eq(false)),
+          .and(not(comment::removed.or(comment::deleted))),
       );
     };
 

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -397,9 +397,11 @@ fn queries<'a>() -> Queries<
     if let Some(search_term) = &options.search_term {
       let searcher = fuzzy_search(search_term);
       query = query.filter(
-        post::name
+        (post::name
           .ilike(searcher.clone())
-          .or(post::body.ilike(searcher)),
+          .or(post::body.ilike(searcher)))
+        .and(post::removed.eq(false))
+        .and(post::deleted.eq(false)),
       );
     }
 

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -396,13 +396,13 @@ fn queries<'a>() -> Queries<
 
     if let Some(search_term) = &options.search_term {
       let searcher = fuzzy_search(search_term);
-      query = query.filter(
-        (post::name
-          .ilike(searcher.clone())
-          .or(post::body.ilike(searcher)))
-        .and(post::removed.eq(false))
-        .and(post::deleted.eq(false)),
-      );
+      query = query
+        .filter(
+          post::name
+            .ilike(searcher.clone())
+            .or(post::body.ilike(searcher)),
+        )
+        .filter(not(post::removed.or(post::deleted)));
     }
 
     // If there is a content warning, show nsfw content by default.


### PR DESCRIPTION
This was done for comments already, but should also be done for posts.