### PR TITLE
Stop using a diesel_cli docker image, use cargo-install in woodpecker.

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -28,6 +28,7 @@ variables:
       - wget https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz
       - tar -xvf cargo-binstall-x86_64-unknown-linux-musl.tgz
       - cp cargo-binstall /usr/local/cargo/bin
+      - export PATH="$CARGO_HOME/bin:$PATH"
 
 # Broken for cron jobs currently, see
 # https://github.com/woodpecker-ci/woodpecker/issues/1716
@@ -205,7 +206,6 @@ steps:
       - <<: *install_binstall
       # Install diesel_cli
       - cargo binstall -y diesel_cli -- --no-default-features --features postgres
-      - export PATH="$CARGO_HOME/bin:$PATH"
       # Run all migrations
       - diesel migration run
       # Dump schema to before.sqldump (PostgreSQL apt repo is used to prevent pg_dump version mismatch error)

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -32,7 +32,7 @@ variables:
       - apt update && apt install -y lsb-release build-essential
       - sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
       - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-      - apt update && apt install -y postgresql-client-16 libsqlite3-dev libpq-dev libmariaclient-dev-compat
+      - apt update && apt install -y postgresql-client-16 libsqlite3-dev libpq-dev libmariadbclient-dev-compat
       - ls -al /usr/local/lib/
       - ls -al /usr/local/mysql/lib/
       - export LD_LIBRARY_PATH=/usr/local/mysql/lib

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -31,6 +31,10 @@ variables:
   - install_diesel_cli: &install_diesel_cli
       - cargo binstall -y diesel_cli
       - export PATH="$CARGO_HOME/bin:$PATH"
+      - apt update && apt install -y lsb-release
+      - sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+      - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+      - apt update && apt install -y postgresql-client-16 default-mysql-client
 
 steps:
   prepare_repo:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -29,12 +29,12 @@ variables:
       - tar -xvf cargo-binstall-x86_64-unknown-linux-musl.tgz
       - cp cargo-binstall /usr/local/cargo/bin
   - install_diesel_cli: &install_diesel_cli
-      - cargo binstall -y diesel_cli
-      - export PATH="$CARGO_HOME/bin:$PATH"
       - apt update && apt install -y lsb-release
       - sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
       - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-      - apt update && apt install -y postgresql-client-16 default-libmysqlclient-dev
+      - apt update && apt install -y postgresql-client-16 default-libmysqlclient-dev libmysqlclient-dev
+      - cargo binstall -y diesel_cli
+      - export PATH="$CARGO_HOME/bin:$PATH"
 
 steps:
   prepare_repo:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -55,10 +55,8 @@ steps:
       - event: pull_request
 
   toml_fmt:
-    image: *rust_image
+    image: tamasfe/taplo:0.8.1-alpine
     commands:
-      - <<: *install_binstall
-      - cargo binstall -y taplo-cli
       - taplo format --check
     when:
       - event: pull_request

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -24,10 +24,10 @@ variables:
             "diesel.toml",
             ".gitmodules",
           ]
-  - &install_binstall |
-    - wget https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz
-    - tar -xvf cargo-binstall-x86_64-unknown-linux-musl.tgz
-    - cp cargo-binstall /usr/local/cargo/bin
+  - install_binstall: &install_binstall
+      - wget https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz
+      - tar -xvf cargo-binstall-x86_64-unknown-linux-musl.tgz
+      - cp cargo-binstall /usr/local/cargo/bin
 
 # Broken for cron jobs currently, see
 # https://github.com/woodpecker-ci/woodpecker/issues/1716
@@ -47,6 +47,20 @@ steps:
       - git submodule update
     when:
       - event: [pull_request, tag]
+
+  check_diesel_schema:
+    image: *rust_image
+    environment:
+      CARGO_HOME: .cargo_home
+      DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
+    commands:
+      - <<: *install_binstall
+      # Install diesel_cli
+      - cargo binstall -y diesel_cli -- --no-default-features --features postgres
+      - diesel migration run
+      - diesel print-schema --config-file=diesel.toml > tmp.schema
+      - diff tmp.schema crates/db_schema/src/schema.rs
+    when: *slow_check_paths
 
   prettier_check:
     image: tmknom/prettier:3.0.0
@@ -83,7 +97,7 @@ steps:
   cargo_machete:
     image: rustlang/rust:nightly
     commands:
-      - *install_binstall
+      - <<: *install_binstall
       - cargo binstall -y cargo-machete
       - cargo machete
     when:
@@ -132,20 +146,6 @@ steps:
       - export LEMMY_CONFIG_LOCATION=./config/config.hjson
       - ./scripts/update_config_defaults.sh config/defaults_current.hjson
       - diff config/defaults.hjson config/defaults_current.hjson
-    when: *slow_check_paths
-
-  check_diesel_schema:
-    image: *rust_image
-    environment:
-      CARGO_HOME: .cargo_home
-      DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
-    commands:
-      - *install_binstall
-      # Install diesel_cli
-      - cargo binstall -y diesel_cli -- --no-default-features --features postgres
-      - diesel migration run
-      - diesel print-schema --config-file=diesel.toml > tmp.schema
-      - diff tmp.schema crates/db_schema/src/schema.rs
     when: *slow_check_paths
 
   check_db_perf_tool:
@@ -202,7 +202,7 @@ steps:
       PGHOST: database
       PGDATABASE: lemmy
     commands:
-      - *install_binstall
+      - <<: *install_binstall
       # Install diesel_cli
       - cargo binstall -y diesel_cli -- --no-default-features --features postgres
       - export PATH="$CARGO_HOME/bin:$PATH"
@@ -283,7 +283,7 @@ steps:
   publish_to_crates_io:
     image: *rust_image
     commands:
-      - *install_binstall
+      - <<: *install_binstall
       # Install cargo-workspaces
       - cargo binstall -y cargo-workspaces
       - cp -r migrations crates/db_schema/

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -32,9 +32,10 @@ variables:
       - apt update && apt install -y lsb-release build-essential
       - sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
       - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-      - apt update && apt install -y postgresql-client-16 libsqlite3-dev libpq-dev default-libmysqlclient-dev
-      - export LD_LIBRARY_PATH=/usr/local/mysql/lib
+      - apt update && apt install -y postgresql-client-16 libsqlite3-dev libpq-dev libmariaclient-dev-compat
       - ls -al /usr/local/lib/
+      - ls -al /usr/local/mysql/lib/
+      - export LD_LIBRARY_PATH=/usr/local/mysql/lib
       - cargo binstall -y diesel_cli
       - export PATH="$CARGO_HOME/bin:$PATH"
 

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -32,7 +32,8 @@ variables:
       - apt update && apt install -y lsb-release build-essential
       - sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
       - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-      - apt update && apt install -y postgresql-client-16 libsqlite3-dev libpq-dev default-mysql-client
+      - apt update && apt install -y postgresql-client-16 libsqlite3-dev libpq-dev default-libmysqlclient-dev
+      - export LD_LIBRARY_PATH=/usr/local/mysql/lib
       - cargo binstall -y diesel_cli
       - export PATH="$CARGO_HOME/bin:$PATH"
 

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -28,16 +28,9 @@ variables:
       - wget https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz
       - tar -xvf cargo-binstall-x86_64-unknown-linux-musl.tgz
       - cp cargo-binstall /usr/local/cargo/bin
+  - install_diesel_cli: &install_diesel_cli
+      - cargo binstall -y diesel_cli
       - export PATH="$CARGO_HOME/bin:$PATH"
-
-# Broken for cron jobs currently, see
-# https://github.com/woodpecker-ci/woodpecker/issues/1716
-# clone:
-#   git:
-#     image: woodpeckerci/plugin-git
-#     settings:
-#       recursive: true
-#       submodule_update_remote: true
 
 steps:
   prepare_repo:
@@ -56,8 +49,7 @@ steps:
       DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
     commands:
       - <<: *install_binstall
-      # Install diesel_cli
-      - cargo binstall -y diesel_cli
+      - <<: *install_diesel_cli
       - diesel migration run
       - diesel print-schema --config-file=diesel.toml > tmp.schema
       - diff tmp.schema crates/db_schema/src/schema.rs

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -29,10 +29,10 @@ variables:
       - tar -xvf cargo-binstall-x86_64-unknown-linux-musl.tgz
       - cp cargo-binstall /usr/local/cargo/bin
   - install_diesel_cli: &install_diesel_cli
-      - apt update && apt install -y lsb-release
+      - apt update && apt install -y lsb-release build-essential
       - sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
       - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-      - apt update && apt install -y postgresql-client-16 libsqlite3-dev libmysqlclient20 libpq-dev
+      - apt update && apt install -y postgresql-client-16 libsqlite3-dev libpq-dev default-libmysqlclient-dev
       - cargo binstall -y diesel_cli
       - export PATH="$CARGO_HOME/bin:$PATH"
 

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -32,7 +32,7 @@ variables:
       - apt update && apt install -y lsb-release build-essential
       - sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
       - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-      - apt update && apt install -y postgresql-client-16 libsqlite3-dev libpq-dev mysql-server
+      - apt update && apt install -y postgresql-client-16 libsqlite3-dev libpq-dev default-mysql-client
       - cargo binstall -y diesel_cli
       - export PATH="$CARGO_HOME/bin:$PATH"
 

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -32,7 +32,7 @@ variables:
       - apt update && apt install -y lsb-release
       - sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
       - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-      - apt update && apt install -y postgresql-client-16 default-libmysqlclient-dev libmariadbclient-dev-compat libsqlite3-dev libpq-dev
+      - apt update && apt install -y postgresql-client-16 libmariadbclient-dev-compat libsqlite3-dev libpq-dev
       - cargo binstall -y diesel_cli
       - export PATH="$CARGO_HOME/bin:$PATH"
 

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -55,7 +55,7 @@ steps:
       - event: pull_request
 
   toml_fmt:
-    image: tamasfe/taplo:0.8.1-alpine
+    image: tamasfe/taplo:0.8.1
     commands:
       - taplo format --check
     when:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -56,7 +56,7 @@ steps:
     commands:
       - <<: *install_binstall
       # Install diesel_cli
-      - cargo binstall -y diesel_cli -- --no-default-features --features postgres
+      - cargo binstall -y diesel_cli
       - diesel migration run
       - diesel print-schema --config-file=diesel.toml > tmp.schema
       - diff tmp.schema crates/db_schema/src/schema.rs

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -32,7 +32,7 @@ variables:
       - apt update && apt install -y lsb-release build-essential
       - sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
       - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-      - apt update && apt install -y postgresql-client-16 libsqlite3-dev libpq-dev default-mysqlclient
+      - apt update && apt install -y postgresql-client-16 libsqlite3-dev libpq-dev mysql-server
       - cargo binstall -y diesel_cli
       - export PATH="$CARGO_HOME/bin:$PATH"
 

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -32,7 +32,7 @@ variables:
       - apt update && apt install -y lsb-release build-essential
       - sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
       - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-      - apt update && apt install -y postgresql-client-16 libsqlite3-dev libpq-dev default-libmysqlclient-dev
+      - apt update && apt install -y postgresql-client-16 libsqlite3-dev libpq-dev default-mysqlclient
       - cargo binstall -y diesel_cli
       - export PATH="$CARGO_HOME/bin:$PATH"
 

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -31,10 +31,10 @@ variables:
   - install_diesel_cli: &install_diesel_cli
       - cargo binstall -y diesel_cli
       - export PATH="$CARGO_HOME/bin:$PATH"
-      - apt update && apt install -y lsb-release
-      - sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-      - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-      - apt update && apt install -y postgresql-client-16 default-mysql-client
+      # - apt update && apt install -y lsb-release
+      # - sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+      # - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+      - apt update && apt install -y postgresql-client-16 default-libmysqlclient-dev
 
 steps:
   prepare_repo:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -24,6 +24,10 @@ variables:
             "diesel.toml",
             ".gitmodules",
           ]
+  - &install_binstall |
+    - wget https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz
+    - tar -xvf cargo-binstall-x86_64-unknown-linux-musl.tgz
+    - cp cargo-binstall /usr/local/cargo/bin
 
 # Broken for cron jobs currently, see
 # https://github.com/woodpecker-ci/woodpecker/issues/1716
@@ -79,11 +83,7 @@ steps:
   cargo_machete:
     image: rustlang/rust:nightly
     commands:
-      # Install cargo binstall
-      - wget https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz
-      - tar -xvf cargo-binstall-x86_64-unknown-linux-musl.tgz
-      - cp cargo-binstall /usr/local/cargo/bin
-      # Install cargo-machete
+      - *install_binstall
       - cargo binstall -y cargo-machete
       - cargo machete
     when:
@@ -140,12 +140,9 @@ steps:
       CARGO_HOME: .cargo_home
       DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
     commands:
-      # Install cargo binstall
-      - wget https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz
-      - tar -xvf cargo-binstall-x86_64-unknown-linux-musl.tgz
-      - cp cargo-binstall /usr/local/cargo/bin
+      - *install_binstall
       # Install diesel_cli
-      - cargo binstall -y diesel_cli --no-default-features --features postgres
+      - cargo binstall -y diesel_cli -- --no-default-features --features postgres
       - diesel migration run
       - diesel print-schema --config-file=diesel.toml > tmp.schema
       - diff tmp.schema crates/db_schema/src/schema.rs
@@ -205,12 +202,9 @@ steps:
       PGHOST: database
       PGDATABASE: lemmy
     commands:
-      # Install cargo binstall
-      - wget https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz
-      - tar -xvf cargo-binstall-x86_64-unknown-linux-musl.tgz
-      - cp cargo-binstall /usr/local/cargo/bin
+      - *install_binstall
       # Install diesel_cli
-      - cargo binstall -y diesel_cli --no-default-features --features postgres
+      - cargo binstall -y diesel_cli -- --no-default-features --features postgres
       - export PATH="$CARGO_HOME/bin:$PATH"
       # Run all migrations
       - diesel migration run
@@ -289,10 +283,7 @@ steps:
   publish_to_crates_io:
     image: *rust_image
     commands:
-      # Install cargo binstall
-      - wget https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz
-      - tar -xvf cargo-binstall-x86_64-unknown-linux-musl.tgz
-      - cp cargo-binstall /usr/local/cargo/bin
+      - *install_binstall
       # Install cargo-workspaces
       - cargo binstall -y cargo-workspaces
       - cp -r migrations crates/db_schema/

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -32,7 +32,7 @@ variables:
       - apt update && apt install -y lsb-release
       - sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
       - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-      - apt update && apt install -y postgresql-client-16 default-libmysqlclient-dev libmysqlclient-dev
+      - apt update && apt install -y postgresql-client-16 default-libmysqlclient-dev
       - cargo binstall -y diesel_cli
       - export PATH="$CARGO_HOME/bin:$PATH"
 

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -79,9 +79,11 @@ steps:
   cargo_machete:
     image: rustlang/rust:nightly
     commands:
+      # Install cargo binstall
       - wget https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz
       - tar -xvf cargo-binstall-x86_64-unknown-linux-musl.tgz
       - cp cargo-binstall /usr/local/cargo/bin
+      # Install cargo-machete
       - cargo binstall -y cargo-machete
       - cargo machete
     when:
@@ -133,11 +135,17 @@ steps:
     when: *slow_check_paths
 
   check_diesel_schema:
-    image: willsquire/diesel-cli
+    image: *rust_image
     environment:
       CARGO_HOME: .cargo_home
       DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
     commands:
+      # Install cargo binstall
+      - wget https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz
+      - tar -xvf cargo-binstall-x86_64-unknown-linux-musl.tgz
+      - cp cargo-binstall /usr/local/cargo/bin
+      # Install diesel_cli
+      - cargo binstall -y diesel_cli --no-default-features --features postgres
       - diesel migration run
       - diesel print-schema --config-file=diesel.toml > tmp.schema
       - diff tmp.schema crates/db_schema/src/schema.rs
@@ -197,7 +205,12 @@ steps:
       PGHOST: database
       PGDATABASE: lemmy
     commands:
-      - cargo install diesel_cli
+      # Install cargo binstall
+      - wget https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz
+      - tar -xvf cargo-binstall-x86_64-unknown-linux-musl.tgz
+      - cp cargo-binstall /usr/local/cargo/bin
+      # Install diesel_cli
+      - cargo binstall -y diesel_cli --no-default-features --features postgres
       - export PATH="$CARGO_HOME/bin:$PATH"
       # Run all migrations
       - diesel migration run
@@ -276,7 +289,12 @@ steps:
   publish_to_crates_io:
     image: *rust_image
     commands:
-      - cargo install cargo-workspaces
+      # Install cargo binstall
+      - wget https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz
+      - tar -xvf cargo-binstall-x86_64-unknown-linux-musl.tgz
+      - cp cargo-binstall /usr/local/cargo/bin
+      # Install cargo-workspaces
+      - cargo binstall -y cargo-workspaces
       - cp -r migrations crates/db_schema/
       - cargo workspaces publish --token "$CARGO_API_TOKEN" --from-git --allow-dirty --no-verify --allow-branch "${CI_COMMIT_TAG}" --yes custom "${CI_COMMIT_TAG}"
     secrets: [cargo_api_token]

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -32,11 +32,8 @@ variables:
       - apt update && apt install -y lsb-release build-essential
       - sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
       - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-      - apt update && apt install -y postgresql-client-16 libsqlite3-dev default-libmysqlclient-dev libpq-dev
-      - ls -al /usr/lib/
-      # - ls -al /usr/local/mysql/lib/
-      - export LD_LIBRARY_PATH=/usr/lib
-      - cargo binstall -y diesel_cli
+      - apt update && apt install -y postgresql-client-16
+      - cargo install diesel_cli --no-default-features --features postgres
       - export PATH="$CARGO_HOME/bin:$PATH"
 
 steps:
@@ -55,7 +52,6 @@ steps:
       CARGO_HOME: .cargo_home
       DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
     commands:
-      - <<: *install_binstall
       - <<: *install_diesel_cli
       - diesel migration run
       - diesel print-schema --config-file=diesel.toml > tmp.schema
@@ -202,9 +198,8 @@ steps:
       PGHOST: database
       PGDATABASE: lemmy
     commands:
-      - <<: *install_binstall
       # Install diesel_cli
-      - cargo binstall -y diesel_cli -- --no-default-features --features postgres
+      - <<: *install_diesel_cli
       # Run all migrations
       - diesel migration run
       # Dump schema to before.sqldump (PostgreSQL apt repo is used to prevent pg_dump version mismatch error)

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -3,6 +3,7 @@
 
 variables:
   - &rust_image "rust:1.77"
+  - &rust_nightly_image "rustlang/rust:nightly"
   - &install_pnpm "corepack enable pnpm"
   - &slow_check_paths
     - event: pull_request
@@ -46,18 +47,6 @@ steps:
     when:
       - event: [pull_request, tag]
 
-  check_diesel_schema:
-    image: *rust_image
-    environment:
-      CARGO_HOME: .cargo_home
-      DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
-    commands:
-      - <<: *install_diesel_cli
-      - diesel migration run
-      - diesel print-schema --config-file=diesel.toml > tmp.schema
-      - diff tmp.schema crates/db_schema/src/schema.rs
-    when: *slow_check_paths
-
   prettier_check:
     image: tmknom/prettier:3.0.0
     commands:
@@ -66,8 +55,10 @@ steps:
       - event: pull_request
 
   toml_fmt:
-    image: tamasfe/taplo:0.8.1
+    image: *rust_image
     commands:
+      - <<: *install_binstall
+      - cargo binstall -y taplo-cli
       - taplo format --check
     when:
       - event: pull_request
@@ -80,7 +71,7 @@ steps:
       - event: pull_request
 
   cargo_fmt:
-    image: rustlang/rust:nightly
+    image: *rust_nightly_image
     environment:
       # store cargo data in repo folder so that it gets cached between steps
       CARGO_HOME: .cargo_home
@@ -91,7 +82,7 @@ steps:
       - event: pull_request
 
   cargo_machete:
-    image: rustlang/rust:nightly
+    image: *rust_nightly_image
     commands:
       - <<: *install_binstall
       - cargo binstall -y cargo-machete
@@ -142,6 +133,18 @@ steps:
       - export LEMMY_CONFIG_LOCATION=./config/config.hjson
       - ./scripts/update_config_defaults.sh config/defaults_current.hjson
       - diff config/defaults.hjson config/defaults_current.hjson
+    when: *slow_check_paths
+
+  check_diesel_schema:
+    image: *rust_image
+    environment:
+      CARGO_HOME: .cargo_home
+      DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
+    commands:
+      - <<: *install_diesel_cli
+      - diesel migration run
+      - diesel print-schema --config-file=diesel.toml > tmp.schema
+      - diff tmp.schema crates/db_schema/src/schema.rs
     when: *slow_check_paths
 
   check_db_perf_tool:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -34,6 +34,7 @@ variables:
       - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
       - apt update && apt install -y postgresql-client-16 libsqlite3-dev libpq-dev default-libmysqlclient-dev
       - export LD_LIBRARY_PATH=/usr/local/mysql/lib
+      - ls -al /usr/local/lib/
       - cargo binstall -y diesel_cli
       - export PATH="$CARGO_HOME/bin:$PATH"
 

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -32,7 +32,7 @@ variables:
       - apt update && apt install -y lsb-release
       - sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
       - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-      - apt update && apt install -y postgresql-client-16 libmariadbclient-dev-compat libsqlite3-dev libpq-dev
+      - apt update && apt install -y postgresql-client-16 libsqlite3-dev libmysqlclient20 libpq-dev
       - cargo binstall -y diesel_cli
       - export PATH="$CARGO_HOME/bin:$PATH"
 

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -32,7 +32,7 @@ variables:
       - apt update && apt install -y lsb-release
       - sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
       - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-      - apt update && apt install -y postgresql-client-16 default-libmysqlclient-dev
+      - apt update && apt install -y postgresql-client-16 default-libmysqlclient-dev libmariadbclient-dev-compat libsqlite3-dev libpq-dev
       - cargo binstall -y diesel_cli
       - export PATH="$CARGO_HOME/bin:$PATH"
 

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -32,10 +32,10 @@ variables:
       - apt update && apt install -y lsb-release build-essential
       - sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
       - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-      - apt update && apt install -y postgresql-client-16 libsqlite3-dev libpq-dev libmariadbclient-dev-compat
-      - ls -al /usr/local/lib/
-      - ls -al /usr/local/mysql/lib/
-      - export LD_LIBRARY_PATH=/usr/local/mysql/lib
+      - apt update && apt install -y postgresql-client-16 libsqlite3-dev default-libmysqlclient-dev libpq-dev
+      - ls -al /usr/lib/
+      # - ls -al /usr/local/mysql/lib/
+      - export LD_LIBRARY_PATH=/usr/lib
       - cargo binstall -y diesel_cli
       - export PATH="$CARGO_HOME/bin:$PATH"
 

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -31,9 +31,9 @@ variables:
   - install_diesel_cli: &install_diesel_cli
       - cargo binstall -y diesel_cli
       - export PATH="$CARGO_HOME/bin:$PATH"
-      # - apt update && apt install -y lsb-release
-      # - sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-      # - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+      - apt update && apt install -y lsb-release
+      - sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+      - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
       - apt update && apt install -y postgresql-client-16 default-libmysqlclient-dev
 
 steps:


### PR DESCRIPTION
- The diesel_cli image is 500MB, and rebuilt daily. Much easier to use binstall to install it.