### PR TITLE
Add default RustTLS provider

### DIFF
--- a/crates/db_schema/src/utils.rs
+++ b/crates/db_schema/src/utils.rs
@@ -50,6 +50,7 @@ use rustls::{
   },
   crypto::{self, verify_tls12_signature, verify_tls13_signature},
   pki_types::{CertificateDer, ServerName, UnixTime},
+  ring::default_provider().install_default().expect("Failed to install rustls crypto provider"),
   ClientConfig,
   DigitallySignedStruct,
   SignatureScheme,

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,10 +7,6 @@ pub async fn main() -> LemmyResult<()> {
   init_logging(&SETTINGS.opentelemetry_url)?;
   let args = CmdArgs::parse();
 
-  rustls::crypto::ring::default_provider()
-    .install_default()
-    .expect("Failed to install rustls crypto provider");
-
   #[cfg(not(feature = "embed-pictrs"))]
   start_lemmy_server(args).await?;
   #[cfg(feature = "embed-pictrs")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,10 @@ pub async fn main() -> LemmyResult<()> {
   init_logging(&SETTINGS.opentelemetry_url)?;
   let args = CmdArgs::parse();
 
+  rusttls::crypto::ring::default_provider()
+    .install_default()
+    .expect("Failed to install rusttls crypto provider");
+
   #[cfg(not(feature = "embed-pictrs"))]
   start_lemmy_server(args).await?;
   #[cfg(feature = "embed-pictrs")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,9 @@ pub async fn main() -> LemmyResult<()> {
   init_logging(&SETTINGS.opentelemetry_url)?;
   let args = CmdArgs::parse();
 
-  rusttls::crypto::ring::default_provider()
+  rustls::crypto::ring::default_provider()
     .install_default()
-    .expect("Failed to install rusttls crypto provider");
+    .expect("Failed to install rustls crypto provider");
 
   #[cfg(not(feature = "embed-pictrs"))]
   start_lemmy_server(args).await?;


### PR DESCRIPTION
Install a default `rusttls` provider to fix issues with connecting to TLS Postgres servers/clusters.

Fixes #4795 - see notes on comment, PR is based on a suggestion from @makotech222 