### PR TITLE
Move aggregates to replaceable_schema, fix error (fixes #5186)

### DIFF
--- a/crates/db_schema/replaceable_schema/utils.sql
+++ b/crates/db_schema/replaceable_schema/utils.sql
@@ -151,3 +151,117 @@ DECLARE
 END;
 $a$;
 
+-- Edit community aggregates to include voters as active users
+CREATE OR REPLACE FUNCTION community_aggregates_activity (i text)
+    RETURNS TABLE (
+        count_ bigint,
+        community_id_ integer)
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    RETURN query
+    SELECT
+        count(*),
+        community_id
+    FROM (
+        SELECT
+            c.creator_id,
+            p.community_id
+        FROM
+            comment c
+            INNER JOIN post p ON c.post_id = p.id
+            INNER JOIN person pe ON c.creator_id = pe.id
+        WHERE
+            c.published > ('now'::timestamp - i::interval)
+            AND pe.bot_account = FALSE
+        UNION
+        SELECT
+            p.creator_id,
+            p.community_id
+        FROM
+            post p
+            INNER JOIN person pe ON p.creator_id = pe.id
+        WHERE
+            p.published > ('now'::timestamp - i::interval)
+            AND pe.bot_account = FALSE
+        UNION
+        SELECT
+            pl.person_id,
+            p.community_id
+        FROM
+            post_like pl
+            INNER JOIN post p ON pl.post_id = p.id
+            INNER JOIN person pe ON pl.person_id = pe.id
+        WHERE
+            pl.published > ('now'::timestamp - i::interval)
+            AND pe.bot_account = FALSE
+        UNION
+        SELECT
+            cl.person_id,
+            p.community_id
+        FROM
+            comment_like cl
+            INNER JOIN comment c ON cl.comment_id = c.id
+            INNER JOIN post p ON c.post_id = p.id
+            INNER JOIN person pe ON cl.person_id = pe.id
+        WHERE
+            cl.published > ('now'::timestamp - i::interval)
+            AND pe.bot_account = FALSE) a
+GROUP BY
+    community_id;
+END;
+$$;
+
+-- Edit site aggregates to include voters and people who have read posts as active users
+CREATE OR REPLACE FUNCTION site_aggregates_activity (i text)
+    RETURNS integer
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    count_ integer;
+BEGIN
+    SELECT
+        count(*) INTO count_
+    FROM (
+        SELECT
+            c.creator_id
+        FROM
+            comment c
+            INNER JOIN person pe ON c.creator_id = pe.id
+        WHERE
+            c.published > ('now'::timestamp - i::interval)
+            AND pe.local = TRUE
+            AND pe.bot_account = FALSE
+        UNION
+        SELECT
+            p.creator_id
+        FROM
+            post p
+            INNER JOIN person pe ON p.creator_id = pe.id
+        WHERE
+            p.published > ('now'::timestamp - i::interval)
+            AND pe.local = TRUE
+            AND pe.bot_account = FALSE
+        UNION
+        SELECT
+            pl.person_id
+        FROM
+            post_like pl
+            INNER JOIN person pe ON pl.person_id = pe.id
+        WHERE
+            pl.published > ('now'::timestamp - i::interval)
+            AND pe.local = TRUE
+            AND pe.bot_account = FALSE
+        UNION
+        SELECT
+            cl.person_id
+        FROM
+            comment_like cl
+            INNER JOIN person pe ON cl.person_id = pe.id
+        WHERE
+            cl.published > ('now'::timestamp - i::interval)
+            AND pe.local = TRUE
+            AND pe.bot_account = FALSE) a;
+    RETURN count_;
+END;
+$$;

--- a/migrations/2024-11-12-090437_move-triggers/down.sql
+++ b/migrations/2024-11-12-090437_move-triggers/down.sql
@@ -1,0 +1,115 @@
+
+-- Edit community aggregates to include voters as active users
+CREATE OR REPLACE FUNCTION community_aggregates_activity (i text)
+    RETURNS TABLE (
+        count_ bigint,
+        community_id_ integer)
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    RETURN query
+    SELECT
+        count(*),
+        community_id
+    FROM (
+        SELECT
+            c.creator_id,
+            p.community_id
+        FROM
+            comment c
+            INNER JOIN post p ON c.post_id = p.id
+            INNER JOIN person pe ON c.creator_id = pe.id
+        WHERE
+            c.published > ('now'::timestamp - i::interval)
+            AND pe.bot_account = FALSE
+        UNION
+        SELECT
+            p.creator_id,
+            p.community_id
+        FROM
+            post p
+            INNER JOIN person pe ON p.creator_id = pe.id
+        WHERE
+            p.published > ('now'::timestamp - i::interval)
+            AND pe.bot_account = FALSE
+        UNION
+        SELECT
+            pl.person_id,
+            p.community_id
+        FROM
+            post_like pl
+            INNER JOIN post p ON pl.post_id = p.id
+            INNER JOIN person pe ON pl.person_id = pe.id
+        WHERE
+            pl.published > ('now'::timestamp - i::interval)
+            AND pe.bot_account = FALSE
+        UNION
+        SELECT
+            cl.person_id,
+            p.community_id
+        FROM
+            comment_like cl
+            INNER JOIN comment c ON cl.comment_id = comment.id
+            INNER JOIN post p ON comment.post_id = p.id
+            INNER JOIN person pe ON cl.person_id = pe.id
+        WHERE
+            cl.published > ('now'::timestamp - i::interval)
+            AND pe.bot_account = FALSE) a
+GROUP BY
+    community_id;
+END;
+$$;
+
+-- Edit site aggregates to include voters and people who have read posts as active users
+CREATE OR REPLACE FUNCTION site_aggregates_activity (i text)
+    RETURNS integer
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    count_ integer;
+BEGIN
+    SELECT
+        count(*) INTO count_
+    FROM (
+        SELECT
+            c.creator_id
+        FROM
+            comment c
+            INNER JOIN person pe ON c.creator_id = pe.id
+        WHERE
+            c.published > ('now'::timestamp - i::interval)
+            AND pe.local = TRUE
+            AND pe.bot_account = FALSE
+        UNION
+        SELECT
+            p.creator_id
+        FROM
+            post p
+            INNER JOIN person pe ON p.creator_id = pe.id
+        WHERE
+            p.published > ('now'::timestamp - i::interval)
+            AND pe.local = TRUE
+            AND pe.bot_account = FALSE
+        UNION
+        SELECT
+            pl.person_id
+        FROM
+            post_like pl
+            INNER JOIN person pe ON pl.person_id = pe.id
+        WHERE
+            pl.published > ('now'::timestamp - i::interval)
+            AND pe.local = TRUE
+            AND pe.bot_account = FALSE
+        UNION
+        SELECT
+            cl.person_id
+        FROM
+            comment_like cl
+            INNER JOIN person pe ON cl.person_id = pe.id
+        WHERE
+            cl.published > ('now'::timestamp - i::interval)
+            AND pe.local = TRUE
+            AND pe.bot_account = FALSE) a;
+    RETURN count_;
+END;
+$$;

--- a/migrations/2024-11-12-090437_move-triggers/up.sql
+++ b/migrations/2024-11-12-090437_move-triggers/up.sql
@@ -1,0 +1,1 @@
+drop function community_aggregates_activity, site_aggregates_activity cascade;


### PR DESCRIPTION
This error was actually shown in the logs, but because it didnt lead to a crash we didnt notice it. Maybe we should change the scheduled tasks to return errors only in development mode to catch cases like this.

```
2024-11-12T09:24:05.317025Z ERROR lemmy_server::scheduled_tasks: Failed to update community stats: column cl.post_id does not exist
2024-11-12T09:24:05.318234Z  INFO lemmy_federate::stats: Federation state as of 2024-11-12T10:24:05.318164912+01:00:
2024-11-12T09:24:05.318250Z  INFO lemmy_federate::stats: 0 others up to date. 0 instances behind.
2024-11-12T09:24:05.318974Z ERROR lemmy_server::scheduled_tasks: Failed to update community stats: column cl.post_id does not exist
2024-11-12T09:24:05.320563Z ERROR lemmy_server::scheduled_tasks: Failed to update community stats: column cl.post_id does not exist
2024-11-12T09:24:05.322135Z ERROR lemmy_server::scheduled_tasks: Failed to update community stats: column cl.post_id does not exist
```