### PR TITLE
Add category to RSS feeds (fixes #3446)

### DIFF
--- a/crates/routes/src/feeds.rs
+++ b/crates/routes/src/feeds.rs
@@ -27,6 +27,7 @@ use lemmy_utils::{
 };
 use rss::{
   extension::{dublincore::DublinCoreExtension, ExtensionBuilder, ExtensionMap},
+  Category,
   Channel,
   EnclosureBuilder,
   Guid,
@@ -559,6 +560,10 @@ fn create_post_items(posts: Vec<PostView>, protocol_and_hostname: &str) -> Lemmy
         BTreeMap::from([("content".to_string(), vec![thumbnail_ext.build()])]),
       );
     }
+    let category = Category {
+      name: p.community.title,
+      domain: Some(p.community.actor_id.to_string()),
+    };
 
     let i = Item {
       title: Some(sanitize_html(sanitize_xml(p.post.name).as_str())),
@@ -570,6 +575,7 @@ fn create_post_items(posts: Vec<PostView>, protocol_and_hostname: &str) -> Lemmy
       link: Some(post_url.clone()),
       extensions,
       enclosure: enclosure_opt,
+      categories: vec![category],
       ..Default::default()
     };
 


### PR DESCRIPTION
Adds a field like `<category domain="https://lemmy-alpha/c/test">Test Community</category>`