### PR TITLE
Instance.preferred_username should be optional (fixes #4701)

### DIFF
--- a/crates/apub/src/objects/instance.rs
+++ b/crates/apub/src/objects/instance.rs
@@ -100,7 +100,7 @@ impl Object for ApubSite {
       kind: ApplicationType::Application,
       id: self.id().into(),
       name: self.name.clone(),
-      preferred_username: data.domain().to_string(),
+      preferred_username: Some(data.domain().to_string()),
       content: self.sidebar.as_ref().map(|d| markdown_to_html(d)),
       source: self.sidebar.clone().map(Source::new),
       summary: self.description.clone(),

--- a/crates/apub/src/protocol/objects/instance.rs
+++ b/crates/apub/src/protocol/objects/instance.rs
@@ -22,7 +22,7 @@ pub struct Instance {
   /// site name
   pub(crate) name: String,
   /// instance domain, necessary for mastodon authorized fetch
-  pub(crate) preferred_username: String,
+  pub(crate) preferred_username: Option<String>,
   pub(crate) inbox: Url,
   /// mandatory field in activitypub, lemmy currently serves an empty outbox
   pub(crate) outbox: Url,


### PR DESCRIPTION
This made it impossible to fetch `Site` from 0.19.3 instances.