### PR TITLE
Remove .json from nodeinfo urls, according to spec.

### DIFF
--- a/crates/routes/src/nodeinfo.rs
+++ b/crates/routes/src/nodeinfo.rs
@@ -12,15 +12,18 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use url::Url;
 
+/// A description of the nodeinfo endpoint is here:
+/// https://github.com/jhass/nodeinfo/blob/main/PROTOCOL.md
 pub fn config(cfg: &mut web::ServiceConfig) {
   cfg
     .route(
-      "/nodeinfo/2.1.json",
+      "/nodeinfo/2.1",
       web::get().to(node_info).wrap(cache_1hour()),
     )
-    .service(web::redirect("/version", "/nodeinfo/2.1.json"))
+    .service(web::redirect("/version", "/nodeinfo/2.1"))
     // For backwards compatibility, can be removed after Lemmy 0.20
-    .service(web::redirect("/nodeinfo/2.0.json", "/nodeinfo/2.1.json"))
+    .service(web::redirect("/nodeinfo/2.0.json", "/nodeinfo/2.1"))
+    .service(web::redirect("/nodeinfo/2.1.json", "/nodeinfo/2.1"))
     .route(
       "/.well-known/nodeinfo",
       web::get().to(node_info_well_known).wrap(cache_3days()),
@@ -32,7 +35,7 @@ async fn node_info_well_known(context: web::Data<LemmyContext>) -> LemmyResult<H
     links: vec![NodeInfoWellKnownLinks {
       rel: Url::parse("http://nodeinfo.diaspora.software/ns/schema/2.1")?,
       href: Url::parse(&format!(
-        "{}/nodeinfo/2.1.json",
+        "{}/nodeinfo/2.1",
         &context.settings().get_protocol_and_hostname(),
       ))?,
     }],


### PR DESCRIPTION
I added a comment for this, but according to the nodeinfo spec, the endpoint should end with `2.0`, not `2.0.json` .

I've added redirects for backwards compatibility.