### PR TITLE
Upping default max_image_size from 256 to 512.

### DIFF
--- a/config/defaults.hjson
+++ b/config/defaults.hjson
@@ -76,7 +76,7 @@
     # Timeout for uploading images to pictrs (in seconds)
     upload_timeout: 30
     # Resize post thumbnails to this maximum width/height.
-    max_thumbnail_size: 256
+    max_thumbnail_size: 512
   }
   # Email sending configuration. All options except login/password are mandatory
   email: {

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -92,7 +92,7 @@ pub struct PictrsConfig {
   pub upload_timeout: u64,
 
   /// Resize post thumbnails to this maximum width/height.
-  #[default(256)]
+  #[default(512)]
   pub max_thumbnail_size: u32,
 }
 


### PR DESCRIPTION
- Context: https://github.com/LemmyNet/lemmy-ui/issues/2796