### PR TITLE
Update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,18 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "schedule": ["every weekend"],
-  "automerge": true
+  "schedule": ["every three months on the weekend"],
+  "automerge": true,
+  "ignoreDeps": ["lemmy-js-client"],
+  "rebaseWhen": "conflicted",
+  "packageRules": [
+    {
+      "groupName": "docker",
+      "matchDatasources": ["docker"]
+    },
+    {
+      "groupName": "npm",
+      "matchDatasources": ["npm"]
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "schedule": ["every three months on the weekend"],
-  "automerge": true,
-  "ignoreDeps": ["lemmy-js-client"],
+  "schedule": ["before 4am on the first day of the month"],
   "rebaseWhen": "conflicted",
   "packageRules": [
     {
@@ -14,5 +12,7 @@
       "groupName": "npm",
       "matchDatasources": ["npm"]
     }
-  ]
+  ],
+  "ignoreDeps": ["lemmy-js-client", "pgautoupgrade/pgautoupgrade"],
+  "ignorePaths": ["(^|/)Cargo\\.toml$"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "schedule": ["before 4am on the first day of the month"],
+  "automerge": true,
   "rebaseWhen": "conflicted",
   "packageRules": [
     {


### PR DESCRIPTION
- Only perform upgrades on first day of the month. Upgrading every weekend gives no benefit but lots of problems (repo gets spammed with PRs and commits, unnecessary CI usage, build cache becomes ineffective). I would prefer running every three months, but the schedule is too crude for that.
- Group docker and npm updates together, so there is only a single PR for all of them. Anyway these generally pass ci
- Only rebase when there is a conflict, to reduce CI usage
- Ignore updates to lemmy-js-client and postgres
- Ignore Rust updates, its better to do these manually when we actually need it