### PR TITLE
Adding skip_serializing_none to another OAuth API request.

### DIFF
--- a/crates/api_common/src/oauth_provider.rs
+++ b/crates/api_common/src/oauth_provider.rs
@@ -5,6 +5,7 @@ use serde_with::skip_serializing_none;
 use ts_rs::TS;
 use url::Url;
 
+#[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "full", derive(TS))]
 #[cfg_attr(feature = "full", ts(export))]

--- a/crates/db_schema/src/schema.rs
+++ b/crates/db_schema/src/schema.rs
@@ -769,7 +769,7 @@ diesel::table! {
         featured_local -> Bool,
         url_content_type -> Nullable<Text>,
         alt_text -> Nullable<Text>,
-        scheduled_publish_time -> Nullable<Timestamptz>
+        scheduled_publish_time -> Nullable<Timestamptz>,
     }
 }
 


### PR DESCRIPTION
Found another missing skip_serializing_none from lemmy-js-client generation.