### PR TITLE
Remove login step from publish to crates.io

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -278,8 +278,7 @@ steps:
     commands:
       - cargo install cargo-workspaces
       - cp -r migrations crates/db_schema/
-      - cargo login "$CARGO_API_TOKEN"
-      - cargo workspaces publish --from-git --allow-dirty --no-verify --allow-branch "${CI_COMMIT_TAG}" --yes custom "${CI_COMMIT_TAG}"
+      - cargo workspaces publish --token "$CARGO_API_TOKEN" --from-git --allow-dirty --no-verify --allow-branch "${CI_COMMIT_TAG}" --yes custom "${CI_COMMIT_TAG}"
     secrets: [cargo_api_token]
     when:
       - event: tag


### PR DESCRIPTION
While working on a [similar PR for the rust client](https://github.com/LemmyNet/lemmy-client-rs/pull/2), I noticed that `cargo publish` takes a `--token` option. Since this is being done as a CI step and `cargo login` is made for if you're publishing multiple times from the same machine, I think using the arg is more appropriate.