### PR TITLE
Dont pass settings as parameter

### DIFF
--- a/crates/api/src/comment_report/create.rs
+++ b/crates/api/src/comment_report/create.rs
@@ -72,7 +72,6 @@ pub async fn create_comment_report(
       &comment_report_view.creator.name,
       &comment_report_view.comment_creator.name,
       &mut context.pool(),
-      context.settings(),
     )
     .await?;
   }

--- a/crates/api/src/local_user/login.rs
+++ b/crates/api/src/local_user/login.rs
@@ -11,7 +11,10 @@ use lemmy_api_common::{
   utils::{check_email_verified, check_registration_application, check_user_valid},
 };
 use lemmy_db_views::structs::{LocalUserView, SiteView};
-use lemmy_utils::error::{LemmyErrorType, LemmyResult};
+use lemmy_utils::{
+  error::{LemmyErrorType, LemmyResult},
+  settings::SETTINGS,
+};
 
 #[tracing::instrument(skip(context))]
 pub async fn login(
@@ -44,11 +47,7 @@ pub async fn login(
 
   // Check the totp if enabled
   if local_user_view.local_user.totp_2fa_enabled {
-    check_totp_2fa_valid(
-      &local_user_view,
-      &data.totp_2fa_token,
-      &context.settings().hostname,
-    )?;
+    check_totp_2fa_valid(&local_user_view, &data.totp_2fa_token, &SETTINGS.hostname)?;
   }
 
   let jwt = Claims::generate(local_user_view.local_user.id, req, &context).await?;

--- a/crates/api/src/local_user/reset_password.rs
+++ b/crates/api/src/local_user/reset_password.rs
@@ -23,6 +23,6 @@ pub async fn reset_password(
   check_email_verified(&local_user_view, &site_view)?;
 
   // Email the pure token to the user.
-  send_password_reset_email(&local_user_view, &mut context.pool(), context.settings()).await?;
+  send_password_reset_email(&local_user_view, &mut context.pool()).await?;
   Ok(Json(SuccessResponse::default()))
 }

--- a/crates/api/src/local_user/save_settings.rs
+++ b/crates/api/src/local_user/save_settings.rs
@@ -64,13 +64,7 @@ pub async fn save_user_settings(
     // if email was changed, check that it is not taken and send verification mail
     if previous_email.deref() != email {
       LocalUser::check_is_email_taken(&mut context.pool(), email).await?;
-      send_verification_email(
-        &local_user_view,
-        email,
-        &mut context.pool(),
-        context.settings(),
-      )
-      .await?;
+      send_verification_email(&local_user_view, email, &mut context.pool()).await?;
     }
   }
 

--- a/crates/api/src/local_user/update_totp.rs
+++ b/crates/api/src/local_user/update_totp.rs
@@ -6,7 +6,7 @@ use lemmy_api_common::{
 };
 use lemmy_db_schema::source::local_user::{LocalUser, LocalUserUpdateForm};
 use lemmy_db_views::structs::LocalUserView;
-use lemmy_utils::error::LemmyResult;
+use lemmy_utils::{error::LemmyResult, settings::SETTINGS};
 
 /// Enable or disable two-factor-authentication. The current setting is determined from
 /// [LocalUser.totp_2fa_enabled].
@@ -25,7 +25,7 @@ pub async fn update_totp(
   check_totp_2fa_valid(
     &local_user_view,
     &Some(data.totp_token.clone()),
-    &context.settings().hostname,
+    &SETTINGS.hostname,
   )?;
 
   // toggle the 2fa setting

--- a/crates/api/src/local_user/verify_email.rs
+++ b/crates/api/src/local_user/verify_email.rs
@@ -37,12 +37,7 @@ pub async fn verify_email(
   if site_view.local_site.application_email_admins {
     let local_user = LocalUserView::read(&mut context.pool(), local_user_id).await?;
 
-    send_new_applicant_email_to_admins(
-      &local_user.person.name,
-      &mut context.pool(),
-      context.settings(),
-    )
-    .await?;
+    send_new_applicant_email_to_admins(&local_user.person.name, &mut context.pool()).await?;
   }
 
   Ok(Json(SuccessResponse::default()))

--- a/crates/api/src/post_report/create.rs
+++ b/crates/api/src/post_report/create.rs
@@ -67,7 +67,6 @@ pub async fn create_post_report(
       &post_report_view.creator.name,
       &post_report_view.post_creator.name,
       &mut context.pool(),
-      context.settings(),
     )
     .await?;
   }

--- a/crates/api/src/private_message_report/create.rs
+++ b/crates/api/src/private_message_report/create.rs
@@ -56,7 +56,6 @@ pub async fn create_pm_report(
       &private_message_report_view.creator.name,
       &private_message_report_view.private_message_creator.name,
       &mut context.pool(),
-      context.settings(),
     )
     .await?;
   }

--- a/crates/api/src/site/registration_applications/approve.rs
+++ b/crates/api/src/site/registration_applications/approve.rs
@@ -62,7 +62,7 @@ pub async fn approve_registration_application(
       LocalUserView::read(&mut context.pool(), approved_user_id).await?;
     if approved_local_user_view.local_user.email.is_some() {
       // Email sending may fail, but this won't revert the application approval
-      send_application_approved_email(&approved_local_user_view, context.settings()).await?;
+      send_application_approved_email(&approved_local_user_view).await?;
     }
   };
 

--- a/crates/api_common/src/build_response.rs
+++ b/crates/api_common/src/build_response.rs
@@ -26,6 +26,7 @@ use lemmy_db_views::structs::{CommentView, LocalUserView, PostView};
 use lemmy_db_views_actor::structs::CommunityView;
 use lemmy_utils::{
   error::LemmyResult,
+  settings::SETTINGS,
   utils::{markdown::markdown_to_html, mention::MentionData},
 };
 
@@ -99,7 +100,7 @@ pub async fn send_local_notifs(
   local_user_view: Option<&LocalUserView>,
 ) -> LemmyResult<Vec<LocalUserId>> {
   let mut recipient_ids = Vec::new();
-  let inbox_link = format!("{}/inbox", context.settings().get_protocol_and_hostname());
+  let inbox_link = format!("{}/inbox", SETTINGS.get_protocol_and_hostname());
 
   // let person = my_local_user.person;
   // Read the comment view to get extra info
@@ -116,7 +117,7 @@ pub async fn send_local_notifs(
   // Send the local mentions
   for mention in mentions
     .iter()
-    .filter(|m| m.is_local(&context.settings().hostname) && m.name.ne(&person.name))
+    .filter(|m| m.is_local() && m.name.ne(&person.name))
   {
     let mention_name = mention.name.clone();
     let user_view = LocalUserView::read_from_name(&mut context.pool(), &mention_name).await;
@@ -147,7 +148,6 @@ pub async fn send_local_notifs(
           &mention_user_view,
           &lang.notification_mentioned_by_subject(&person.name),
           &lang.notification_mentioned_by_body(&content, &inbox_link, &person.name),
-          context.settings(),
         )
         .await
       }
@@ -199,7 +199,6 @@ pub async fn send_local_notifs(
               &parent_user_view,
               &lang.notification_comment_reply_subject(&person.name),
               &lang.notification_comment_reply_body(&content, &inbox_link, &person.name),
-              context.settings(),
             )
             .await
           }
@@ -245,7 +244,6 @@ pub async fn send_local_notifs(
               &parent_user_view,
               &lang.notification_post_reply_subject(&person.name),
               &lang.notification_post_reply_body(&content, &inbox_link, &person.name),
-              context.settings(),
             )
             .await
           }

--- a/crates/api_common/src/claims.rs
+++ b/crates/api_common/src/claims.rs
@@ -7,7 +7,10 @@ use lemmy_db_schema::{
   sensitive::SensitiveString,
   source::login_token::{LoginToken, LoginTokenCreateForm},
 };
-use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
+use lemmy_utils::{
+  error::{LemmyErrorExt, LemmyErrorType, LemmyResult},
+  settings::SETTINGS,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
@@ -38,7 +41,7 @@ impl Claims {
     req: HttpRequest,
     context: &LemmyContext,
   ) -> LemmyResult<SensitiveString> {
-    let hostname = context.settings().hostname.clone();
+    let hostname = SETTINGS.hostname.clone();
     let my_claims = Claims {
       sub: user_id.0.to_string(),
       iss: hostname,

--- a/crates/api_common/src/context.rs
+++ b/crates/api_common/src/context.rs
@@ -4,10 +4,7 @@ use lemmy_db_schema::{
   source::secret::Secret,
   utils::{build_db_pool_for_tests, ActualDbPool, DbPool},
 };
-use lemmy_utils::{
-  rate_limit::RateLimitCell,
-  settings::{structs::Settings, SETTINGS},
-};
+use lemmy_utils::{rate_limit::RateLimitCell, settings::SETTINGS};
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use std::sync::Arc;
 
@@ -42,9 +39,6 @@ impl LemmyContext {
   pub fn client(&self) -> &ClientWithMiddleware {
     &self.client
   }
-  pub fn settings(&self) -> &'static Settings {
-    &SETTINGS
-  }
   pub fn secret(&self) -> &Secret {
     &self.secret
   }
@@ -72,7 +66,7 @@ impl LemmyContext {
     let context = LemmyContext::create(pool, client, secret, rate_limit_cell.clone());
 
     FederationConfig::builder()
-      .domain(context.settings().hostname.clone())
+      .domain(SETTINGS.hostname.clone())
       .app_data(context)
       .debug(true)
       // Dont allow any network fetches

--- a/crates/api_crud/src/community/create.rs
+++ b/crates/api_crud/src/community/create.rs
@@ -74,11 +74,7 @@ pub async fn create_community(
   }
 
   // Double check for duplicate community actor_ids
-  let community_actor_id = generate_local_apub_endpoint(
-    EndpointType::Community,
-    &data.name,
-    &context.settings().get_protocol_and_hostname(),
-  )?;
+  let community_actor_id = generate_local_apub_endpoint(EndpointType::Community, &data.name)?;
   let community_dupe =
     Community::read_from_apub_id(&mut context.pool(), &community_actor_id).await?;
   if community_dupe.is_some() {
@@ -97,7 +93,7 @@ pub async fn create_community(
     private_key: Some(keypair.private_key),
     followers_url: Some(generate_followers_url(&community_actor_id)?),
     inbox_url: Some(generate_inbox_url(&community_actor_id)?),
-    shared_inbox_url: Some(generate_shared_inbox_url(context.settings())?),
+    shared_inbox_url: Some(generate_shared_inbox_url()?),
     posting_restricted_to_mods: data.posting_restricted_to_mods,
     visibility: data.visibility,
     ..CommunityInsertForm::new(

--- a/crates/api_crud/src/private_message/create.rs
+++ b/crates/api_crud/src/private_message/create.rs
@@ -23,6 +23,7 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::{LocalUserView, PrivateMessageView};
 use lemmy_utils::{
   error::{LemmyErrorExt, LemmyErrorType, LemmyResult},
+  settings::SETTINGS,
   utils::{markdown::markdown_to_html, validation::is_valid_body_field},
 };
 
@@ -63,14 +64,13 @@ pub async fn create_private_message(
     let recipient_id = data.recipient_id;
     let local_recipient = LocalUserView::read_person(&mut context.pool(), recipient_id).await?;
     let lang = get_interface_language(&local_recipient);
-    let inbox_link = format!("{}/inbox", context.settings().get_protocol_and_hostname());
+    let inbox_link = format!("{}/inbox", SETTINGS.get_protocol_and_hostname());
     let sender_name = &local_user_view.person.name;
     let content = markdown_to_html(&content);
     send_email_to_user(
       &local_recipient,
       &lang.notification_private_message_subject(sender_name),
       &lang.notification_private_message_body(inbox_link, &content, sender_name),
-      context.settings(),
     )
     .await;
   }

--- a/crates/api_crud/src/site/create.rs
+++ b/crates/api_crud/src/site/create.rs
@@ -28,6 +28,7 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::{LocalUserView, SiteView};
 use lemmy_utils::{
   error::{LemmyErrorType, LemmyResult},
+  settings::SETTINGS,
   utils::{
     slurs::{check_slurs, check_slurs_opt},
     validation::{
@@ -54,8 +55,8 @@ pub async fn create_site(
 
   validate_create_payload(&local_site, &data)?;
 
-  let actor_id: DbUrl = Url::parse(&context.settings().get_protocol_and_hostname())?.into();
-  let inbox_url = Some(generate_shared_inbox_url(context.settings())?);
+  let actor_id: DbUrl = Url::parse(&SETTINGS.get_protocol_and_hostname())?.into();
+  let inbox_url = Some(generate_shared_inbox_url()?);
   let keypair = generate_actor_keypair()?;
 
   let slur_regex = local_site_to_slur_regex(&local_site);

--- a/crates/api_crud/src/user/create.rs
+++ b/crates/api_crud/src/user/create.rs
@@ -161,8 +161,7 @@ pub async fn register(
 
   // Email the admins, only if email verification is not required
   if local_site.application_email_admins && !local_site.require_email_verification {
-    send_new_applicant_email_to_admins(&data.username, &mut context.pool(), context.settings())
-      .await?;
+    send_new_applicant_email_to_admins(&data.username, &mut context.pool()).await?;
   }
 
   let mut login_response = LoginResponse {
@@ -409,17 +408,13 @@ async fn create_person(
 ) -> Result<Person, LemmyError> {
   let actor_keypair = generate_actor_keypair()?;
   is_valid_actor_name(&username, local_site.actor_name_max_length as usize)?;
-  let actor_id = generate_local_apub_endpoint(
-    EndpointType::Person,
-    &username,
-    &context.settings().get_protocol_and_hostname(),
-  )?;
+  let actor_id = generate_local_apub_endpoint(EndpointType::Person, &username)?;
 
   // Register the new person
   let person_form = PersonInsertForm {
     actor_id: Some(actor_id.clone()),
     inbox_url: Some(generate_inbox_url(&actor_id)?),
-    shared_inbox_url: Some(generate_shared_inbox_url(context.settings())?),
+    shared_inbox_url: Some(generate_shared_inbox_url()?),
     private_key: Some(actor_keypair.private_key),
     ..PersonInsertForm::new(username.clone(), actor_keypair.public_key, instance_id)
   };
@@ -487,7 +482,6 @@ async fn send_verification_email_if_required(
         .clone()
         .expect("invalid verification email"),
       &mut context.pool(),
-      context.settings(),
     )
     .await?;
 

--- a/crates/apub/src/activities/block/block_user.rs
+++ b/crates/apub/src/activities/block/block_user.rs
@@ -41,6 +41,7 @@ use lemmy_db_schema::{
 };
 use lemmy_utils::{
   error::{LemmyError, LemmyResult},
+  settings::SETTINGS,
   LemmyErrorType,
 };
 use url::Url;
@@ -69,10 +70,7 @@ impl BlockUser {
       kind: BlockType::Block,
       remove_data,
       summary: reason,
-      id: generate_activity_id(
-        BlockType::Block,
-        &context.settings().get_protocol_and_hostname(),
-      )?,
+      id: generate_activity_id(BlockType::Block)?,
       audience,
       end_time: expires,
     })
@@ -136,7 +134,7 @@ impl ActivityHandler for BlockUser {
           .inner()
           .domain()
           .ok_or(LemmyErrorType::UrlWithoutDomain)?;
-        if context.settings().hostname == domain {
+        if SETTINGS.hostname == domain {
           return Err(
             anyhow!("Site bans from remote instance can't affect user's home instance").into(),
           );

--- a/crates/apub/src/activities/block/undo_block_user.rs
+++ b/crates/apub/src/activities/block/undo_block_user.rs
@@ -50,10 +50,7 @@ impl UndoBlockUser {
       None
     };
 
-    let id = generate_activity_id(
-      UndoType::Undo,
-      &context.settings().get_protocol_and_hostname(),
-    )?;
+    let id = generate_activity_id(UndoType::Undo)?;
     let undo = UndoBlockUser {
       actor: mod_.id().into(),
       to: vec![public()],

--- a/crates/apub/src/activities/community/collection_add.rs
+++ b/crates/apub/src/activities/community/collection_add.rs
@@ -47,10 +47,7 @@ impl CollectionAdd {
     actor: &ApubPerson,
     context: &Data<LemmyContext>,
   ) -> LemmyResult<()> {
-    let id = generate_activity_id(
-      AddType::Add,
-      &context.settings().get_protocol_and_hostname(),
-    )?;
+    let id = generate_activity_id(AddType::Add)?;
     let add = CollectionAdd {
       actor: actor.id().into(),
       to: vec![public()],
@@ -73,10 +70,7 @@ impl CollectionAdd {
     actor: &ApubPerson,
     context: &Data<LemmyContext>,
   ) -> LemmyResult<()> {
-    let id = generate_activity_id(
-      AddType::Add,
-      &context.settings().get_protocol_and_hostname(),
-    )?;
+    let id = generate_activity_id(AddType::Add)?;
     let add = CollectionAdd {
       actor: actor.id().into(),
       to: vec![public()],

--- a/crates/apub/src/activities/community/collection_remove.rs
+++ b/crates/apub/src/activities/community/collection_remove.rs
@@ -42,10 +42,7 @@ impl CollectionRemove {
     actor: &ApubPerson,
     context: &Data<LemmyContext>,
   ) -> LemmyResult<()> {
-    let id = generate_activity_id(
-      RemoveType::Remove,
-      &context.settings().get_protocol_and_hostname(),
-    )?;
+    let id = generate_activity_id(RemoveType::Remove)?;
     let remove = CollectionRemove {
       actor: actor.id().into(),
       to: vec![public()],
@@ -68,10 +65,7 @@ impl CollectionRemove {
     actor: &ApubPerson,
     context: &Data<LemmyContext>,
   ) -> LemmyResult<()> {
-    let id = generate_activity_id(
-      RemoveType::Remove,
-      &context.settings().get_protocol_and_hostname(),
-    )?;
+    let id = generate_activity_id(RemoveType::Remove)?;
     let remove = CollectionRemove {
       actor: actor.id().into(),
       to: vec![public()],

--- a/crates/apub/src/activities/community/lock_page.rs
+++ b/crates/apub/src/activities/community/lock_page.rs
@@ -130,10 +130,7 @@ pub(crate) async fn send_lock_post(
   let community: ApubCommunity = Community::read(&mut context.pool(), post.community_id)
     .await?
     .into();
-  let id = generate_activity_id(
-    LockType::Lock,
-    &context.settings().get_protocol_and_hostname(),
-  )?;
+  let id = generate_activity_id(LockType::Lock)?;
   let community_id = community.actor_id.inner().clone();
   let lock = LockPage {
     actor: actor.actor_id.clone().into(),
@@ -147,10 +144,7 @@ pub(crate) async fn send_lock_post(
   let activity = if locked {
     AnnouncableActivities::LockPost(lock)
   } else {
-    let id = generate_activity_id(
-      UndoType::Undo,
-      &context.settings().get_protocol_and_hostname(),
-    )?;
+    let id = generate_activity_id(UndoType::Undo)?;
     let undo = UndoLockPage {
       actor: lock.actor.clone(),
       to: vec![public()],

--- a/crates/apub/src/activities/community/report.rs
+++ b/crates/apub/src/activities/community/report.rs
@@ -44,10 +44,7 @@ impl Report {
     let actor: ApubPerson = actor.into();
     let community: ApubCommunity = community.into();
     let kind = FlagType::Flag;
-    let id = generate_activity_id(
-      kind.clone(),
-      &context.settings().get_protocol_and_hostname(),
-    )?;
+    let id = generate_activity_id(kind.clone())?;
     let report = Report {
       actor: actor.id().into(),
       to: [community.id().into()],

--- a/crates/apub/src/activities/community/update.rs
+++ b/crates/apub/src/activities/community/update.rs
@@ -36,10 +36,7 @@ pub(crate) async fn send_update_community(
 ) -> LemmyResult<()> {
   let community: ApubCommunity = community.into();
   let actor: ApubPerson = actor.into();
-  let id = generate_activity_id(
-    UpdateType::Update,
-    &context.settings().get_protocol_and_hostname(),
-  )?;
+  let id = generate_activity_id(UpdateType::Update)?;
   let update = UpdateCommunity {
     actor: actor.id().into(),
     to: vec![public()],

--- a/crates/apub/src/activities/create_or_update/comment.rs
+++ b/crates/apub/src/activities/create_or_update/comment.rs
@@ -62,10 +62,7 @@ impl CreateOrUpdateNote {
       .await?
       .into();
 
-    let id = generate_activity_id(
-      kind.clone(),
-      &context.settings().get_protocol_and_hostname(),
-    )?;
+    let id = generate_activity_id(kind.clone())?;
     let note = ApubComment(comment).into_json(&context).await?;
 
     let create_or_update = CreateOrUpdateNote {

--- a/crates/apub/src/activities/create_or_update/post.rs
+++ b/crates/apub/src/activities/create_or_update/post.rs
@@ -43,10 +43,7 @@ impl CreateOrUpdatePage {
     kind: CreateOrUpdateType,
     context: &Data<LemmyContext>,
   ) -> LemmyResult<CreateOrUpdatePage> {
-    let id = generate_activity_id(
-      kind.clone(),
-      &context.settings().get_protocol_and_hostname(),
-    )?;
+    let id = generate_activity_id(kind.clone())?;
     Ok(CreateOrUpdatePage {
       actor: actor.id().into(),
       to: vec![public()],

--- a/crates/apub/src/activities/create_or_update/private_message.rs
+++ b/crates/apub/src/activities/create_or_update/private_message.rs
@@ -26,10 +26,7 @@ pub(crate) async fn send_create_or_update_pm(
   let actor: ApubPerson = pm_view.creator.into();
   let recipient: ApubPerson = pm_view.recipient.into();
 
-  let id = generate_activity_id(
-    kind.clone(),
-    &context.settings().get_protocol_and_hostname(),
-  )?;
+  let id = generate_activity_id(kind.clone())?;
   let create_or_update = CreateOrUpdateChatMessage {
     id: id.clone(),
     actor: actor.id().into(),

--- a/crates/apub/src/activities/deletion/delete.rs
+++ b/crates/apub/src/activities/deletion/delete.rs
@@ -87,12 +87,8 @@ impl Delete {
     to: Url,
     community: Option<&Community>,
     summary: Option<String>,
-    context: &Data<LemmyContext>,
   ) -> LemmyResult<Delete> {
-    let id = generate_activity_id(
-      DeleteType::Delete,
-      &context.settings().get_protocol_and_hostname(),
-    )?;
+    let id = generate_activity_id(DeleteType::Delete)?;
     let cc: Option<Url> = community.map(|c| c.actor_id.clone().into());
     Ok(Delete {
       actor: actor.actor_id.clone().into(),

--- a/crates/apub/src/activities/deletion/mod.rs
+++ b/crates/apub/src/activities/deletion/mod.rs
@@ -60,10 +60,10 @@ pub(crate) async fn send_apub_delete_in_community(
   let actor = ApubPerson::from(actor);
   let is_mod_action = reason.is_some();
   let activity = if deleted {
-    let delete = Delete::new(&actor, object, public(), Some(&community), reason, context)?;
+    let delete = Delete::new(&actor, object, public(), Some(&community), reason)?;
     AnnouncableActivities::Delete(delete)
   } else {
-    let undo = UndoDelete::new(&actor, object, public(), Some(&community), reason, context)?;
+    let undo = UndoDelete::new(&actor, object, public(), Some(&community), reason)?;
     AnnouncableActivities::UndoDelete(undo)
   };
   send_activity_in_community(
@@ -92,10 +92,10 @@ pub(crate) async fn send_apub_delete_private_message(
   let deletable = DeletableObjects::PrivateMessage(pm.into());
   let inbox = ActivitySendTargets::to_inbox(recipient.shared_inbox_or_inbox());
   if deleted {
-    let delete: Delete = Delete::new(actor, deletable, recipient.id(), None, None, &context)?;
+    let delete: Delete = Delete::new(actor, deletable, recipient.id(), None, None)?;
     send_lemmy_activity(&context, delete, actor, inbox, true).await?;
   } else {
-    let undo = UndoDelete::new(actor, deletable, recipient.id(), None, None, &context)?;
+    let undo = UndoDelete::new(actor, deletable, recipient.id(), None, None)?;
     send_lemmy_activity(&context, undo, actor, inbox, true).await?;
   };
   Ok(())
@@ -109,7 +109,7 @@ pub async fn send_apub_delete_user(
   let person: ApubPerson = person.into();
 
   let deletable = DeletableObjects::Person(person.clone());
-  let mut delete: Delete = Delete::new(&person, deletable, public(), None, None, &context)?;
+  let mut delete: Delete = Delete::new(&person, deletable, public(), None, None)?;
   delete.remove_data = Some(remove_data);
 
   let inboxes = ActivitySendTargets::to_all_instances();

--- a/crates/apub/src/activities/deletion/undo_delete.rs
+++ b/crates/apub/src/activities/deletion/undo_delete.rs
@@ -71,14 +71,10 @@ impl UndoDelete {
     to: Url,
     community: Option<&Community>,
     summary: Option<String>,
-    context: &Data<LemmyContext>,
   ) -> LemmyResult<UndoDelete> {
-    let object = Delete::new(actor, object, to.clone(), community, summary, context)?;
+    let object = Delete::new(actor, object, to.clone(), community, summary)?;
 
-    let id = generate_activity_id(
-      UndoType::Undo,
-      &context.settings().get_protocol_and_hostname(),
-    )?;
+    let id = generate_activity_id(UndoType::Undo)?;
     let cc: Option<Url> = community.map(|c| c.actor_id.clone().into());
     Ok(UndoDelete {
       actor: actor.actor_id.clone().into(),

--- a/crates/apub/src/activities/following/accept.rs
+++ b/crates/apub/src/activities/following/accept.rs
@@ -27,10 +27,7 @@ impl AcceptFollow {
       to: Some([person.id().into()]),
       object: follow,
       kind: AcceptType::Accept,
-      id: generate_activity_id(
-        AcceptType::Accept,
-        &context.settings().get_protocol_and_hostname(),
-      )?,
+      id: generate_activity_id(AcceptType::Accept)?,
     };
     let inbox = ActivitySendTargets::to_inbox(person.shared_inbox_or_inbox());
     send_lemmy_activity(context, accept, &user_or_community, inbox, true).await

--- a/crates/apub/src/activities/following/follow.rs
+++ b/crates/apub/src/activities/following/follow.rs
@@ -33,17 +33,13 @@ impl Follow {
   pub(in crate::activities::following) fn new(
     actor: &ApubPerson,
     community: &ApubCommunity,
-    context: &Data<LemmyContext>,
   ) -> LemmyResult<Follow> {
     Ok(Follow {
       actor: actor.id().into(),
       object: community.id().into(),
       to: Some([community.id().into()]),
       kind: FollowType::Follow,
-      id: generate_activity_id(
-        FollowType::Follow,
-        &context.settings().get_protocol_and_hostname(),
-      )?,
+      id: generate_activity_id(FollowType::Follow)?,
     })
   }
 
@@ -53,7 +49,7 @@ impl Follow {
     community: &ApubCommunity,
     context: &Data<LemmyContext>,
   ) -> LemmyResult<()> {
-    let follow = Follow::new(actor, community, context)?;
+    let follow = Follow::new(actor, community)?;
     let inbox = if community.local {
       ActivitySendTargets::empty()
     } else {

--- a/crates/apub/src/activities/following/undo_follow.rs
+++ b/crates/apub/src/activities/following/undo_follow.rs
@@ -30,16 +30,13 @@ impl UndoFollow {
     community: &ApubCommunity,
     context: &Data<LemmyContext>,
   ) -> LemmyResult<()> {
-    let object = Follow::new(actor, community, context)?;
+    let object = Follow::new(actor, community)?;
     let undo = UndoFollow {
       actor: actor.id().into(),
       to: Some([community.id().into()]),
       object,
       kind: UndoType::Undo,
-      id: generate_activity_id(
-        UndoType::Undo,
-        &context.settings().get_protocol_and_hostname(),
-      )?,
+      id: generate_activity_id(UndoType::Undo)?,
     };
     let inbox = if community.local {
       ActivitySendTargets::empty()

--- a/crates/apub/src/activities/mod.rs
+++ b/crates/apub/src/activities/mod.rs
@@ -42,7 +42,10 @@ use lemmy_db_schema::{
   traits::Crud,
 };
 use lemmy_db_views_actor::structs::{CommunityPersonBanView, CommunityView};
-use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType, LemmyResult};
+use lemmy_utils::{
+  error::{LemmyError, LemmyErrorExt, LemmyErrorType, LemmyResult},
+  settings::SETTINGS,
+};
 use serde::Serialize;
 use tracing::info;
 use url::{ParseError, Url};
@@ -142,10 +145,11 @@ pub(crate) fn check_community_deleted_or_removed(community: &Community) -> Lemmy
 
 /// Generate a unique ID for an activity, in the format:
 /// `http(s)://example.com/receive/create/202daf0a-1489-45df-8d2e-c8a3173fed36`
-fn generate_activity_id<T>(kind: T, protocol_and_hostname: &str) -> Result<Url, ParseError>
+fn generate_activity_id<T>(kind: T) -> Result<Url, ParseError>
 where
   T: ToString,
 {
+  let protocol_and_hostname = &SETTINGS.get_protocol_and_hostname();
   let id = format!(
     "{}/activities/{}/{}",
     protocol_and_hostname,
@@ -156,10 +160,8 @@ where
 }
 
 /// like generate_activity_id but also add the inner kind for easier debugging
-fn generate_announce_activity_id(
-  inner_kind: &str,
-  protocol_and_hostname: &str,
-) -> Result<Url, ParseError> {
+fn generate_announce_activity_id(inner_kind: &str) -> Result<Url, ParseError> {
+  let protocol_and_hostname = &SETTINGS.get_protocol_and_hostname();
   let id = format!(
     "{}/activities/{}/{}/{}",
     protocol_and_hostname,

--- a/crates/apub/src/activities/voting/mod.rs
+++ b/crates/apub/src/activities/voting/mod.rs
@@ -40,13 +40,13 @@ pub(crate) async fn send_like_activity(
   let empty = ActivitySendTargets::empty();
   // score of 1 means upvote, -1 downvote, 0 undo a previous vote
   if score != 0 {
-    let vote = Vote::new(object_id, &actor, &community, score.try_into()?, &context)?;
+    let vote = Vote::new(object_id, &actor, &community, score.try_into()?)?;
     let activity = AnnouncableActivities::Vote(vote);
     send_activity_in_community(activity, &actor, &community, empty, false, &context).await
   } else {
     // Lemmy API doesn't distinguish between Undo/Like and Undo/Dislike, so we hardcode it here.
-    let vote = Vote::new(object_id, &actor, &community, VoteType::Like, &context)?;
-    let undo_vote = UndoVote::new(vote, &actor, &community, &context)?;
+    let vote = Vote::new(object_id, &actor, &community, VoteType::Like)?;
+    let undo_vote = UndoVote::new(vote, &actor, &community)?;
     let activity = AnnouncableActivities::UndoVote(undo_vote);
     send_activity_in_community(activity, &actor, &community, empty, false, &context).await
   }

--- a/crates/apub/src/activities/voting/undo_vote.rs
+++ b/crates/apub/src/activities/voting/undo_vote.rs
@@ -27,16 +27,12 @@ impl UndoVote {
     vote: Vote,
     actor: &ApubPerson,
     community: &ApubCommunity,
-    context: &Data<LemmyContext>,
   ) -> LemmyResult<Self> {
     Ok(UndoVote {
       actor: actor.id().into(),
       object: vote,
       kind: UndoType::Undo,
-      id: generate_activity_id(
-        UndoType::Undo,
-        &context.settings().get_protocol_and_hostname(),
-      )?,
+      id: generate_activity_id(UndoType::Undo)?,
       audience: Some(community.id().into()),
     })
   }

--- a/crates/apub/src/activities/voting/vote.rs
+++ b/crates/apub/src/activities/voting/vote.rs
@@ -28,13 +28,12 @@ impl Vote {
     actor: &ApubPerson,
     community: &ApubCommunity,
     kind: VoteType,
-    context: &Data<LemmyContext>,
   ) -> LemmyResult<Vote> {
     Ok(Vote {
       actor: actor.id().into(),
       object: object_id,
       kind: kind.clone(),
-      id: generate_activity_id(kind, &context.settings().get_protocol_and_hostname())?,
+      id: generate_activity_id(kind)?,
       audience: Some(community.id().into()),
     })
   }

--- a/crates/apub/src/collections/community_outbox.rs
+++ b/crates/apub/src/collections/community_outbox.rs
@@ -57,7 +57,7 @@ impl Collection for ApubCommunityOutbox {
       )
       .await?;
       let announcable = AnnouncableActivities::CreateOrUpdatePost(create);
-      let announce = AnnounceActivity::new(announcable.try_into()?, owner, data)?;
+      let announce = AnnounceActivity::new(announcable.try_into()?, owner)?;
       ordered_items.push(announce);
     }
 

--- a/crates/apub/src/fetcher/markdown_links.rs
+++ b/crates/apub/src/fetcher/markdown_links.rs
@@ -8,6 +8,7 @@ use lemmy_api_common::{
 use lemmy_db_schema::{newtypes::InstanceId, source::instance::Instance};
 use lemmy_utils::{
   error::LemmyResult,
+  settings::SETTINGS,
   utils::markdown::image_links::{markdown_find_links, markdown_handle_title},
 };
 use url::Url;
@@ -52,7 +53,7 @@ pub async fn markdown_rewrite_remote_links(
 }
 
 pub(crate) async fn to_local_url(url: &str, context: &Data<LemmyContext>) -> Option<Url> {
-  let local_domain = &context.settings().get_protocol_and_hostname();
+  let local_domain = &SETTINGS.get_protocol_and_hostname();
   let object_id = ObjectId::<SearchableObjects>::parse(url).ok()?;
   if object_id.inner().domain() == Some(local_domain) {
     return None;
@@ -61,10 +62,10 @@ pub(crate) async fn to_local_url(url: &str, context: &Data<LemmyContext>) -> Opt
   match dereferenced {
     SearchableObjects::PostOrComment(pc) => match *pc {
       PostOrComment::Post(post) => {
-        generate_local_apub_endpoint(EndpointType::Post, &post.id.to_string(), local_domain)
+        generate_local_apub_endpoint(EndpointType::Post, &post.id.to_string())
       }
       PostOrComment::Comment(comment) => {
-        generate_local_apub_endpoint(EndpointType::Comment, &comment.id.to_string(), local_domain)
+        generate_local_apub_endpoint(EndpointType::Comment, &comment.id.to_string())
       }
     }
     .ok()
@@ -87,8 +88,8 @@ async fn format_actor_url(
   instance_id: InstanceId,
   context: &LemmyContext,
 ) -> LemmyResult<Url> {
-  let local_protocol_and_hostname = context.settings().get_protocol_and_hostname();
-  let local_hostname = &context.settings().hostname;
+  let local_protocol_and_hostname = SETTINGS.get_protocol_and_hostname();
+  let local_hostname = &SETTINGS.hostname;
   let instance = Instance::read(&mut context.pool(), instance_id).await?;
   let url = if &instance.domain != local_hostname {
     format!(

--- a/crates/apub/src/http/mod.rs
+++ b/crates/apub/src/http/mod.rs
@@ -17,7 +17,10 @@ use lemmy_db_schema::{
   source::{activity::SentActivity, community::Community},
   CommunityVisibility,
 };
-use lemmy_utils::error::{LemmyErrorType, LemmyResult};
+use lemmy_utils::{
+  error::{LemmyErrorType, LemmyResult},
+  settings::SETTINGS,
+};
 use serde::{Deserialize, Serialize};
 use std::{ops::Deref, time::Duration};
 use tokio::time::timeout;
@@ -98,10 +101,9 @@ pub(crate) async fn get_activity(
   info: web::Path<ActivityQuery>,
   context: web::Data<LemmyContext>,
 ) -> LemmyResult<HttpResponse> {
-  let settings = context.settings();
   let activity_id = Url::parse(&format!(
     "{}/activities/{}/{}",
-    settings.get_protocol_and_hostname(),
+    SETTINGS.get_protocol_and_hostname(),
     info.type_,
     info.id
   ))?

--- a/crates/apub/src/http/site.rs
+++ b/crates/apub/src/http/site.rs
@@ -7,7 +7,7 @@ use activitypub_federation::{config::Data, traits::Object};
 use actix_web::HttpResponse;
 use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::source::site::Site;
-use lemmy_utils::error::LemmyResult;
+use lemmy_utils::{error::LemmyResult, settings::SETTINGS};
 use url::Url;
 
 pub(crate) async fn get_apub_site_http(context: Data<LemmyContext>) -> LemmyResult<HttpResponse> {
@@ -18,11 +18,8 @@ pub(crate) async fn get_apub_site_http(context: Data<LemmyContext>) -> LemmyResu
 }
 
 #[tracing::instrument(skip_all)]
-pub(crate) async fn get_apub_site_outbox(context: Data<LemmyContext>) -> LemmyResult<HttpResponse> {
-  let outbox_id = format!(
-    "{}/site_outbox",
-    context.settings().get_protocol_and_hostname()
-  );
+pub(crate) async fn get_apub_site_outbox() -> LemmyResult<HttpResponse> {
+  let outbox_id = format!("{}/site_outbox", SETTINGS.get_protocol_and_hostname());
   let outbox = EmptyOutbox::new(Url::parse(&outbox_id)?)?;
   create_apub_response(&outbox)
 }

--- a/crates/apub/src/lib.rs
+++ b/crates/apub/src/lib.rs
@@ -11,6 +11,7 @@ use lemmy_db_schema::{
 };
 use lemmy_utils::{
   error::{LemmyError, LemmyErrorType, LemmyResult},
+  settings::SETTINGS,
   CACHE_DURATION_FEDERATION,
 };
 use moka::future::Cache;
@@ -166,8 +167,7 @@ pub(crate) async fn check_apub_id_valid_with_strictness(
     .domain()
     .ok_or(LemmyErrorType::UrlWithoutDomain)?
     .to_string();
-  let local_instance = context
-    .settings()
+  let local_instance = SETTINGS
     .get_hostname_without_port()
     .expect("local hostname is valid");
   if domain == local_instance {
@@ -186,8 +186,7 @@ pub(crate) async fn check_apub_id_valid_with_strictness(
       .iter()
       .map(|i| i.domain.clone())
       .collect::<Vec<String>>();
-    let local_instance = context
-      .settings()
+    let local_instance = SETTINGS
       .get_hostname_without_port()
       .expect("local hostname is valid");
     allowed_and_local.push(local_instance);

--- a/crates/apub/src/mentions.rs
+++ b/crates/apub/src/mentions.rs
@@ -67,7 +67,7 @@ pub async fn collect_non_local_mentions(
   let mentions = scrape_text_for_mentions(&comment.content)
     .into_iter()
     // Filter only the non-local ones
-    .filter(|m| !m.is_local(&context.settings().hostname));
+    .filter(|m| !m.is_local());
 
   for mention in mentions {
     let identifier = format!("{}@{}", mention.name, mention.domain);

--- a/crates/apub/src/objects/community.rs
+++ b/crates/apub/src/objects/community.rs
@@ -42,6 +42,7 @@ use lemmy_db_schema::{
 use lemmy_db_views_actor::structs::CommunityFollowerView;
 use lemmy_utils::{
   error::{LemmyError, LemmyResult},
+  settings::SETTINGS,
   spawn_try_task,
   utils::markdown::markdown_to_html,
 };
@@ -247,7 +248,7 @@ impl ApubCommunity {
     let inboxes: Vec<Url> = follows
       .into_iter()
       .map(Into::into)
-      .filter(|inbox: &Url| inbox.host_str() != Some(&context.settings().hostname))
+      .filter(|inbox: &Url| inbox.host_str() != Some(&SETTINGS.hostname))
       // Don't send to blocked instances
       .filter(|inbox| check_apub_id_valid(inbox, &local_site_data).is_ok())
       .collect();

--- a/crates/federate/src/lib.rs
+++ b/crates/federate/src/lib.rs
@@ -5,7 +5,7 @@ use lemmy_api_common::{
   lemmy_utils::settings::structs::FederationWorkerConfig,
 };
 use lemmy_db_schema::{newtypes::InstanceId, source::instance::Instance};
-use lemmy_utils::error::LemmyResult;
+use lemmy_utils::{error::LemmyResult, settings::SETTINGS};
 use stats::receive_print_stats;
 use std::{collections::HashMap, time::Duration};
 use tokio::{
@@ -105,7 +105,7 @@ impl SendManager {
       "Starting federation workers for process count {} and index {}",
       self.opts.process_count, process_index
     );
-    let local_domain = self.context.settings().get_hostname_without_port()?;
+    let local_domain = SETTINGS.get_hostname_without_port()?;
     let mut pool = self.context.pool();
     loop {
       let mut total_count = 0;

--- a/crates/federate/src/worker.rs
+++ b/crates/federate/src/worker.rs
@@ -492,7 +492,7 @@ mod test {
         actor_id: Some(actor_id.clone()),
         private_key: (Some(actor_keypair.private_key)),
         inbox_url: Some(generate_inbox_url(&actor_id)?),
-        shared_inbox_url: Some(generate_shared_inbox_url(context.settings())?),
+        shared_inbox_url: Some(generate_shared_inbox_url()?),
         ..PersonInsertForm::new("alice".to_string(), actor_keypair.public_key, instance.id)
       };
       let person = Person::create(&mut context.pool(), &person_form).await?;

--- a/crates/routes/src/nodeinfo.rs
+++ b/crates/routes/src/nodeinfo.rs
@@ -5,6 +5,7 @@ use lemmy_db_views::structs::SiteView;
 use lemmy_utils::{
   cache_header::{cache_1hour, cache_3days},
   error::LemmyResult,
+  settings::SETTINGS,
   VERSION,
 };
 use serde::{Deserialize, Serialize};
@@ -29,13 +30,13 @@ pub fn config(cfg: &mut web::ServiceConfig) {
     );
 }
 
-async fn node_info_well_known(context: web::Data<LemmyContext>) -> LemmyResult<HttpResponse> {
+async fn node_info_well_known() -> LemmyResult<HttpResponse> {
   let node_info = NodeInfoWellKnown {
     links: vec![NodeInfoWellKnownLinks {
       rel: Url::parse("http://nodeinfo.diaspora.software/ns/schema/2.1")?,
       href: Url::parse(&format!(
         "{}/nodeinfo/2.1",
-        &context.settings().get_protocol_and_hostname(),
+        &SETTINGS.get_protocol_and_hostname(),
       ))?,
     }],
   };

--- a/crates/utils/src/email.rs
+++ b/crates/utils/src/email.rs
@@ -1,6 +1,6 @@
 use crate::{
   error::{LemmyErrorExt, LemmyErrorType, LemmyResult},
-  settings::structs::Settings,
+  settings::SETTINGS,
 };
 use html2text;
 use lettre::{
@@ -24,10 +24,9 @@ pub async fn send_email(
   to_email: &str,
   to_username: &str,
   html: &str,
-  settings: &Settings,
 ) -> LemmyResult<()> {
-  let email_config = settings.email.clone().ok_or(LemmyErrorType::NoEmailSetup)?;
-  let domain = settings.hostname.clone();
+  let email_config = SETTINGS.email.clone().ok_or(LemmyErrorType::NoEmailSetup)?;
+  let domain = SETTINGS.hostname.clone();
 
   let (smtp_server, smtp_port) = {
     let email_and_port = email_config.smtp_server.split(':').collect::<Vec<&str>>();
@@ -56,7 +55,7 @@ pub async fn send_email(
       Some(to_username.to_string()),
       Address::from_str(to_email).expect("email to address isn't valid"),
     ))
-    .message_id(Some(format!("<{}@{}>", Uuid::new_v4(), settings.hostname)))
+    .message_id(Some(format!("<{}@{}>", Uuid::new_v4(), SETTINGS.hostname)))
     .subject(subject)
     .multipart(MultiPart::alternative_plain_html(
       plain_text,

--- a/crates/utils/src/utils/mention.rs
+++ b/crates/utils/src/utils/mention.rs
@@ -1,3 +1,4 @@
+use crate::settings::SETTINGS;
 use itertools::Itertools;
 use regex::Regex;
 use std::sync::LazyLock;
@@ -13,8 +14,8 @@ pub struct MentionData {
 }
 
 impl MentionData {
-  pub fn is_local(&self, hostname: &str) -> bool {
-    hostname.eq(&self.domain)
+  pub fn is_local(&self) -> bool {
+    SETTINGS.hostname.eq(&self.domain)
   }
   pub fn full_name(&self) -> String {
     format!("@{}@{}", &self.name, &self.domain)


### PR DESCRIPTION
We are passing settings around as function parameters in many places, or accessing via `context.settings()`. That is completely unnecessary because we can always access the static `SETTINGS`.