### PR TITLE
Increase speed check limit.

### DIFF
--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -2047,7 +2047,7 @@ mod tests {
     let data = init_data(pool).await?;
 
     // Make sure the post_view query is less than this time
-    let duration_max = Duration::from_millis(40);
+    let duration_max = Duration::from_millis(80);
 
     // Create some dummy posts
     let num_posts = 1000;


### PR DESCRIPTION
My speed check time limit `40ms` was too restrictive for my slower CI runners, and its breaking other PRs.

I'll merge this immediately as its minor and those need to be re-ran.