### PR TITLE
Removing strip = true from release profile.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,12 +24,14 @@ doctest = false
 [lints]
 workspace = true
 
+# See https://github.com/johnthagen/min-sized-rust for additional optimizations
 [profile.release]
 debug = 0
 lto = "fat"
 strip = true      # Automatically strip symbols from the binary.
 opt-level = 3     # Optimize for speed, not size.
 codegen-units = 1 # Reduce parallel code generation.
+panic = "abort"   # Removes unecessary unwinding code.
 
 # This profile significantly speeds up build time. If debug info is needed you can comment the line
 # out temporarily, but make sure to leave this in the main branch.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,8 @@ workspace = true
 [profile.release]
 debug = 0
 lto = "fat"
-strip = true      # Automatically strip symbols from the binary.
 opt-level = 3     # Optimize for speed, not size.
 codegen-units = 1 # Reduce parallel code generation.
-panic = "abort"   # Removes unecessary unwinding code.
 
 # This profile significantly speeds up build time. If debug info is needed you can comment the line
 # out temporarily, but make sure to leave this in the main branch.


### PR DESCRIPTION
Adding another profile optimization.

See https://github.com/johnthagen/min-sized-rust?tab=readme-ov-file#abort-on-panic for context.