### PR TITLE
Fix issue with avatar / icon deletion when saving settings.

### DIFF
--- a/api_tests/src/user.spec.ts
+++ b/api_tests/src/user.spec.ts
@@ -186,10 +186,16 @@ test("Set a new avatar, old avatar is deleted", async () => {
   expect(upload2.url).toBeDefined();
 
   let form2 = {
-    avatar: upload1.url,
+    avatar: upload2.url,
   };
   await saveUserSettings(alpha, form2);
   // make sure only the new avatar is kept
   const listMediaRes2 = await alphaImage.listMedia();
   expect(listMediaRes2.images.length).toBe(1);
+
+  // Upload that same form2 avatar, make sure it isn't replaced / deleted
+  await saveUserSettings(alpha, form2);
+  // make sure only the new avatar is kept
+  const listMediaRes3 = await alphaImage.listMedia();
+  expect(listMediaRes3.images.length).toBe(1);
 });

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -345,8 +345,9 @@ pub async fn replace_image(
   context: &Data<LemmyContext>,
 ) -> LemmyResult<()> {
   if let (Some(new_image), Some(old_image)) = (new_image, old_image) {
-    // Note: Oftentimes front ends will include the current image in the form,
-    // so only delete if the urls are different.
+    // Note: Oftentimes front ends will include the current image in the form.
+    // In this case, deleting `old_image` would also be deletion of `new_image`,
+    // so the deletion must be skipped for the image to be kept.
     if new_image != old_image.as_str() {
       // Ignore errors because image may be stored externally.
       let image = LocalImage::delete_by_url(&mut context.pool(), old_image)


### PR DESCRIPTION
- Fixes #4763

See above issue for context, but UI's like lemmy-ui often pre-populate their update forms with the existing avatar url.

Before this change, it would delete existing image in pictrs, even if there wasn't actually a change in the url.