### PR TITLE
Resize post thumbnails (fixes #4053)

### DIFF
--- a/config/defaults.hjson
+++ b/config/defaults.hjson
@@ -75,6 +75,8 @@
       "ProxyAllImages"
     # Timeout for uploading images to pictrs (in seconds)
     upload_timeout: 30
+    # Resize post thumbnails to this maximum width/height.
+    max_thumbnail_size: 100
   }
   # Email sending configuration. All options except login/password are mandatory
   email: {

--- a/config/defaults.hjson
+++ b/config/defaults.hjson
@@ -76,7 +76,7 @@
     # Timeout for uploading images to pictrs (in seconds)
     upload_timeout: 30
     # Resize post thumbnails to this maximum width/height.
-    max_thumbnail_size: 100
+    max_thumbnail_size: 256
   }
   # Email sending configuration. All options except login/password are mandatory
   email: {

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -354,9 +354,10 @@ async fn generate_pictrs_thumbnail(image_url: &Url, context: &LemmyContext) -> L
   // fetch remote non-pictrs images for persistent thumbnail link
   // TODO: should limit size once supported by pictrs
   let fetch_url = format!(
-    "{}image/download?url={}",
+    "{}image/download?url={}&resize={}",
     pictrs_config.url,
-    encode(image_url.as_str())
+    encode(image_url.as_str()),
+    context.settings().pictrs_config()?.max_thumbnail_size
   );
 
   let res = context

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -92,7 +92,7 @@ pub struct PictrsConfig {
   pub upload_timeout: u64,
 
   /// Resize post thumbnails to this maximum width/height.
-  #[default(100)]
+  #[default(256)]
   pub max_thumbnail_size: u32,
 }
 

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -90,6 +90,10 @@ pub struct PictrsConfig {
   /// Timeout for uploading images to pictrs (in seconds)
   #[default(30)]
   pub upload_timeout: u64,
+
+  /// Resize post thumbnails to this maximum width/height.
+  #[default(100)]
+  pub max_thumbnail_size: u32,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, SmartDefault, Document, PartialEq)]


### PR DESCRIPTION
Tested this manually using docker. Should be cherry-picked to 0.19.6