### PR TITLE
Simplify handling of NotFound SQL errors (fixes #4633)

### DIFF
--- a/crates/api_crud/src/post/read.rs
+++ b/crates/api_crud/src/post/read.rs
@@ -40,10 +40,7 @@ pub async fn get_post(
   };
 
   // Check to see if the person is a mod or admin, to show deleted / removed
-  let community_id = Post::read(&mut context.pool(), post_id)
-    .await?
-    .ok_or(LemmyErrorType::CouldntFindPost)?
-    .community_id;
+  let community_id = Post::read_xx(&mut context.pool(), post_id).await?.community_id;
 
   let is_mod_or_admin = is_mod_or_admin_opt(
     &mut context.pool(),

--- a/crates/db_schema/src/impls/post.rs
+++ b/crates/db_schema/src/impls/post.rs
@@ -68,6 +68,10 @@ impl Crud for Post {
 }
 
 impl Post {
+  pub async fn read_xx(pool: &mut DbPool<'_>, id: PostId) -> Result<Self, Error> {
+    let conn = &mut *get_conn(pool).await?;
+    post::table.find(id).first(conn).await
+  }
   pub async fn insert_apub(
     pool: &mut DbPool<'_>,
     timestamp: DateTime<Utc>,


### PR DESCRIPTION
There is actually no reason to use `.optional().ok_or(LemmyErrorType::CouldntFindPost)?` for all SQL queries. Instead we can simply convert from diesel::NotFound to LemmyErrorType::NotFound in our error implementation.