### PR TITLE
Switch PostgreSQL container to use pgautoupgrade

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -306,7 +306,7 @@ steps:
 
 services:
   database:
-    image: postgres:16-alpine
+    image: pgautoupgrade/pgautoupgrade:16-alpine
     environment:
       POSTGRES_USER: lemmy
       POSTGRES_PASSWORD: password

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -97,7 +97,7 @@ services:
     logging: *default-logging
 
   postgres:
-    image: postgres:16-alpine
+    image: pgautoupgrade/pgautoupgrade:16-alpine
     # this needs to match the database host in lemmy.hson
     # Tune your settings via
     # https://pgtune.leopard.in.ua/#/

--- a/docker/federation/docker-compose.yml
+++ b/docker/federation/docker-compose.yml
@@ -20,7 +20,7 @@ x-lemmy-default: &lemmy-default
   restart: always
 
 x-postgres-default: &postgres-default
-  image: postgres:16-alpine
+  image: pgautoupgrade/pgautoupgrade:16-alpine
   environment:
     - POSTGRES_USER=lemmy
     - POSTGRES_PASSWORD=password

--- a/scripts/postgres_12_to_15_upgrade.sh
+++ b/scripts/postgres_12_to_15_upgrade.sh
@@ -1,48 +1,8 @@
 #!/bin/sh
 set -e
 
-echo "Do not stop in the middle of this upgrade, wait until you see the message: Upgrade complete."
-
-echo "Stopping lemmy and all services..."
-sudo docker-compose stop
-
-echo "Make sure postgres is started..."
-sudo docker-compose up -d postgres
-sleep 20s
-
-echo "Exporting the Database to 12_15.dump.sql ..."
-sudo docker-compose exec -T postgres pg_dumpall -c -U lemmy > 12_15_dump.sql
-echo "Done."
-
-echo "Stopping postgres..."
-sudo docker-compose stop postgres
-sleep 20s
-
-echo "Removing the old postgres folder"
-sudo rm -rf volumes/postgres
-
-echo "Updating docker-compose to use postgres version 15."
-sudo sed -i "s/image: .*postgres:.*/image: pgautoupgrade\/pgautoupgrade:15-alpine/" ./docker-compose.yml
-
-echo "Starting up new postgres..."
-sudo docker-compose up -d postgres
-sleep 20s
-
-echo "Importing the database...."
-cat 12_15_dump.sql | sudo docker-compose exec -T postgres psql -U lemmy
-echo "Done."
-
-POSTGRES_PASSWORD=$(grep "POSTGRES_PASSWORD" ./docker-compose.yml | cut -d"=" -f2)
-
-echo "Fixing a weird password issue with postgres 15"
-sudo docker-compose exec -T postgres psql -U lemmy -c "alter user lemmy with password '$POSTGRES_PASSWORD'"
-sudo docker-compose restart postgres
-
-echo "Setting correct perms for pictrs folder"
-sudo chown -R 991:991 volumes/pictrs
+echo "Updating docker-compose to use postgres version 16."
+sudo sed -i "s/image: .*postgres:.*/image: pgautoupgrade\/pgautoupgrade:16-alpine/" ./docker-compose.yml
 
 echo "Starting up lemmy..."
 sudo docker-compose up -d
-
-echo "A copy of your old database is at 12_15.dump.sql . You can delete this file if the upgrade went smoothly."
-echo "Upgrade complete."

--- a/scripts/postgres_12_to_15_upgrade.sh
+++ b/scripts/postgres_12_to_15_upgrade.sh
@@ -22,7 +22,7 @@ echo "Removing the old postgres folder"
 sudo rm -rf volumes/postgres
 
 echo "Updating docker-compose to use postgres version 15."
-sed -i "s/image: postgres:.*/image: postgres:15-alpine/" ./docker-compose.yml
+sudo sed -i "s/image: .*postgres:.*/image: pgautoupgrade\/pgautoupgrade:15-alpine/" ./docker-compose.yml
 
 echo "Starting up new postgres..."
 sudo docker-compose up -d postgres

--- a/scripts/postgres_15_to_16_upgrade.sh
+++ b/scripts/postgres_15_to_16_upgrade.sh
@@ -1,42 +1,8 @@
 #!/bin/sh
 set -e
 
-echo "Do not stop in the middle of this upgrade, wait until you see the message: Upgrade complete."
-
-echo "Stopping lemmy and all services..."
-sudo docker compose stop
-
-echo "Make sure postgres is started..."
-sudo docker compose up -d postgres
-echo "Waiting..."
-sleep 20s
-
-echo "Exporting the Database to 15_16.dump.sql ..."
-sudo docker compose exec -T postgres pg_dumpall -c -U lemmy | sudo tee 15_16_dump.sql > /dev/null
-echo "Done."
-
-echo "Stopping postgres..."
-sudo docker compose stop postgres
-echo "Waiting..."
-sleep 20s
-
-echo "Removing the old postgres folder"
-sudo rm -rf volumes/postgres
-
-echo "Updating docker compose to use postgres version 16."
+echo "Updating docker-compose to use postgres version 16."
 sudo sed -i "s/image: .*postgres:.*/image: pgautoupgrade\/pgautoupgrade:16-alpine/" ./docker-compose.yml
 
-echo "Starting up new postgres..."
-sudo docker compose up -d postgres
-echo "Waiting..."
-sleep 20s
-
-echo "Importing the database...."
-sudo cat 15_16_dump.sql | sudo docker compose exec -T postgres psql -U lemmy
-echo "Done."
-
 echo "Starting up lemmy..."
-sudo docker compose up -d
-
-echo "A copy of your old database is at 15_16.dump.sql . You can delete this file if the upgrade went smoothly."
-echo "Upgrade complete."
+sudo docker-compose up -d

--- a/scripts/postgres_15_to_16_upgrade.sh
+++ b/scripts/postgres_15_to_16_upgrade.sh
@@ -24,7 +24,7 @@ echo "Removing the old postgres folder"
 sudo rm -rf volumes/postgres
 
 echo "Updating docker compose to use postgres version 16."
-sudo sed -i "s/image: .*postgres:.*/image: docker.io\/postgres:16-alpine/" ./docker-compose.yml
+sudo sed -i "s/image: .*postgres:.*/image: pgautoupgrade\/pgautoupgrade:16-alpine/" ./docker-compose.yml
 
 echo "Starting up new postgres..."
 sudo docker compose up -d postgres


### PR DESCRIPTION
Lemmy changed from PostgreSQL 15 to 16 at some point, and trying to switch from 15 to 16 in `docker-compose.yml` results in errors like this at startup:

> DETAIL:  The data directory was initialized by PostgreSQL version 15, which is not compatible with this version 16.3

This PR changes the PostgreSQL container to use [pgautoupgrade](https://github.com/pgautoupgrade/docker-pgautoupgrade). The pgautoupgrade image is based on the regular PostgreSQL one, but it automatically updates the data to the newer format on startup. This avoids users having to [figure it out manually](https://github.com/docker-library/postgres/issues/37).