### PR TITLE
Make vote timestamps optional (ref #5016)

### DIFF
--- a/api_tests/prepare-drone-federation-test.sh
+++ b/api_tests/prepare-drone-federation-test.sh
@@ -23,7 +23,7 @@ fi
   --danger-dummy-mode \
   --api-key "my-pictrs-key" \
   filesystem -p /tmp/pictrs/files \
-  sled -p /tmp/pictrs/sled-repo &
+  sled -p /tmp/pictrs/sled-repo 2>&1 &
 
 for INSTANCE in lemmy_alpha lemmy_beta lemmy_gamma lemmy_delta lemmy_epsilon; do
   echo "DB URL: ${LEMMY_DATABASE_URL} INSTANCE: $INSTANCE"

--- a/api_tests/prepare-drone-federation-test.sh
+++ b/api_tests/prepare-drone-federation-test.sh
@@ -23,7 +23,7 @@ fi
   --danger-dummy-mode \
   --api-key "my-pictrs-key" \
   filesystem -p /tmp/pictrs/files \
-  sled -p /tmp/pictrs/sled-repo 2>&1 &
+  sled -p /tmp/pictrs/sled-repo &
 
 for INSTANCE in lemmy_alpha lemmy_beta lemmy_gamma lemmy_delta lemmy_epsilon; do
   echo "DB URL: ${LEMMY_DATABASE_URL} INSTANCE: $INSTANCE"

--- a/api_tests/run-federation-test.sh
+++ b/api_tests/run-federation-test.sh
@@ -11,7 +11,7 @@ killall -s1 lemmy_server || true
 popd
 
 pnpm i
-pnpm api-test || true
+pnpm api-test-image || true
 
 killall -s1 lemmy_server || true
 killall -s1 pict-rs || true

--- a/api_tests/run-federation-test.sh
+++ b/api_tests/run-federation-test.sh
@@ -11,7 +11,7 @@ killall -s1 lemmy_server || true
 popd
 
 pnpm i
-pnpm api-test-image || true
+pnpm api-test || true
 
 killall -s1 lemmy_server || true
 killall -s1 pict-rs || true

--- a/config/defaults.hjson
+++ b/config/defaults.hjson
@@ -35,6 +35,9 @@
     database: "string"
     # Maximum number of active sql connections
     pool_size: 30
+    # Set true to store the time when votes were cast. Requires more storage space but can be
+    # used to detect vote manipulation.
+    store_vote_timestamps: false
   }
   # Pictrs image server configuration.
   pictrs: {

--- a/crates/api/src/comment/like.rs
+++ b/crates/api/src/comment/like.rs
@@ -67,7 +67,6 @@ pub async fn like_comment(
 
   let like_form = CommentLikeForm {
     comment_id: data.comment_id,
-    post_id: orig_comment.post.id,
     person_id: local_user_view.person.id,
     score: data.score,
   };

--- a/crates/api_crud/src/comment/create.rs
+++ b/crates/api_crud/src/comment/create.rs
@@ -132,7 +132,6 @@ pub async fn create_comment(
   // You like your own comment by default
   let like_form = CommentLikeForm {
     comment_id: inserted_comment.id,
-    post_id: post.id,
     person_id: local_user_view.person.id,
     score: 1,
   };

--- a/crates/api_crud/src/comment/create.rs
+++ b/crates/api_crud/src/comment/create.rs
@@ -19,7 +19,7 @@ use lemmy_db_schema::{
   impls::actor_language::default_post_language,
   source::{
     actor_language::CommunityLanguage,
-    comment::{Comment, CommentInsertForm, CommentLike, CommentLikeForm},
+    comment::{Comment, CommentInsertForm, CommentLike},
     comment_reply::{CommentReply, CommentReplyUpdateForm},
     local_site::LocalSite,
     person_mention::{PersonMention, PersonMentionUpdateForm},
@@ -130,15 +130,15 @@ pub async fn create_comment(
   .await?;
 
   // You like your own comment by default
-  let like_form = CommentLikeForm {
-    comment_id: inserted_comment.id,
-    person_id: local_user_view.person.id,
-    score: 1,
-  };
-
-  CommentLike::like(&mut context.pool(), &like_form)
-    .await
-    .with_lemmy_type(LemmyErrorType::CouldntLikeComment)?;
+  CommentLike::like(
+    &mut context.pool(),
+    local_user_view.person.id,
+    inserted_comment.id,
+    1,
+    context.settings(),
+  )
+  .await
+  .with_lemmy_type(LemmyErrorType::CouldntLikeComment)?;
 
   ActivityChannel::submit_activity(
     SendActivityData::CreateComment(inserted_comment.clone()),

--- a/crates/api_crud/src/post/create.rs
+++ b/crates/api_crud/src/post/create.rs
@@ -22,7 +22,7 @@ use lemmy_db_schema::{
     actor_language::CommunityLanguage,
     community::Community,
     local_site::LocalSite,
-    post::{Post, PostInsertForm, PostLike, PostLikeForm},
+    post::{Post, PostInsertForm, PostLike},
   },
   traits::{Crud, Likeable},
   utils::diesel_url_create,
@@ -159,15 +159,15 @@ pub async fn create_post(
   // They like their own post by default
   let person_id = local_user_view.person.id;
   let post_id = inserted_post.id;
-  let like_form = PostLikeForm {
-    post_id,
+  PostLike::like(
+    &mut context.pool(),
     person_id,
-    score: 1,
-  };
-
-  PostLike::like(&mut context.pool(), &like_form)
-    .await
-    .with_lemmy_type(LemmyErrorType::CouldntLikePost)?;
+    post_id,
+    1,
+    context.settings(),
+  )
+  .await
+  .with_lemmy_type(LemmyErrorType::CouldntLikePost)?;
 
   mark_post_as_read(person_id, post_id, &mut context.pool()).await?;
 

--- a/crates/apub/src/activities/create_or_update/comment.rs
+++ b/crates/apub/src/activities/create_or_update/comment.rs
@@ -153,7 +153,6 @@ impl ActivityHandler for CreateOrUpdateNote {
     // author likes their own comment by default
     let like_form = CommentLikeForm {
       comment_id: comment.id,
-      post_id: comment.post_id,
       person_id: comment.creator_id,
       score: 1,
     };

--- a/crates/apub/src/activities/create_or_update/comment.rs
+++ b/crates/apub/src/activities/create_or_update/comment.rs
@@ -32,7 +32,7 @@ use lemmy_db_schema::{
   newtypes::PersonId,
   source::{
     activity::ActivitySendTargets,
-    comment::{Comment, CommentLike, CommentLikeForm},
+    comment::{Comment, CommentLike},
     community::Community,
     person::Person,
     post::Post,
@@ -151,12 +151,14 @@ impl ActivityHandler for CreateOrUpdateNote {
     let comment = ApubComment::from_json(self.object, context).await?;
 
     // author likes their own comment by default
-    let like_form = CommentLikeForm {
-      comment_id: comment.id,
-      person_id: comment.creator_id,
-      score: 1,
-    };
-    CommentLike::like(&mut context.pool(), &like_form).await?;
+    CommentLike::like(
+      &mut context.pool(),
+      comment.creator_id,
+      comment.id,
+      1,
+      context.settings(),
+    )
+    .await?;
 
     // Calculate initial hot_rank
     CommentAggregates::update_hot_rank(&mut context.pool(), comment.id).await?;

--- a/crates/apub/src/activities/create_or_update/post.rs
+++ b/crates/apub/src/activities/create_or_update/post.rs
@@ -28,7 +28,7 @@ use lemmy_db_schema::{
     activity::ActivitySendTargets,
     community::Community,
     person::Person,
-    post::{Post, PostLike, PostLikeForm},
+    post::{Post, PostLike},
   },
   traits::{Crud, Likeable},
 };
@@ -118,12 +118,14 @@ impl ActivityHandler for CreateOrUpdatePage {
     let post = ApubPost::from_json(self.object, context).await?;
 
     // author likes their own post by default
-    let like_form = PostLikeForm {
-      post_id: post.id,
-      person_id: post.creator_id,
-      score: 1,
-    };
-    PostLike::like(&mut context.pool(), &like_form).await?;
+    PostLike::like(
+      &mut context.pool(),
+      post.creator_id,
+      post.id,
+      1,
+      context.settings(),
+    )
+    .await?;
 
     // Calculate initial hot_rank for post
     PostAggregates::update_ranks(&mut context.pool(), post.id).await?;

--- a/crates/apub/src/activities/voting/mod.rs
+++ b/crates/apub/src/activities/voting/mod.rs
@@ -62,7 +62,6 @@ async fn vote_comment(
   let comment_id = comment.id;
   let like_form = CommentLikeForm {
     comment_id,
-    post_id: comment.post_id,
     person_id: actor.id,
     score: vote_type.into(),
   };

--- a/crates/apub/src/activities/voting/mod.rs
+++ b/crates/apub/src/activities/voting/mod.rs
@@ -14,10 +14,10 @@ use lemmy_db_schema::{
   newtypes::DbUrl,
   source::{
     activity::ActivitySendTargets,
-    comment::{CommentLike, CommentLikeForm},
+    comment::CommentLike,
     community::Community,
     person::Person,
-    post::{PostLike, PostLikeForm},
+    post::PostLike,
   },
   traits::Likeable,
 };
@@ -59,15 +59,15 @@ async fn vote_comment(
   comment: &ApubComment,
   context: &Data<LemmyContext>,
 ) -> LemmyResult<()> {
-  let comment_id = comment.id;
-  let like_form = CommentLikeForm {
-    comment_id,
-    person_id: actor.id,
-    score: vote_type.into(),
-  };
-  let person_id = actor.id;
-  CommentLike::remove(&mut context.pool(), person_id, comment_id).await?;
-  CommentLike::like(&mut context.pool(), &like_form).await?;
+  CommentLike::remove(&mut context.pool(), actor.id, comment.id).await?;
+  CommentLike::like(
+    &mut context.pool(),
+    actor.id,
+    comment.id,
+    vote_type.into(),
+    context.settings(),
+  )
+  .await?;
   Ok(())
 }
 
@@ -78,15 +78,15 @@ async fn vote_post(
   post: &ApubPost,
   context: &Data<LemmyContext>,
 ) -> LemmyResult<()> {
-  let post_id = post.id;
-  let like_form = PostLikeForm {
-    post_id: post.id,
-    person_id: actor.id,
-    score: vote_type.into(),
-  };
-  let person_id = actor.id;
-  PostLike::remove(&mut context.pool(), person_id, post_id).await?;
-  PostLike::like(&mut context.pool(), &like_form).await?;
+  PostLike::remove(&mut context.pool(), actor.id, post.id).await?;
+  PostLike::like(
+    &mut context.pool(),
+    actor.id,
+    post.id,
+    vote_type.into(),
+    context.settings(),
+  )
+  .await?;
   Ok(())
 }
 

--- a/crates/db_schema/src/aggregates/comment_aggregates.rs
+++ b/crates/db_schema/src/aggregates/comment_aggregates.rs
@@ -96,7 +96,6 @@ mod tests {
 
     let comment_like = CommentLikeForm {
       comment_id: inserted_comment.id,
-      post_id: inserted_post.id,
       person_id: inserted_person.id,
       score: 1,
     };
@@ -112,7 +111,6 @@ mod tests {
     // Add a post dislike from the other person
     let comment_dislike = CommentLikeForm {
       comment_id: inserted_comment.id,
-      post_id: inserted_post.id,
       person_id: another_inserted_person.id,
       score: -1,
     };

--- a/crates/db_schema/src/aggregates/person_aggregates.rs
+++ b/crates/db_schema/src/aggregates/person_aggregates.rs
@@ -82,7 +82,6 @@ mod tests {
     let mut comment_like = CommentLikeForm {
       comment_id: inserted_comment.id,
       person_id: inserted_person.id,
-      post_id: inserted_post.id,
       score: 1,
     };
 
@@ -99,7 +98,6 @@ mod tests {
     let child_comment_like = CommentLikeForm {
       comment_id: inserted_child_comment.id,
       person_id: another_inserted_person.id,
-      post_id: inserted_post.id,
       score: 1,
     };
 

--- a/crates/db_schema/src/impls/comment.rs
+++ b/crates/db_schema/src/impls/comment.rs
@@ -289,7 +289,6 @@ mod tests {
     // Comment Like
     let comment_like_form = CommentLikeForm {
       comment_id: inserted_comment.id,
-      post_id: inserted_post.id,
       person_id: inserted_person.id,
       score: 1,
     };
@@ -298,7 +297,6 @@ mod tests {
 
     let expected_comment_like = CommentLike {
       comment_id: inserted_comment.id,
-      post_id: inserted_post.id,
       person_id: inserted_person.id,
       score: 1,
     };

--- a/crates/db_schema/src/impls/comment.rs
+++ b/crates/db_schema/src/impls/comment.rs
@@ -300,7 +300,6 @@ mod tests {
       comment_id: inserted_comment.id,
       post_id: inserted_post.id,
       person_id: inserted_person.id,
-      published: inserted_comment_like.published,
       score: 1,
     };
 

--- a/crates/db_schema/src/impls/post.rs
+++ b/crates/db_schema/src/impls/post.rs
@@ -500,7 +500,6 @@ mod tests {
     let expected_post_like = PostLike {
       post_id: inserted_post.id,
       person_id: inserted_person.id,
-      published: inserted_post_like.published,
       score: 1,
     };
 

--- a/crates/db_schema/src/schema.rs
+++ b/crates/db_schema/src/schema.rs
@@ -125,7 +125,6 @@ diesel::table! {
         comment_id -> Int4,
         post_id -> Int4,
         score -> Int2,
-        published -> Timestamptz,
     }
 }
 
@@ -816,7 +815,6 @@ diesel::table! {
         post_id -> Int4,
         person_id -> Int4,
         score -> Int2,
-        published -> Timestamptz,
     }
 }
 

--- a/crates/db_schema/src/schema.rs
+++ b/crates/db_schema/src/schema.rs
@@ -123,7 +123,6 @@ diesel::table! {
     comment_like (person_id, comment_id) {
         person_id -> Int4,
         comment_id -> Int4,
-        post_id -> Int4,
         score -> Int2,
     }
 }
@@ -997,7 +996,6 @@ diesel::joinable!(comment -> post (post_id));
 diesel::joinable!(comment_aggregates -> comment (comment_id));
 diesel::joinable!(comment_like -> comment (comment_id));
 diesel::joinable!(comment_like -> person (person_id));
-diesel::joinable!(comment_like -> post (post_id));
 diesel::joinable!(comment_reply -> comment (comment_id));
 diesel::joinable!(comment_reply -> person (recipient_id));
 diesel::joinable!(comment_report -> comment (comment_id));

--- a/crates/db_schema/src/schema.rs
+++ b/crates/db_schema/src/schema.rs
@@ -124,6 +124,7 @@ diesel::table! {
         person_id -> Int4,
         comment_id -> Int4,
         score -> Int2,
+        published -> Nullable<Timestamptz>,
     }
 }
 
@@ -814,6 +815,7 @@ diesel::table! {
         post_id -> Int4,
         person_id -> Int4,
         score -> Int2,
+        published -> Nullable<Timestamptz>,
     }
 }
 

--- a/crates/db_schema/src/source/comment.rs
+++ b/crates/db_schema/src/source/comment.rs
@@ -102,7 +102,6 @@ pub struct CommentUpdateForm {
 pub struct CommentLike {
   pub person_id: PersonId,
   pub comment_id: CommentId,
-  pub post_id: PostId, // TODO this is redundant
   pub score: i16,
 }
 
@@ -112,7 +111,6 @@ pub struct CommentLike {
 pub struct CommentLikeForm {
   pub person_id: PersonId,
   pub comment_id: CommentId,
-  pub post_id: PostId, // TODO this is redundant
   pub score: i16,
 }
 

--- a/crates/db_schema/src/source/comment.rs
+++ b/crates/db_schema/src/source/comment.rs
@@ -103,15 +103,17 @@ pub struct CommentLike {
   pub person_id: PersonId,
   pub comment_id: CommentId,
   pub score: i16,
+  pub published: Option<DateTime<Utc>>,
 }
 
 #[derive(Clone)]
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = comment_like))]
-pub struct CommentLikeForm {
+pub(crate) struct CommentLikeForm {
   pub person_id: PersonId,
   pub comment_id: CommentId,
   pub score: i16,
+  pub published: Option<DateTime<Utc>>,
 }
 
 #[derive(PartialEq, Eq, Debug)]

--- a/crates/db_schema/src/source/comment.rs
+++ b/crates/db_schema/src/source/comment.rs
@@ -104,7 +104,6 @@ pub struct CommentLike {
   pub comment_id: CommentId,
   pub post_id: PostId, // TODO this is redundant
   pub score: i16,
-  pub published: DateTime<Utc>,
 }
 
 #[derive(Clone)]

--- a/crates/db_schema/src/source/post.rs
+++ b/crates/db_schema/src/source/post.rs
@@ -150,15 +150,17 @@ pub struct PostLike {
   pub post_id: PostId,
   pub person_id: PersonId,
   pub score: i16,
+  pub published: Option<DateTime<Utc>>,
 }
 
 #[derive(Clone)]
 #[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = post_like))]
-pub struct PostLikeForm {
+pub(crate) struct PostLikeForm {
   pub post_id: PostId,
   pub person_id: PersonId,
   pub score: i16,
+  pub published: Option<DateTime<Utc>>,
 }
 
 #[derive(PartialEq, Eq, Debug)]

--- a/crates/db_schema/src/source/post.rs
+++ b/crates/db_schema/src/source/post.rs
@@ -150,7 +150,6 @@ pub struct PostLike {
   pub post_id: PostId,
   pub person_id: PersonId,
   pub score: i16,
-  pub published: DateTime<Utc>,
 }
 
 #[derive(Clone)]

--- a/crates/db_schema/src/traits.rs
+++ b/crates/db_schema/src/traits.rs
@@ -15,6 +15,7 @@ use diesel_async::{
   AsyncPgConnection,
   RunQueryDsl,
 };
+use lemmy_utils::settings::structs::Settings;
 
 /// Returned by `diesel::delete`
 pub type Delete<T> = DeleteStatement<<T as HasTable>::Table, <T as IntoUpdateTarget>::WhereClause>;
@@ -94,9 +95,14 @@ pub trait Joinable {
 
 #[async_trait]
 pub trait Likeable {
-  type Form;
   type IdType;
-  async fn like(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<Self, Error>
+  async fn like(
+    pool: &mut DbPool<'_>,
+    person_id: PersonId,
+    item_id: Self::IdType,
+    score: i16,
+    settings: &Settings,
+  ) -> Result<Self, Error>
   where
     Self: Sized;
   async fn remove(

--- a/crates/db_views/src/comment_view.rs
+++ b/crates/db_views/src/comment_view.rs
@@ -601,7 +601,6 @@ mod tests {
 
     let comment_like_form = CommentLikeForm {
       comment_id: inserted_comment_0.id,
-      post_id: inserted_post.id,
       person_id: inserted_timmy_person.id,
       score: 1,
     };
@@ -701,7 +700,6 @@ mod tests {
     // Like a new comment
     let comment_like_form = CommentLikeForm {
       comment_id: data.inserted_comment_1.id,
-      post_id: data.inserted_post.id,
       person_id: data.timmy_local_user_view.person.id,
       score: 1,
     };

--- a/crates/db_views/src/comment_view.rs
+++ b/crates/db_views/src/comment_view.rs
@@ -438,7 +438,6 @@ mod tests {
         Comment,
         CommentInsertForm,
         CommentLike,
-        CommentLikeForm,
         CommentSaved,
         CommentSavedForm,
         CommentUpdateForm,
@@ -466,7 +465,7 @@ mod tests {
     CommunityVisibility,
     SubscribedType,
   };
-  use lemmy_utils::error::LemmyResult;
+  use lemmy_utils::{error::LemmyResult, settings::structs::Settings};
   use pretty_assertions::assert_eq;
   use serial_test::serial;
 
@@ -599,13 +598,15 @@ mod tests {
     };
     assert_eq!(expected_block, inserted_block);
 
-    let comment_like_form = CommentLikeForm {
-      comment_id: inserted_comment_0.id,
-      person_id: inserted_timmy_person.id,
-      score: 1,
-    };
-
-    let _inserted_comment_like = CommentLike::like(pool, &comment_like_form).await?;
+    let settings = Settings::default();
+    CommentLike::like(
+      pool,
+      inserted_timmy_person.id,
+      inserted_comment_0.id,
+      1,
+      &settings,
+    )
+    .await?;
 
     let timmy_local_user_view = LocalUserView {
       local_user: inserted_timmy_local_user.clone(),
@@ -698,12 +699,15 @@ mod tests {
     PersonBlock::unblock(pool, &timmy_unblocks_sara_form).await?;
 
     // Like a new comment
-    let comment_like_form = CommentLikeForm {
-      comment_id: data.inserted_comment_1.id,
-      person_id: data.timmy_local_user_view.person.id,
-      score: 1,
-    };
-    CommentLike::like(pool, &comment_like_form).await?;
+    let settings = Settings::default();
+    CommentLike::like(
+      pool,
+      data.timmy_local_user_view.person.id,
+      data.inserted_comment_1.id,
+      1,
+      &settings,
+    )
+    .await?;
 
     let read_liked_comment_views = CommentQuery {
       local_user: Some(&data.timmy_local_user_view.local_user),

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -1125,7 +1125,6 @@ mod tests {
     let expected_post_like = PostLike {
       post_id: data.inserted_post.id,
       person_id: data.local_user_view.person.id,
-      published: inserted_post_like.published,
       score: 1,
     };
     assert_eq!(expected_post_like, inserted_post_like);

--- a/crates/db_views/src/structs.rs
+++ b/crates/db_views/src/structs.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 #[cfg(feature = "full")]
 use diesel::Queryable;
 use lemmy_db_schema::{
@@ -216,6 +217,7 @@ pub struct VoteView {
   pub creator: Person,
   pub creator_banned_from_community: bool,
   pub score: i16,
+  pub published: Option<DateTime<Utc>>,
 }
 
 #[skip_serializing_none]

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -128,6 +128,11 @@ pub struct DatabaseConfig {
   /// Maximum number of active sql connections
   #[default(30)]
   pub pool_size: usize,
+
+  /// Set true to store the time when votes were cast. Requires more storage space but can be
+  /// used to detect vote manipulation.
+  #[default(false)]
+  pub store_vote_timestamps: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, SmartDefault, Document)]

--- a/migrations/2024-10-17-091053_vote-no-timestamp/down.sql
+++ b/migrations/2024-10-17-091053_vote-no-timestamp/down.sql
@@ -1,6 +1,23 @@
 ALTER TABLE post_like
     ADD COLUMN published timestamptz NOT NULL DEFAULT now();
+
 ALTER TABLE comment_like
     ADD COLUMN published timestamptz NOT NULL DEFAULT now();
+
 ALTER TABLE comment_like
-    ADD COLUMN post_id int NOT NULL;
+    ADD COLUMN post_id int REFERENCES post ON UPDATE CASCADE ON DELETE CASCADE;
+
+UPDATE
+    comment_like
+SET
+    post_id = (
+        SELECT
+            post_id
+        FROM
+            comment
+        WHERE
+            comment.id = comment_like.comment_id);
+
+ALTER TABLE comment_like
+    ALTER COLUMN post_id SET NOT NULL;
+

--- a/migrations/2024-10-17-091053_vote-no-timestamp/down.sql
+++ b/migrations/2024-10-17-091053_vote-no-timestamp/down.sql
@@ -1,0 +1,2 @@
+alter table post_like add column published timestamptz not null default now();
+alter table comment_like add column published timestamptz not null default now();

--- a/migrations/2024-10-17-091053_vote-no-timestamp/down.sql
+++ b/migrations/2024-10-17-091053_vote-no-timestamp/down.sql
@@ -1,2 +1,6 @@
-alter table post_like add column published timestamptz not null default now();
-alter table comment_like add column published timestamptz not null default now();
+ALTER TABLE post_like
+    ADD COLUMN published timestamptz NOT NULL DEFAULT now();
+
+ALTER TABLE comment_like
+    ADD COLUMN published timestamptz NOT NULL DEFAULT now();
+

--- a/migrations/2024-10-17-091053_vote-no-timestamp/down.sql
+++ b/migrations/2024-10-17-091053_vote-no-timestamp/down.sql
@@ -1,6 +1,6 @@
 ALTER TABLE post_like
     ADD COLUMN published timestamptz NOT NULL DEFAULT now();
-
 ALTER TABLE comment_like
     ADD COLUMN published timestamptz NOT NULL DEFAULT now();
-
+ALTER TABLE comment_like
+    ADD COLUMN post_id int NOT NULL;

--- a/migrations/2024-10-17-091053_vote-no-timestamp/down.sql
+++ b/migrations/2024-10-17-091053_vote-no-timestamp/down.sql
@@ -1,9 +1,17 @@
+-- make published not null again and add default
 ALTER TABLE post_like
-    ADD COLUMN published timestamptz NOT NULL DEFAULT now();
+    ALTER COLUMN published SET NOT NULL;
+
+ALTER TABLE post_like
+    ALTER COLUMN published SET DEFAULT now();
 
 ALTER TABLE comment_like
-    ADD COLUMN published timestamptz NOT NULL DEFAULT now();
+    ALTER COLUMN published DROP NOT NULL;
 
+ALTER TABLE comment_like
+    ALTER COLUMN published SET DEFAULT now();
+
+-- restore comment_like.post_id
 ALTER TABLE comment_like
     ADD COLUMN post_id int REFERENCES post ON UPDATE CASCADE ON DELETE CASCADE;
 

--- a/migrations/2024-10-17-091053_vote-no-timestamp/up.sql
+++ b/migrations/2024-10-17-091053_vote-no-timestamp/up.sql
@@ -1,2 +1,6 @@
-alter table post_like drop published;
-alter table comment_like drop published;
+ALTER TABLE post_like
+    DROP published;
+
+ALTER TABLE comment_like
+    DROP published;
+

--- a/migrations/2024-10-17-091053_vote-no-timestamp/up.sql
+++ b/migrations/2024-10-17-091053_vote-no-timestamp/up.sql
@@ -1,3 +1,30 @@
+-- set all column values to null to reclaim disk space
+-- https://dba.stackexchange.com/a/117513
+ALTER TABLE post_like
+    ALTER COLUMN published DROP NOT NULL;
+
+UPDATE
+    post_like
+SET
+    published = NULL;
+
+ALTER TABLE comment_like
+    ALTER COLUMN published DROP NOT NULL;
+
+UPDATE
+    comment_like
+SET
+    published = NULL;
+
+ALTER TABLE comment_like
+    ALTER COLUMN post_id DROP NOT NULL;
+
+UPDATE
+    post_like
+SET
+    post_id = NULL;
+
+-- drop the columns
 ALTER TABLE post_like
     DROP published;
 

--- a/migrations/2024-10-17-091053_vote-no-timestamp/up.sql
+++ b/migrations/2024-10-17-091053_vote-no-timestamp/up.sql
@@ -1,21 +1,18 @@
--- set all column values to null to reclaim disk space
--- https://dba.stackexchange.com/a/117513
+-- make published columns nullable and remove default value
 ALTER TABLE post_like
     ALTER COLUMN published DROP NOT NULL;
 
-UPDATE
-    post_like
-SET
-    published = NULL;
+ALTER TABLE post_like
+    ALTER COLUMN published DROP DEFAULT;
 
 ALTER TABLE comment_like
     ALTER COLUMN published DROP NOT NULL;
 
-UPDATE
-    comment_like
-SET
-    published = NULL;
+ALTER TABLE comment_like
+    ALTER COLUMN published DROP DEFAULT;
 
+-- get rid of comment_like.post_id, setting null first to reclaim space
+-- https://dba.stackexchange.com/a/117513
 ALTER TABLE comment_like
     ALTER COLUMN post_id DROP NOT NULL;
 
@@ -25,12 +22,6 @@ SET
     post_id = NULL;
 
 -- drop the columns
-ALTER TABLE post_like
-    DROP published;
-
-ALTER TABLE comment_like
-    DROP published;
-
 ALTER TABLE comment_like
     DROP post_id;
 

--- a/migrations/2024-10-17-091053_vote-no-timestamp/up.sql
+++ b/migrations/2024-10-17-091053_vote-no-timestamp/up.sql
@@ -1,7 +1,9 @@
 ALTER TABLE post_like
     DROP published;
+
 ALTER TABLE comment_like
     DROP published;
+
 ALTER TABLE comment_like
     DROP post_id;
 

--- a/migrations/2024-10-17-091053_vote-no-timestamp/up.sql
+++ b/migrations/2024-10-17-091053_vote-no-timestamp/up.sql
@@ -1,6 +1,7 @@
 ALTER TABLE post_like
     DROP published;
-
 ALTER TABLE comment_like
     DROP published;
+ALTER TABLE comment_like
+    DROP post_id;
 

--- a/migrations/2024-10-17-091053_vote-no-timestamp/up.sql
+++ b/migrations/2024-10-17-091053_vote-no-timestamp/up.sql
@@ -1,0 +1,2 @@
+alter table post_like drop published;
+alter table comment_like drop published;


### PR DESCRIPTION
Turns out timestamps and comment_like.post_id arent used at all in the backend. So this PR adds a setting `database.store_vote_timestamps: bool` to avoid storing them (default false). Also comment_like.post_id is removed. If timestamps are enabled, they are now returned by the api in like list endpoints. With the setting disabled, storage usage changes like this:

Previous size of post_like column: 4 + 4 + 2 + 8 = 18 bytes
Previous size of comment_like: 4 + 4 + 2 + 8 + 4 = 22 bytes

After this change both are 10 bytes so the table size should also be reduzed by half roughly, so in case of lemmy.ml from 15 gb to ~7.5 gb. With 40gb total db size this is a reduction by 19%.