### PR TITLE
upgrade rust to 1.78 to fix diesel cli

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -2,7 +2,7 @@
 # See https://github.com/woodpecker-ci/woodpecker/issues/1677
 
 variables:
-  - &rust_image "rust:1.77"
+  - &rust_image "rust:1.78"
   - &rust_nightly_image "rustlang/rust:nightly"
   - &install_pnpm "corepack enable pnpm"
   - &slow_check_paths

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-ARG RUST_VERSION=1.77
+ARG RUST_VERSION=1.78
 ARG CARGO_BUILD_FEATURES=default
 ARG RUST_RELEASE_MODE=debug
 


### PR DESCRIPTION
CI currently fails because diesel was upgraded and newest diesel cli requires 1.78. this might fix it. log from ci:

```
Setting up postgresql-client-common (260.pgdg120+1) ...
Setting up libpq5:amd64 (16.3-1.pgdg120+1) ...
Setting up libpq-dev (16.3-1.pgdg120+1) ...
Setting up postgresql-client-16 (16.3-1.pgdg120+1) ...
update-alternatives: using /usr/share/postgresql/16/man/man1/psql.1.gz to provide /usr/share/man/man1/psql.1.gz (psql.1.gz) in auto mode
Processing triggers for libc-bin (2.36-9+deb12u6) ...
+ cargo install diesel_cli --no-default-features --features postgres
    Updating crates.io index
error: cannot install package `diesel_cli 2.2.0`, it requires rustc 1.78.0 or newer, while the currently active rustc version is 1.77.2
`diesel_cli 2.1.1` supports rustc 1.65.0
```