### PR TITLE
Dont exit early when running only scheduled tasks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,10 +160,10 @@ pub async fn start_lemmy_server(args: CmdArgs) -> LemmyResult<()> {
     rate_limit_cell.clone(),
   );
 
-  if !args.disable_scheduled_tasks {
+  let scheduled_tasks = (!args.disable_scheduled_tasks).then(|| {
     // Schedules various cleanup tasks for the DB
-    let _scheduled_tasks = tokio::task::spawn(scheduled_tasks::setup(context.clone()));
-  }
+    tokio::task::spawn(scheduled_tasks::setup(context.clone()))
+  });
 
   if let Some(prometheus) = SETTINGS.prometheus.clone() {
     serve_prometheus(prometheus, context.clone())?;
@@ -218,15 +218,17 @@ pub async fn start_lemmy_server(args: CmdArgs) -> LemmyResult<()> {
   let mut interrupt = tokio::signal::unix::signal(SignalKind::interrupt())?;
   let mut terminate = tokio::signal::unix::signal(SignalKind::terminate())?;
 
-  tokio::select! {
-    _ = tokio::signal::ctrl_c() => {
-      tracing::warn!("Received ctrl-c, shutting down gracefully...");
-    }
-    _ = interrupt.recv() => {
-      tracing::warn!("Received interrupt, shutting down gracefully...");
-    }
-    _ = terminate.recv() => {
-      tracing::warn!("Received terminate, shutting down gracefully...");
+  if server.is_some() || federate.is_some() || scheduled_tasks.is_some() {
+    tokio::select! {
+      _ = tokio::signal::ctrl_c() => {
+        tracing::warn!("Received ctrl-c, shutting down gracefully...");
+      }
+      _ = interrupt.recv() => {
+        tracing::warn!("Received interrupt, shutting down gracefully...");
+      }
+      _ = terminate.recv() => {
+        tracing::warn!("Received terminate, shutting down gracefully...");
+      }
     }
   }
   if let Some(server) = server {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,17 +218,15 @@ pub async fn start_lemmy_server(args: CmdArgs) -> LemmyResult<()> {
   let mut interrupt = tokio::signal::unix::signal(SignalKind::interrupt())?;
   let mut terminate = tokio::signal::unix::signal(SignalKind::terminate())?;
 
-  if server.is_some() || federate.is_some() {
-    tokio::select! {
-      _ = tokio::signal::ctrl_c() => {
-        tracing::warn!("Received ctrl-c, shutting down gracefully...");
-      }
-      _ = interrupt.recv() => {
-        tracing::warn!("Received interrupt, shutting down gracefully...");
-      }
-      _ = terminate.recv() => {
-        tracing::warn!("Received terminate, shutting down gracefully...");
-      }
+  tokio::select! {
+    _ = tokio::signal::ctrl_c() => {
+      tracing::warn!("Received ctrl-c, shutting down gracefully...");
+    }
+    _ = interrupt.recv() => {
+      tracing::warn!("Received interrupt, shutting down gracefully...");
+    }
+    _ = terminate.recv() => {
+      tracing::warn!("Received terminate, shutting down gracefully...");
     }
   }
   if let Some(server) = server {


### PR DESCRIPTION
Lemmy would exit immediately when running only scheduled tasks, instead of running forever as it should. It was broken in [this commit](https://github.com/LemmyNet/lemmy/commit/4ba6221e04ab3e186669aeaa890d23b1e3f3d1a9#).

Edit: You can test it with `cargo run -- --disable-http-server --disable-activity-sending`