### PR TITLE
Fix scheduled task to delete users with denied applications

### DIFF
--- a/crates/db_schema/src/impls/local_user.rs
+++ b/crates/db_schema/src/impls/local_user.rs
@@ -115,11 +115,11 @@ impl LocalUser {
     let conn = &mut get_conn(pool).await?;
 
     // Make sure:
-    // - The deny reason exists
+    // - An admin has interacted with the application
     // - The app is older than a week
     // - The accepted_application is false
     let old_denied_registrations = registration_application::table
-      .filter(registration_application::deny_reason.is_not_null())
+      .filter(registration_application::admin_id.is_not_null())
       .filter(registration_application::published.lt(now() - 1.week()))
       .select(registration_application::local_user_id);
 


### PR DESCRIPTION
After an admin interacted with an application it can only be accepted or denied.
Denial reasons are not required by Lemmys backend, even though they're mandatory in Lemmy-UI, and therefore they are not a reliable indicator of an application being denied.
This aligns the cleanup logic  with the logic used for the unread application count.

Reference for unread count:
https://github.com/LemmyNet/lemmy/blob/847c01f3483eeb388ad8bc53f6ef173d41ddce26/crates/db_views/src/registration_application_view.rs#L84-L111

Reference for Lemmy-UI using the same logic to determine which buttons to show:
https://github.com/LemmyNet/lemmy-ui/blob/5cd66bb037aca82bef396d48dd9e4ec6f21ef747/src/shared/components/common/registration-application.tsx#L131-L156

This flaw exists since the scheduled task was originally introduced in #4448 where the intention of the reason check was to determine whether it was rejected: https://github.com/LemmyNet/lemmy/pull/4448#discussion_r1487487423