### PR TITLE
Fix tls pool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,6 +203,7 @@ opentelemetry = { workspace = true, optional = true }
 console-subscriber = { version = "0.3.0", optional = true }
 opentelemetry-otlp = { version = "0.12.0", optional = true }
 pict-rs = { version = "0.5.15", optional = true }
+rustls = { version = "0.23.9", features = ["ring"] }
 tokio.workspace = true
 actix-cors = "0.7.0"
 futures-util = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,7 +203,7 @@ opentelemetry = { workspace = true, optional = true }
 console-subscriber = { version = "0.3.0", optional = true }
 opentelemetry-otlp = { version = "0.12.0", optional = true }
 pict-rs = { version = "0.5.15", optional = true }
-rustls = { version = "0.23.9", features = ["ring"] }
+rustls = { workspace = true }
 tokio.workspace = true
 actix-cors = "0.7.0"
 futures-util = { workspace = true }

--- a/crates/db_schema/src/utils.rs
+++ b/crates/db_schema/src/utils.rs
@@ -327,10 +327,6 @@ fn establish_connection(config: &str) -> BoxFuture<ConnectionResult<AsyncPgConne
   let fut = async {
     // We only support TLS with sslmode=require currently
     let mut conn = if config.contains("sslmode=require") {
-      rustls::crypto::ring::default_provider()
-        .install_default()
-        .expect("Failed to install rustls crypto provider");
-
       let rustls_config = DangerousClientConfigBuilder {
         cfg: ClientConfig::builder(),
       }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,16 @@ use clap::Parser;
 use lemmy_server::{init_logging, start_lemmy_server, CmdArgs};
 use lemmy_utils::{error::LemmyResult, settings::SETTINGS};
 
+pub extern crate rustls;
+
 #[tokio::main]
 pub async fn main() -> LemmyResult<()> {
   init_logging(&SETTINGS.opentelemetry_url)?;
   let args = CmdArgs::parse();
+
+  rustls::crypto::ring::default_provider()
+    .install_default()
+    .expect("Failed to install rustls crypto provider");
 
   #[cfg(not(feature = "embed-pictrs"))]
   start_lemmy_server(args).await?;


### PR DESCRIPTION
Addresses #4795. Apologies in advance for my poor rust competency. 

This patch moves the `rustls` invocation into `src/main.rs` for the default provider to load without error.

From the suggestions in [the rustls documentation](https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html#using-the-per-process-default-cryptoprovider), this patch follows the guidance described in the 2nd bullet point:

> The intention is that an application can specify the [`CryptoProvider`](https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html) they wish to use once, and have that apply to the variety of places where their application does TLS (which may be wrapped inside other libraries). They should do this by calling [`CryptoProvider::install_default()`](https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html#method.install_default) early on.
>
> To achieve this goal:
>
> * libraries should use [`ClientConfig::builder()`](https://docs.rs/rustls/latest/rustls/client/struct.ClientConfig.html#method.builder)/[`ServerConfig::builder()`](https://docs.rs/rustls/latest/rustls/server/struct.ServerConfig.html#method.builder) or otherwise rely on the [`CryptoProvider::get_default()`](https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html#method.get_default) provider.
> * applications should call [`CryptoProvider::install_default()`](https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html#method.install_default) early in their `fn main()`.

This call is positioned in `src/main.rs` because it needs to happen before pict-rs, which installs the provider if it's not set: [source code reference](https://git.asonix.dog/asonix/pict-rs/src/commit/fb80f7713609ceab42df577168e8e539c2d78b16/src/lib.rs#L1990).

FWIW, doing a similar tactic of "ignore the error" also works, but the nuances with making that choice are beyond my current understanding of the code base.