### PR TITLE
Update dependencies to alleviate cargo audit peer dependency vulnerability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,11 +250,9 @@ dependencies = [
  "pin-project-lite",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.23.4",
  "tokio-rustls 0.26.0",
  "tokio-util",
  "tracing",
- "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -2711,7 +2709,7 @@ dependencies = [
  "base64 0.21.7",
  "js-sys",
  "pem",
- "ring 0.17.8",
+ "ring",
  "serde",
  "serde_json",
  "simple_asn1",
@@ -4075,7 +4073,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "webpki-roots 0.26.1",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4677,7 +4675,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.26.1",
+ "webpki-roots",
  "winreg 0.52.0",
 ]
 
@@ -4768,21 +4766,6 @@ checksum = "b9b1a3d5f46d53f4a3478e2be4a5a5ce5108ea58b100dcd139830eae7f79a3a1"
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
@@ -4791,7 +4774,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "libc",
- "spin 0.9.8",
+ "spin",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
@@ -4876,24 +4859,12 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
-dependencies = [
- "log",
- "ring 0.16.20",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
- "ring 0.17.8",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -4909,7 +4880,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring 0.17.8",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -4958,7 +4929,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
 dependencies = [
  "aws-lc-rs",
- "ring 0.17.8",
+ "ring",
  "rustls-pki-types",
  "untrusted 0.9.0",
 ]
@@ -5036,16 +5007,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
-]
 
 [[package]]
 name = "sdd"
@@ -5371,12 +5332,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -5821,23 +5776,12 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04fb792ccd6bbcd4bba408eb8a292f70fc4a3589e5d793626f45190e6454b6ab"
 dependencies = [
- "ring 0.17.8",
+ "ring",
  "rustls 0.23.8",
  "tokio",
  "tokio-postgres",
  "tokio-rustls 0.26.0",
  "x509-certificate",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
-dependencies = [
- "rustls 0.20.9",
- "tokio",
- "webpki",
 ]
 
 [[package]]
@@ -6628,25 +6572,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
-dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6929,7 +6854,7 @@ dependencies = [
  "der",
  "hex",
  "pem",
- "ring 0.17.8",
+ "ring",
  "signature",
  "spki",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ serde = { version = "1.0.202", features = ["derive"] }
 serde_with = "3.8.1"
 actix-web = { version = "4.6.0", default-features = false, features = [
   "macros",
-  "rustls",
+  "rustls-0_23",
   "compress-brotli",
   "compress-gzip",
   "compress-zstd",


### PR DESCRIPTION
This fixes another vulnerability revealed by running `cargo audit`.

```
Crate:     rustls
Version:   0.20.9
Title:     `rustls::ConnectionCommon::complete_io` could fall into an infinite loop based on network input
Date:      2024-04-19
ID:        RUSTSEC-2024-0336
URL:       https://rustsec.org/advisories/RUSTSEC-2024-0336
Severity:  7.5 (high)
Solution:  Upgrade to >=0.23.5 OR >=0.22.4, <0.23.0 OR >=0.21.11, <0.22.0
Dependency tree:
rustls 0.20.9
└── tokio-rustls 0.23.4
    └── actix-tls 3.4.0
        ├── actix-web 4.6.0
        │   ├── tracing-actix-web 0.7.10
        │   │   ├── pict-rs 0.5.14
        │   │   │   └── lemmy_server 0.19.4-rc.3
        │   │   └── lemmy_server 0.19.4-rc.3
        │   ├── pict-rs 0.5.14
        │   ├── lemmy_utils 0.19.4-rc.3
        │   │   ├── lemmy_server 0.19.4-rc.3
        │   │   ├── lemmy_routes 0.19.4-rc.3
        │   │   │   └── lemmy_server 0.19.4-rc.3
        │   │   ├── lemmy_federate 0.19.4-rc.3
        │   │   │   └── lemmy_server 0.19.4-rc.3
        │   │   ├── lemmy_db_views_actor 0.19.4-rc.3
        │   │   │   ├── lemmy_routes 0.19.4-rc.3
        │   │   │   ├── lemmy_federate 0.19.4-rc.3
        │   │   │   ├── lemmy_apub 0.19.4-rc.3
        │   │   │   │   ├── lemmy_server 0.19.4-rc.3
        │   │   │   │   └── lemmy_federate 0.19.4-rc.3
        │   │   │   ├── lemmy_api_crud 0.19.4-rc.3
        │   │   │   │   └── lemmy_server 0.19.4-rc.3
        │   │   │   ├── lemmy_api_common 0.19.4-rc.3
        │   │   │   │   ├── lemmy_server 0.19.4-rc.3
        │   │   │   │   ├── lemmy_routes 0.19.4-rc.3
        │   │   │   │   ├── lemmy_federate 0.19.4-rc.3
        │   │   │   │   ├── lemmy_apub 0.19.4-rc.3
        │   │   │   │   ├── lemmy_api_crud 0.19.4-rc.3
        │   │   │   │   └── lemmy_api 0.19.4-rc.3
        │   │   │   │       └── lemmy_server 0.19.4-rc.3
        │   │   │   └── lemmy_api 0.19.4-rc.3
        │   │   ├── lemmy_db_views 0.19.4-rc.3
        │   │   │   ├── lemmy_routes 0.19.4-rc.3
        │   │   │   ├── lemmy_db_perf 0.19.4-rc.3
        │   │   │   ├── lemmy_apub 0.19.4-rc.3
        │   │   │   ├── lemmy_api_crud 0.19.4-rc.3
        │   │   │   ├── lemmy_api_common 0.19.4-rc.3
        │   │   │   └── lemmy_api 0.19.4-rc.3
        │   │   ├── lemmy_db_schema 0.19.4-rc.3
        │   │   │   ├── lemmy_server 0.19.4-rc.3
        │   │   │   ├── lemmy_routes 0.19.4-rc.3
        │   │   │   ├── lemmy_federate 0.19.4-rc.3
        │   │   │   ├── lemmy_db_views_moderator 0.19.4-rc.3
        │   │   │   │   ├── lemmy_api_common 0.19.4-rc.3
        │   │   │   │   └── lemmy_api 0.19.4-rc.3
        │   │   │   ├── lemmy_db_views_actor 0.19.4-rc.3
        │   │   │   ├── lemmy_db_views 0.19.4-rc.3
        │   │   │   ├── lemmy_db_perf 0.19.4-rc.3
        │   │   │   ├── lemmy_apub 0.19.4-rc.3
        │   │   │   ├── lemmy_api_crud 0.19.4-rc.3
        │   │   │   ├── lemmy_api_common 0.19.4-rc.3
        │   │   │   └── lemmy_api 0.19.4-rc.3
        │   │   ├── lemmy_db_perf 0.19.4-rc.3
        │   │   ├── lemmy_apub 0.19.4-rc.3
        │   │   ├── lemmy_api_crud 0.19.4-rc.3
        │   │   ├── lemmy_api_common 0.19.4-rc.3
        │   │   └── lemmy_api 0.19.4-rc.3
        │   ├── lemmy_server 0.19.4-rc.3
        │   ├── lemmy_routes 0.19.4-rc.3
        │   ├── lemmy_db_views 0.19.4-rc.3
        │   ├── lemmy_apub 0.19.4-rc.3
        │   ├── lemmy_api_crud 0.19.4-rc.3
        │   ├── lemmy_api_common 0.19.4-rc.3
        │   ├── lemmy_api 0.19.4-rc.3
        │   ├── actix-web-prom 0.8.0
        │   │   └── lemmy_server 0.19.4-rc.3
        │   ├── actix-web-httpauth 0.8.1
        │   │   └── lemmy_api 0.19.4-rc.3
        │   ├── actix-multipart 0.6.1
        │   │   └── actix-form-data 0.7.0-beta.7
        │   │       └── pict-rs 0.5.14
        │   ├── actix-form-data 0.7.0-beta.7
        │   ├── actix-cors 0.7.0
        │   │   └── lemmy_server 0.19.4-rc.3
        │   └── activitypub_federation 0.5.6
        │       ├── lemmy_server 0.19.4-rc.3
        │       ├── lemmy_routes 0.19.4-rc.3
        │       ├── lemmy_federate 0.19.4-rc.3
        │       ├── lemmy_db_schema 0.19.4-rc.3
        │       ├── lemmy_apub 0.19.4-rc.3
        │       ├── lemmy_api_crud 0.19.4-rc.3
        │       ├── lemmy_api_common 0.19.4-rc.3
        │       └── lemmy_api 0.19.4-rc.3
        └── actix-http 3.7.0
            └── actix-web 4.6.0
```