### PR TITLE
Removing renovate schedule.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "schedule": ["before 4am on the first day of the month"]
+  "extends": ["config:recommended"]
 }


### PR DESCRIPTION
I've just installed a 3rd CI runner today, so these jobs blocking the CI should be less of an issue.

We've also removed the schedule on a few other lemmy repos, and it hasn't been a problem to merge these at the click of a button.