### PR TITLE
Allow bypassing proxy for some domains with ProxyAllImages

### DIFF
--- a/config/defaults.hjson
+++ b/config/defaults.hjson
@@ -73,6 +73,11 @@
       # 
       # Requires pict-rs 0.5
       "ProxyAllImages"
+    # Allows bypassing proxy for specific image hosts when using ProxyAllImages
+    proxy_bypass_domains: [
+      "string"
+      /* ... */
+    ]
     # Timeout for uploading images to pictrs (in seconds)
     upload_timeout: 30
   }

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -91,6 +91,10 @@ pub struct PictrsConfig {
   #[default(PictrsImageMode::StoreLinkPreviews)]
   pub(super) image_mode: PictrsImageMode,
 
+  /// Allows bypassing proxy for specific image hosts when using ProxyAllImages
+  #[default([].to_vec())]
+  pub proxy_bypass_domains: Vec<String>,
+
   /// Timeout for uploading images to pictrs (in seconds)
   #[default(30)]
   pub upload_timeout: u64,


### PR DESCRIPTION
This PR introduces a new settings parameter, `proxy_bypass_domains`, which allows admins to configure some domains for which image proxying will be skipped. 

The skipping logic is within the image_proxy/ endpoint itself, so URLs do not have to change whenever the bypass list is modified by admins. If any domain is on this bypass list, then instead of trying to proxy the image through pict-rs, Lemmy will just issue a HTTP redirect to the source image.

There are a couple of reasons such configuration can be useful. For example, imgur will very quickly start blocking all requests from Lemmy when running with ProxyAllImages, due do its rate limits. Additionally, a few Lemmy instances provide their own external image hosting service, this setting will allow them to not duplicate the same images in two places.


