### PR TITLE
Add user setting to auto-mark fetched posts as read.

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -139,18 +139,6 @@ steps:
       - diff tmp.schema crates/db_schema/src/schema.rs
     when: *slow_check_paths
 
-  check_db_perf_tool:
-    image: *rust_image
-    environment:
-      LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
-      RUST_BACKTRACE: "1"
-      CARGO_HOME: .cargo_home
-    commands:
-      # same as scripts/db_perf.sh but without creating a new database server
-      - export LEMMY_CONFIG_LOCATION=config/config.hjson
-      - cargo run --package lemmy_db_perf -- --posts 10 --read-post-pages 1
-    when: *slow_check_paths
-
   cargo_clippy:
     image: *rust_image
     environment:
@@ -212,6 +200,18 @@ steps:
       - psql -c "DROP SCHEMA IF EXISTS r CASCADE;"
       - pg_dump --no-owner --no-privileges --no-table-access-method --schema-only --no-sync -f after.sqldump
       - diff before.sqldump after.sqldump
+    when: *slow_check_paths
+
+  check_db_perf_tool:
+    image: *rust_image
+    environment:
+      LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
+      RUST_BACKTRACE: "1"
+      CARGO_HOME: .cargo_home
+    commands:
+      # same as scripts/db_perf.sh but without creating a new database server
+      - export LEMMY_CONFIG_LOCATION=config/config.hjson
+      - cargo run --package lemmy_db_perf -- --posts 10 --read-post-pages 1
     when: *slow_check_paths
 
   run_federation_tests:

--- a/crates/api/src/local_user/save_settings.rs
+++ b/crates/api/src/local_user/save_settings.rs
@@ -142,6 +142,7 @@ pub async fn save_user_settings(
     enable_keyboard_navigation: data.enable_keyboard_navigation,
     enable_animated_images: data.enable_animated_images,
     collapse_bot_comments: data.collapse_bot_comments,
+    auto_mark_fetched_posts_as_read: data.auto_mark_fetched_posts_as_read,
     ..Default::default()
   };
 

--- a/crates/api/src/post/like.rs
+++ b/crates/api/src/post/like.rs
@@ -10,7 +10,7 @@ use lemmy_api_common::{
 use lemmy_db_schema::{
   source::{
     local_site::LocalSite,
-    post::{Post, PostLike, PostLikeForm, PostRead},
+    post::{PostLike, PostLikeForm, PostRead},
   },
   traits::Likeable,
 };

--- a/crates/api/src/post/like.rs
+++ b/crates/api/src/post/like.rs
@@ -5,19 +5,13 @@ use lemmy_api_common::{
   context::LemmyContext,
   post::{CreatePostLike, PostResponse},
   send_activity::{ActivityChannel, SendActivityData},
-  utils::{
-    check_bot_account,
-    check_community_user_action,
-    check_local_vote_mode,
-    mark_post_as_read,
-    VoteItem,
-  },
+  utils::{check_bot_account, check_community_user_action, check_local_vote_mode, VoteItem},
 };
 use lemmy_db_schema::{
   source::{
     community::Community,
     local_site::LocalSite,
-    post::{Post, PostLike, PostLikeForm},
+    post::{Post, PostLike, PostLikeForm, PostRead},
   },
   traits::{Crud, Likeable},
 };
@@ -73,7 +67,8 @@ pub async fn like_post(
       .with_lemmy_type(LemmyErrorType::CouldntLikePost)?;
   }
 
-  mark_post_as_read(person_id, post_id, &mut context.pool()).await?;
+  // Mark Post Read
+  PostRead::mark_as_read(&mut context.pool(), &[post_id], person_id).await?;
 
   let community = Community::read(&mut context.pool(), post.community_id).await?;
 

--- a/crates/api/src/post/mark_read.rs
+++ b/crates/api/src/post/mark_read.rs
@@ -2,8 +2,7 @@ use actix_web::web::{Data, Json};
 use lemmy_api_common::{context::LemmyContext, post::MarkPostAsRead, SuccessResponse};
 use lemmy_db_schema::source::post::PostRead;
 use lemmy_db_views::structs::LocalUserView;
-use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult, MAX_API_PARAM_ELEMENTS};
-use std::collections::HashSet;
+use lemmy_utils::error::{LemmyErrorType, LemmyResult, MAX_API_PARAM_ELEMENTS};
 
 #[tracing::instrument(skip(context))]
 pub async fn mark_post_as_read(
@@ -11,7 +10,7 @@ pub async fn mark_post_as_read(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<SuccessResponse>> {
-  let post_ids = HashSet::from_iter(data.post_ids.clone());
+  let post_ids = &data.post_ids;
 
   if post_ids.len() > MAX_API_PARAM_ELEMENTS {
     Err(LemmyErrorType::TooManyItems)?;
@@ -21,13 +20,9 @@ pub async fn mark_post_as_read(
 
   // Mark the post as read / unread
   if data.read {
-    PostRead::mark_as_read(&mut context.pool(), post_ids, person_id)
-      .await
-      .with_lemmy_type(LemmyErrorType::CouldntMarkPostAsRead)?;
+    PostRead::mark_as_read(&mut context.pool(), post_ids, person_id).await?;
   } else {
-    PostRead::mark_as_unread(&mut context.pool(), post_ids, person_id)
-      .await
-      .with_lemmy_type(LemmyErrorType::CouldntMarkPostAsRead)?;
+    PostRead::mark_as_unread(&mut context.pool(), post_ids, person_id).await?;
   }
 
   Ok(Json(SuccessResponse::default()))

--- a/crates/api/src/post/save.rs
+++ b/crates/api/src/post/save.rs
@@ -2,10 +2,9 @@ use actix_web::web::{Data, Json};
 use lemmy_api_common::{
   context::LemmyContext,
   post::{PostResponse, SavePost},
-  utils::mark_post_as_read,
 };
 use lemmy_db_schema::{
-  source::post::{PostSaved, PostSavedForm},
+  source::post::{PostRead, PostSaved, PostSavedForm},
   traits::Saveable,
 };
 use lemmy_db_views::structs::{LocalUserView, PostView};
@@ -42,7 +41,7 @@ pub async fn save_post(
   )
   .await?;
 
-  mark_post_as_read(person_id, post_id, &mut context.pool()).await?;
+  PostRead::mark_as_read(&mut context.pool(), &[post_id], person_id).await?;
 
   Ok(Json(PostResponse { post_view }))
 }

--- a/crates/api_common/src/person.rs
+++ b/crates/api_common/src/person.rs
@@ -176,6 +176,7 @@ pub struct SaveUserSettings {
   #[cfg_attr(feature = "full", ts(optional))]
   pub show_upvote_percentage: Option<bool>,
   /// Whether to automatically mark fetched posts as read.
+  #[cfg_attr(feature = "full", ts(optional))]
   pub auto_mark_fetched_posts_as_read: Option<bool>,
 }
 

--- a/crates/api_common/src/person.rs
+++ b/crates/api_common/src/person.rs
@@ -138,6 +138,8 @@ pub struct SaveUserSettings {
   pub show_upvotes: Option<bool>,
   pub show_downvotes: Option<bool>,
   pub show_upvote_percentage: Option<bool>,
+  /// Whether to automatically mark fetched posts as read.
+  pub auto_mark_fetched_posts_as_read: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, Eq, Hash)]

--- a/crates/api_common/src/post.rs
+++ b/crates/api_common/src/post.rs
@@ -85,6 +85,8 @@ pub struct GetPosts {
   pub show_read: Option<bool>,
   /// If true, then show the nsfw posts (even if your user setting is to hide them)
   pub show_nsfw: Option<bool>,
+  /// Whether to automatically mark fetched posts as read.
+  pub auto_mark_fetched_posts_as_read: Option<bool>,
   pub page_cursor: Option<PaginationCursor>,
 }
 

--- a/crates/api_common/src/post.rs
+++ b/crates/api_common/src/post.rs
@@ -110,7 +110,7 @@ pub struct GetPosts {
   pub show_nsfw: Option<bool>,
   /// Whether to automatically mark fetched posts as read.
   #[cfg_attr(feature = "full", ts(optional))]
-  pub auto_mark_fetched_posts_as_read: Option<bool>,
+  pub mark_as_read: Option<bool>,
   #[cfg_attr(feature = "full", ts(optional))]
   /// If true, then only show posts with no comments
   pub no_comments_only: Option<bool>,

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -28,7 +28,7 @@ use lemmy_db_schema::{
     password_reset_request::PasswordResetRequest,
     person::{Person, PersonUpdateForm},
     person_block::PersonBlock,
-    post::{Post, PostLike, PostRead},
+    post::{Post, PostLike},
     registration_application::RegistrationApplication,
     site::Site,
   },
@@ -64,7 +64,7 @@ use lemmy_utils::{
 use moka::future::Cache;
 use regex::{escape, Regex, RegexSet};
 use rosetta_i18n::{Language, LanguageId};
-use std::{collections::HashSet, sync::LazyLock};
+use std::sync::LazyLock;
 use tracing::warn;
 use url::{ParseError, Url};
 use urlencoding::encode;
@@ -138,19 +138,6 @@ pub fn is_top_mod(
   } else {
     Ok(())
   }
-}
-
-/// Marks a post as read for a given person.
-#[tracing::instrument(skip_all)]
-pub async fn mark_post_as_read(
-  person_id: PersonId,
-  post_id: PostId,
-  pool: &mut DbPool<'_>,
-) -> LemmyResult<()> {
-  PostRead::mark_as_read(pool, HashSet::from([post_id]), person_id)
-    .await
-    .with_lemmy_type(LemmyErrorType::CouldntMarkPostAsRead)?;
-  Ok(())
 }
 
 /// Updates the read comment count for a post. Usually done when reading or creating a new comment.

--- a/crates/api_crud/src/post/create.rs
+++ b/crates/api_crud/src/post/create.rs
@@ -12,7 +12,6 @@ use lemmy_api_common::{
     get_url_blocklist,
     honeypot_check,
     local_site_to_slur_regex,
-    mark_post_as_read,
     process_markdown_opt,
   },
 };
@@ -22,7 +21,7 @@ use lemmy_db_schema::{
     actor_language::CommunityLanguage,
     community::Community,
     local_site::LocalSite,
-    post::{Post, PostInsertForm, PostLike, PostLikeForm},
+    post::{Post, PostInsertForm, PostLike, PostLikeForm, PostRead},
   },
   traits::{Crud, Likeable},
   utils::diesel_url_create,
@@ -169,7 +168,7 @@ pub async fn create_post(
     .await
     .with_lemmy_type(LemmyErrorType::CouldntLikePost)?;
 
-  mark_post_as_read(person_id, post_id, &mut context.pool()).await?;
+  PostRead::mark_as_read(&mut context.pool(), &[post_id], person_id).await?;
 
   build_post_response(&context, community_id, local_user_view, post_id).await
 }

--- a/crates/api_crud/src/post/read.rs
+++ b/crates/api_crud/src/post/read.rs
@@ -2,10 +2,13 @@ use actix_web::web::{Data, Json, Query};
 use lemmy_api_common::{
   context::LemmyContext,
   post::{GetPost, GetPostResponse},
-  utils::{check_private_instance, is_mod_or_admin_opt, mark_post_as_read, update_read_comments},
+  utils::{check_private_instance, is_mod_or_admin_opt, update_read_comments},
 };
 use lemmy_db_schema::{
-  source::{comment::Comment, post::Post},
+  source::{
+    comment::Comment,
+    post::{Post, PostRead},
+  },
   traits::Crud,
 };
 use lemmy_db_views::{
@@ -62,7 +65,7 @@ pub async fn get_post(
 
   let post_id = post_view.post.id;
   if let Some(person_id) = person_id {
-    mark_post_as_read(person_id, post_id, &mut context.pool()).await?;
+    PostRead::mark_as_read(&mut context.pool(), &[post_id], person_id).await?;
 
     update_read_comments(
       person_id,

--- a/crates/apub/src/api/list_posts.rs
+++ b/crates/apub/src/api/list_posts.rs
@@ -10,7 +10,10 @@ use lemmy_api_common::{
   post::{GetPosts, GetPostsResponse},
   utils::{check_conflicting_like_filters, check_private_instance},
 };
-use lemmy_db_schema::source::community::Community;
+use lemmy_db_schema::{
+  newtypes::PostId,
+  source::{community::Community, post::PostRead},
+};
 use lemmy_db_views::{
   post_view::PostQuery,
   structs::{LocalUserView, PaginationCursor, SiteView},
@@ -87,6 +90,14 @@ pub async fn list_posts(
   .list(&local_site.site, &mut context.pool())
   .await
   .with_lemmy_type(LemmyErrorType::CouldntGetPosts)?;
+
+  // If in their user settings, auto-mark fetched posts as read
+  if let Some(local_user) = local_user {
+    if local_user.auto_mark_fetched_posts_as_read {
+      let post_ids = posts.iter().map(|p| p.post.id).collect::<Vec<PostId>>();
+      PostRead::mark_as_read(&mut context.pool(), &post_ids, local_user.person_id).await?;
+    }
+  }
 
   // if this page wasn't empty, then there is a next page after the last post on this page
   let next_page = posts.last().map(PaginationCursor::after_post);

--- a/crates/apub/src/api/list_posts.rs
+++ b/crates/apub/src/api/list_posts.rs
@@ -91,9 +91,12 @@ pub async fn list_posts(
   .await
   .with_lemmy_type(LemmyErrorType::CouldntGetPosts)?;
 
-  // If in their user settings, auto-mark fetched posts as read
+  // If in their user settings (or as part of the API request), auto-mark fetched posts as read
   if let Some(local_user) = local_user {
-    if local_user.auto_mark_fetched_posts_as_read {
+    if data
+      .auto_mark_fetched_posts_as_read
+      .unwrap_or(local_user.auto_mark_fetched_posts_as_read)
+    {
       let post_ids = posts.iter().map(|p| p.post.id).collect::<Vec<PostId>>();
       PostRead::mark_as_read(&mut context.pool(), &post_ids, local_user.person_id).await?;
     }

--- a/crates/apub/src/api/list_posts.rs
+++ b/crates/apub/src/api/list_posts.rs
@@ -96,7 +96,7 @@ pub async fn list_posts(
   // If in their user settings (or as part of the API request), auto-mark fetched posts as read
   if let Some(local_user) = local_user {
     if data
-      .auto_mark_fetched_posts_as_read
+      .mark_as_read
       .unwrap_or(local_user.auto_mark_fetched_posts_as_read)
     {
       let post_ids = posts.iter().map(|p| p.post.id).collect::<Vec<PostId>>();

--- a/crates/apub/src/api/list_posts.rs
+++ b/crates/apub/src/api/list_posts.rs
@@ -95,9 +95,9 @@ pub async fn list_posts(
 
   // If in their user settings (or as part of the API request), auto-mark fetched posts as read
   if let Some(local_user) = local_user {
-    // If false is passed, then don't mark as read
-    if data.auto_mark_fetched_posts_as_read.unwrap_or(true)
-      && local_user.auto_mark_fetched_posts_as_read
+    if data
+      .auto_mark_fetched_posts_as_read
+      .unwrap_or(local_user.auto_mark_fetched_posts_as_read)
     {
       let post_ids = posts.iter().map(|p| p.post.id).collect::<Vec<PostId>>();
       PostRead::mark_as_read(&mut context.pool(), &post_ids, local_user.person_id).await?;

--- a/crates/apub/src/api/list_posts.rs
+++ b/crates/apub/src/api/list_posts.rs
@@ -95,9 +95,9 @@ pub async fn list_posts(
 
   // If in their user settings (or as part of the API request), auto-mark fetched posts as read
   if let Some(local_user) = local_user {
-    if data
-      .auto_mark_fetched_posts_as_read
-      .unwrap_or(local_user.auto_mark_fetched_posts_as_read)
+    // If false is passed, then don't mark as read
+    if data.auto_mark_fetched_posts_as_read.unwrap_or(true)
+      && local_user.auto_mark_fetched_posts_as_read
     {
       let post_ids = posts.iter().map(|p| p.post.id).collect::<Vec<PostId>>();
       PostRead::mark_as_read(&mut context.pool(), &post_ids, local_user.person_id).await?;

--- a/crates/db_schema/src/impls/post.rs
+++ b/crates/db_schema/src/impls/post.rs
@@ -39,10 +39,7 @@ use diesel::{
   TextExpressionMethods,
 };
 use diesel_async::RunQueryDsl;
-use lemmy_utils::{
-  error::{LemmyErrorExt, LemmyResult},
-  LemmyErrorType,
-};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 use std::collections::HashSet;
 
 #[async_trait]

--- a/crates/db_schema/src/schema.rs
+++ b/crates/db_schema/src/schema.rs
@@ -474,6 +474,7 @@ diesel::table! {
         enable_animated_images -> Bool,
         collapse_bot_comments -> Bool,
         default_comment_sort_type -> CommentSortTypeEnum,
+        auto_mark_fetched_posts_as_read -> Bool,
     }
 }
 

--- a/crates/db_schema/src/source/local_user.rs
+++ b/crates/db_schema/src/source/local_user.rs
@@ -65,6 +65,8 @@ pub struct LocalUser {
   /// Whether to auto-collapse bot comments.
   pub collapse_bot_comments: bool,
   pub default_comment_sort_type: CommentSortType,
+  /// Whether to automatically mark fetched posts as read.
+  pub auto_mark_fetched_posts_as_read: bool,
 }
 
 #[derive(Clone, derive_new::new)]
@@ -119,6 +121,8 @@ pub struct LocalUserInsertForm {
   pub collapse_bot_comments: Option<bool>,
   #[new(default)]
   pub default_comment_sort_type: Option<CommentSortType>,
+  #[new(default)]
+  pub auto_mark_fetched_posts_as_read: Option<bool>,
 }
 
 #[derive(Clone, Default)]
@@ -149,4 +153,5 @@ pub struct LocalUserUpdateForm {
   pub enable_animated_images: Option<bool>,
   pub collapse_bot_comments: Option<bool>,
   pub default_comment_sort_type: Option<CommentSortType>,
+  pub auto_mark_fetched_posts_as_read: Option<bool>,
 }

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -1644,7 +1644,7 @@ mod tests {
     // Mark a post as read
     PostRead::mark_as_read(
       pool,
-      HashSet::from([data.inserted_bot_post.id]),
+      &[data.inserted_bot_post.id],
       data.local_user_view.person.id,
     )
     .await?;

--- a/crates/db_views/src/registration_application_view.rs
+++ b/crates/db_views/src/registration_application_view.rs
@@ -241,6 +241,7 @@ mod tests {
         enable_keyboard_navigation: inserted_sara_local_user.enable_keyboard_navigation,
         enable_animated_images: inserted_sara_local_user.enable_animated_images,
         collapse_bot_comments: inserted_sara_local_user.collapse_bot_comments,
+        auto_mark_fetched_posts_as_read: false,
       },
       creator: Person {
         id: inserted_sara_person.id,

--- a/migrations/2024-11-01-233231_add_mark_fetched_posts_as_read/down.sql
+++ b/migrations/2024-11-01-233231_add_mark_fetched_posts_as_read/down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE local_user
+    DROP COLUMN auto_mark_fetched_posts_as_read;
+

--- a/migrations/2024-11-01-233231_add_mark_fetched_posts_as_read/up.sql
+++ b/migrations/2024-11-01-233231_add_mark_fetched_posts_as_read/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE local_user
+    ADD COLUMN auto_mark_fetched_posts_as_read boolean DEFAULT FALSE NOT NULL;
+


### PR DESCRIPTION
- Rather than apps collecting up viewed posts ids, and sending many mark as read requests, users can now turn this setting on, and any results from /post/list will be auto-marked as read.
- Fixes #5144