### PR TITLE
Cleanup remaining use of Result<bool, Error> (fixes #4862)

### DIFF
--- a/crates/api_crud/src/user/create.rs
+++ b/crates/api_crud/src/user/create.rs
@@ -107,9 +107,7 @@ pub async fn register(
   check_slurs(&data.username, &slur_regex)?;
   check_slurs_opt(&data.answer, &slur_regex)?;
 
-  if Person::is_username_taken(&mut context.pool(), &data.username).await? {
-    return Err(LemmyErrorType::UsernameAlreadyExists)?;
-  }
+  Person::check_username_taken(&mut context.pool(), &data.username).await?;
 
   if let Some(email) = &data.email {
     LocalUser::check_is_email_taken(&mut context.pool(), email).await?;
@@ -329,9 +327,7 @@ pub async fn authenticate_with_oauth(
       check_slurs(username, &slur_regex)?;
       check_slurs_opt(&data.answer, &slur_regex)?;
 
-      if Person::is_username_taken(&mut context.pool(), username).await? {
-        return Err(LemmyErrorType::UsernameAlreadyExists)?;
-      }
+      Person::check_username_taken(&mut context.pool(), username).await?;
 
       // We have to create a person, a local_user, and an oauth_account
       person = create_person(

--- a/crates/db_schema/src/impls/oauth_account.rs
+++ b/crates/db_schema/src/impls/oauth_account.rs
@@ -1,48 +1,18 @@
 use crate::{
-  newtypes::{LocalUserId, OAuthProviderId},
+  newtypes::LocalUserId,
   schema::{oauth_account, oauth_account::dsl::local_user_id},
   source::oauth_account::{OAuthAccount, OAuthAccountInsertForm},
   utils::{get_conn, DbPool},
 };
-use diesel::{
-  dsl::{exists, insert_into},
-  result::Error,
-  select,
-  ExpressionMethods,
-  QueryDsl,
-};
+use diesel::{insert_into, result::Error, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 
 impl OAuthAccount {
-  pub async fn read(
-    pool: &mut DbPool<'_>,
-    for_oauth_provider_id: OAuthProviderId,
-    for_local_user_id: LocalUserId,
-  ) -> Result<bool, Error> {
-    let conn = &mut get_conn(pool).await?;
-    select(exists(
-      oauth_account::table.find((for_oauth_provider_id, for_local_user_id)),
-    ))
-    .get_result(conn)
-    .await
-  }
-
   pub async fn create(pool: &mut DbPool<'_>, form: &OAuthAccountInsertForm) -> Result<Self, Error> {
     let conn = &mut get_conn(pool).await?;
     insert_into(oauth_account::table)
       .values(form)
       .get_result::<Self>(conn)
-      .await
-  }
-
-  pub async fn delete(
-    pool: &mut DbPool<'_>,
-    for_oauth_provider_id: OAuthProviderId,
-    for_local_user_id: LocalUserId,
-  ) -> Result<usize, Error> {
-    let conn = &mut get_conn(pool).await?;
-    diesel::delete(oauth_account::table.find((for_oauth_provider_id, for_local_user_id)))
-      .execute(conn)
       .await
   }
 

--- a/crates/db_schema/src/impls/person.rs
+++ b/crates/db_schema/src/impls/person.rs
@@ -21,6 +21,7 @@ use diesel::{
   QueryDsl,
 };
 use diesel_async::RunQueryDsl;
+use lemmy_utils::{error::LemmyResult, LemmyErrorType};
 
 #[async_trait]
 impl Crud for Person {
@@ -121,16 +122,18 @@ impl Person {
       .await
   }
 
-  pub async fn is_username_taken(pool: &mut DbPool<'_>, username: &str) -> Result<bool, Error> {
+  pub async fn check_username_taken(pool: &mut DbPool<'_>, username: &str) -> LemmyResult<()> {
     use diesel::dsl::{exists, select};
     let conn = &mut get_conn(pool).await?;
-    select(exists(
+    select(not(exists(
       person::table
         .filter(lower(person::name).eq(username.to_lowercase()))
         .filter(person::local.eq(true)),
-    ))
-    .get_result(conn)
-    .await
+    )))
+    .get_result::<bool>(conn)
+    .await?
+    .then_some(())
+    .ok_or(LemmyErrorType::UsernameAlreadyExists.into())
   }
 }
 


### PR DESCRIPTION
Found a last case with `rg "Result<bool"`, as well as some unused oauth functions. There is [one more place with Result<bool>](https://github.com/LemmyNet/lemmy/blob/main/crates/api_crud/src/user/create.rs#L477) but that one looks fine because the bool is returned via api, not used in Rust.