### PR TITLE
Replace 3rd party once_cell crate with recently stabilized standard library API

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -2,7 +2,7 @@
 # See https://github.com/woodpecker-ci/woodpecker/issues/1677
 
 variables:
-  - &rust_image "rust:1.78"
+  - &rust_image "rust:1.80"
   - &rust_nightly_image "rustlang/rust:nightly"
   - &install_pnpm "corepack enable pnpm"
   - &slow_check_paths

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,7 @@ dependencies = [
  "actix-utils",
  "futures-core",
  "futures-util",
- "mio",
+ "mio 0.8.11",
  "socket2",
  "tokio",
  "tracing",
@@ -423,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -438,33 +438,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -970,9 +970,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.9"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64acc1846d54c1fe936a78dc189c34e28d3f5afc348403f28ecf53660b9b8462"
+checksum = "35723e6a11662c2afb578bcf0b88bf6ea8e21282a953428f240574fcc3a2b5b3"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -980,9 +980,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.9"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8393d67ba2e7bfaf28a23458e4e2b543cc73a99595511eb207fdb8aede942"
+checksum = "49eb96cbfa7cfa35017b7cd548c75b14c3118c98b423041d70562665e07fb0fa"
 dependencies = [
  "anstream",
  "anstyle",
@@ -992,9 +992,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.8"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
+checksum = "5d029b67f89d30bbb547c89fd5161293c0aec155fc691d7924b64550662db93e"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -1004,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "clokwerk"
@@ -1061,9 +1061,9 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "combine"
@@ -1096,7 +1096,7 @@ dependencies = [
  "ron",
  "serde",
  "serde_json",
- "toml 0.8.15",
+ "toml 0.8.16",
  "yaml-rust",
 ]
 
@@ -2435,7 +2435,7 @@ dependencies = [
  "http 1.1.0",
  "hyper 1.4.1",
  "hyper-util",
- "rustls 0.23.11",
+ "rustls 0.23.12",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -2630,9 +2630,9 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.0"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -2689,9 +2689,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
@@ -2790,7 +2790,6 @@ dependencies = [
  "lemmy_utils",
  "mime",
  "moka",
- "once_cell",
  "pretty_assertions",
  "regex",
  "reqwest 0.11.27",
@@ -2824,7 +2823,6 @@ dependencies = [
  "lemmy_db_views_actor",
  "lemmy_utils",
  "moka",
- "once_cell",
  "tracing",
  "url",
  "uuid",
@@ -2854,7 +2852,6 @@ dependencies = [
  "lemmy_db_views_actor",
  "lemmy_utils",
  "moka",
- "once_cell",
  "pretty_assertions",
  "reqwest 0.11.27",
  "serde",
@@ -2905,10 +2902,9 @@ dependencies = [
  "i-love-jesus",
  "lemmy_utils",
  "moka",
- "once_cell",
  "pretty_assertions",
  "regex",
- "rustls 0.23.11",
+ "rustls 0.23.12",
  "serde",
  "serde_json",
  "serde_with",
@@ -2997,7 +2993,6 @@ dependencies = [
  "lemmy_utils",
  "mockall",
  "moka",
- "once_cell",
  "reqwest 0.11.27",
  "serde_json",
  "serial_test",
@@ -3024,7 +3019,6 @@ dependencies = [
  "lemmy_db_views",
  "lemmy_db_views_actor",
  "lemmy_utils",
- "once_cell",
  "reqwest 0.11.27",
  "reqwest-middleware 0.2.5",
  "rss",
@@ -3066,7 +3060,7 @@ dependencies = [
  "reqwest 0.11.27",
  "reqwest-middleware 0.2.5",
  "reqwest-tracing 0.4.8",
- "rustls 0.23.11",
+ "rustls 0.23.12",
  "serde_json",
  "serial_test",
  "tokio",
@@ -3096,7 +3090,6 @@ dependencies = [
  "itertools 0.13.0",
  "lettre",
  "markdown-it",
- "once_cell",
  "pretty_assertions",
  "regex",
  "reqwest 0.11.27",
@@ -3136,7 +3129,7 @@ dependencies = [
  "nom",
  "percent-encoding",
  "quoted_printable",
- "rustls 0.23.11",
+ "rustls 0.23.12",
  "rustls-pemfile 2.1.2",
  "socket2",
  "tokio",
@@ -3471,6 +3464,18 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "wasi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4108,7 +4113,7 @@ dependencies = [
  "reqwest 0.12.5",
  "reqwest-middleware 0.3.2",
  "reqwest-tracing 0.5.2",
- "rustls 0.23.11",
+ "rustls 0.23.12",
  "rustls-channel-resolver",
  "rustls-pemfile 2.1.2",
  "rusty-s3",
@@ -4126,7 +4131,7 @@ dependencies = [
  "tokio-postgres",
  "tokio-postgres-generic-rustls",
  "tokio-util",
- "toml 0.8.15",
+ "toml 0.8.16",
  "tracing",
  "tracing-actix-web",
  "tracing-error",
@@ -4305,9 +4310,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "predicates"
-version = "3.1.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
+checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
 dependencies = [
  "anstyle",
  "predicates-core",
@@ -4315,15 +4320,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -4523,7 +4528,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.11",
+ "rustls 0.23.12",
  "thiserror",
  "tokio",
  "tracing",
@@ -4539,7 +4544,7 @@ dependencies = [
  "rand",
  "ring",
  "rustc-hash",
- "rustls 0.23.11",
+ "rustls 0.23.12",
  "slab",
  "thiserror",
  "tinyvec",
@@ -4548,9 +4553,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a78e6f726d84fcf960409f509ae354a32648f090c8d32a2ea8b1a1bc3bab14"
+checksum = "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
 dependencies = [
  "libc",
  "once_cell",
@@ -4677,7 +4682,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-postgres",
- "toml 0.8.15",
+ "toml 0.8.16",
  "url",
  "walkdir",
 ]
@@ -4818,7 +4823,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.11",
+ "rustls 0.23.12",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "serde",
@@ -5044,9 +5049,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.11"
+version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4828ea528154ae444e5a642dbb7d5623354030dc9822b83fd9bb79683c7399d0"
+checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -5065,7 +5070,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fede2a247359da6b4998f7723ec6468c2d6a577a5d8c17e54f21806426ad2290"
 dependencies = [
  "nanorand",
- "rustls 0.23.11",
+ "rustls 0.23.12",
 ]
 
 [[package]]
@@ -5157,9 +5162,9 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "2.1.4"
+version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4465c22496331e20eb047ff46e7366455bc01c0c02015c4a376de0b2cd3a1af"
+checksum = "1fadf67e3cf23f8b11a6c8c48a16cb2437381503615acd91094ec7b4686a5a53"
 dependencies = [
  "sdd",
 ]
@@ -5297,9 +5302,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
 dependencies = [
  "serde",
 ]
@@ -5909,22 +5914,21 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.38.1"
+version = "1.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
+checksum = "d040ac2b29ab03b09d4129c2f5bbd012a3ac2f79d38ff506a4bf8dd34b0eac8a"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio",
- "num_cpus",
+ "mio 1.0.1",
  "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "tracing",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5939,9 +5943,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5991,7 +5995,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8e98c31c29b2666fb28720739e11476166be4ead1610a37dcd7414bb124413a"
 dependencies = [
  "aws-lc-rs",
- "rustls 0.23.11",
+ "rustls 0.23.12",
  "tokio",
  "tokio-postgres",
  "tokio-rustls 0.26.0",
@@ -6005,7 +6009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04fb792ccd6bbcd4bba408eb8a292f70fc4a3589e5d793626f45190e6454b6ab"
 dependencies = [
  "ring",
- "rustls 0.23.11",
+ "rustls 0.23.12",
  "tokio",
  "tokio-postgres",
  "tokio-rustls 0.26.0",
@@ -6028,7 +6032,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.11",
+ "rustls 0.23.12",
  "rustls-pki-types",
  "tokio",
 ]
@@ -6071,21 +6075,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2caab0bf757388c6c0ae23b3293fdb463fee59434529014f85e3263b995c28"
+checksum = "81967dd0dd2c1ab0bc3468bd7caecc32b8a4aa47d0c8c695d8c2b2108168d62c"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.16",
+ "toml_edit 0.22.17",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+checksum = "f8fb9f64314842840f1d940ac544da178732128f1c78c21772e876579e0da1db"
 dependencies = [
  "serde",
 ]
@@ -6105,15 +6109,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.16"
+version = "0.22.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "278f3d518e152219c994ce877758516bca5e118eaed6996192a774fb9fbf0788"
+checksum = "8d9f8729f5aea9562aac1cc0441f5d6de3cff1ee0c5d67293eeca5eb36ee7c16"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.14",
+ "winnow 0.6.16",
 ]
 
 [[package]]
@@ -6204,9 +6208,9 @@ dependencies = [
 
 [[package]]
 name = "totp-rs"
-version = "5.5.1"
+version = "5.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4ae9724c5888c0417d2396037ed3b60665925624766416e3e342b6ba5dbd3f"
+checksum = "17b2f27dad992486c26b4e7455f38aa487e838d6d61b57e72906ee2b8c287a90"
 dependencies = [
  "base32",
  "constant_time_eq",
@@ -7015,9 +7019,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.14"
+version = "0.6.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374ec40a2d767a3c1b4972d9475ecd557356637be906f2cb3f7fe17a6eb5e22f"
+checksum = "b480ae9340fc261e6be3e95a1ba86d54ae3f9171132a73ce8d4bbaf68339507c"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,6 @@ typed-builder = "0.18.2"
 serial_test = "3.1.1"
 tokio = { version = "1.38.0", features = ["full"] }
 regex = "1.10.4"
-once_cell = "1.19.0"
 diesel-derive-newtype = "2.1.2"
 diesel-derive-enum = { version = "2.1.0", features = ["postgres"] }
 strum = { version = "0.26.3", features = ["derive"] }

--- a/crates/api_common/Cargo.toml
+++ b/crates/api_common/Cargo.toml
@@ -34,7 +34,6 @@ full = [
   "reqwest",
   "actix-web",
   "futures",
-  "once_cell",
   "jsonwebtoken",
   "mime",
 ]
@@ -61,7 +60,6 @@ reqwest = { workspace = true, optional = true }
 ts-rs = { workspace = true, optional = true }
 moka.workspace = true
 anyhow.workspace = true
-once_cell = { workspace = true, optional = true }
 actix-web = { workspace = true, optional = true }
 enum-map = { workspace = true }
 urlencoding = { workspace = true }

--- a/crates/api_common/src/send_activity.rs
+++ b/crates/api_common/src/send_activity.rs
@@ -13,7 +13,7 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views::structs::PrivateMessageView;
 use lemmy_utils::error::LemmyResult;
-use once_cell::sync::{Lazy, OnceCell};
+use std::sync::{LazyLock, OnceLock};
 use tokio::{
   sync::{
     mpsc,
@@ -28,7 +28,7 @@ type MatchOutgoingActivitiesBoxed =
   Box<for<'a> fn(SendActivityData, &'a Data<LemmyContext>) -> BoxFuture<'a, LemmyResult<()>>>;
 
 /// This static is necessary so that the api_common crates don't need to depend on lemmy_apub
-pub static MATCH_OUTGOING_ACTIVITIES: OnceCell<MatchOutgoingActivitiesBoxed> = OnceCell::new();
+pub static MATCH_OUTGOING_ACTIVITIES: OnceLock<MatchOutgoingActivitiesBoxed> = OnceLock::new();
 
 #[derive(Debug)]
 pub enum SendActivityData {
@@ -101,7 +101,7 @@ pub enum SendActivityData {
 
 // TODO: instead of static, move this into LemmyContext. make sure that stopping the process with
 //       ctrl+c still works.
-static ACTIVITY_CHANNEL: Lazy<ActivityChannel> = Lazy::new(|| {
+static ACTIVITY_CHANNEL: LazyLock<ActivityChannel> = LazyLock::new(|| {
   let (sender, receiver) = mpsc::unbounded_channel();
   let weak_sender = sender.downgrade();
   ActivityChannel {

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -53,10 +53,9 @@ use lemmy_utils::{
   CACHE_DURATION_FEDERATION,
 };
 use moka::future::Cache;
-use once_cell::sync::Lazy;
 use regex::{escape, Regex, RegexSet};
 use rosetta_i18n::{Language, LanguageId};
-use std::collections::HashSet;
+use std::{collections::HashSet, sync::LazyLock};
 use tracing::warn;
 use url::{ParseError, Url};
 use urlencoding::encode;
@@ -546,7 +545,7 @@ pub fn local_site_opt_to_sensitive(local_site: &Option<LocalSite>) -> bool {
 }
 
 pub async fn get_url_blocklist(context: &LemmyContext) -> LemmyResult<RegexSet> {
-  static URL_BLOCKLIST: Lazy<Cache<(), RegexSet>> = Lazy::new(|| {
+  static URL_BLOCKLIST: LazyLock<Cache<(), RegexSet>> = LazyLock::new(|| {
     Cache::builder()
       .max_capacity(1)
       .time_to_live(CACHE_DURATION_FEDERATION)

--- a/crates/api_crud/Cargo.toml
+++ b/crates/api_crud/Cargo.toml
@@ -26,7 +26,6 @@ url = { workspace = true }
 futures.workspace = true
 uuid = { workspace = true }
 moka.workspace = true
-once_cell.workspace = true
 anyhow.workspace = true
 webmention = "0.5.0"
 accept-language = "3.1.0"

--- a/crates/api_crud/src/site/read.rs
+++ b/crates/api_crud/src/site/read.rs
@@ -24,14 +24,14 @@ use lemmy_utils::{
   VERSION,
 };
 use moka::future::Cache;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
 #[tracing::instrument(skip(context))]
 pub async fn get_site(
   local_user_view: Option<LocalUserView>,
   context: Data<LemmyContext>,
 ) -> LemmyResult<Json<GetSiteResponse>> {
-  static CACHE: Lazy<Cache<(), GetSiteResponse>> = Lazy::new(|| {
+  static CACHE: LazyLock<Cache<(), GetSiteResponse>> = LazyLock::new(|| {
     Cache::builder()
       .max_capacity(1)
       .time_to_live(CACHE_DURATION_API)

--- a/crates/apub/Cargo.toml
+++ b/crates/apub/Cargo.toml
@@ -40,7 +40,6 @@ uuid = { workspace = true }
 async-trait = { workspace = true }
 anyhow = { workspace = true }
 reqwest = { workspace = true }
-once_cell = { workspace = true }
 moka.workspace = true
 serde_with.workspace = true
 html2md = "0.2.14"

--- a/crates/apub/src/lib.rs
+++ b/crates/apub/src/lib.rs
@@ -14,9 +14,8 @@ use lemmy_utils::{
   CACHE_DURATION_FEDERATION,
 };
 use moka::future::Cache;
-use once_cell::sync::Lazy;
 use serde_json::Value;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use url::Url;
 
 pub mod activities;
@@ -36,7 +35,7 @@ pub const FEDERATION_HTTP_FETCH_LIMIT: u32 = 100;
 /// Only include a basic context to save space and bandwidth. The main context is hosted statically
 /// on join-lemmy.org. Include activitystreams explicitly for better compat, but this could
 /// theoretically also be moved.
-pub static FEDERATION_CONTEXT: Lazy<Value> = Lazy::new(|| {
+pub static FEDERATION_CONTEXT: LazyLock<Value> = LazyLock::new(|| {
   Value::Array(vec![
     Value::String("https://join-lemmy.org/context.json".to_string()),
     Value::String("https://www.w3.org/ns/activitystreams".to_string()),
@@ -129,7 +128,7 @@ pub(crate) async fn local_site_data_cached(
   // multiple times. This causes a huge number of database reads if we hit the db directly. So we
   // cache these values for a short time, which will already make a huge difference and ensures that
   // changes take effect quickly.
-  static CACHE: Lazy<Cache<(), Arc<LocalSiteData>>> = Lazy::new(|| {
+  static CACHE: LazyLock<Cache<(), Arc<LocalSiteData>>> = LazyLock::new(|| {
     Cache::builder()
       .max_capacity(1)
       .time_to_live(CACHE_DURATION_FEDERATION)

--- a/crates/db_schema/Cargo.toml
+++ b/crates/db_schema/Cargo.toml
@@ -27,7 +27,6 @@ full = [
   "lemmy_utils",
   "activitypub_federation",
   "regex",
-  "once_cell",
   "serde_json",
   "diesel_ltree",
   "diesel-async",
@@ -64,7 +63,6 @@ diesel-async = { workspace = true, features = [
   "deadpool",
 ], optional = true }
 regex = { workspace = true, optional = true }
-once_cell = { workspace = true, optional = true }
 diesel_ltree = { workspace = true, optional = true }
 typed-builder = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/db_schema/src/impls/local_site.rs
+++ b/crates/db_schema/src/impls/local_site.rs
@@ -7,7 +7,7 @@ use diesel::{dsl::insert_into, result::Error};
 use diesel_async::RunQueryDsl;
 use lemmy_utils::{error::LemmyResult, CACHE_DURATION_API};
 use moka::future::Cache;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
 impl LocalSite {
   pub async fn create(pool: &mut DbPool<'_>, form: &LocalSiteInsertForm) -> Result<Self, Error> {
@@ -18,7 +18,7 @@ impl LocalSite {
       .await
   }
   pub async fn read(pool: &mut DbPool<'_>) -> LemmyResult<Self> {
-    static CACHE: Lazy<Cache<(), LocalSite>> = Lazy::new(|| {
+    static CACHE: LazyLock<Cache<(), LocalSite>> = LazyLock::new(|| {
       Cache::builder()
         .max_capacity(1)
         .time_to_live(CACHE_DURATION_API)

--- a/crates/db_schema/src/utils.rs
+++ b/crates/db_schema/src/utils.rs
@@ -32,7 +32,6 @@ use lemmy_utils::{
   settings::SETTINGS,
   utils::validation::clean_url_params,
 };
-use once_cell::sync::Lazy;
 use regex::Regex;
 use rustls::{
   client::danger::{
@@ -49,7 +48,7 @@ use rustls::{
 };
 use std::{
   ops::{Deref, DerefMut},
-  sync::Arc,
+  sync::{Arc, LazyLock},
   time::Duration,
 };
 use tracing::error;
@@ -478,7 +477,7 @@ pub fn post_to_comment_sort_type(sort: SortType) -> CommentSortType {
   }
 }
 
-static EMAIL_REGEX: Lazy<Regex> = Lazy::new(|| {
+static EMAIL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
   Regex::new(r"^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$")
     .expect("compile email regex")
 });

--- a/crates/federate/Cargo.toml
+++ b/crates/federate/Cargo.toml
@@ -27,7 +27,6 @@ futures.workspace = true
 chrono.workspace = true
 diesel = { workspace = true, features = ["postgres", "chrono", "serde_json"] }
 diesel-async = { workspace = true, features = ["deadpool", "postgres"] }
-once_cell.workspace = true
 reqwest.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["full"] }

--- a/crates/federate/src/inboxes.rs
+++ b/crates/federate/src/inboxes.rs
@@ -8,9 +8,11 @@ use lemmy_db_schema::{
   utils::{ActualDbPool, DbPool},
 };
 use lemmy_db_views_actor::structs::CommunityFollowerView;
-use once_cell::sync::Lazy;
 use reqwest::Url;
-use std::collections::{HashMap, HashSet};
+use std::{
+  collections::{HashMap, HashSet},
+  sync::LazyLock,
+};
 
 /// interval with which new additions to community_followers are queried.
 ///
@@ -21,7 +23,7 @@ use std::collections::{HashMap, HashSet};
 /// currently fairly high because of the current structure of storing inboxes for every person, not
 /// having a separate list of shared_inboxes, and the architecture of having every instance queue be
 /// fully separate. (see https://github.com/LemmyNet/lemmy/issues/3958)
-static FOLLOW_ADDITIONS_RECHECK_DELAY: Lazy<chrono::TimeDelta> = Lazy::new(|| {
+static FOLLOW_ADDITIONS_RECHECK_DELAY: LazyLock<chrono::TimeDelta> = LazyLock::new(|| {
   if *LEMMY_TEST_FAST_FEDERATION {
     chrono::TimeDelta::try_seconds(1).expect("TimeDelta out of bounds")
   } else {
@@ -31,8 +33,8 @@ static FOLLOW_ADDITIONS_RECHECK_DELAY: Lazy<chrono::TimeDelta> = Lazy::new(|| {
 /// The same as FOLLOW_ADDITIONS_RECHECK_DELAY, but triggering when the last person on an instance
 /// unfollows a specific remote community. This is expected to happen pretty rarely and updating it
 /// in a timely manner is not too important.
-static FOLLOW_REMOVALS_RECHECK_DELAY: Lazy<chrono::TimeDelta> =
-  Lazy::new(|| chrono::TimeDelta::try_hours(1).expect("TimeDelta out of bounds"));
+static FOLLOW_REMOVALS_RECHECK_DELAY: LazyLock<chrono::TimeDelta> =
+  LazyLock::new(|| chrono::TimeDelta::try_hours(1).expect("TimeDelta out of bounds"));
 
 #[async_trait]
 pub trait DataSource: Send + Sync {

--- a/crates/routes/Cargo.toml
+++ b/crates/routes/Cargo.toml
@@ -30,7 +30,6 @@ reqwest = { workspace = true, features = ["stream"] }
 reqwest-middleware = { workspace = true }
 serde = { workspace = true }
 url = { workspace = true }
-once_cell = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 urlencoding = { workspace = true }

--- a/crates/routes/src/feeds.rs
+++ b/crates/routes/src/feeds.rs
@@ -25,7 +25,6 @@ use lemmy_utils::{
   error::{LemmyError, LemmyErrorType, LemmyResult},
   utils::markdown::{markdown_to_html, sanitize_html},
 };
-use once_cell::sync::Lazy;
 use rss::{
   extension::{dublincore::DublinCoreExtension, ExtensionBuilder, ExtensionMap},
   Channel,
@@ -34,7 +33,7 @@ use rss::{
   Item,
 };
 use serde::Deserialize;
-use std::{collections::BTreeMap, str::FromStr};
+use std::{collections::BTreeMap, str::FromStr, sync::LazyLock};
 
 const RSS_FETCH_LIMIT: i64 = 20;
 
@@ -80,7 +79,7 @@ pub fn config(cfg: &mut web::ServiceConfig) {
   );
 }
 
-static RSS_NAMESPACE: Lazy<BTreeMap<String, String>> = Lazy::new(|| {
+static RSS_NAMESPACE: LazyLock<BTreeMap<String, String>> = LazyLock::new(|| {
   let mut h = BTreeMap::new();
   h.insert(
     "dc".to_string(),

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -39,7 +39,6 @@ full = [
   "dep:urlencoding",
   "dep:doku",
   "dep:url",
-  "dep:once_cell",
   "dep:smart-default",
   "dep:enum-map",
   "dep:futures",
@@ -58,7 +57,6 @@ tracing-error = { workspace = true, optional = true }
 itertools = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
-once_cell = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
 actix-web = { workspace = true, optional = true }
 anyhow = { workspace = true, optional = true }

--- a/crates/utils/src/rate_limit/rate_limiter.rs
+++ b/crates/utils/src/rate_limit/rate_limiter.rs
@@ -1,15 +1,15 @@
 use enum_map::EnumMap;
-use once_cell::sync::Lazy;
 use std::{
   collections::HashMap,
   hash::Hash,
   net::{IpAddr, Ipv4Addr, Ipv6Addr},
+  sync::LazyLock,
   time::Instant,
 };
 use strum::{AsRefStr, Display};
 use tracing::debug;
 
-static START_TIME: Lazy<Instant> = Lazy::new(Instant::now);
+static START_TIME: LazyLock<Instant> = LazyLock::new(Instant::now);
 
 /// Smaller than `std::time::Instant` because it uses a smaller integer for seconds and doesn't
 /// store nanoseconds

--- a/crates/utils/src/settings/mod.rs
+++ b/crates/utils/src/settings/mod.rs
@@ -1,9 +1,8 @@
 use crate::{error::LemmyResult, location_info};
 use anyhow::{anyhow, Context};
 use deser_hjson::from_str;
-use once_cell::sync::Lazy;
 use regex::Regex;
-use std::{env, fs, io::Error};
+use std::{env, fs, io::Error, sync::LazyLock};
 use urlencoding::encode;
 
 pub mod structs;
@@ -12,7 +11,7 @@ use structs::{DatabaseConnection, PictrsConfig, PictrsImageMode, Settings};
 
 static DEFAULT_CONFIG_FILE: &str = "config/config.hjson";
 
-pub static SETTINGS: Lazy<Settings> = Lazy::new(|| {
+pub static SETTINGS: LazyLock<Settings> = LazyLock::new(|| {
   if env::var("LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS").is_ok() {
     println!(
       "LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS was set, any configuration file has been ignored."
@@ -24,7 +23,7 @@ pub static SETTINGS: Lazy<Settings> = Lazy::new(|| {
   }
 });
 
-static WEBFINGER_REGEX: Lazy<Regex> = Lazy::new(|| {
+static WEBFINGER_REGEX: LazyLock<Regex> = LazyLock::new(|| {
   Regex::new(&format!(
     "^acct:([a-zA-Z0-9_]{{3,}})@{}$",
     SETTINGS.hostname

--- a/crates/utils/src/utils/markdown/mod.rs
+++ b/crates/utils/src/utils/markdown/mod.rs
@@ -1,14 +1,14 @@
 use crate::{error::LemmyResult, settings::SETTINGS, LemmyErrorType};
 use markdown_it::{plugins::cmark::inline::image::Image, MarkdownIt};
-use once_cell::sync::Lazy;
 use regex::RegexSet;
+use std::sync::LazyLock;
 use url::Url;
 use urlencoding::encode;
 
 mod link_rule;
 mod spoiler_rule;
 
-static MARKDOWN_PARSER: Lazy<MarkdownIt> = Lazy::new(|| {
+static MARKDOWN_PARSER: LazyLock<MarkdownIt> = LazyLock::new(|| {
   let mut parser = MarkdownIt::new();
   markdown_it::plugins::cmark::add(&mut parser);
   markdown_it::plugins::extra::add(&mut parser);

--- a/crates/utils/src/utils/markdown/spoiler_rule.rs
+++ b/crates/utils/src/utils/markdown/spoiler_rule.rs
@@ -34,8 +34,8 @@ use markdown_it::{
   NodeValue,
   Renderer,
 };
-use once_cell::sync::Lazy;
 use regex::Regex;
+use std::sync::LazyLock;
 
 #[derive(Debug)]
 struct SpoilerBlock {
@@ -46,8 +46,8 @@ const SPOILER_PREFIX: &str = "::: spoiler ";
 const SPOILER_SUFFIX: &str = ":::";
 const SPOILER_SUFFIX_NEWLINE: &str = ":::\n";
 
-static SPOILER_REGEX: Lazy<Regex> =
-  Lazy::new(|| Regex::new(r"^::: spoiler .*$").expect("compile spoiler markdown regex."));
+static SPOILER_REGEX: LazyLock<Regex> =
+  LazyLock::new(|| Regex::new(r"^::: spoiler .*$").expect("compile spoiler markdown regex."));
 
 impl NodeValue for SpoilerBlock {
   // Formats any node marked as a 'SpoilerBlock' into HTML.

--- a/crates/utils/src/utils/mention.rs
+++ b/crates/utils/src/utils/mention.rs
@@ -1,8 +1,8 @@
 use itertools::Itertools;
-use once_cell::sync::Lazy;
 use regex::Regex;
+use std::sync::LazyLock;
 
-static MENTIONS_REGEX: Lazy<Regex> = Lazy::new(|| {
+static MENTIONS_REGEX: LazyLock<Regex> = LazyLock::new(|| {
   Regex::new(r"@(?P<name>[\w.]+)@(?P<domain>[a-zA-Z0-9._:-]+)").expect("compile regex")
 });
 // TODO nothing is done with community / group webfingers yet, so just ignore those for now

--- a/crates/utils/src/utils/validation.rs
+++ b/crates/utils/src/utils/validation.rs
@@ -1,16 +1,16 @@
 use crate::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 use itertools::Itertools;
-use once_cell::sync::Lazy;
 use regex::{Regex, RegexBuilder, RegexSet};
+use std::sync::LazyLock;
 use url::{ParseError, Url};
 
 // From here: https://github.com/vector-im/element-android/blob/develop/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/MatrixPatterns.kt#L35
-static VALID_MATRIX_ID_REGEX: Lazy<Regex> = Lazy::new(|| {
+static VALID_MATRIX_ID_REGEX: LazyLock<Regex> = LazyLock::new(|| {
   Regex::new(r"^@[A-Za-z0-9\x21-\x39\x3B-\x7F]+:[A-Za-z0-9.-]+(:[0-9]{2,5})?$")
     .expect("compile regex")
 });
 // taken from https://en.wikipedia.org/wiki/UTM_parameters
-static CLEAN_URL_PARAMS_REGEX: Lazy<Regex> = Lazy::new(|| {
+static CLEAN_URL_PARAMS_REGEX: LazyLock<Regex> = LazyLock::new(|| {
   Regex::new(
     r"^(utm_source|utm_medium|utm_campaign|utm_term|utm_content|gclid|gclsrc|dclid|fbclid)=",
   )
@@ -87,12 +87,12 @@ fn has_newline(name: &str) -> bool {
 }
 
 pub fn is_valid_actor_name(name: &str, actor_name_max_length: usize) -> LemmyResult<()> {
-  static VALID_ACTOR_NAME_REGEX_EN: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^[a-zA-Z0-9_]{3,}$").expect("compile regex"));
-  static VALID_ACTOR_NAME_REGEX_AR: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^[\p{Arabic}0-9_]{3,}$").expect("compile regex"));
-  static VALID_ACTOR_NAME_REGEX_RU: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^[\p{Cyrillic}0-9_]{3,}$").expect("compile regex"));
+  static VALID_ACTOR_NAME_REGEX_EN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9_]{3,}$").expect("compile regex"));
+  static VALID_ACTOR_NAME_REGEX_AR: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[\p{Arabic}0-9_]{3,}$").expect("compile regex"));
+  static VALID_ACTOR_NAME_REGEX_RU: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[\p{Cyrillic}0-9_]{3,}$").expect("compile regex"));
 
   let check = name.chars().count() <= actor_name_max_length && !has_newline(name);
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.8
-ARG RUST_VERSION=1.78
+ARG RUST_VERSION=1.80
 ARG CARGO_BUILD_FEATURES=default
 ARG RUST_RELEASE_MODE=debug
 


### PR DESCRIPTION
Rust released [version 1.80.0](https://blog.rust-lang.org/2024/07/25/Rust-1.80.0.html) on the day of this PR's creation. This makes the 3rd party `once_cell` trait redundant. 

Need to wait for https://github.com/rust-lang/docker-rust/pull/208 to be merged so Lemmy can run in docker.