### PR TITLE
Trying to up connection limit.

### DIFF
--- a/docker/federation/nginx.conf
+++ b/docker/federation/nginx.conf
@@ -1,5 +1,5 @@
 events {
-    worker_connections 1024;
+    worker_connections 10000;
 }
 
 http {

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,6 +1,6 @@
 worker_processes 1;
 events {
-    worker_connections 1024;
+    worker_connections 10000;
 }
 http {
     upstream lemmy {


### PR DESCRIPTION
We're getting a ton of intermittent errors on federation tests for my CI machines. 

The specific error we see is `SocketError: other side closed`

[It might be due to limited worker connections by nginx.](https://github.com/nodejs/undici/issues/583#issuecomment-2220912602)