### PR TITLE
Set release flags for 0.19.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,12 @@ doctest = false
 [lints]
 workspace = true
 
+# See https://github.com/johnthagen/min-sized-rust for additional optimizations
 [profile.release]
 debug = 0
-lto = "thin"
-strip = true    # Automatically strip symbols from the binary.
-opt-level = "z" # Optimize for size.
+lto = "fat"
+opt-level = 3     # Optimize for speed, not size.
+codegen-units = 1 # Reduce parallel code generation.
 
 # This profile significantly speeds up build time. If debug info is needed you can comment the line
 # out temporarily, but make sure to leave this in the main branch.


### PR DESCRIPTION
Set the same flags for release build from https://github.com/LemmyNet/lemmy/pull/5140 and https://github.com/LemmyNet/lemmy/pull/5166 for 0.19.6. Not using cherry-pick here to avoid pulling in upx compression which needs further testing.