### PR TITLE
Check dockerfile during CI, ignore error

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -138,6 +138,11 @@ steps:
       - diff tmp.schema crates/db_schema/src/schema.rs
     when: *slow_check_paths
 
+  docker_check:
+    image: docker/dockerfile:1.11
+    commands:
+      - docker build --check . -f docker/Dockerfile
+
   cargo_clippy:
     image: *rust_image
     environment:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -139,7 +139,7 @@ steps:
     when: *slow_check_paths
 
   docker_check:
-    image: docker/dockerfile:1.11
+    image: docker:27-cli
     commands:
       - docker build --check . -f docker/Dockerfile
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
 # syntax=docker/dockerfile:1.10
+#check=skip=FromPlatformFlagConstDisallowed
 ARG RUST_VERSION=1.81
 ARG CARGO_BUILD_FEATURES=default
 ARG RUST_RELEASE_MODE=debug


### PR DESCRIPTION
This caused an error during release build so we should check it during normal ci.

https://woodpecker.join-lemmy.org/repos/129/pipeline/10219/5#L2909

Edit: I cant find a dockerfile that allows running `docker build --check`, and the woodpeckerci/plugin-docker-buildx also doesnt have a setting for that.