### PR TITLE
Replace clippy allow annotation with expect (fixes #5012)

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -265,8 +265,6 @@ pub async fn local_user_view_from_jwt(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
 mod tests {
 
   use super::*;

--- a/crates/api/src/site/registration_applications/tests.rs
+++ b/crates/api/src/site/registration_applications/tests.rs
@@ -34,7 +34,7 @@ use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::{error::LemmyResult, LemmyErrorType, CACHE_DURATION_API};
 use serial_test::serial;
 
-#[allow(clippy::unwrap_used)]
+#[expect(clippy::unwrap_used)]
 async fn create_test_site(context: &Data<LemmyContext>) -> LemmyResult<(Instance, LocalUserView)> {
   let pool = &mut context.pool();
 
@@ -109,7 +109,7 @@ async fn signup(
   Ok((local_user, application))
 }
 
-#[allow(clippy::unwrap_used)]
+#[expect(clippy::unwrap_used)]
 async fn get_application_statuses(
   context: &Data<LemmyContext>,
   admin: LocalUserView,
@@ -138,10 +138,9 @@ async fn get_application_statuses(
   Ok((application_count, unread_applications, all_applications))
 }
 
-#[allow(clippy::indexing_slicing)]
-#[allow(clippy::unwrap_used)]
-#[tokio::test]
 #[serial]
+#[tokio::test]
+#[expect(clippy::indexing_slicing)]
 async fn test_application_approval() -> LemmyResult<()> {
   let context = LemmyContext::init_test_context().await;
   let pool = &mut context.pool();

--- a/crates/api/src/sitemap.rs
+++ b/crates/api/src/sitemap.rs
@@ -42,7 +42,7 @@ pub async fn get_sitemap(context: Data<LemmyContext>) -> LemmyResult<HttpRespons
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[expect(clippy::unwrap_used)]
 pub(crate) mod tests {
 
   use crate::sitemap::generate_urlset;

--- a/crates/api_common/src/claims.rs
+++ b/crates/api_common/src/claims.rs
@@ -69,8 +69,7 @@ impl Claims {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
 mod tests {
 
   use crate::{claims::Claims, context::LemmyContext};

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -471,8 +471,7 @@ pub async fn replace_image(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
 mod tests {
 
   use crate::{

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -1067,8 +1067,7 @@ fn build_proxied_image_url(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
 mod tests {
 
   use super::*;

--- a/crates/api_crud/src/site/create.rs
+++ b/crates/api_crud/src/site/create.rs
@@ -189,8 +189,6 @@ fn validate_create_payload(local_site: &LocalSite, create_site: &CreateSite) -> 
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
 mod tests {
 
   use crate::site::create::validate_create_payload;

--- a/crates/api_crud/src/site/mod.rs
+++ b/crates/api_crud/src/site/mod.rs
@@ -48,8 +48,6 @@ fn not_zero(val: Option<i32>) -> Option<i32> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
 mod tests {
 
   use crate::site::{application_question_check, not_zero, site_default_post_listing_type_check};

--- a/crates/api_crud/src/site/update.rs
+++ b/crates/api_crud/src/site/update.rs
@@ -241,8 +241,6 @@ fn validate_update_payload(local_site: &LocalSite, edit_site: &EditSite) -> Lemm
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
 mod tests {
 
   use crate::site::update::validate_update_payload;

--- a/crates/apub/src/activity_lists.rs
+++ b/crates/apub/src/activity_lists.rs
@@ -123,7 +123,6 @@ impl InCommunity for AnnouncableActivities {
 }
 
 #[cfg(test)]
-#[allow(clippy::indexing_slicing)]
 mod tests {
 
   use crate::{

--- a/crates/apub/src/api/user_settings_backup.rs
+++ b/crates/apub/src/api/user_settings_backup.rs
@@ -308,8 +308,9 @@ where
   });
   Ok(failed_items.into_iter().join(","))
 }
+
 #[cfg(test)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::indexing_slicing)]
 mod tests {
 
   use crate::api::user_settings_backup::{export_settings, import_settings, UserSettingsBackup};

--- a/crates/apub/src/collections/community_moderators.rs
+++ b/crates/apub/src/collections/community_moderators.rs
@@ -98,7 +98,7 @@ impl Collection for ApubCommunityModerators {
 }
 
 #[cfg(test)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::indexing_slicing)]
 mod tests {
 
   use super::*;

--- a/crates/apub/src/http/community.rs
+++ b/crates/apub/src/http/community.rs
@@ -120,8 +120,7 @@ pub(crate) async fn get_apub_community_featured(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
 pub(crate) mod tests {
 
   use super::*;

--- a/crates/db_perf/src/series.rs
+++ b/crates/db_perf/src/series.rs
@@ -75,7 +75,7 @@ impl<S: ValidGrouping<(), IsAggregate = is_aggregate::No>> ValidGrouping<()>
   type IsAggregate = is_aggregate::No;
 }
 
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 #[derive(QueryId, Clone, Copy, Debug)]
 pub struct current_value;
 

--- a/crates/db_schema/src/aggregates/comment_aggregates.rs
+++ b/crates/db_schema/src/aggregates/comment_aggregates.rs
@@ -30,8 +30,7 @@ impl CommentAggregates {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
 mod tests {
 
   use crate::{

--- a/crates/db_schema/src/aggregates/community_aggregates.rs
+++ b/crates/db_schema/src/aggregates/community_aggregates.rs
@@ -36,8 +36,7 @@ impl CommunityAggregates {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
 mod tests {
 
   use crate::{

--- a/crates/db_schema/src/aggregates/person_aggregates.rs
+++ b/crates/db_schema/src/aggregates/person_aggregates.rs
@@ -20,8 +20,7 @@ impl PersonAggregates {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
 mod tests {
 
   use crate::{

--- a/crates/db_schema/src/aggregates/post_aggregates.rs
+++ b/crates/db_schema/src/aggregates/post_aggregates.rs
@@ -49,8 +49,8 @@ impl PostAggregates {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
+
 mod tests {
 
   use crate::{

--- a/crates/db_schema/src/aggregates/site_aggregates.rs
+++ b/crates/db_schema/src/aggregates/site_aggregates.rs
@@ -15,8 +15,8 @@ impl SiteAggregates {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
+
 mod tests {
 
   use crate::{

--- a/crates/db_schema/src/impls/activity.rs
+++ b/crates/db_schema/src/impls/activity.rs
@@ -58,8 +58,7 @@ impl ReceivedActivity {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
 mod tests {
 
   use super::*;

--- a/crates/db_schema/src/impls/actor_language.rs
+++ b/crates/db_schema/src/impls/actor_language.rs
@@ -392,8 +392,8 @@ async fn convert_read_languages(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
+#[expect(clippy::indexing_slicing)]
 mod tests {
 
   use super::*;

--- a/crates/db_schema/src/impls/captcha_answer.rs
+++ b/crates/db_schema/src/impls/captcha_answer.rs
@@ -51,8 +51,6 @@ impl CaptchaAnswer {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
 mod tests {
 
   use crate::{

--- a/crates/db_schema/src/impls/comment.rs
+++ b/crates/db_schema/src/impls/comment.rs
@@ -196,8 +196,7 @@ impl Saveable for CommentSaved {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
 mod tests {
 
   use crate::{

--- a/crates/db_schema/src/impls/community.rs
+++ b/crates/db_schema/src/impls/community.rs
@@ -431,7 +431,6 @@ impl ApubActor for Community {
 }
 
 #[cfg(test)]
-#[allow(clippy::indexing_slicing)]
 mod tests {
   use crate::{
     source::{

--- a/crates/db_schema/src/impls/federation_allowlist.rs
+++ b/crates/db_schema/src/impls/federation_allowlist.rs
@@ -48,8 +48,7 @@ impl FederationAllowList {
   }
 }
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
 mod tests {
 
   use crate::{

--- a/crates/db_schema/src/impls/language.rs
+++ b/crates/db_schema/src/impls/language.rs
@@ -41,8 +41,8 @@ impl Language {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
+#[expect(clippy::indexing_slicing)]
 mod tests {
 
   use crate::{source::language::Language, utils::build_db_pool_for_tests};

--- a/crates/db_schema/src/impls/local_user.rs
+++ b/crates/db_schema/src/impls/local_user.rs
@@ -369,7 +369,6 @@ pub struct UserBackupLists {
 }
 
 #[cfg(test)]
-#[allow(clippy::indexing_slicing)]
 mod tests {
   use crate::{
     source::{

--- a/crates/db_schema/src/impls/moderator.rs
+++ b/crates/db_schema/src/impls/moderator.rs
@@ -465,8 +465,7 @@ impl Crud for AdminPurgeComment {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
 mod tests {
 
   use crate::{

--- a/crates/db_schema/src/impls/password_reset_request.rs
+++ b/crates/db_schema/src/impls/password_reset_request.rs
@@ -42,8 +42,6 @@ impl PasswordResetRequest {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
 mod tests {
 
   use crate::{

--- a/crates/db_schema/src/impls/person.rs
+++ b/crates/db_schema/src/impls/person.rs
@@ -232,7 +232,6 @@ impl PersonFollower {
 }
 
 #[cfg(test)]
-#[allow(clippy::indexing_slicing)]
 mod tests {
 
   use crate::{

--- a/crates/db_schema/src/impls/post.rs
+++ b/crates/db_schema/src/impls/post.rs
@@ -392,8 +392,7 @@ impl PostHide {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
 mod tests {
 
   use crate::{

--- a/crates/db_schema/src/impls/post_report.rs
+++ b/crates/db_schema/src/impls/post_report.rs
@@ -80,8 +80,7 @@ impl Reportable for PostReport {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
 mod tests {
 
   use super::*;

--- a/crates/db_schema/src/impls/private_message.rs
+++ b/crates/db_schema/src/impls/private_message.rs
@@ -85,8 +85,7 @@ impl PrivateMessage {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
 mod tests {
 
   use crate::{

--- a/crates/db_schema/src/lib.rs
+++ b/crates/db_schema/src/lib.rs
@@ -27,7 +27,6 @@ pub mod newtypes;
 pub mod sensitive;
 #[cfg(feature = "full")]
 #[rustfmt::skip]
-#[allow(clippy::wildcard_imports)]
 pub mod schema;
 #[cfg(feature = "full")]
 pub mod aliases {

--- a/crates/db_schema/src/newtypes.rs
+++ b/crates/db_schema/src/newtypes.rs
@@ -191,13 +191,13 @@ impl Display for DbUrl {
 }
 
 // the project doesn't compile with From
-#[allow(clippy::from_over_into)]
+#[expect(clippy::from_over_into)]
 impl Into<DbUrl> for Url {
   fn into(self) -> DbUrl {
     DbUrl(Box::new(self))
   }
 }
-#[allow(clippy::from_over_into)]
+#[expect(clippy::from_over_into)]
 impl Into<Url> for DbUrl {
   fn into(self) -> Url {
     *self.0

--- a/crates/db_schema/src/utils.rs
+++ b/crates/db_schema/src/utils.rs
@@ -595,7 +595,6 @@ impl<RF, LF> Queries<RF, LF> {
 }
 
 #[cfg(test)]
-#[allow(clippy::indexing_slicing)]
 mod tests {
 
   use super::*;

--- a/crates/db_views/src/comment_report_view.rs
+++ b/crates/db_views/src/comment_report_view.rs
@@ -259,8 +259,8 @@ impl CommentReportQuery {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
+#[expect(clippy::indexing_slicing)]
 mod tests {
 
   use crate::{

--- a/crates/db_views/src/comment_view.rs
+++ b/crates/db_views/src/comment_view.rs
@@ -422,8 +422,8 @@ impl<'a> CommentQuery<'a> {
 }
 
 #[cfg(test)]
-#[allow(clippy::indexing_slicing)]
-#[allow(clippy::unwrap_used)]
+#[expect(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
 mod tests {
 
   use crate::{

--- a/crates/db_views/src/post_report_view.rs
+++ b/crates/db_views/src/post_report_view.rs
@@ -284,8 +284,8 @@ impl PostReportQuery {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
+#[expect(clippy::indexing_slicing)]
 mod tests {
 
   use crate::{

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -741,7 +741,7 @@ impl<'a> PostQuery<'a> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[expect(clippy::unwrap_used)]
 mod tests {
   use crate::{
     post_view::{PaginationCursorData, PostQuery, PostView},

--- a/crates/db_views/src/private_message_report_view.rs
+++ b/crates/db_views/src/private_message_report_view.rs
@@ -111,8 +111,8 @@ impl PrivateMessageReportQuery {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
+#[expect(clippy::indexing_slicing)]
 mod tests {
 
   use crate::private_message_report_view::PrivateMessageReportQuery;

--- a/crates/db_views/src/private_message_view.rs
+++ b/crates/db_views/src/private_message_view.rs
@@ -173,8 +173,8 @@ impl PrivateMessageQuery {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
+#[expect(clippy::indexing_slicing)]
 mod tests {
 
   use crate::{private_message_view::PrivateMessageQuery, structs::PrivateMessageView};

--- a/crates/db_views/src/registration_application_view.rs
+++ b/crates/db_views/src/registration_application_view.rs
@@ -135,8 +135,7 @@ impl RegistrationApplicationQuery {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
 mod tests {
 
   use crate::registration_application_view::{

--- a/crates/db_views/src/vote_view.rs
+++ b/crates/db_views/src/vote_view.rs
@@ -83,8 +83,7 @@ impl VoteView {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
 mod tests {
 
   use crate::structs::VoteView;

--- a/crates/db_views_actor/src/comment_reply_view.rs
+++ b/crates/db_views_actor/src/comment_reply_view.rs
@@ -303,7 +303,6 @@ impl CommentReplyQuery {
 }
 
 #[cfg(test)]
-#[allow(clippy::indexing_slicing)]
 mod tests {
 
   use crate::{comment_reply_view::CommentReplyQuery, structs::CommentReplyView};

--- a/crates/db_views_actor/src/community_view.rs
+++ b/crates/db_views_actor/src/community_view.rs
@@ -242,8 +242,7 @@ impl<'a> CommunityQuery<'a> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
 mod tests {
 
   use crate::{community_view::CommunityQuery, structs::CommunityView};

--- a/crates/db_views_actor/src/person_mention_view.rs
+++ b/crates/db_views_actor/src/person_mention_view.rs
@@ -303,7 +303,6 @@ impl PersonMentionQuery {
 }
 
 #[cfg(test)]
-#[allow(clippy::indexing_slicing)]
 mod tests {
 
   use crate::{person_mention_view::PersonMentionQuery, structs::PersonMentionView};

--- a/crates/db_views_actor/src/person_view.rs
+++ b/crates/db_views_actor/src/person_view.rs
@@ -164,7 +164,7 @@ impl PersonQuery {
 }
 
 #[cfg(test)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::indexing_slicing)]
 mod tests {
 
   use super::*;

--- a/crates/federate/src/inboxes.rs
+++ b/crates/federate/src/inboxes.rs
@@ -222,8 +222,8 @@ impl<T: DataSource> CommunityInboxCollector<T> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
+#[expect(clippy::indexing_slicing)]
 mod tests {
   use super::*;
   use lemmy_db_schema::{

--- a/crates/federate/src/lib.rs
+++ b/crates/federate/src/lib.rs
@@ -192,8 +192,8 @@ impl SendManager {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
+#[expect(clippy::indexing_slicing)]
 mod test {
 
   use super::*;

--- a/crates/federate/src/worker.rs
+++ b/crates/federate/src/worker.rs
@@ -439,8 +439,8 @@ impl InstanceWorker {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
+#[expect(clippy::indexing_slicing)]
 mod test {
 
   use super::*;

--- a/crates/utils/src/rate_limit/mod.rs
+++ b/crates/utils/src/rate_limit/mod.rs
@@ -221,8 +221,6 @@ fn parse_ip(addr: &str) -> Option<IpAddr> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
 mod tests {
 
   #[test]

--- a/crates/utils/src/rate_limit/rate_limiter.rs
+++ b/crates/utils/src/rate_limit/rate_limiter.rs
@@ -136,7 +136,6 @@ impl<K: Eq + Hash, C: MapLevel> MapLevel for Map<K, C> {
       .entry(addr_part)
       .or_insert(RateLimitedGroup::new(now, adjusted_configs));
 
-    #[allow(clippy::indexing_slicing)]
     let total_passes = group.check_total(action_type, now, adjusted_configs[action_type]);
 
     let children_pass = group.children.check(
@@ -161,7 +160,6 @@ impl<K: Eq + Hash, C: MapLevel> MapLevel for Map<K, C> {
       // Evaluated if `some_children_remaining` is false
       let total_has_refill_in_future = || {
         group.total.into_iter().any(|(action_type, bucket)| {
-          #[allow(clippy::indexing_slicing)]
           let config = configs[action_type];
           bucket.update(now, config).tokens != config.capacity
         })
@@ -214,7 +212,6 @@ impl<C: Default> RateLimitedGroup<C> {
     now: InstantSecs,
     config: BucketConfig,
   ) -> bool {
-    #[allow(clippy::indexing_slicing)] // `EnumMap` has no `get` function
     let bucket = &mut self.total[action_type];
 
     let new_bucket = bucket.update(now, config);
@@ -311,8 +308,7 @@ fn split_ipv6(ip: Ipv6Addr) -> ([u8; 6], u8, u8) {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
 mod tests {
 
   use super::{ActionType, BucketConfig, InstantSecs, RateLimitState, RateLimitedGroup};
@@ -361,7 +357,6 @@ mod tests {
       assert!(post_passed);
     }
 
-    #[allow(clippy::indexing_slicing)]
     let expected_buckets = |factor: u32, tokens_consumed: u32| {
       let adjusted_configs = bucket_configs.map(|_, config| BucketConfig {
         capacity: config.capacity.saturating_mul(factor),

--- a/crates/utils/src/utils/markdown/mod.rs
+++ b/crates/utils/src/utils/markdown/mod.rs
@@ -107,8 +107,7 @@ pub fn markdown_check_for_blocked_urls(text: &str, blocklist: &RegexSet) -> Lemm
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
 mod tests {
 
   use super::*;

--- a/crates/utils/src/utils/markdown/spoiler_rule.rs
+++ b/crates/utils/src/utils/markdown/spoiler_rule.rs
@@ -134,8 +134,6 @@ pub fn add(markdown_parser: &mut MarkdownIt) {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
 mod tests {
 
   use crate::utils::markdown::spoiler_rule::add;

--- a/crates/utils/src/utils/mention.rs
+++ b/crates/utils/src/utils/mention.rs
@@ -34,8 +34,7 @@ pub fn scrape_text_for_mentions(text: &str) -> Vec<MentionData> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::indexing_slicing)]
 mod test {
 
   use crate::utils::mention::scrape_text_for_mentions;

--- a/crates/utils/src/utils/slurs.rs
+++ b/crates/utils/src/utils/slurs.rs
@@ -61,8 +61,7 @@ pub(crate) fn slurs_vec_to_str(slurs: &[&str]) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
 mod test {
 
   use crate::utils::slurs::{remove_slurs, slur_check, slurs_vec_to_str};

--- a/crates/utils/src/utils/validation.rs
+++ b/crates/utils/src/utils/validation.rs
@@ -351,7 +351,6 @@ pub fn build_url_str_without_scheme(url_str: &str) -> LemmyResult<String> {
 }
 
 #[cfg(test)]
-#[allow(clippy::indexing_slicing)]
 mod tests {
 
   use crate::{

--- a/src/scheduled_tasks.rs
+++ b/src/scheduled_tasks.rs
@@ -605,7 +605,6 @@ async fn build_update_instance_form(
 }
 
 #[cfg(test)]
-#[allow(clippy::indexing_slicing)]
 mod tests {
 
   use crate::scheduled_tasks::build_update_instance_form;

--- a/src/session_middleware.rs
+++ b/src/session_middleware.rs
@@ -97,8 +97,7 @@ where
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
 mod tests {
 
   use super::*;


### PR DESCRIPTION
https://blog.rust-lang.org/2024/09/05/Rust-1.81.0.html#expectlint

I also tried to add a [lint](https://rust-lang.github.io/rust-clippy/master/index.html#/allow_attributes) to deny `allow` usage but that fails on macro generated code.