### PR TITLE
Changing renovate to run on the weekends.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "schedule": ["before 4am on the first day of the month"],
+  "schedule": ["every weekend"],
   "automerge": true
 }


### PR DESCRIPTION
- Lemmy builds take a long time, and the current schedule only runs for about 4 hours once a month, and renovate also rate-limits itself to ~ 2 per hour. This gives it a large enough window, without clogging up my runner machines.