### PR TITLE
Dont federate post locking via Update activity

### DIFF
--- a/crates/apub/assets/lemmy/activities/create_or_update/create_page.json
+++ b/crates/apub/assets/lemmy/activities/create_or_update/create_page.json
@@ -23,7 +23,6 @@
         "href": "https://lemmy.ml/pictrs/image/xl8W7FZfk9.jpg"
       }
     ],
-    "commentsEnabled": true,
     "sensitive": false,
     "language": {
       "identifier": "ko",

--- a/crates/apub/assets/lemmy/activities/create_or_update/update_page.json
+++ b/crates/apub/assets/lemmy/activities/create_or_update/update_page.json
@@ -23,7 +23,6 @@
         "href": "https://lemmy.ml/pictrs/image/xl8W7FZfk9.jpg"
       }
     ],
-    "commentsEnabled": true,
     "sensitive": false,
     "published": "2021-10-29T15:10:51.557399Z",
     "updated": "2021-10-29T15:11:35.976374Z"

--- a/crates/apub/assets/lemmy/collections/group_featured_posts.json
+++ b/crates/apub/assets/lemmy/collections/group_featured_posts.json
@@ -15,7 +15,6 @@
       "cc": [],
       "mediaType": "text/html",
       "attachment": [],
-      "commentsEnabled": true,
       "sensitive": false,
       "published": "2023-02-06T06:42:41.939437Z",
       "language": {
@@ -36,7 +35,6 @@
       "cc": [],
       "mediaType": "text/html",
       "attachment": [],
-      "commentsEnabled": true,
       "sensitive": false,
       "published": "2023-02-06T06:42:37.119567Z",
       "language": {

--- a/crates/apub/assets/lemmy/collections/group_outbox.json
+++ b/crates/apub/assets/lemmy/collections/group_outbox.json
@@ -22,7 +22,6 @@
           ],
           "name": "another outbox test",
           "mediaType": "text/html",
-          "commentsEnabled": true,
           "sensitive": false,
           "stickied": false,
           "published": "2021-11-18T17:19:45.895163Z"
@@ -51,7 +50,6 @@
           ],
           "name": "outbox test",
           "mediaType": "text/html",
-          "commentsEnabled": true,
           "sensitive": false,
           "stickied": false,
           "published": "2021-11-18T17:19:05.763109Z"

--- a/crates/apub/assets/lemmy/objects/page.json
+++ b/crates/apub/assets/lemmy/objects/page.json
@@ -25,7 +25,6 @@
     "url": "https://enterprise.lemmy.ml/pictrs/image/eOtYb9iEiB.png"
   },
   "sensitive": false,
-  "commentsEnabled": true,
   "language": {
     "identifier": "fr",
     "name": "Français"

--- a/crates/apub/src/activities/community/lock_page.rs
+++ b/crates/apub/src/activities/community/lock_page.rs
@@ -26,6 +26,7 @@ use lemmy_db_schema::{
   source::{
     activity::ActivitySendTargets,
     community::Community,
+    moderator::{ModLockPost, ModLockPostForm},
     person::Person,
     post::{Post, PostUpdateForm},
   },
@@ -60,12 +61,22 @@ impl ActivityHandler for LockPage {
   }
 
   async fn receive(self, context: &Data<Self::DataType>) -> Result<(), Self::Error> {
+    insert_received_activity(&self.id, context).await?;
+    let locked = Some(true);
     let form = PostUpdateForm {
-      locked: Some(true),
+      locked,
       ..Default::default()
     };
     let post = self.object.dereference(context).await?;
     Post::update(&mut context.pool(), post.id, &form).await?;
+
+    let form = ModLockPostForm {
+      mod_person_id: self.actor.dereference(context).await?.id,
+      post_id: post.id,
+      locked,
+    };
+    ModLockPost::create(&mut context.pool(), &form).await?;
+
     Ok(())
   }
 }
@@ -94,12 +105,21 @@ impl ActivityHandler for UndoLockPage {
 
   async fn receive(self, context: &Data<Self::DataType>) -> Result<(), Self::Error> {
     insert_received_activity(&self.id, context).await?;
+    let locked = Some(false);
     let form = PostUpdateForm {
-      locked: Some(false),
+      locked,
       ..Default::default()
     };
     let post = self.object.object.dereference(context).await?;
     Post::update(&mut context.pool(), post.id, &form).await?;
+
+    let form = ModLockPostForm {
+      mod_person_id: self.actor.dereference(context).await?.id,
+      post_id: post.id,
+      locked,
+    };
+    ModLockPost::create(&mut context.pool(), &form).await?;
+
     Ok(())
   }
 }

--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -244,7 +244,6 @@ impl Object for ApubPost {
       .alt_text(alt_text)
       .creator_id(creator.id)
       .community_id(community.id)
-      //.locked(page.comments_enabled.map(|e| !e))
       .published(page.published.map(Into::into))
       .updated(page.updated.map(Into::into))
       .deleted(Some(false))

--- a/crates/apub/src/protocol/objects/page.rs
+++ b/crates/apub/src/protocol/objects/page.rs
@@ -60,7 +60,6 @@ pub struct Page {
   #[serde(default)]
   pub(crate) attachment: Vec<Attachment>,
   pub(crate) image: Option<ImageObject>,
-  pub(crate) comments_enabled: Option<bool>,
   pub(crate) sensitive: Option<bool>,
   pub(crate) published: Option<DateTime<Utc>>,
   pub(crate) updated: Option<DateTime<Utc>>,
@@ -156,28 +155,6 @@ pub enum HashtagType {
 }
 
 impl Page {
-  /// Only mods can change the post's locked status. So if it is changed from the default value,
-  /// it is a mod action and needs to be verified as such.
-  ///
-  /// Locked needs to be false on a newly created post (verified in [[CreatePost]].
-  pub(crate) async fn is_mod_action(&self, context: &Data<LemmyContext>) -> LemmyResult<bool> {
-    let old_post = self.id.clone().dereference_local(context).await;
-    Ok(Page::is_locked_changed(&old_post, &self.comments_enabled))
-  }
-
-  pub(crate) fn is_locked_changed<E>(
-    old_post: &Result<ApubPost, E>,
-    new_comments_enabled: &Option<bool>,
-  ) -> bool {
-    if let Some(new_comments_enabled) = new_comments_enabled {
-      if let Ok(old_post) = old_post {
-        return new_comments_enabled != &!old_post.locked;
-      }
-    }
-
-    false
-  }
-
   pub(crate) fn creator(&self) -> LemmyResult<ObjectId<ApubPerson>> {
     match &self.attributed_to {
       AttributedTo::Lemmy(l) => Ok(l.clone()),


### PR DESCRIPTION
This receiving logic has actually not been used for a while now so we can safely remove it. It also has some rather messy logic that could result in security problems so better to get rid of it soon.