### PR TITLE
Attempt to fix test for fetching deeply nested comment

### DIFF
--- a/crates/apub/src/objects/comment.rs
+++ b/crates/apub/src/objects/comment.rs
@@ -128,6 +128,8 @@ impl Object for ApubComment {
     Ok(note)
   }
 
+  /// Recursively fetches all parent comments. This can lead to a stack overflow so we need to
+  /// Box::pin all large futures on the heap.
   #[tracing::instrument(skip_all)]
   async fn verify(
     note: &Note,
@@ -137,14 +139,24 @@ impl Object for ApubComment {
     verify_domains_match(note.id.inner(), expected_domain)?;
     verify_domains_match(note.attributed_to.inner(), note.id.inner())?;
     verify_is_public(&note.to, &note.cc)?;
-    let community = note.community(context).await?;
+    let community = Box::pin(note.community(context)).await?;
 
-    check_apub_id_valid_with_strictness(note.id.inner(), community.local, context).await?;
+    Box::pin(check_apub_id_valid_with_strictness(
+      note.id.inner(),
+      community.local,
+      context,
+    ))
+    .await?;
     verify_is_remote_object(&note.id, context)?;
-    verify_person_in_community(&note.attributed_to, &community, context).await?;
+    Box::pin(verify_person_in_community(
+      &note.attributed_to,
+      &community,
+      context,
+    ))
+    .await?;
 
-    let (post, _) = note.get_parents(context).await?;
-    let creator = note.attributed_to.dereference(context).await?;
+    let (post, _) = Box::pin(note.get_parents(context)).await?;
+    let creator = Box::pin(note.attributed_to.dereference(context)).await?;
     let is_mod_or_admin = is_mod_or_admin(&mut context.pool(), &creator, community.id)
       .await
       .is_ok();


### PR DESCRIPTION
The test was added in https://github.com/LemmyNet/lemmy/pull/5009 and passed fine. But now its failing in various other ci runs for different pull requests ([example](https://woodpecker.join-lemmy.org/repos/129/pipeline/9286/21#L450)). Maybe this will fix it, we should restart the ci a few times as the failure seems random.