### PR TITLE
Fixing apt-key deprecation, and using apt-get.

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -7,7 +7,7 @@ variables:
   - &install_pnpm "corepack enable pnpm"
   - &install_binstall "wget -O- https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz | tar -xvz -C /usr/local/cargo/bin"
   - install_diesel_cli: &install_diesel_cli
-      - apt-get update && apt-get install lsb-release ca-certificates
+      - apt-get update && apt-get -y install lsb-release ca-certificates
       # Instructions taken from here: https://www.postgresql.org/download/linux/ubuntu/
       - install -d /usr/share/postgresql-common/pgdg
       - curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -9,7 +9,7 @@ variables:
   - install_diesel_cli: &install_diesel_cli
       - apt-get update && apt-get install -y lsb-release build-essential
       - sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-      - curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc|sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
+      - curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc|gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
       - apt-get update && apt-get install -y postgresql-client-16
       - cargo install diesel_cli --no-default-features --features postgres
       - export PATH="$CARGO_HOME/bin:$PATH"

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -7,14 +7,7 @@ variables:
   - &install_pnpm "corepack enable pnpm"
   - &install_binstall "wget -O- https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz | tar -xvz -C /usr/local/cargo/bin"
   - install_diesel_cli: &install_diesel_cli
-      - apt-get update && apt-get -y install curl lsb-release ca-certificates
-      # Instructions taken from here: https://www.postgresql.org/download/linux/ubuntu/
-      - install -d /usr/share/postgresql-common/pgdg
-      - curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
-      - sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-      - apt-get update
-      - apt-cache search postgresql
-      - apt-get -y install postgresql-client-16
+      - apt-get update && apt-get install -y postgresql-client
       - cargo install diesel_cli --no-default-features --features postgres
       - export PATH="$CARGO_HOME/bin:$PATH"
   - &slow_check_paths
@@ -304,7 +297,7 @@ steps:
 
 services:
   database:
-    image: pgautoupgrade/pgautoupgrade:16-alpine
+    image: pgautoupgrade/pgautoupgrade:15-alpine
     environment:
       POSTGRES_USER: lemmy
       POSTGRES_PASSWORD: password

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -7,13 +7,19 @@ variables:
   - &install_pnpm "corepack enable pnpm"
   - &install_binstall "wget -O- https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz | tar -xvz -C /usr/local/cargo/bin"
   - install_diesel_cli: &install_diesel_cli
-      - apt-get update && apt-get install -y postgresql-common
+      # - apt-get update && apt-get install -y postgresql-common
       # - apt-get update && apt-get install -y lsb-release build-essential ca-certificates
-      - /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
+      # - /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
       # - sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
       # - curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc|gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
       # - apt-get update
       # - apt-get install -y postgresql-client-16
+      - apt-get install curl ca-certificates
+      - install -d /usr/share/postgresql-common/pgdg
+      - curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
+      - sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+      - apt-get update
+      - apt-get -y install postgresql-client-16
       - cargo install diesel_cli --no-default-features --features postgres
       - export PATH="$CARGO_HOME/bin:$PATH"
   - &slow_check_paths

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -7,15 +7,12 @@ variables:
   - &install_pnpm "corepack enable pnpm"
   - &install_binstall "wget -O- https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz | tar -xvz -C /usr/local/cargo/bin"
   - install_diesel_cli: &install_diesel_cli
-      # - apt-get update && apt-get install -y postgresql-common
-      # - apt-get update && apt-get install -y lsb-release build-essential ca-certificates
-      # - /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
-      # - sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-      # - curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc|gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
-      - apt-get update && apt-get install lsb-release
-      - install -d /usr/share/postgresql-common/pgdg
-      - curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
-      - sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+      # - apt-get update && apt-get install lsb-release
+      # Instructions taken from here: https://www.postgresql.org/download/linux/ubuntu/
+      # - install -d /usr/share/postgresql-common/pgdg
+      # - curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
+      # - sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+      # - apt-get update && apt-get -y install postgresql-client
       - apt-get update && apt-get -y install postgresql-client
       - cargo install diesel_cli --no-default-features --features postgres
       - export PATH="$CARGO_HOME/bin:$PATH"

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -12,13 +12,11 @@ variables:
       # - /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
       # - sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
       # - curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc|gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
-      # - apt-get update
-      # - apt-get install -y postgresql-client-16
       - apt-get update && apt-get install lsb-release
       - install -d /usr/share/postgresql-common/pgdg
       - curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
       - sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-      - apt-get update && apt-get -y install postgresql-client-16
+      - apt-get update && apt-get -y install postgresql-client
       - cargo install diesel_cli --no-default-features --features postgres
       - export PATH="$CARGO_HOME/bin:$PATH"
   - &slow_check_paths

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -7,12 +7,13 @@ variables:
   - &install_pnpm "corepack enable pnpm"
   - &install_binstall "wget -O- https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz | tar -xvz -C /usr/local/cargo/bin"
   - install_diesel_cli: &install_diesel_cli
-      - apt-get update && apt-get install lsb-release
+      - apt-get update && apt-get install lsb-release ca-certificates
       # Instructions taken from here: https://www.postgresql.org/download/linux/ubuntu/
       - install -d /usr/share/postgresql-common/pgdg
       - curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
       - sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-      - apt-get update && apt-get -y install postgresql-client-16
+      - apt-get update
+      - apt-get -y install postgresql-client-16
       - cargo install diesel_cli --no-default-features --features postgres
       - export PATH="$CARGO_HOME/bin:$PATH"
   - &slow_check_paths

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -7,13 +7,13 @@ variables:
   - &install_pnpm "corepack enable pnpm"
   - &install_binstall "wget -O- https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz | tar -xvz -C /usr/local/cargo/bin"
   - install_diesel_cli: &install_diesel_cli
-      - apt-get update && apt-get -y install lsb-release ca-certificates
+      - apt update && apt -y install curl lsb-release ca-certificates
       # Instructions taken from here: https://www.postgresql.org/download/linux/ubuntu/
       - install -d /usr/share/postgresql-common/pgdg
       - curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
       - sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-      - apt-get update
-      - apt-get -y install postgresql-16
+      - apt update
+      - apt -y install postgresql-client-16
       - cargo install diesel_cli --no-default-features --features postgres
       - export PATH="$CARGO_HOME/bin:$PATH"
   - &slow_check_paths

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -7,7 +7,12 @@ variables:
   - &install_pnpm "corepack enable pnpm"
   - &install_binstall "wget -O- https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz | tar -xvz -C /usr/local/cargo/bin"
   - install_diesel_cli: &install_diesel_cli
-      - apt-get update && apt-get -y install postgresql-client
+      - apt-get update && apt-get install lsb-release
+      # Instructions taken from here: https://www.postgresql.org/download/linux/ubuntu/
+      - install -d /usr/share/postgresql-common/pgdg
+      - curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
+      - sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+      - apt-get update && apt-get -y install postgresql-client-16
       - cargo install diesel_cli --no-default-features --features postgres
       - export PATH="$CARGO_HOME/bin:$PATH"
   - &slow_check_paths

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -5,6 +5,14 @@ variables:
   - &rust_image "rust:1.80"
   - &rust_nightly_image "rustlang/rust:nightly"
   - &install_pnpm "corepack enable pnpm"
+  - &install_binstall "wget -O- https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz | tar -xvz -C /usr/local/cargo/bin"
+  - install_diesel_cli: &install_diesel_cli
+      - apt-get update && apt-get install -y lsb-release build-essential
+      - sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+      - curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc|sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
+      - apt-get update && apt-get install -y postgresql-client-16
+      - cargo install diesel_cli --no-default-features --features postgres
+      - export PATH="$CARGO_HOME/bin:$PATH"
   - &slow_check_paths
     - event: pull_request
       path:
@@ -25,17 +33,6 @@ variables:
             "diesel.toml",
             ".gitmodules",
           ]
-  - install_binstall: &install_binstall
-      - wget https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz
-      - tar -xvf cargo-binstall-x86_64-unknown-linux-musl.tgz
-      - cp cargo-binstall /usr/local/cargo/bin
-  - install_diesel_cli: &install_diesel_cli
-      - apt update && apt install -y lsb-release build-essential
-      - sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-      - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-      - apt update && apt install -y postgresql-client-16
-      - cargo install diesel_cli --no-default-features --features postgres
-      - export PATH="$CARGO_HOME/bin:$PATH"
 
 steps:
   prepare_repo:
@@ -82,7 +79,7 @@ steps:
   cargo_machete:
     image: *rust_nightly_image
     commands:
-      - <<: *install_binstall
+      - *install_binstall
       - cargo binstall -y cargo-machete
       - cargo machete
     when:
@@ -205,10 +202,6 @@ steps:
       # Run all migrations
       - diesel migration run
       # Dump schema to before.sqldump (PostgreSQL apt repo is used to prevent pg_dump version mismatch error)
-      - apt update && apt install -y lsb-release
-      - sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-      - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-      - apt update && apt install -y postgresql-client-16
       - psql -c "DROP SCHEMA IF EXISTS r CASCADE;"
       - pg_dump --no-owner --no-privileges --no-table-access-method --schema-only --no-sync -f before.sqldump
       # Make sure that the newest migration is revertable without the `r` schema
@@ -232,7 +225,7 @@ steps:
       DO_WRITE_HOSTS_FILE: "1"
     commands:
       - *install_pnpm
-      - apt update && apt install -y bash curl postgresql-client
+      - apt-get update && apt-get install -y bash curl postgresql-client
       - bash api_tests/prepare-drone-federation-test.sh
       - cd api_tests/
       - pnpm i
@@ -279,7 +272,7 @@ steps:
   publish_to_crates_io:
     image: *rust_image
     commands:
-      - <<: *install_binstall
+      - *install_binstall
       # Install cargo-workspaces
       - cargo binstall -y cargo-workspaces
       - cp -r migrations crates/db_schema/

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -41,52 +41,6 @@ steps:
     when:
       - event: [pull_request, tag]
 
-  check_diesel_migration:
-    # TODO: use willsquire/diesel-cli image when shared libraries become optional in lemmy_server
-    image: *rust_image
-    environment:
-      LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
-      RUST_BACKTRACE: "1"
-      CARGO_HOME: .cargo_home
-      DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
-      PGUSER: lemmy
-      PGPASSWORD: password
-      PGHOST: database
-      PGDATABASE: lemmy
-    commands:
-      # Install diesel_cli
-      - <<: *install_diesel_cli
-      # Run all migrations
-      - diesel migration run
-      # Dump schema to before.sqldump (PostgreSQL apt repo is used to prevent pg_dump version mismatch error)
-      - psql -c "DROP SCHEMA IF EXISTS r CASCADE;"
-      - pg_dump --no-owner --no-privileges --no-table-access-method --schema-only --no-sync -f before.sqldump
-      # Make sure that the newest migration is revertable without the `r` schema
-      - diesel migration redo
-      # Run schema setup twice, which fails on the 2nd time if `DROP SCHEMA IF EXISTS r CASCADE` drops the wrong things
-      - alias lemmy_schema_setup="target/lemmy_server --disable-scheduled-tasks --disable-http-server --disable-activity-sending"
-      - lemmy_schema_setup
-      - lemmy_schema_setup
-      # Make sure that the newest migration is revertable with the `r` schema
-      - diesel migration redo
-      # Check for changes in the schema, which would be caused by an incorrect migration
-      - psql -c "DROP SCHEMA IF EXISTS r CASCADE;"
-      - pg_dump --no-owner --no-privileges --no-table-access-method --schema-only --no-sync -f after.sqldump
-      - diff before.sqldump after.sqldump
-    when: *slow_check_paths
-
-  check_diesel_schema:
-    image: *rust_image
-    environment:
-      CARGO_HOME: .cargo_home
-      DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
-    commands:
-      - <<: *install_diesel_cli
-      - diesel migration run
-      - diesel print-schema --config-file=diesel.toml > tmp.schema
-      - diff tmp.schema crates/db_schema/src/schema.rs
-    when: *slow_check_paths
-
   prettier_check:
     image: tmknom/prettier:3.0.0
     commands:
@@ -173,6 +127,18 @@ steps:
       - diff config/defaults.hjson config/defaults_current.hjson
     when: *slow_check_paths
 
+  check_diesel_schema:
+    image: *rust_image
+    environment:
+      CARGO_HOME: .cargo_home
+      DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
+    commands:
+      - <<: *install_diesel_cli
+      - diesel migration run
+      - diesel print-schema --config-file=diesel.toml > tmp.schema
+      - diff tmp.schema crates/db_schema/src/schema.rs
+    when: *slow_check_paths
+
   check_db_perf_tool:
     image: *rust_image
     environment:
@@ -213,6 +179,39 @@ steps:
     commands:
       - export LEMMY_CONFIG_LOCATION=../../config/config.hjson
       - cargo test --workspace --no-fail-fast
+    when: *slow_check_paths
+
+  check_diesel_migration:
+    # TODO: use willsquire/diesel-cli image when shared libraries become optional in lemmy_server
+    image: *rust_image
+    environment:
+      LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
+      RUST_BACKTRACE: "1"
+      CARGO_HOME: .cargo_home
+      DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
+      PGUSER: lemmy
+      PGPASSWORD: password
+      PGHOST: database
+      PGDATABASE: lemmy
+    commands:
+      # Install diesel_cli
+      - <<: *install_diesel_cli
+      # Run all migrations
+      - diesel migration run
+      - psql -c "DROP SCHEMA IF EXISTS r CASCADE;"
+      - pg_dump --no-owner --no-privileges --no-table-access-method --schema-only --no-sync -f before.sqldump
+      # Make sure that the newest migration is revertable without the `r` schema
+      - diesel migration redo
+      # Run schema setup twice, which fails on the 2nd time if `DROP SCHEMA IF EXISTS r CASCADE` drops the wrong things
+      - alias lemmy_schema_setup="target/lemmy_server --disable-scheduled-tasks --disable-http-server --disable-activity-sending"
+      - lemmy_schema_setup
+      - lemmy_schema_setup
+      # Make sure that the newest migration is revertable with the `r` schema
+      - diesel migration redo
+      # Check for changes in the schema, which would be caused by an incorrect migration
+      - psql -c "DROP SCHEMA IF EXISTS r CASCADE;"
+      - pg_dump --no-owner --no-privileges --no-table-access-method --schema-only --no-sync -f after.sqldump
+      - diff before.sqldump after.sqldump
     when: *slow_check_paths
 
   run_federation_tests:
@@ -297,6 +296,7 @@ steps:
 
 services:
   database:
+    # 15-alpine image necessary because of diesel tests
     image: pgautoupgrade/pgautoupgrade:15-alpine
     environment:
       POSTGRES_USER: lemmy

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -14,12 +14,11 @@ variables:
       # - curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc|gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
       # - apt-get update
       # - apt-get install -y postgresql-client-16
-      - apt-get install curl ca-certificates
+      - apt-get update && apt-get install curl ca-certificates
       - install -d /usr/share/postgresql-common/pgdg
       - curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
       - sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-      - apt-get update
-      - apt-get -y install postgresql-client-16
+      - apt-get update && apt-get -y install postgresql-client-16
       - cargo install diesel_cli --no-default-features --features postgres
       - export PATH="$CARGO_HOME/bin:$PATH"
   - &slow_check_paths

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -7,12 +7,6 @@ variables:
   - &install_pnpm "corepack enable pnpm"
   - &install_binstall "wget -O- https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz | tar -xvz -C /usr/local/cargo/bin"
   - install_diesel_cli: &install_diesel_cli
-      # - apt-get update && apt-get install lsb-release
-      # Instructions taken from here: https://www.postgresql.org/download/linux/ubuntu/
-      # - install -d /usr/share/postgresql-common/pgdg
-      # - curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
-      # - sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-      # - apt-get update && apt-get -y install postgresql-client
       - apt-get update && apt-get -y install postgresql-client
       - cargo install diesel_cli --no-default-features --features postgres
       - export PATH="$CARGO_HOME/bin:$PATH"
@@ -46,6 +40,40 @@ steps:
       - git submodule update
     when:
       - event: [pull_request, tag]
+
+  check_diesel_migration:
+    # TODO: use willsquire/diesel-cli image when shared libraries become optional in lemmy_server
+    image: *rust_image
+    environment:
+      LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
+      RUST_BACKTRACE: "1"
+      CARGO_HOME: .cargo_home
+      DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
+      PGUSER: lemmy
+      PGPASSWORD: password
+      PGHOST: database
+      PGDATABASE: lemmy
+    commands:
+      # Install diesel_cli
+      - <<: *install_diesel_cli
+      # Run all migrations
+      - diesel migration run
+      # Dump schema to before.sqldump (PostgreSQL apt repo is used to prevent pg_dump version mismatch error)
+      - psql -c "DROP SCHEMA IF EXISTS r CASCADE;"
+      - pg_dump --no-owner --no-privileges --no-table-access-method --schema-only --no-sync -f before.sqldump
+      # Make sure that the newest migration is revertable without the `r` schema
+      - diesel migration redo
+      # Run schema setup twice, which fails on the 2nd time if `DROP SCHEMA IF EXISTS r CASCADE` drops the wrong things
+      - alias lemmy_schema_setup="target/lemmy_server --disable-scheduled-tasks --disable-http-server --disable-activity-sending"
+      - lemmy_schema_setup
+      - lemmy_schema_setup
+      # Make sure that the newest migration is revertable with the `r` schema
+      - diesel migration redo
+      # Check for changes in the schema, which would be caused by an incorrect migration
+      - psql -c "DROP SCHEMA IF EXISTS r CASCADE;"
+      - pg_dump --no-owner --no-privileges --no-table-access-method --schema-only --no-sync -f after.sqldump
+      - diff before.sqldump after.sqldump
+    when: *slow_check_paths
 
   check_diesel_schema:
     image: *rust_image
@@ -185,40 +213,6 @@ steps:
     commands:
       - export LEMMY_CONFIG_LOCATION=../../config/config.hjson
       - cargo test --workspace --no-fail-fast
-    when: *slow_check_paths
-
-  check_diesel_migration:
-    # TODO: use willsquire/diesel-cli image when shared libraries become optional in lemmy_server
-    image: *rust_image
-    environment:
-      LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
-      RUST_BACKTRACE: "1"
-      CARGO_HOME: .cargo_home
-      DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
-      PGUSER: lemmy
-      PGPASSWORD: password
-      PGHOST: database
-      PGDATABASE: lemmy
-    commands:
-      # Install diesel_cli
-      - <<: *install_diesel_cli
-      # Run all migrations
-      - diesel migration run
-      # Dump schema to before.sqldump (PostgreSQL apt repo is used to prevent pg_dump version mismatch error)
-      - psql -c "DROP SCHEMA IF EXISTS r CASCADE;"
-      - pg_dump --no-owner --no-privileges --no-table-access-method --schema-only --no-sync -f before.sqldump
-      # Make sure that the newest migration is revertable without the `r` schema
-      - diesel migration redo
-      # Run schema setup twice, which fails on the 2nd time if `DROP SCHEMA IF EXISTS r CASCADE` drops the wrong things
-      - alias lemmy_schema_setup="target/lemmy_server --disable-scheduled-tasks --disable-http-server --disable-activity-sending"
-      - lemmy_schema_setup
-      - lemmy_schema_setup
-      # Make sure that the newest migration is revertable with the `r` schema
-      - diesel migration redo
-      # Check for changes in the schema, which would be caused by an incorrect migration
-      - psql -c "DROP SCHEMA IF EXISTS r CASCADE;"
-      - pg_dump --no-owner --no-privileges --no-table-access-method --schema-only --no-sync -f after.sqldump
-      - diff before.sqldump after.sqldump
     when: *slow_check_paths
 
   run_federation_tests:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -14,7 +14,7 @@ variables:
       # - curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc|gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
       # - apt-get update
       # - apt-get install -y postgresql-client-16
-      - apt-get update && apt-get install curl ca-certificates
+      - apt-get update && apt-get install lsb-release
       - install -d /usr/share/postgresql-common/pgdg
       - curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
       - sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -7,10 +7,13 @@ variables:
   - &install_pnpm "corepack enable pnpm"
   - &install_binstall "wget -O- https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz | tar -xvz -C /usr/local/cargo/bin"
   - install_diesel_cli: &install_diesel_cli
-      - apt-get update && apt-get install -y lsb-release build-essential
-      - sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-      - curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc|gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
-      - apt-get update && apt-get install -y postgresql-client-16
+      - apt-get update && apt-get install -y postgresql-common
+      # - apt-get update && apt-get install -y lsb-release build-essential ca-certificates
+      - /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
+      # - sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+      # - curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc|gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
+      # - apt-get update
+      # - apt-get install -y postgresql-client-16
       - cargo install diesel_cli --no-default-features --features postgres
       - export PATH="$CARGO_HOME/bin:$PATH"
   - &slow_check_paths
@@ -43,6 +46,18 @@ steps:
       - git submodule update
     when:
       - event: [pull_request, tag]
+
+  check_diesel_schema:
+    image: *rust_image
+    environment:
+      CARGO_HOME: .cargo_home
+      DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
+    commands:
+      - <<: *install_diesel_cli
+      - diesel migration run
+      - diesel print-schema --config-file=diesel.toml > tmp.schema
+      - diff tmp.schema crates/db_schema/src/schema.rs
+    when: *slow_check_paths
 
   prettier_check:
     image: tmknom/prettier:3.0.0
@@ -128,18 +143,6 @@ steps:
       - export LEMMY_CONFIG_LOCATION=./config/config.hjson
       - ./scripts/update_config_defaults.sh config/defaults_current.hjson
       - diff config/defaults.hjson config/defaults_current.hjson
-    when: *slow_check_paths
-
-  check_diesel_schema:
-    image: *rust_image
-    environment:
-      CARGO_HOME: .cargo_home
-      DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
-    commands:
-      - <<: *install_diesel_cli
-      - diesel migration run
-      - diesel print-schema --config-file=diesel.toml > tmp.schema
-      - diff tmp.schema crates/db_schema/src/schema.rs
     when: *slow_check_paths
 
   check_db_perf_tool:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -7,13 +7,14 @@ variables:
   - &install_pnpm "corepack enable pnpm"
   - &install_binstall "wget -O- https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz | tar -xvz -C /usr/local/cargo/bin"
   - install_diesel_cli: &install_diesel_cli
-      - apt update && apt -y install curl lsb-release ca-certificates
+      - apt-get update && apt-get -y install curl lsb-release ca-certificates
       # Instructions taken from here: https://www.postgresql.org/download/linux/ubuntu/
       - install -d /usr/share/postgresql-common/pgdg
       - curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
       - sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-      - apt update
-      - apt -y install postgresql-client-16
+      - apt-get update
+      - apt-cache search postgresql
+      - apt-get -y install postgresql-client-16
       - cargo install diesel_cli --no-default-features --features postgres
       - export PATH="$CARGO_HOME/bin:$PATH"
   - &slow_check_paths

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -13,7 +13,7 @@ variables:
       - curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
       - sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
       - apt-get update
-      - apt-get -y install postgresql-client-16
+      - apt-get -y install postgresql-16
       - cargo install diesel_cli --no-default-features --features postgres
       - export PATH="$CARGO_HOME/bin:$PATH"
   - &slow_check_paths

--- a/docker/federation/docker-compose.yml
+++ b/docker/federation/docker-compose.yml
@@ -20,7 +20,7 @@ x-lemmy-default: &lemmy-default
   restart: always
 
 x-postgres-default: &postgres-default
-  image: pgautoupgrade/pgautoupgrade:16-alpine
+  image: pgautoupgrade/pgautoupgrade:15-alpine
   environment:
     - POSTGRES_USER=lemmy
     - POSTGRES_PASSWORD=password


### PR DESCRIPTION
We're always getting failing tests by manually adding the postgres's apt repository to get `postgres-client-16`. I'm fairly certain its due to their apt repository having intermittent issues.

This downgrades our test woodpecker test DB to `postgres-15`, so we can get the client from debians official repo.