### PR TITLE
Avoid breaking changes, keep response fields as deprecated

### DIFF
--- a/crates/api/src/site/leave_admin.rs
+++ b/crates/api/src/site/leave_admin.rs
@@ -76,5 +76,7 @@ pub async fn leave_admin(
     admin_oauth_providers: None,
     blocked_urls,
     tagline,
+    taglines: vec![],
+    custom_emojis: vec![],
   }))
 }

--- a/crates/api_common/src/site.rs
+++ b/crates/api_common/src/site.rs
@@ -306,6 +306,8 @@ pub struct EditSite {
 /// The response for a site.
 pub struct SiteResponse {
   pub site_view: SiteView,
+  /// deprecated, use field `tagline` or /api/v3/tagline/list
+  pub taglines: Vec<()>,
 }
 
 #[skip_serializing_none]
@@ -320,6 +322,10 @@ pub struct GetSiteResponse {
   pub my_user: Option<MyUserInfo>,
   pub all_languages: Vec<Language>,
   pub discussion_languages: Vec<LanguageId>,
+  /// deprecated, use field `tagline` or /api/v3/tagline/list
+  pub taglines: Vec<()>,
+  /// deprecated, use /api/v3/custom_emoji/list
+  pub custom_emojis: Vec<()>,
   /// If the site has any taglines, a random one is included here for displaying
   pub tagline: Option<Tagline>,
   /// A list of external auth methods your site supports.

--- a/crates/api_crud/src/site/create.rs
+++ b/crates/api_crud/src/site/create.rs
@@ -139,7 +139,10 @@ pub async fn create_site(
     local_site_rate_limit_to_rate_limit_config(&site_view.local_site_rate_limit);
   context.rate_limit_cell().set_config(rate_limit_config);
 
-  Ok(Json(SiteResponse { site_view }))
+  Ok(Json(SiteResponse {
+    site_view,
+    taglines: vec![],
+  }))
 }
 
 fn validate_create_payload(local_site: &LocalSite, create_site: &CreateSite) -> LemmyResult<()> {

--- a/crates/api_crud/src/site/read.rs
+++ b/crates/api_crud/src/site/read.rs
@@ -59,6 +59,8 @@ pub async fn get_site(
         tagline,
         oauth_providers: Some(oauth_providers),
         admin_oauth_providers: Some(admin_oauth_providers),
+        taglines: vec![],
+        custom_emojis: vec![],
       })
     })
     .await

--- a/crates/api_crud/src/site/update.rs
+++ b/crates/api_crud/src/site/update.rs
@@ -193,7 +193,10 @@ pub async fn update_site(
     local_site_rate_limit_to_rate_limit_config(&site_view.local_site_rate_limit);
   context.rate_limit_cell().set_config(rate_limit_config);
 
-  Ok(Json(SiteResponse { site_view }))
+  Ok(Json(SiteResponse {
+    site_view,
+    taglines: vec![],
+  }))
 }
 
 fn validate_update_payload(local_site: &LocalSite, edit_site: &EditSite) -> LemmyResult<()> {


### PR DESCRIPTION
If we remove response fields like `GetSiteResponse.taglines`, it will likely break many clients completely, and will take a while for them to upgrade to support Lemmy 0.20. So we should keep these fields around as deprecated with empty values, to ensure that clients dont crash. Then they can be removed in 0.21.

There are other fields `LocalSite.default_sort_type` where this cannot easily be done as its based on database tables. Other fields were changed in POST endpoints, keeping those compatible is less important. There may be other fields that I missed.