### PR TITLE
Prevent bot replies from increasing unread reply count when bot accounts are not shown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2948,6 +2948,7 @@ dependencies = [
  "diesel",
  "diesel-async",
  "lemmy_db_schema",
+ "lemmy_db_views",
  "lemmy_utils",
  "pretty_assertions",
  "serde",

--- a/api_tests/src/shared.ts
+++ b/api_tests/src/shared.ts
@@ -370,7 +370,7 @@ export async function getReplies(
 ): Promise<GetRepliesResponse> {
   let form: GetReplies = {
     sort: "New",
-    unread_only: unread_only,
+    unread_only,
   };
   return api.getReplies(form);
 }

--- a/api_tests/src/shared.ts
+++ b/api_tests/src/shared.ts
@@ -364,10 +364,13 @@ export async function getUnreadCount(
   return api.getUnreadCount();
 }
 
-export async function getReplies(api: LemmyHttp): Promise<GetRepliesResponse> {
+export async function getReplies(
+  api: LemmyHttp,
+  unread_only: boolean = false,
+): Promise<GetRepliesResponse> {
   let form: GetReplies = {
     sort: "New",
-    unread_only: false,
+    unread_only: unread_only,
   };
   return api.getReplies(form);
 }

--- a/crates/api/src/local_user/notifications/unread_count.rs
+++ b/crates/api/src/local_user/notifications/unread_count.rs
@@ -11,7 +11,12 @@ pub async fn unread_count(
 ) -> LemmyResult<Json<GetUnreadCountResponse>> {
   let person_id = local_user_view.person.id;
 
-  let replies = CommentReplyView::get_unread_replies(&mut context.pool(), person_id).await?;
+  let replies = CommentReplyView::get_unread_replies(
+    &mut context.pool(),
+    person_id,
+    local_user_view.local_user.show_bot_accounts,
+  )
+  .await?;
 
   let mentions = PersonMentionView::get_unread_mentions(&mut context.pool(), person_id).await?;
 

--- a/crates/api/src/local_user/notifications/unread_count.rs
+++ b/crates/api/src/local_user/notifications/unread_count.rs
@@ -14,7 +14,9 @@ pub async fn unread_count(
   let replies =
     CommentReplyView::get_unread_replies(&mut context.pool(), &local_user_view.local_user).await?;
 
-  let mentions = PersonMentionView::get_unread_mentions(&mut context.pool(), person_id).await?;
+  let mentions =
+    PersonMentionView::get_unread_mentions(&mut context.pool(), &local_user_view.local_user)
+      .await?;
 
   let private_messages =
     PrivateMessageView::get_unread_messages(&mut context.pool(), person_id).await?;

--- a/crates/api/src/local_user/notifications/unread_count.rs
+++ b/crates/api/src/local_user/notifications/unread_count.rs
@@ -11,12 +11,8 @@ pub async fn unread_count(
 ) -> LemmyResult<Json<GetUnreadCountResponse>> {
   let person_id = local_user_view.person.id;
 
-  let replies = CommentReplyView::get_unread_replies(
-    &mut context.pool(),
-    person_id,
-    local_user_view.local_user.show_bot_accounts,
-  )
-  .await?;
+  let replies =
+    CommentReplyView::get_unread_replies(&mut context.pool(), &local_user_view.local_user).await?;
 
   let mentions = PersonMentionView::get_unread_mentions(&mut context.pool(), person_id).await?;
 

--- a/crates/db_views_actor/Cargo.toml
+++ b/crates/db_views_actor/Cargo.toml
@@ -40,6 +40,7 @@ serial_test = { workspace = true }
 tokio = { workspace = true }
 pretty_assertions = { workspace = true }
 url.workspace = true
+lemmy_db_views.workspace = true
 lemmy_utils.workspace = true
 
 [package.metadata.cargo-machete]

--- a/crates/db_views_actor/src/comment_reply_view.rs
+++ b/crates/db_views_actor/src/comment_reply_view.rs
@@ -269,7 +269,7 @@ impl CommentReplyView {
 
     // These filters need to be kept in sync with the filters in queries().list()
     if !local_user.show_bot_accounts {
-      query = query.filter(person::bot_account.eq(false));
+      query = query.filter(not(person::bot_account));
     }
 
     query

--- a/crates/db_views_actor/src/person_mention_view.rs
+++ b/crates/db_views_actor/src/person_mention_view.rs
@@ -31,6 +31,7 @@ use lemmy_db_schema::{
     person_mention,
     post,
   },
+  source::local_user::LocalUser,
   utils::{get_conn, limit_and_offset, DbConn, DbPool, ListFn, Queries, ReadFn},
   CommentSortType,
 };
@@ -192,6 +193,8 @@ fn queries<'a>() -> Queries<
     };
 
   let list = move |mut conn: DbConn<'a>, options: PersonMentionQuery| async move {
+    // These filters need to be kept in sync with the filters in
+    // PersonMentionView::get_unread_mentions()
     let mut query = all_joins(person_mention::table.into_boxed(), options.my_person_id);
 
     if let Some(recipient_id) = options.recipient_id {
@@ -203,7 +206,7 @@ fn queries<'a>() -> Queries<
     }
 
     if !options.show_bot_accounts {
-      query = query.filter(person::bot_account.eq(false));
+      query = query.filter(not(person::bot_account));
     };
 
     query = match options.sort.unwrap_or(CommentSortType::Hot) {
@@ -247,23 +250,32 @@ impl PersonMentionView {
   /// Gets the number of unread mentions
   pub async fn get_unread_mentions(
     pool: &mut DbPool<'_>,
-    my_person_id: PersonId,
+    local_user: &LocalUser,
   ) -> Result<i64, Error> {
     use diesel::dsl::count;
     let conn = &mut get_conn(pool).await?;
 
-    person_mention::table
+    let mut query = person_mention::table
       .inner_join(comment::table)
       .left_join(
         person_block::table.on(
           comment::creator_id
             .eq(person_block::target_id)
-            .and(person_block::person_id.eq(my_person_id)),
+            .and(person_block::person_id.eq(local_user.person_id)),
         ),
       )
-      // Dont count replies from blocked users
+      .inner_join(person::table.on(comment::creator_id.eq(person::id)))
+      .into_boxed();
+
+    // These filters need to be kept in sync with the filters in queries().list()
+    if !local_user.show_bot_accounts {
+      query = query.filter(not(person::bot_account));
+    }
+
+    query
+      // Don't count replies from blocked users
       .filter(person_block::person_id.is_null())
-      .filter(person_mention::recipient_id.eq(my_person_id))
+      .filter(person_mention::recipient_id.eq(local_user.person_id))
       .filter(person_mention::read.eq(false))
       .filter(comment::deleted.eq(false))
       .filter(comment::removed.eq(false))
@@ -300,7 +312,8 @@ mod tests {
       comment::{Comment, CommentInsertForm},
       community::{Community, CommunityInsertForm},
       instance::Instance,
-      person::{Person, PersonInsertForm},
+      local_user::{LocalUser, LocalUserInsertForm, LocalUserUpdateForm},
+      person::{Person, PersonInsertForm, PersonUpdateForm},
       person_block::{PersonBlock, PersonBlockForm},
       person_mention::{PersonMention, PersonMentionInsertForm, PersonMentionUpdateForm},
       post::{Post, PostInsertForm},
@@ -308,6 +321,7 @@ mod tests {
     traits::{Blockable, Crud},
     utils::build_db_pool_for_tests,
   };
+  use lemmy_db_views::structs::LocalUserView;
   use lemmy_utils::{error::LemmyResult, LemmyErrorType};
   use pretty_assertions::assert_eq;
   use serial_test::serial;
@@ -336,6 +350,9 @@ mod tests {
 
     let inserted_recipient = Person::create(pool, &recipient_form).await?;
     let recipient_id = inserted_recipient.id;
+
+    let recipient_local_user =
+      LocalUser::create(pool, &LocalUserInsertForm::test_form(recipient_id), vec![]).await?;
 
     let new_community = CommunityInsertForm::builder()
       .name("test community lake".to_string())
@@ -387,7 +404,8 @@ mod tests {
       PersonMention::update(pool, inserted_mention.id, &person_mention_update_form).await?;
 
     // Test to make sure counts and blocks work correctly
-    let unread_mentions = PersonMentionView::get_unread_mentions(pool, recipient_id).await?;
+    let unread_mentions =
+      PersonMentionView::get_unread_mentions(pool, &recipient_local_user).await?;
 
     let query = PersonMentionQuery {
       recipient_id: Some(recipient_id),
@@ -410,10 +428,43 @@ mod tests {
     PersonBlock::block(pool, &block_form).await?;
 
     let unread_mentions_after_block =
-      PersonMentionView::get_unread_mentions(pool, recipient_id).await?;
-    let mentions_after_block = query.list(pool).await?;
+      PersonMentionView::get_unread_mentions(pool, &recipient_local_user).await?;
+    let mentions_after_block = query.clone().list(pool).await?;
     assert_eq!(0, unread_mentions_after_block);
     assert_eq!(0, mentions_after_block.len());
+
+    // Unblock user so we can reuse the same person
+    PersonBlock::unblock(pool, &block_form).await?;
+
+    // Turn Terry into a bot account
+    let person_update_form = PersonUpdateForm {
+      bot_account: Some(true),
+      ..Default::default()
+    };
+    Person::update(pool, inserted_person.id, &person_update_form).await?;
+
+    let recipient_local_user_update_form = LocalUserUpdateForm {
+      show_bot_accounts: Some(false),
+      ..Default::default()
+    };
+    LocalUser::update(
+      pool,
+      recipient_local_user.id,
+      &recipient_local_user_update_form,
+    )
+    .await?;
+    let recipient_local_user_view = LocalUserView::read(pool, recipient_local_user.id)
+      .await?
+      .ok_or(LemmyErrorType::CouldntFindLocalUser)?;
+
+    let unread_mentions_after_hide_bots =
+      PersonMentionView::get_unread_mentions(pool, &recipient_local_user_view.local_user).await?;
+
+    let mut query_without_bots = query.clone();
+    query_without_bots.show_bot_accounts = false;
+    let replies_after_hide_bots = query_without_bots.list(pool).await?;
+    assert_eq!(0, unread_mentions_after_hide_bots);
+    assert_eq!(0, replies_after_hide_bots.len());
 
     Comment::delete(pool, inserted_comment.id).await?;
     Post::delete(pool, inserted_post.id).await?;


### PR DESCRIPTION
Bot replies are currently not excluded from unread reply counts, even if the user has disabled showing bot accounts.

Multiple users already ran into this issue, such as https://lemm.ee/comment/12150802 and https://lemmy.world/comment/10261061.

This fixes the filter to also exclude bot replies in the unread replies query and also adds a few tests around this functionality, both in api tests and rust tests.