### PR TITLE
Ignore zero values when setting rate limits (fixes #4280)

### DIFF
--- a/crates/api_crud/src/site/create.rs
+++ b/crates/api_crud/src/site/create.rs
@@ -1,3 +1,4 @@
+use super::not_zero;
 use crate::site::{application_question_check, site_default_post_listing_type_check};
 use activitypub_federation::{config::Data, http_signatures::generate_actor_keypair};
 use actix_web::web::Json;
@@ -40,8 +41,6 @@ use lemmy_utils::{
   },
 };
 use url::Url;
-
-use super::not_zero;
 
 #[tracing::instrument(skip(context))]
 pub async fn create_site(

--- a/crates/api_crud/src/site/create.rs
+++ b/crates/api_crud/src/site/create.rs
@@ -41,6 +41,8 @@ use lemmy_utils::{
 };
 use url::Url;
 
+use super::not_zero;
+
 #[tracing::instrument(skip(context))]
 pub async fn create_site(
   data: Json<CreateSite>,
@@ -117,17 +119,17 @@ pub async fn create_site(
 
   let local_site_rate_limit_form = LocalSiteRateLimitUpdateForm {
     message: data.rate_limit_message,
-    message_per_second: data.rate_limit_message_per_second,
+    message_per_second: not_zero(data.rate_limit_message_per_second),
     post: data.rate_limit_post,
-    post_per_second: data.rate_limit_post_per_second,
+    post_per_second: not_zero(data.rate_limit_post_per_second),
     register: data.rate_limit_register,
-    register_per_second: data.rate_limit_register_per_second,
+    register_per_second: not_zero(data.rate_limit_register_per_second),
     image: data.rate_limit_image,
-    image_per_second: data.rate_limit_image_per_second,
+    image_per_second: not_zero(data.rate_limit_image_per_second),
     comment: data.rate_limit_comment,
-    comment_per_second: data.rate_limit_comment_per_second,
+    comment_per_second: not_zero(data.rate_limit_comment_per_second),
     search: data.rate_limit_search,
-    search_per_second: data.rate_limit_search_per_second,
+    search_per_second: not_zero(data.rate_limit_search_per_second),
     ..Default::default()
   };
 

--- a/crates/api_crud/src/site/mod.rs
+++ b/crates/api_crud/src/site/mod.rs
@@ -40,12 +40,19 @@ pub fn application_question_check(
   }
 }
 
+fn not_zero(val: Option<i32>) -> Option<i32> {
+  match val {
+    Some(0) => None,
+    v => v,
+  }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 #[allow(clippy::indexing_slicing)]
 mod tests {
 
-  use crate::site::{application_question_check, site_default_post_listing_type_check};
+  use crate::site::{application_question_check, not_zero, site_default_post_listing_type_check};
   use lemmy_db_schema::{ListingType, RegistrationMode};
 
   #[test]
@@ -93,11 +100,11 @@ mod tests {
       RegistrationMode::RequireApplication
     );
   }
-}
 
-fn not_zero(val: Option<i32>) -> Option<i32> {
-  match val {
-    Some(0) => None,
-    v => v,
+  #[test]
+  fn test_not_zero() {
+    assert_eq!(None, not_zero(None));
+    assert_eq!(None, not_zero(Some(0)));
+    assert_eq!(Some(5), not_zero(Some(5)));
   }
 }

--- a/crates/api_crud/src/site/mod.rs
+++ b/crates/api_crud/src/site/mod.rs
@@ -98,6 +98,6 @@ mod tests {
 fn not_zero(val: Option<i32>) -> Option<i32> {
   match val {
     Some(0) => None,
-    v => v
+    v => v,
   }
 }

--- a/crates/api_crud/src/site/mod.rs
+++ b/crates/api_crud/src/site/mod.rs
@@ -94,3 +94,10 @@ mod tests {
     );
   }
 }
+
+fn not_zero(val: Option<i32>) -> Option<i32> {
+  match val {
+    Some(0) => None,
+    v => v
+  }
+}

--- a/crates/api_crud/src/site/update.rs
+++ b/crates/api_crud/src/site/update.rs
@@ -1,3 +1,4 @@
+use super::not_zero;
 use crate::site::{application_question_check, site_default_post_listing_type_check};
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
@@ -45,8 +46,6 @@ use lemmy_utils::{
     },
   },
 };
-
-use super::not_zero;
 
 #[tracing::instrument(skip(context))]
 pub async fn update_site(

--- a/crates/api_crud/src/site/update.rs
+++ b/crates/api_crud/src/site/update.rs
@@ -46,6 +46,8 @@ use lemmy_utils::{
   },
 };
 
+use super::not_zero;
+
 #[tracing::instrument(skip(context))]
 pub async fn update_site(
   data: Json<EditSite>,
@@ -130,17 +132,17 @@ pub async fn update_site(
 
   let local_site_rate_limit_form = LocalSiteRateLimitUpdateForm {
     message: data.rate_limit_message,
-    message_per_second: data.rate_limit_message_per_second,
+    message_per_second: not_zero(data.rate_limit_message_per_second),
     post: data.rate_limit_post,
-    post_per_second: data.rate_limit_post_per_second,
+    post_per_second: not_zero(data.rate_limit_post_per_second),
     register: data.rate_limit_register,
-    register_per_second: data.rate_limit_register_per_second,
+    register_per_second: not_zero(data.rate_limit_register_per_second),
     image: data.rate_limit_image,
-    image_per_second: data.rate_limit_image_per_second,
+    image_per_second: not_zero(data.rate_limit_image_per_second),
     comment: data.rate_limit_comment,
-    comment_per_second: data.rate_limit_comment_per_second,
+    comment_per_second: not_zero(data.rate_limit_comment_per_second),
     search: data.rate_limit_search,
-    search_per_second: data.rate_limit_search_per_second,
+    search_per_second: not_zero(data.rate_limit_search_per_second),
     ..Default::default()
   };
 


### PR DESCRIPTION
Havent bothered to add an error message for such an uncommon case.