### PR TITLE
Fix admin notification for new user registration (fixes #4916)

### DIFF
--- a/crates/api/src/local_user/verify_email.rs
+++ b/crates/api/src/local_user/verify_email.rs
@@ -5,12 +5,9 @@ use lemmy_api_common::{
   utils::send_new_applicant_email_to_admins,
   SuccessResponse,
 };
-use lemmy_db_schema::{
-  source::{
-    email_verification::EmailVerification,
-    local_user::{LocalUser, LocalUserUpdateForm},
-  },
-  RegistrationMode,
+use lemmy_db_schema::source::{
+  email_verification::EmailVerification,
+  local_user::{LocalUser, LocalUserUpdateForm},
 };
 use lemmy_db_views::structs::{LocalUserView, SiteView};
 use lemmy_utils::error::{LemmyErrorType, LemmyResult};
@@ -41,9 +38,7 @@ pub async fn verify_email(
   EmailVerification::delete_old_tokens_for_local_user(&mut context.pool(), local_user_id).await?;
 
   // send out notification about registration application to admins if enabled
-  if site_view.local_site.registration_mode == RegistrationMode::RequireApplication
-    && site_view.local_site.application_email_admins
-  {
+  if site_view.local_site.application_email_admins {
     let local_user = LocalUserView::read(&mut context.pool(), local_user_id)
       .await?
       .ok_or(LemmyErrorType::CouldntFindPerson)?;


### PR DESCRIPTION
Admin notifications should be sent regardless of registration mode.