### PR TITLE
Conditionally hide comments on nsfw posts (fixes #4237)

### DIFF
--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -854,12 +854,13 @@ pub async fn remove_or_restore_user_data_in_community(
 
   // Comments
   // TODO Diesel doesn't allow updates with joins, so this has to be a loop
+  let site = Site::read_local(pool).await?;
   let comments = CommentQuery {
     creator_id: Some(banned_person_id),
     community_id: Some(community_id),
     ..Default::default()
   }
-  .list(pool)
+  .list(&site, pool)
   .await?;
 
   for comment_view in &comments {

--- a/crates/apub/src/api/list_comments.rs
+++ b/crates/apub/src/api/list_comments.rs
@@ -12,10 +12,13 @@ use lemmy_api_common::{
   utils::check_private_instance,
 };
 use lemmy_db_schema::{
-  source::{comment::Comment, community::Community, local_site::LocalSite},
+  source::{comment::Comment, community::Community},
   traits::Crud,
 };
-use lemmy_db_views::{comment_view::CommentQuery, structs::LocalUserView};
+use lemmy_db_views::{
+  comment_view::CommentQuery,
+  structs::{LocalUserView, SiteView},
+};
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 #[tracing::instrument(skip(context))]
@@ -24,8 +27,8 @@ pub async fn list_comments(
   context: Data<LemmyContext>,
   local_user_view: Option<LocalUserView>,
 ) -> LemmyResult<Json<GetCommentsResponse>> {
-  let local_site = LocalSite::read(&mut context.pool()).await?;
-  check_private_instance(&local_user_view, &local_site)?;
+  let site_view = SiteView::read_local(&mut context.pool()).await?;
+  check_private_instance(&local_user_view, &site_view.local_site)?;
 
   let community_id = if let Some(name) = &data.community_name {
     Some(
@@ -40,7 +43,7 @@ pub async fn list_comments(
   let sort = Some(comment_sort_type_with_default(
     data.sort,
     local_user_ref,
-    &local_site,
+    &site_view.local_site,
   ));
   let max_depth = data.max_depth;
   let saved_only = data.saved_only;
@@ -58,7 +61,7 @@ pub async fn list_comments(
   let listing_type = Some(listing_type_with_default(
     data.type_,
     local_user_view.as_ref().map(|u| &u.local_user),
-    &local_site,
+    &site_view.local_site,
     community_id,
   ));
 
@@ -93,7 +96,7 @@ pub async fn list_comments(
     limit,
     ..Default::default()
   }
-  .list(&mut context.pool())
+  .list(&site_view.site, &mut context.pool())
   .await
   .with_lemmy_type(LemmyErrorType::CouldntGetComments)?;
 

--- a/crates/apub/src/api/read_person.rs
+++ b/crates/apub/src/api/read_person.rs
@@ -88,7 +88,7 @@ pub async fn read_person(
     creator_id,
     ..Default::default()
   }
-  .list(&mut context.pool())
+  .list(&local_site.site, &mut context.pool())
   .await?;
 
   let moderates = CommunityModeratorView::for_person(

--- a/crates/apub/src/api/search.rs
+++ b/crates/apub/src/api/search.rs
@@ -107,7 +107,9 @@ pub async fn search(
         .await?;
     }
     SearchType::Comments => {
-      comments = comment_query.list(&mut context.pool()).await?;
+      comments = comment_query
+        .list(&local_site.site, &mut context.pool())
+        .await?;
     }
     SearchType::Communities => {
       communities = community_query
@@ -126,7 +128,9 @@ pub async fn search(
         .list(&local_site.site, &mut context.pool())
         .await?;
 
-      comments = comment_query.list(&mut context.pool()).await?;
+      comments = comment_query
+        .list(&local_site.site, &mut context.pool())
+        .await?;
 
       communities = if community_or_creator_included {
         vec![]


### PR DESCRIPTION
Same logic which is used by post_view, except I havent an explicit api parameter for show_nsfw.