### PR TITLE
Make sure you can view your moderated deleted and removed communities.

### DIFF
--- a/crates/api_crud/src/site/read.rs
+++ b/crates/api_crud/src/site/read.rs
@@ -84,7 +84,7 @@ pub async fn get_site(
       |pool| CommunityBlockView::for_person(pool, person_id),
       |pool| InstanceBlockView::for_person(pool, person_id),
       |pool| PersonBlockView::for_person(pool, person_id),
-      |pool| CommunityModeratorView::for_person(pool, person_id, true),
+      |pool| CommunityModeratorView::for_person(pool, person_id, Some(&local_user_view.local_user)),
       |pool| LocalUserLanguage::read(pool, local_user_id)
     ))
     .with_lemmy_type(LemmyErrorType::SystemErrLogin)?;

--- a/crates/apub/src/api/read_person.rs
+++ b/crates/apub/src/api/read_person.rs
@@ -96,7 +96,7 @@ pub async fn read_person(
   let moderates = CommunityModeratorView::for_person(
     &mut context.pool(),
     person_details_id,
-    local_user_view.is_some(),
+    local_user_view.map(|l| l.local_user).as_ref(),
   )
   .await?;
 

--- a/crates/db_views_actor/src/community_moderator_view.rs
+++ b/crates/db_views_actor/src/community_moderator_view.rs
@@ -2,8 +2,10 @@ use crate::structs::CommunityModeratorView;
 use diesel::{dsl::exists, result::Error, select, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema::{
+  impls::local_user::LocalUserOptionHelper,
   newtypes::{CommunityId, PersonId},
   schema::{community, community_moderator, person},
+  source::local_user::LocalUser,
   utils::{get_conn, DbPool},
   CommunityVisibility,
 };
@@ -57,10 +59,10 @@ impl CommunityModeratorView {
       .await
   }
 
-  pub async fn for_person(
+  pub async fn for_person<'a>(
     pool: &mut DbPool<'_>,
     person_id: PersonId,
-    is_authenticated: bool,
+    local_user: Option<&'a LocalUser>,
   ) -> Result<Vec<Self>, Error> {
     let conn = &mut get_conn(pool).await?;
     let mut query = community_moderator::table
@@ -69,9 +71,21 @@ impl CommunityModeratorView {
       .filter(community_moderator::person_id.eq(person_id))
       .select((community::all_columns, person::all_columns))
       .into_boxed();
-    if !is_authenticated {
+
+    if local_user.is_none() {
       query = query.filter(community::visibility.eq(CommunityVisibility::Public));
     }
+
+    // only show deleted communities to creator
+    if Some(person_id) != local_user.person_id() {
+      query = query.filter(community::deleted.eq(false));
+    }
+
+    // Show removed communities to admins only
+    if !local_user.is_admin() {
+      query = query.filter(community::removed.eq(false))
+    }
+
     query.load::<CommunityModeratorView>(conn).await
   }
 

--- a/crates/db_views_actor/src/community_moderator_view.rs
+++ b/crates/db_views_actor/src/community_moderator_view.rs
@@ -67,8 +67,6 @@ impl CommunityModeratorView {
       .inner_join(community::table)
       .inner_join(person::table)
       .filter(community_moderator::person_id.eq(person_id))
-      .filter(community::deleted.eq(false))
-      .filter(community::removed.eq(false))
       .select((community::all_columns, person::all_columns))
       .into_boxed();
     if !is_authenticated {


### PR DESCRIPTION
- The front end checks to see whether you are a mod, in order to be able to restore deleted / removed communities. This removes a filter which prevents that.
- Fixes #4911