### PR TITLE
Add option to search exclusively by post title

### DIFF
--- a/crates/api_common/src/site.rs
+++ b/crates/api_common/src/site.rs
@@ -77,6 +77,7 @@ pub struct Search {
   pub listing_type: Option<ListingType>,
   pub page: Option<i64>,
   pub limit: Option<i64>,
+  pub post_title_only: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/crates/apub/src/api/search.rs
+++ b/crates/apub/src/api/search.rs
@@ -206,7 +206,7 @@ pub async fn search(
         listing_type: (listing_type),
         community_id: (community_id),
         creator_id: (creator_id),
-        url_search: (Some(q)),
+        search_term: (Some(q)),
         local_user,
         page: (page),
         limit: (limit),

--- a/crates/apub/src/api/search.rs
+++ b/crates/apub/src/api/search.rs
@@ -200,6 +200,22 @@ pub async fn search(
       .list(&local_site.site, &mut context.pool())
       .await?;
     }
+    SearchType::Title => {
+      posts = PostQuery {
+        sort: (sort),
+        listing_type: (listing_type),
+        community_id: (community_id),
+        creator_id: (creator_id),
+        url_search: (Some(q)),
+        local_user,
+        page: (page),
+        limit: (limit),
+        title_only: (Some(true)),
+        ..Default::default()
+      }
+      .list(&local_site.site, &mut context.pool())
+      .await?;
+    }
   };
 
   // Return the jwt

--- a/crates/apub/src/api/search.rs
+++ b/crates/apub/src/api/search.rs
@@ -57,21 +57,23 @@ pub async fn search(
   let creator_id = data.creator_id;
   let local_user = local_user_view.as_ref().map(|l| &l.local_user);
 
+  let mut posts_query = PostQuery {
+    sort: (sort),
+    listing_type: (listing_type),
+    community_id: (community_id),
+    creator_id: (creator_id),
+    local_user,
+    search_term: (Some(q.clone())),
+    page: (page),
+    limit: (limit),
+    ..Default::default()
+  };
+
   match search_type {
     SearchType::Posts => {
-      posts = PostQuery {
-        sort: (sort),
-        listing_type: (listing_type),
-        community_id: (community_id),
-        creator_id: (creator_id),
-        local_user,
-        search_term: (Some(q)),
-        page: (page),
-        limit: (limit),
-        ..Default::default()
-      }
-      .list(&local_site.site, &mut context.pool())
-      .await?;
+      posts = posts_query
+        .list(&local_site.site, &mut context.pool())
+        .await?;
     }
     SearchType::Comments => {
       comments = CommentQuery {
@@ -118,21 +120,9 @@ pub async fn search(
       let community_or_creator_included =
         data.community_id.is_some() || data.community_name.is_some() || data.creator_id.is_some();
 
-      let q = data.q.clone();
-
-      posts = PostQuery {
-        sort: (sort),
-        listing_type: (listing_type),
-        community_id: (community_id),
-        creator_id: (creator_id),
-        local_user,
-        search_term: (Some(q)),
-        page: (page),
-        limit: (limit),
-        ..Default::default()
-      }
-      .list(&local_site.site, &mut context.pool())
-      .await?;
+      posts = posts_query
+        .list(&local_site.site, &mut context.pool())
+        .await?;
 
       let q = data.q.clone();
 
@@ -200,21 +190,11 @@ pub async fn search(
       .list(&local_site.site, &mut context.pool())
       .await?;
     }
-    SearchType::Title => {
-      posts = PostQuery {
-        sort: (sort),
-        listing_type: (listing_type),
-        community_id: (community_id),
-        creator_id: (creator_id),
-        search_term: (Some(q)),
-        local_user,
-        page: (page),
-        limit: (limit),
-        title_only: (Some(true)),
-        ..Default::default()
-      }
-      .list(&local_site.site, &mut context.pool())
-      .await?;
+    SearchType::PostTitle => {
+      posts_query.title_only = Some(true);
+      posts = posts_query
+        .list(&local_site.site, &mut context.pool())
+        .await?;
     }
   };
 

--- a/crates/apub/src/api/search.rs
+++ b/crates/apub/src/api/search.rs
@@ -144,7 +144,7 @@ pub async fn search(
         person_query.list(&mut context.pool()).await?
       };
     }
-    SearchType::PostUrl => {
+    SearchType::Url => {
       posts = PostQuery {
         sort: (sort),
         listing_type: (listing_type),

--- a/crates/db_schema/src/lib.rs
+++ b/crates/db_schema/src/lib.rs
@@ -174,8 +174,7 @@ pub enum SearchType {
   Posts,
   Communities,
   Users,
-  Url,
-  PostTitle,
+  PostUrl,
 }
 
 #[derive(EnumString, Display, Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Copy, Hash)]

--- a/crates/db_schema/src/lib.rs
+++ b/crates/db_schema/src/lib.rs
@@ -175,6 +175,7 @@ pub enum SearchType {
   Communities,
   Users,
   Url,
+  Title,
 }
 
 #[derive(EnumString, Display, Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Copy, Hash)]

--- a/crates/db_schema/src/lib.rs
+++ b/crates/db_schema/src/lib.rs
@@ -175,7 +175,7 @@ pub enum SearchType {
   Communities,
   Users,
   Url,
-  Title,
+  PostTitle,
 }
 
 #[derive(EnumString, Display, Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Copy, Hash)]

--- a/crates/db_schema/src/lib.rs
+++ b/crates/db_schema/src/lib.rs
@@ -174,7 +174,7 @@ pub enum SearchType {
   Posts,
   Communities,
   Users,
-  PostUrl,
+  Url,
 }
 
 #[derive(EnumString, Display, Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Copy, Hash)]

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -387,13 +387,22 @@ fn queries<'a>() -> Queries<
 
     if let Some(search_term) = &options.search_term {
       let searcher = fuzzy_search(search_term);
-      query = query
+      if options.title_only.unwrap_or_default() {
+        query = query
         .filter(
           post::name
-            .ilike(searcher.clone())
-            .or(post::body.ilike(searcher)),
+            .ilike(searcher)
         )
         .filter(not(post::removed.or(post::deleted)));
+      } else {
+        query = query
+          .filter(
+            post::name
+              .ilike(searcher.clone())
+              .or(post::body.ilike(searcher)),
+          )
+          .filter(not(post::removed.or(post::deleted)));
+      }
     }
 
     if !options
@@ -617,6 +626,7 @@ pub struct PostQuery<'a> {
   pub saved_only: Option<bool>,
   pub liked_only: Option<bool>,
   pub disliked_only: Option<bool>,
+  pub title_only: Option<bool>,
   pub page: Option<i64>,
   pub limit: Option<i64>,
   pub page_after: Option<PaginationCursorData>,

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -389,11 +389,8 @@ fn queries<'a>() -> Queries<
       let searcher = fuzzy_search(search_term);
       if options.title_only.unwrap_or_default() {
         query = query
-        .filter(
-          post::name
-            .ilike(searcher)
-        )
-        .filter(not(post::removed.or(post::deleted)));
+          .filter(post::name.ilike(searcher))
+          .filter(not(post::removed.or(post::deleted)));
       } else {
         query = query
           .filter(

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -387,19 +387,16 @@ fn queries<'a>() -> Queries<
 
     if let Some(search_term) = &options.search_term {
       let searcher = fuzzy_search(search_term);
-      if options.title_only.unwrap_or_default() {
-        query = query
-          .filter(post::name.ilike(searcher))
-          .filter(not(post::removed.or(post::deleted)));
+      query = if options.title_only.unwrap_or_default() {
+        query.filter(post::name.ilike(searcher))
       } else {
-        query = query
-          .filter(
-            post::name
-              .ilike(searcher.clone())
-              .or(post::body.ilike(searcher)),
-          )
-          .filter(not(post::removed.or(post::deleted)));
+        query.filter(
+          post::name
+            .ilike(searcher.clone())
+            .or(post::body.ilike(searcher)),
+        )
       }
+      .filter(not(post::removed.or(post::deleted)));
     }
 
     if !options


### PR DESCRIPTION
This PR covers #4677  and does the following:
- Adds a new ```SearchType``` called ```Title```.
- Adds a new boolean member to ```PostQuery``` called ```title_only```.
- For the ```Title``` arm in search, use the existing ```PostQuery``` with ```title_only``` set to ```true```.
- If ```title_only``` is ```true```, omit ```or(post::body.ilike...``` from ```queries```