### PR TITLE
Change type of concurrent sends in config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3075,6 +3075,7 @@ dependencies = [
  "reqwest 0.11.27",
  "reqwest-middleware 0.2.5",
  "reqwest-tracing 0.4.8",
+ "rustls 0.23.10",
  "serde_json",
  "serial_test",
  "tokio",

--- a/crates/federate/src/worker.rs
+++ b/crates/federate/src/worker.rs
@@ -76,7 +76,7 @@ pub(crate) struct InstanceWorker {
   // that are not the lowest number and thus can't be written to the database yet
   successfuls: BinaryHeap<SendSuccessInfo>,
   // number of activities that currently have a task spawned to send it
-  in_flight: i32,
+  in_flight: i8,
 }
 
 impl InstanceWorker {
@@ -127,7 +127,7 @@ impl InstanceWorker {
       // too many in flight
       let need_wait_for_event = (self.in_flight != 0 && self.state.fail_count > 0)
         || self.successfuls.len() >= MAX_SUCCESSFULS
-        || i64::from(self.in_flight) >= self.federation_worker_config.concurrent_sends_per_instance;
+        || self.in_flight >= self.federation_worker_config.concurrent_sends_per_instance;
       if need_wait_for_event || self.receive_send_result.len() > MIN_ACTIVITY_SEND_RESULTS_TO_HANDLE
       {
         // if len() > 0 then this does not block and allows us to write to db more often

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -242,5 +242,5 @@ pub struct FederationWorkerConfig {
   /// Set this to a higher value than 1 (e.g. 6) only if you have a huge instance (>10 activities
   /// per second) and if a receiving instance is not keeping up.
   #[default(1)]
-  pub concurrent_sends_per_instance: i64,
+  pub concurrent_sends_per_instance: i8,
 }


### PR DESCRIPTION
Using such a large type doesnt make sense, 10 or 20 parallel sends should be more than enough even for large instances. Also the config value should use the same type so that too large values are rejected at startup, and to avoid a cast.