### PR TITLE
Fixing not being able to create comments on local community posts.

### DIFF
--- a/crates/api/src/comment/distinguish.rs
+++ b/crates/api/src/comment/distinguish.rs
@@ -17,9 +17,13 @@ pub async fn distinguish_comment(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<CommentResponse>> {
-  let orig_comment = CommentView::read(&mut context.pool(), data.comment_id, None)
-    .await?
-    .ok_or(LemmyErrorType::CouldntFindComment)?;
+  let orig_comment = CommentView::read(
+    &mut context.pool(),
+    data.comment_id,
+    Some(local_user_view.person.id),
+  )
+  .await?
+  .ok_or(LemmyErrorType::CouldntFindComment)?;
 
   check_community_user_action(
     &local_user_view.person,

--- a/crates/api/src/comment/distinguish.rs
+++ b/crates/api/src/comment/distinguish.rs
@@ -20,7 +20,7 @@ pub async fn distinguish_comment(
   let orig_comment = CommentView::read(
     &mut context.pool(),
     data.comment_id,
-    Some(local_user_view.person.id),
+    Some(&local_user_view.local_user),
   )
   .await?
   .ok_or(LemmyErrorType::CouldntFindComment)?;
@@ -58,7 +58,7 @@ pub async fn distinguish_comment(
   let comment_view = CommentView::read(
     &mut context.pool(),
     data.comment_id,
-    Some(local_user_view.person.id),
+    Some(&local_user_view.local_user),
   )
   .await?
   .ok_or(LemmyErrorType::CouldntFindComment)?;

--- a/crates/api/src/comment/like.rs
+++ b/crates/api/src/comment/like.rs
@@ -35,9 +35,13 @@ pub async fn like_comment(
   check_bot_account(&local_user_view.person)?;
 
   let comment_id = data.comment_id;
-  let orig_comment = CommentView::read(&mut context.pool(), comment_id, None)
-    .await?
-    .ok_or(LemmyErrorType::CouldntFindComment)?;
+  let orig_comment = CommentView::read(
+    &mut context.pool(),
+    comment_id,
+    Some(local_user_view.person.id),
+  )
+  .await?
+  .ok_or(LemmyErrorType::CouldntFindComment)?;
 
   check_community_user_action(
     &local_user_view.person,

--- a/crates/api/src/comment/like.rs
+++ b/crates/api/src/comment/like.rs
@@ -38,7 +38,7 @@ pub async fn like_comment(
   let orig_comment = CommentView::read(
     &mut context.pool(),
     comment_id,
-    Some(local_user_view.person.id),
+    Some(&local_user_view.local_user),
   )
   .await?
   .ok_or(LemmyErrorType::CouldntFindComment)?;

--- a/crates/api/src/comment/list_comment_likes.rs
+++ b/crates/api/src/comment/list_comment_likes.rs
@@ -17,7 +17,7 @@ pub async fn list_comment_likes(
   let comment_view = CommentView::read(
     &mut context.pool(),
     data.comment_id,
-    Some(local_user_view.person.id),
+    Some(&local_user_view.local_user),
   )
   .await?
   .ok_or(LemmyErrorType::CouldntFindComment)?;

--- a/crates/api/src/comment/save.rs
+++ b/crates/api/src/comment/save.rs
@@ -32,10 +32,13 @@ pub async fn save_comment(
   }
 
   let comment_id = data.comment_id;
-  let person_id = local_user_view.person.id;
-  let comment_view = CommentView::read(&mut context.pool(), comment_id, Some(person_id))
-    .await?
-    .ok_or(LemmyErrorType::CouldntFindComment)?;
+  let comment_view = CommentView::read(
+    &mut context.pool(),
+    comment_id,
+    Some(&local_user_view.local_user),
+  )
+  .await?
+  .ok_or(LemmyErrorType::CouldntFindComment)?;
 
   Ok(Json(CommentResponse {
     comment_view,

--- a/crates/api/src/comment_report/create.rs
+++ b/crates/api/src/comment_report/create.rs
@@ -38,7 +38,7 @@ pub async fn create_comment_report(
   let comment_view = CommentView::read(
     &mut context.pool(),
     comment_id,
-    Some(local_user_view.person.id),
+    Some(&local_user_view.local_user),
   )
   .await?
   .ok_or(LemmyErrorType::CouldntFindComment)?;

--- a/crates/api/src/comment_report/create.rs
+++ b/crates/api/src/comment_report/create.rs
@@ -35,9 +35,13 @@ pub async fn create_comment_report(
 
   let person_id = local_user_view.person.id;
   let comment_id = data.comment_id;
-  let comment_view = CommentView::read(&mut context.pool(), comment_id, None)
-    .await?
-    .ok_or(LemmyErrorType::CouldntFindComment)?;
+  let comment_view = CommentView::read(
+    &mut context.pool(),
+    comment_id,
+    Some(local_user_view.person.id),
+  )
+  .await?
+  .ok_or(LemmyErrorType::CouldntFindComment)?;
 
   check_community_user_action(
     &local_user_view.person,

--- a/crates/api/src/community/block.rs
+++ b/crates/api/src/community/block.rs
@@ -50,10 +50,14 @@ pub async fn block_community(
       .with_lemmy_type(LemmyErrorType::CommunityBlockAlreadyExists)?;
   }
 
-  let community_view =
-    CommunityView::read(&mut context.pool(), community_id, Some(person_id), false)
-      .await?
-      .ok_or(LemmyErrorType::CouldntFindCommunity)?;
+  let community_view = CommunityView::read(
+    &mut context.pool(),
+    community_id,
+    Some(&local_user_view.local_user),
+    false,
+  )
+  .await?
+  .ok_or(LemmyErrorType::CouldntFindCommunity)?;
 
   ActivityChannel::submit_activity(
     SendActivityData::FollowCommunity(

--- a/crates/api/src/community/follow.rs
+++ b/crates/api/src/community/follow.rs
@@ -62,11 +62,14 @@ pub async fn follow_community(
   }
 
   let community_id = data.community_id;
-  let person_id = local_user_view.person.id;
-  let community_view =
-    CommunityView::read(&mut context.pool(), community_id, Some(person_id), false)
-      .await?
-      .ok_or(LemmyErrorType::CouldntFindCommunity)?;
+  let community_view = CommunityView::read(
+    &mut context.pool(),
+    community_id,
+    Some(&local_user_view.local_user),
+    false,
+  )
+  .await?
+  .ok_or(LemmyErrorType::CouldntFindCommunity)?;
 
   let discussion_languages = CommunityLanguage::read(&mut context.pool(), community_id).await?;
 

--- a/crates/api/src/community/transfer.rs
+++ b/crates/api/src/community/transfer.rs
@@ -76,11 +76,14 @@ pub async fn transfer_community(
   ModTransferCommunity::create(&mut context.pool(), &form).await?;
 
   let community_id = data.community_id;
-  let person_id = local_user_view.person.id;
-  let community_view =
-    CommunityView::read(&mut context.pool(), community_id, Some(person_id), false)
-      .await?
-      .ok_or(LemmyErrorType::CouldntFindCommunity)?;
+  let community_view = CommunityView::read(
+    &mut context.pool(),
+    community_id,
+    Some(&local_user_view.local_user),
+    false,
+  )
+  .await?
+  .ok_or(LemmyErrorType::CouldntFindCommunity)?;
 
   let community_id = data.community_id;
   let moderators = CommunityModeratorView::for_community(&mut context.pool(), community_id)

--- a/crates/api/src/post/feature.rs
+++ b/crates/api/src/post/feature.rs
@@ -72,11 +72,5 @@ pub async fn feature_post(
   )
   .await?;
 
-  build_post_response(
-    &context,
-    orig_post.community_id,
-    &local_user_view.person,
-    post_id,
-  )
-  .await
+  build_post_response(&context, orig_post.community_id, local_user_view, post_id).await
 }

--- a/crates/api/src/post/like.rs
+++ b/crates/api/src/post/like.rs
@@ -85,11 +85,5 @@ pub async fn like_post(
   )
   .await?;
 
-  build_post_response(
-    context.deref(),
-    post.community_id,
-    &local_user_view.person,
-    post_id,
-  )
-  .await
+  build_post_response(context.deref(), post.community_id, local_user_view, post_id).await
 }

--- a/crates/api/src/post/lock.rs
+++ b/crates/api/src/post/lock.rs
@@ -63,11 +63,5 @@ pub async fn lock_post(
   )
   .await?;
 
-  build_post_response(
-    &context,
-    orig_post.community_id,
-    &local_user_view.person,
-    post_id,
-  )
-  .await
+  build_post_response(&context, orig_post.community_id, local_user_view, post_id).await
 }

--- a/crates/api/src/post/save.rs
+++ b/crates/api/src/post/save.rs
@@ -34,9 +34,14 @@ pub async fn save_post(
 
   let post_id = data.post_id;
   let person_id = local_user_view.person.id;
-  let post_view = PostView::read(&mut context.pool(), post_id, Some(person_id), false)
-    .await?
-    .ok_or(LemmyErrorType::CouldntFindPost)?;
+  let post_view = PostView::read(
+    &mut context.pool(),
+    post_id,
+    Some(&local_user_view.local_user),
+    false,
+  )
+  .await?
+  .ok_or(LemmyErrorType::CouldntFindPost)?;
 
   mark_post_as_read(person_id, post_id, &mut context.pool()).await?;
 

--- a/crates/api/src/site/purge/comment.rs
+++ b/crates/api/src/site/purge/comment.rs
@@ -32,7 +32,7 @@ pub async fn purge_comment(
   let comment_view = CommentView::read(
     &mut context.pool(),
     comment_id,
-    Some(local_user_view.person.id),
+    Some(&local_user_view.local_user),
   )
   .await?
   .ok_or(LemmyErrorType::CouldntFindComment)?;

--- a/crates/api/src/site/purge/comment.rs
+++ b/crates/api/src/site/purge/comment.rs
@@ -29,9 +29,13 @@ pub async fn purge_comment(
   let comment_id = data.comment_id;
 
   // Read the comment to get the post_id and community
-  let comment_view = CommentView::read(&mut context.pool(), comment_id, None)
-    .await?
-    .ok_or(LemmyErrorType::CouldntFindComment)?;
+  let comment_view = CommentView::read(
+    &mut context.pool(),
+    comment_id,
+    Some(local_user_view.person.id),
+  )
+  .await?
+  .ok_or(LemmyErrorType::CouldntFindComment)?;
 
   let post_id = comment_view.comment.post_id;
 

--- a/crates/api_common/src/build_response.rs
+++ b/crates/api_common/src/build_response.rs
@@ -104,7 +104,7 @@ pub async fn send_local_notifs(
   let inbox_link = format!("{}/inbox", context.settings().get_protocol_and_hostname());
 
   // Read the comment view to get extra info
-  let comment_view = CommentView::read(&mut context.pool(), comment_id, None)
+  let comment_view = CommentView::read(&mut context.pool(), comment_id, Some(person.id))
     .await?
     .ok_or(LemmyErrorType::CouldntFindComment)?;
   let comment = comment_view.comment;

--- a/crates/api_common/src/build_response.rs
+++ b/crates/api_common/src/build_response.rs
@@ -17,6 +17,7 @@ use lemmy_db_schema::{
     actor_language::CommunityLanguage,
     comment::Comment,
     comment_reply::{CommentReply, CommentReplyInsertForm},
+    person::Person,
     person_mention::{PersonMention, PersonMentionInsertForm},
   },
   traits::Crud,
@@ -96,24 +97,18 @@ pub async fn build_post_response(
 pub async fn send_local_notifs(
   mentions: Vec<MentionData>,
   comment_id: CommentId,
-  my_local_user: &LocalUserView,
+  person: &Person,
   do_send_email: bool,
   context: &LemmyContext,
 ) -> LemmyResult<Vec<LocalUserId>> {
   let mut recipient_ids = Vec::new();
   let inbox_link = format!("{}/inbox", context.settings().get_protocol_and_hostname());
 
-  let person = &my_local_user.person;
-
   // let person = my_local_user.person;
   // Read the comment view to get extra info
-  let comment_view = CommentView::read(
-    &mut context.pool(),
-    comment_id,
-    Some(&my_local_user.local_user),
-  )
-  .await?
-  .ok_or(LemmyErrorType::CouldntFindComment)?;
+  let comment_view = CommentView::read(&mut context.pool(), comment_id, None)
+    .await?
+    .ok_or(LemmyErrorType::CouldntFindComment)?;
   let comment = comment_view.comment;
   let post = comment_view.post;
   let community = comment_view.community;

--- a/crates/api_common/src/build_response.rs
+++ b/crates/api_common/src/build_response.rs
@@ -36,8 +36,8 @@ pub async fn build_comment_response(
   local_user_view: Option<LocalUserView>,
   recipient_ids: Vec<LocalUserId>,
 ) -> LemmyResult<CommentResponse> {
-  let person_id = local_user_view.map(|l| l.person.id);
-  let comment_view = CommentView::read(&mut context.pool(), comment_id, person_id)
+  let local_user = local_user_view.map(|l| l.local_user);
+  let comment_view = CommentView::read(&mut context.pool(), comment_id, local_user.as_ref())
     .await?
     .ok_or(LemmyErrorType::CouldntFindComment)?;
   Ok(CommentResponse {
@@ -54,11 +54,11 @@ pub async fn build_community_response(
   let is_mod_or_admin = is_mod_or_admin(&mut context.pool(), &local_user_view.person, community_id)
     .await
     .is_ok();
-  let person_id = local_user_view.person.id;
+  let local_user = local_user_view.local_user;
   let community_view = CommunityView::read(
     &mut context.pool(),
     community_id,
-    Some(person_id),
+    Some(&local_user),
     is_mod_or_admin,
   )
   .await?
@@ -80,14 +80,9 @@ pub async fn build_post_response(
   let is_mod_or_admin = is_mod_or_admin(&mut context.pool(), person, community_id)
     .await
     .is_ok();
-  let post_view = PostView::read(
-    &mut context.pool(),
-    post_id,
-    Some(person.id),
-    is_mod_or_admin,
-  )
-  .await?
-  .ok_or(LemmyErrorType::CouldntFindPost)?;
+  let post_view = PostView::read(&mut context.pool(), post_id, None, is_mod_or_admin)
+    .await?
+    .ok_or(LemmyErrorType::CouldntFindPost)?;
   Ok(Json(PostResponse { post_view }))
 }
 
@@ -96,17 +91,24 @@ pub async fn build_post_response(
 pub async fn send_local_notifs(
   mentions: Vec<MentionData>,
   comment_id: CommentId,
-  person: &Person,
+  my_local_user: &LocalUserView,
   do_send_email: bool,
   context: &LemmyContext,
 ) -> LemmyResult<Vec<LocalUserId>> {
   let mut recipient_ids = Vec::new();
   let inbox_link = format!("{}/inbox", context.settings().get_protocol_and_hostname());
 
+  let person = &my_local_user.person;
+
+  // let person = my_local_user.person;
   // Read the comment view to get extra info
-  let comment_view = CommentView::read(&mut context.pool(), comment_id, Some(person.id))
-    .await?
-    .ok_or(LemmyErrorType::CouldntFindComment)?;
+  let comment_view = CommentView::read(
+    &mut context.pool(),
+    comment_id,
+    Some(&my_local_user.local_user),
+  )
+  .await?
+  .ok_or(LemmyErrorType::CouldntFindComment)?;
   let comment = comment_view.comment;
   let post = comment_view.post;
   let community = comment_view.community;

--- a/crates/api_crud/src/comment/create.rs
+++ b/crates/api_crud/src/comment/create.rs
@@ -56,7 +56,7 @@ pub async fn create_comment(
   let post_view = PostView::read(
     &mut context.pool(),
     post_id,
-    Some(local_user_view.person.id),
+    Some(&local_user_view.local_user),
     true,
   )
   .await?
@@ -151,7 +151,7 @@ pub async fn create_comment(
   let recipient_ids = send_local_notifs(
     mentions,
     inserted_comment_id,
-    &local_user_view.person,
+    &local_user_view,
     true,
     &context,
   )

--- a/crates/api_crud/src/comment/create.rs
+++ b/crates/api_crud/src/comment/create.rs
@@ -131,7 +131,7 @@ pub async fn create_comment(
   let recipient_ids = send_local_notifs(
     mentions,
     inserted_comment_id,
-    &local_user_view,
+    &local_user_view.person,
     true,
     &context,
   )

--- a/crates/api_crud/src/comment/delete.rs
+++ b/crates/api_crud/src/comment/delete.rs
@@ -24,7 +24,7 @@ pub async fn delete_comment(
   let orig_comment = CommentView::read(
     &mut context.pool(),
     comment_id,
-    Some(local_user_view.person.id),
+    Some(&local_user_view.local_user),
   )
   .await?
   .ok_or(LemmyErrorType::CouldntFindComment)?;
@@ -60,7 +60,7 @@ pub async fn delete_comment(
   .with_lemmy_type(LemmyErrorType::CouldntUpdateComment)?;
 
   let recipient_ids =
-    send_local_notifs(vec![], comment_id, &local_user_view.person, false, &context).await?;
+    send_local_notifs(vec![], comment_id, &local_user_view, false, &context).await?;
   let updated_comment_id = updated_comment.id;
 
   ActivityChannel::submit_activity(

--- a/crates/api_crud/src/comment/delete.rs
+++ b/crates/api_crud/src/comment/delete.rs
@@ -60,7 +60,7 @@ pub async fn delete_comment(
   .with_lemmy_type(LemmyErrorType::CouldntUpdateComment)?;
 
   let recipient_ids =
-    send_local_notifs(vec![], comment_id, &local_user_view, false, &context).await?;
+    send_local_notifs(vec![], comment_id, &local_user_view.person, false, &context).await?;
   let updated_comment_id = updated_comment.id;
 
   ActivityChannel::submit_activity(

--- a/crates/api_crud/src/comment/delete.rs
+++ b/crates/api_crud/src/comment/delete.rs
@@ -21,9 +21,13 @@ pub async fn delete_comment(
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<CommentResponse>> {
   let comment_id = data.comment_id;
-  let orig_comment = CommentView::read(&mut context.pool(), comment_id, None)
-    .await?
-    .ok_or(LemmyErrorType::CouldntFindComment)?;
+  let orig_comment = CommentView::read(
+    &mut context.pool(),
+    comment_id,
+    Some(local_user_view.person.id),
+  )
+  .await?
+  .ok_or(LemmyErrorType::CouldntFindComment)?;
 
   // Dont delete it if its already been deleted.
   if orig_comment.comment.deleted == data.deleted {

--- a/crates/api_crud/src/comment/remove.rs
+++ b/crates/api_crud/src/comment/remove.rs
@@ -73,7 +73,7 @@ pub async fn remove_comment(
   ModRemoveComment::create(&mut context.pool(), &form).await?;
 
   let recipient_ids =
-    send_local_notifs(vec![], comment_id, &local_user_view, false, &context).await?;
+    send_local_notifs(vec![], comment_id, &local_user_view.person, false, &context).await?;
   let updated_comment_id = updated_comment.id;
 
   ActivityChannel::submit_activity(

--- a/crates/api_crud/src/comment/remove.rs
+++ b/crates/api_crud/src/comment/remove.rs
@@ -28,7 +28,7 @@ pub async fn remove_comment(
   let orig_comment = CommentView::read(
     &mut context.pool(),
     comment_id,
-    Some(local_user_view.person.id),
+    Some(&local_user_view.local_user),
   )
   .await?
   .ok_or(LemmyErrorType::CouldntFindComment)?;
@@ -72,14 +72,8 @@ pub async fn remove_comment(
   };
   ModRemoveComment::create(&mut context.pool(), &form).await?;
 
-  let recipient_ids = send_local_notifs(
-    vec![],
-    comment_id,
-    &local_user_view.person.clone(),
-    false,
-    &context,
-  )
-  .await?;
+  let recipient_ids =
+    send_local_notifs(vec![], comment_id, &local_user_view, false, &context).await?;
   let updated_comment_id = updated_comment.id;
 
   ActivityChannel::submit_activity(

--- a/crates/api_crud/src/comment/remove.rs
+++ b/crates/api_crud/src/comment/remove.rs
@@ -25,9 +25,13 @@ pub async fn remove_comment(
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<CommentResponse>> {
   let comment_id = data.comment_id;
-  let orig_comment = CommentView::read(&mut context.pool(), comment_id, None)
-    .await?
-    .ok_or(LemmyErrorType::CouldntFindComment)?;
+  let orig_comment = CommentView::read(
+    &mut context.pool(),
+    comment_id,
+    Some(local_user_view.person.id),
+  )
+  .await?
+  .ok_or(LemmyErrorType::CouldntFindComment)?;
 
   check_community_mod_action(
     &local_user_view.person,

--- a/crates/api_crud/src/comment/update.rs
+++ b/crates/api_crud/src/comment/update.rs
@@ -85,8 +85,14 @@ pub async fn update_comment(
   // Do the mentions / recipients
   let updated_comment_content = updated_comment.content.clone();
   let mentions = scrape_text_for_mentions(&updated_comment_content);
-  let recipient_ids =
-    send_local_notifs(mentions, comment_id, &local_user_view, false, &context).await?;
+  let recipient_ids = send_local_notifs(
+    mentions,
+    comment_id,
+    &local_user_view.person,
+    false,
+    &context,
+  )
+  .await?;
 
   ActivityChannel::submit_activity(
     SendActivityData::UpdateComment(updated_comment.clone()),

--- a/crates/api_crud/src/comment/update.rs
+++ b/crates/api_crud/src/comment/update.rs
@@ -36,9 +36,13 @@ pub async fn update_comment(
   let local_site = LocalSite::read(&mut context.pool()).await?;
 
   let comment_id = data.comment_id;
-  let orig_comment = CommentView::read(&mut context.pool(), comment_id, None)
-    .await?
-    .ok_or(LemmyErrorType::CouldntFindComment)?;
+  let orig_comment = CommentView::read(
+    &mut context.pool(),
+    comment_id,
+    Some(local_user_view.person.id),
+  )
+  .await?
+  .ok_or(LemmyErrorType::CouldntFindComment)?;
 
   check_community_user_action(
     &local_user_view.person,

--- a/crates/api_crud/src/comment/update.rs
+++ b/crates/api_crud/src/comment/update.rs
@@ -39,7 +39,7 @@ pub async fn update_comment(
   let orig_comment = CommentView::read(
     &mut context.pool(),
     comment_id,
-    Some(local_user_view.person.id),
+    Some(&local_user_view.local_user),
   )
   .await?
   .ok_or(LemmyErrorType::CouldntFindComment)?;
@@ -85,14 +85,8 @@ pub async fn update_comment(
   // Do the mentions / recipients
   let updated_comment_content = updated_comment.content.clone();
   let mentions = scrape_text_for_mentions(&updated_comment_content);
-  let recipient_ids = send_local_notifs(
-    mentions,
-    comment_id,
-    &local_user_view.person,
-    false,
-    &context,
-  )
-  .await?;
+  let recipient_ids =
+    send_local_notifs(mentions, comment_id, &local_user_view, false, &context).await?;
 
   ActivityChannel::submit_activity(
     SendActivityData::UpdateComment(updated_comment.clone()),

--- a/crates/api_crud/src/post/create.rs
+++ b/crates/api_crud/src/post/create.rs
@@ -208,5 +208,5 @@ pub async fn create_post(
     }
   };
 
-  build_post_response(&context, community_id, &local_user_view.person, post_id).await
+  build_post_response(&context, community_id, local_user_view, post_id).await
 }

--- a/crates/api_crud/src/post/delete.rs
+++ b/crates/api_crud/src/post/delete.rs
@@ -62,7 +62,7 @@ pub async fn delete_post(
   build_post_response(
     &context,
     orig_post.community_id,
-    &local_user_view.person,
+    local_user_view,
     data.post_id,
   )
   .await

--- a/crates/api_crud/src/post/read.rs
+++ b/crates/api_crud/src/post/read.rs
@@ -55,9 +55,15 @@ pub async fn get_post(
   .await
   .is_ok();
 
-  let post_view = PostView::read(&mut context.pool(), post_id, person_id, is_mod_or_admin)
-    .await?
-    .ok_or(LemmyErrorType::CouldntFindPost)?;
+  let local_user = local_user_view.map(|l| l.local_user);
+  let post_view = PostView::read(
+    &mut context.pool(),
+    post_id,
+    local_user.as_ref(),
+    is_mod_or_admin,
+  )
+  .await?
+  .ok_or(LemmyErrorType::CouldntFindPost)?;
 
   let post_id = post_view.post.id;
   if let Some(person_id) = person_id {
@@ -76,20 +82,19 @@ pub async fn get_post(
   let community_view = CommunityView::read(
     &mut context.pool(),
     community_id,
-    person_id,
+    local_user.as_ref(),
     is_mod_or_admin,
   )
   .await?
   .ok_or(LemmyErrorType::CouldntFindCommunity)?;
 
   let moderators = CommunityModeratorView::for_community(&mut context.pool(), community_id).await?;
-  let local_user = local_user_view.as_ref().map(|u| &u.local_user);
 
   // Fetch the cross_posts
   let cross_posts = if let Some(url) = &post_view.post.url {
     let mut x_posts = PostQuery {
       url_search: Some(url.inner().as_str().into()),
-      local_user,
+      local_user: local_user.as_ref(),
       ..Default::default()
     }
     .list(&local_site.site, &mut context.pool())

--- a/crates/api_crud/src/post/remove.rs
+++ b/crates/api_crud/src/post/remove.rs
@@ -73,11 +73,5 @@ pub async fn remove_post(
   )
   .await?;
 
-  build_post_response(
-    &context,
-    orig_post.community_id,
-    &local_user_view.person,
-    post_id,
-  )
-  .await
+  build_post_response(&context, orig_post.community_id, local_user_view, post_id).await
 }

--- a/crates/api_crud/src/post/update.rs
+++ b/crates/api_crud/src/post/update.rs
@@ -137,7 +137,7 @@ pub async fn update_post(
   build_post_response(
     context.deref(),
     orig_post.community_id,
-    &local_user_view.person,
+    local_user_view,
     post_id,
   )
   .await

--- a/crates/apub/src/activities/create_or_update/comment.rs
+++ b/crates/apub/src/activities/create_or_update/comment.rs
@@ -39,7 +39,6 @@ use lemmy_db_schema::{
   },
   traits::{Crud, Likeable},
 };
-use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::{
   error::{LemmyError, LemmyResult},
   utils::mention::scrape_text_for_mentions,
@@ -179,10 +178,8 @@ impl ActivityHandler for CreateOrUpdateNote {
     // anyway.
     // TODO: for compatibility with other projects, it would be much better to read this from cc or
     // tags
-    if let Some(local_user) = LocalUserView::read_person(&mut context.pool(), actor.id).await? {
-      let mentions = scrape_text_for_mentions(&comment.content);
-      send_local_notifs(mentions, comment.id, &local_user, do_send_email, context).await?;
-    }
+    let mentions = scrape_text_for_mentions(&comment.content);
+    send_local_notifs(mentions, comment.id, &actor, do_send_email, context).await?;
     Ok(())
   }
 }

--- a/crates/apub/src/activities/create_or_update/comment.rs
+++ b/crates/apub/src/activities/create_or_update/comment.rs
@@ -39,6 +39,7 @@ use lemmy_db_schema::{
   },
   traits::{Crud, Likeable},
 };
+use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::{
   error::{LemmyError, LemmyResult},
   utils::mention::scrape_text_for_mentions,
@@ -178,8 +179,10 @@ impl ActivityHandler for CreateOrUpdateNote {
     // anyway.
     // TODO: for compatibility with other projects, it would be much better to read this from cc or
     // tags
-    let mentions = scrape_text_for_mentions(&comment.content);
-    send_local_notifs(mentions, comment.id, &actor, do_send_email, context).await?;
+    if let Some(local_user) = LocalUserView::read_person(&mut context.pool(), actor.id).await? {
+      let mentions = scrape_text_for_mentions(&comment.content);
+      send_local_notifs(mentions, comment.id, &local_user, do_send_email, context).await?;
+    }
     Ok(())
   }
 }

--- a/crates/apub/src/api/read_community.rs
+++ b/crates/apub/src/api/read_community.rs
@@ -29,7 +29,7 @@ pub async fn get_community(
 
   check_private_instance(&local_user_view, &local_site)?;
 
-  let person_id = local_user_view.as_ref().map(|u| u.person.id);
+  let local_user = local_user_view.as_ref().map(|u| &u.local_user);
 
   let community_id = match data.id {
     Some(id) => id,
@@ -53,7 +53,7 @@ pub async fn get_community(
   let community_view = CommunityView::read(
     &mut context.pool(),
     community_id,
-    person_id,
+    local_user,
     is_mod_or_admin,
   )
   .await?

--- a/crates/apub/src/api/resolve_object.rs
+++ b/crates/apub/src/api/resolve_object.rs
@@ -10,7 +10,7 @@ use lemmy_api_common::{
   site::{ResolveObject, ResolveObjectResponse},
   utils::check_private_instance,
 };
-use lemmy_db_schema::{newtypes::PersonId, source::local_site::LocalSite, utils::DbPool};
+use lemmy_db_schema::{source::local_site::LocalSite, utils::DbPool};
 use lemmy_db_views::structs::{CommentView, LocalUserView, PostView};
 use lemmy_db_views_actor::structs::{CommunityView, PersonView};
 use lemmy_utils::error::{LemmyErrorExt2, LemmyErrorType, LemmyResult};
@@ -23,10 +23,9 @@ pub async fn resolve_object(
 ) -> LemmyResult<Json<ResolveObjectResponse>> {
   let local_site = LocalSite::read(&mut context.pool()).await?;
   check_private_instance(&local_user_view, &local_site)?;
-  let person_id = local_user_view.map(|v| v.person.id);
   // If we get a valid personId back we can safely assume that the user is authenticated,
   // if there's no personId then the JWT was missing or invalid.
-  let is_authenticated = person_id.is_some();
+  let is_authenticated = local_user_view.is_some();
 
   let res = if is_authenticated {
     // user is fully authenticated; allow remote lookups as well.
@@ -37,24 +36,26 @@ pub async fn resolve_object(
   }
   .with_lemmy_type(LemmyErrorType::CouldntFindObject)?;
 
-  convert_response(res, person_id, &mut context.pool())
+  convert_response(res, local_user_view, &mut context.pool())
     .await
     .with_lemmy_type(LemmyErrorType::CouldntFindObject)
 }
 
 async fn convert_response(
   object: SearchableObjects,
-  user_id: Option<PersonId>,
+  local_user_view: Option<LocalUserView>,
   pool: &mut DbPool<'_>,
 ) -> LemmyResult<Json<ResolveObjectResponse>> {
   use SearchableObjects::*;
   let removed_or_deleted;
   let mut res = ResolveObjectResponse::default();
+  let local_user = local_user_view.map(|l| l.local_user);
+
   match object {
     Post(p) => {
       removed_or_deleted = p.deleted || p.removed;
       res.post = Some(
-        PostView::read(pool, p.id, user_id, false)
+        PostView::read(pool, p.id, local_user.as_ref(), false)
           .await?
           .ok_or(LemmyErrorType::CouldntFindPost)?,
       )
@@ -62,7 +63,7 @@ async fn convert_response(
     Comment(c) => {
       removed_or_deleted = c.deleted || c.removed;
       res.comment = Some(
-        CommentView::read(pool, c.id, user_id)
+        CommentView::read(pool, c.id, local_user.as_ref())
           .await?
           .ok_or(LemmyErrorType::CouldntFindComment)?,
       )
@@ -79,7 +80,7 @@ async fn convert_response(
       UserOrCommunity::Community(c) => {
         removed_or_deleted = c.deleted || c.removed;
         res.community = Some(
-          CommunityView::read(pool, c.id, user_id, false)
+          CommunityView::read(pool, c.id, local_user.as_ref(), false)
             .await?
             .ok_or(LemmyErrorType::CouldntFindCommunity)?,
         )

--- a/crates/db_schema/src/utils.rs
+++ b/crates/db_schema/src/utils.rs
@@ -1,15 +1,7 @@
-use crate::{
-  diesel::ExpressionMethods,
-  newtypes::{DbUrl, PersonId},
-  schema::community,
-  CommentSortType,
-  CommunityVisibility,
-  SortType,
-};
+use crate::{newtypes::DbUrl, CommentSortType, SortType};
 use chrono::{DateTime, TimeDelta, Utc};
 use deadpool::Runtime;
 use diesel::{
-  dsl,
   helper_types::AsExprOf,
   pg::Pg,
   query_builder::{Query, QueryFragment},
@@ -576,20 +568,6 @@ impl<RF, LF> Queries<RF, LF> {
   {
     let conn = get_conn(pool).await?;
     (self.list_fn)(conn, args).await
-  }
-}
-
-pub fn visible_communities_only<Q>(my_person_id: Option<PersonId>, query: Q) -> Q
-where
-  Q: diesel::query_dsl::methods::FilterDsl<
-    dsl::Eq<community::visibility, CommunityVisibility>,
-    Output = Q,
-  >,
-{
-  if my_person_id.is_none() {
-    query.filter(community::visibility.eq(CommunityVisibility::Public))
-  } else {
-    query
   }
 }
 

--- a/crates/db_views/src/comment_view.rs
+++ b/crates/db_views/src/comment_view.rs
@@ -36,22 +36,13 @@ use lemmy_db_schema::{
     post,
   },
   source::local_user::LocalUser,
-  utils::{
-    fuzzy_search,
-    limit_and_offset,
-    visible_communities_only,
-    DbConn,
-    DbPool,
-    ListFn,
-    Queries,
-    ReadFn,
-  },
+  utils::{fuzzy_search, limit_and_offset, DbConn, DbPool, ListFn, Queries, ReadFn},
   CommentSortType,
   ListingType,
 };
 
 fn queries<'a>() -> Queries<
-  impl ReadFn<'a, CommentView, (CommentId, Option<PersonId>)>,
+  impl ReadFn<'a, CommentView, (CommentId, Option<&'a LocalUser>)>,
   impl ListFn<'a, CommentView, CommentQuery<'a>>,
 > {
   let is_creator_banned_from_community = exists(
@@ -182,9 +173,12 @@ fn queries<'a>() -> Queries<
   };
 
   let read = move |mut conn: DbConn<'a>,
-                   (comment_id, my_person_id): (CommentId, Option<PersonId>)| async move {
-    let mut query = all_joins(comment::table.find(comment_id).into_boxed(), my_person_id);
-    query = visible_communities_only(my_person_id, query);
+                   (comment_id, my_local_user): (CommentId, Option<&'a LocalUser>)| async move {
+    let mut query = all_joins(
+      comment::table.find(comment_id).into_boxed(),
+      my_local_user.person_id(),
+    );
+    query = my_local_user.visible_communities_only(query);
     query.first(&mut conn).await
   };
 
@@ -301,7 +295,7 @@ fn queries<'a>() -> Queries<
       query = query.filter(not(is_creator_blocked(person_id_join)));
     };
 
-    query = visible_communities_only(options.local_user.person_id(), query);
+    query = options.local_user.visible_communities_only(query);
 
     // A Max depth given means its a tree fetch
     let (limit, offset) = if let Some(max_depth) = options.max_depth {
@@ -366,16 +360,16 @@ fn queries<'a>() -> Queries<
 }
 
 impl CommentView {
-  pub async fn read(
+  pub async fn read<'a>(
     pool: &mut DbPool<'_>,
     comment_id: CommentId,
-    my_person_id: Option<PersonId>,
+    my_local_user: Option<&'a LocalUser>,
   ) -> Result<Option<Self>, Error> {
     // If a person is given, then my_vote (res.9), if None, should be 0, not null
     // Necessary to differentiate between other person's votes
-    if let Ok(Some(res)) = queries().read(pool, (comment_id, my_person_id)).await {
+    if let Ok(Some(res)) = queries().read(pool, (comment_id, my_local_user)).await {
       let mut new_view = res.clone();
-      if my_person_id.is_some() && res.my_vote.is_none() {
+      if my_local_user.is_some() && res.my_vote.is_none() {
         new_view.my_vote = Some(0);
       }
       if res.comment.deleted || res.comment.removed {
@@ -676,7 +670,7 @@ mod tests {
     let read_comment_from_blocked_person = CommentView::read(
       pool,
       data.inserted_comment_1.id,
-      Some(data.timmy_local_user_view.person.id),
+      Some(&data.timmy_local_user_view.local_user),
     )
     .await?
     .ok_or(LemmyErrorType::CouldntFindComment)?;
@@ -1171,7 +1165,7 @@ mod tests {
     let authenticated_comment = CommentView::read(
       pool,
       data.inserted_comment_0.id,
-      Some(data.timmy_local_user_view.person.id),
+      Some(&data.timmy_local_user_view.local_user),
     )
     .await;
     assert!(authenticated_comment.is_ok());
@@ -1211,7 +1205,7 @@ mod tests {
     let comment_view = CommentView::read(
       pool,
       data.inserted_comment_0.id,
-      Some(inserted_banned_from_comm_local_user.person_id),
+      Some(&inserted_banned_from_comm_local_user),
     )
     .await?
     .ok_or(LemmyErrorType::CouldntFindComment)?;
@@ -1232,7 +1226,7 @@ mod tests {
     let comment_view = CommentView::read(
       pool,
       data.inserted_comment_0.id,
-      Some(data.timmy_local_user_view.person.id),
+      Some(&data.timmy_local_user_view.local_user),
     )
     .await?
     .ok_or(LemmyErrorType::CouldntFindComment)?;

--- a/crates/db_views_actor/src/community_view.rs
+++ b/crates/db_views_actor/src/community_view.rs
@@ -22,27 +22,18 @@ use lemmy_db_schema::{
     instance_block,
   },
   source::{community::CommunityFollower, local_user::LocalUser, site::Site},
-  utils::{
-    fuzzy_search,
-    limit_and_offset,
-    visible_communities_only,
-    DbConn,
-    DbPool,
-    ListFn,
-    Queries,
-    ReadFn,
-  },
+  utils::{fuzzy_search, limit_and_offset, DbConn, DbPool, ListFn, Queries, ReadFn},
   ListingType,
   SortType,
 };
 
 fn queries<'a>() -> Queries<
-  impl ReadFn<'a, CommunityView, (CommunityId, Option<PersonId>, bool)>,
+  impl ReadFn<'a, CommunityView, (CommunityId, Option<&'a LocalUser>, bool)>,
   impl ListFn<'a, CommunityView, (CommunityQuery<'a>, &'a Site)>,
 > {
-  let all_joins = |query: community::BoxedQuery<'a, Pg>, my_person_id: Option<PersonId>| {
+  let all_joins = |query: community::BoxedQuery<'a, Pg>, my_local_user: Option<&'a LocalUser>| {
     // The left join below will return None in this case
-    let person_id_join = my_person_id.unwrap_or(PersonId(-1));
+    let person_id_join = my_local_user.person_id().unwrap_or(PersonId(-1));
 
     query
       .inner_join(community_aggregates::table)
@@ -89,14 +80,14 @@ fn queries<'a>() -> Queries<
     .and(community::deleted.eq(false));
 
   let read = move |mut conn: DbConn<'a>,
-                   (community_id, my_person_id, is_mod_or_admin): (
+                   (community_id, my_local_user, is_mod_or_admin): (
     CommunityId,
-    Option<PersonId>,
+    Option<&'a LocalUser>,
     bool,
   )| async move {
     let mut query = all_joins(
       community::table.find(community_id).into_boxed(),
-      my_person_id,
+      my_local_user,
     )
     .select(selection);
 
@@ -105,7 +96,7 @@ fn queries<'a>() -> Queries<
       query = query.filter(not_removed_or_deleted);
     }
 
-    query = visible_communities_only(my_person_id, query);
+    query = my_local_user.visible_communities_only(query);
 
     query.first(&mut conn).await
   };
@@ -116,11 +107,7 @@ fn queries<'a>() -> Queries<
     // The left join below will return None in this case
     let person_id_join = options.local_user.person_id().unwrap_or(PersonId(-1));
 
-    let mut query = all_joins(
-      community::table.into_boxed(),
-      options.local_user.person_id(),
-    )
-    .select(selection);
+    let mut query = all_joins(community::table.into_boxed(), options.local_user).select(selection);
 
     if let Some(search_term) = options.search_term {
       let searcher = fuzzy_search(&search_term);
@@ -173,7 +160,7 @@ fn queries<'a>() -> Queries<
       query = query.filter(community::nsfw.eq(false));
     }
 
-    query = visible_communities_only(options.local_user.person_id(), query);
+    query = options.local_user.visible_communities_only(query);
 
     let (limit, offset) = limit_and_offset(options.page, options.limit)?;
     query
@@ -187,14 +174,14 @@ fn queries<'a>() -> Queries<
 }
 
 impl CommunityView {
-  pub async fn read(
+  pub async fn read<'a>(
     pool: &mut DbPool<'_>,
     community_id: CommunityId,
-    my_person_id: Option<PersonId>,
+    my_local_user: Option<&'a LocalUser>,
     is_mod_or_admin: bool,
   ) -> Result<Option<Self>, Error> {
     queries()
-      .read(pool, (community_id, my_person_id, is_mod_or_admin))
+      .read(pool, (community_id, my_local_user, is_mod_or_admin))
       .await
   }
 
@@ -388,7 +375,7 @@ mod tests {
     let authenticated_community = CommunityView::read(
       pool,
       data.inserted_community.id,
-      Some(data.local_user.person_id),
+      Some(&data.local_user),
       false,
     )
     .await;


### PR DESCRIPTION
- This was caused by not passing my_person_id into various `CommentView::read` functions. The `visible_communities_only` function only allows you to view local communities if my_person is passed.
- Fixes #4853

@dullbananas logically that check doesn't make sense to me. Should the visible_communities_only function be checking for a `local_user_id`, since those are local only, not a `person_id`, which could be a federated person?