### PR TITLE
In debug mode allow resolving objects without auth

### DIFF
--- a/crates/apub/src/api/resolve_object.rs
+++ b/crates/apub/src/api/resolve_object.rs
@@ -27,7 +27,7 @@ pub async fn resolve_object(
   // if there's no personId then the JWT was missing or invalid.
   let is_authenticated = local_user_view.is_some();
 
-  let res = if is_authenticated {
+  let res = if is_authenticated || cfg!(debug_assertions) {
     // user is fully authenticated; allow remote lookups as well.
     search_query_to_object_id(data.q.clone(), &context).await
   } else {


### PR DESCRIPTION
Makes debugging a bit easier, I kept commenting this line out manually.