### PR TITLE
Apub library 0.5.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,9 +16,9 @@ checksum = "8f27d075294830fcab6f66e320dab524bc6d048f4a151698e153205559113772"
 
 [[package]]
 name = "activitypub_federation"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac8ff2d0151ce9ac02eb29e4a58b41d28693f141f7963d4bfabd2f9d402ecec7"
+checksum = "69876675c80e73ab5e15e07b414cd3aa7c4c4e91f81fa43b52ea3ef28cbc225c"
 dependencies = [
  "activitystreams-kinds",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ lemmy_db_views = { version = "=0.19.4-rc.6", path = "./crates/db_views" }
 lemmy_db_views_actor = { version = "=0.19.4-rc.6", path = "./crates/db_views_actor" }
 lemmy_db_views_moderator = { version = "=0.19.4-rc.6", path = "./crates/db_views_moderator" }
 lemmy_federate = { version = "=0.19.4-rc.6", path = "./crates/federate" }
-activitypub_federation = { version = "0.5.6", default-features = false, features = [
+activitypub_federation = { version = "0.5.7", default-features = false, features = [
   "actix-web",
 ] }
 diesel = "2.1.6"


### PR DESCRIPTION
Reverts https://github.com/LemmyNet/activitypub-federation-rust/pull/102 which is causing federation issues