### PR TITLE
fix: Run extract_opengraph_data only on first 64kB of data and if Content-Type html

### DIFF
--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -106,14 +106,13 @@ async fn collect_bytes_until_limit(
 ) -> Result<Vec<u8>, LemmyError> {
   let mut stream = response.bytes_stream();
   let mut bytes = Vec::with_capacity(requested_bytes);
-  let mut total_bytes = 0;
   while let Some(chunk) = stream.next().await {
     let chunk = chunk.map_err(LemmyError::from)?;
-    total_bytes += chunk.len();
     // we may go over the requested size here but the important part is we don't keep aggregating
     // more chunks than needed
     bytes.extend_from_slice(&chunk);
-    if total_bytes >= requested_bytes {
+    if bytes.len() >= requested_bytes {
+      bytes.truncate(requested_bytes);
       break;
     }
   }


### PR DESCRIPTION
Currently, for metadata extraction the full data is fetched, converted lossily to a string and then parsed as HTML. 

This is expensive: It takes 10-20s of 100% CPU to parse a 20MB response. 1+MB responses are common for image, gif, video URLs.

This changes that method, it tries to fetch only the first 64kB of data and then only runs the expensive HTML parsing if there is no null byte in the data. After this, the whole API request only takes ~0.1 s (including the external fetch)

Fixes #4956.
