### PR TITLE
Remove wrong federation local domain filter

### DIFF
--- a/crates/federate/src/worker.rs
+++ b/crates/federate/src/worker.rs
@@ -297,7 +297,6 @@ impl InstanceWorker {
         .send_inboxes
         .iter()
         .filter_map(std::option::Option::as_ref)
-        .filter(|&u| (u.domain() == Some(&self.instance.domain)))
         .map(|u| u.inner().clone()),
     );
     Ok(inbox_urls)


### PR DESCRIPTION
While working on https://github.com/LemmyNet/lemmy/pull/4751 I noticed that this line is wrong, it should be `!=` instead of `==`. And in fact it is completely unnecessary because the apub library already removes local inbox urls. This means that some activities wont get delivered correctly.

Lets get this into 0.19.4 as the fix is very simple.