### PR TITLE
Add report_counts to post and comment aggregate tables.

### DIFF
--- a/crates/db_schema/src/aggregates/structs.rs
+++ b/crates/db_schema/src/aggregates/structs.rs
@@ -39,8 +39,8 @@ pub struct CommentAggregates {
   pub hot_rank: f64,
   #[serde(skip)]
   pub controversy_rank: f64,
-  pub report_count: i64,
-  pub unresolved_report_count: i64,
+  pub report_count: i16,
+  pub unresolved_report_count: i16,
 }
 
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
@@ -148,8 +148,8 @@ pub struct PostAggregates {
   /// A rank that amplifies smaller communities
   #[serde(skip)]
   pub scaled_rank: f64,
-  pub report_count: i64,
-  pub unresolved_report_count: i64,
+  pub report_count: i16,
+  pub unresolved_report_count: i16,
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]

--- a/crates/db_schema/src/aggregates/structs.rs
+++ b/crates/db_schema/src/aggregates/structs.rs
@@ -39,6 +39,8 @@ pub struct CommentAggregates {
   pub hot_rank: f64,
   #[serde(skip)]
   pub controversy_rank: f64,
+  pub report_count: i64,
+  pub unresolved_report_count: i64,
 }
 
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
@@ -146,6 +148,8 @@ pub struct PostAggregates {
   /// A rank that amplifies smaller communities
   #[serde(skip)]
   pub scaled_rank: f64,
+  pub report_count: i64,
+  pub unresolved_report_count: i64,
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]

--- a/crates/db_schema/src/schema.rs
+++ b/crates/db_schema/src/schema.rs
@@ -130,8 +130,8 @@ diesel::table! {
         child_count -> Int4,
         hot_rank -> Float8,
         controversy_rank -> Float8,
-        report_count -> Int8,
-        unresolved_report_count -> Int8,
+        report_count -> Int2,
+        unresolved_report_count -> Int2,
     }
 }
 
@@ -779,8 +779,8 @@ diesel::table! {
         controversy_rank -> Float8,
         instance_id -> Int4,
         scaled_rank -> Float8,
-        report_count -> Int8,
-        unresolved_report_count -> Int8,
+        report_count -> Int2,
+        unresolved_report_count -> Int2,
     }
 }
 

--- a/crates/db_schema/src/schema.rs
+++ b/crates/db_schema/src/schema.rs
@@ -130,6 +130,8 @@ diesel::table! {
         child_count -> Int4,
         hot_rank -> Float8,
         controversy_rank -> Float8,
+        report_count -> Int8,
+        unresolved_report_count -> Int8,
     }
 }
 
@@ -777,6 +779,8 @@ diesel::table! {
         controversy_rank -> Float8,
         instance_id -> Int4,
         scaled_rank -> Float8,
+        report_count -> Int8,
+        unresolved_report_count -> Int8,
     }
 }
 

--- a/crates/db_views/src/comment_report_view.rs
+++ b/crates/db_views/src/comment_report_view.rs
@@ -444,6 +444,8 @@ mod tests {
         child_count: 0,
         hot_rank: RANK_DEFAULT,
         controversy_rank: 0.0,
+        report_count: 2,
+        unresolved_report_count: 2,
       },
       my_vote: None,
       resolver: None,
@@ -511,6 +513,10 @@ mod tests {
       .updated = read_jessica_report_view_after_resolve
       .comment_report
       .updated;
+    expected_jessica_report_view_after_resolve
+      .counts
+      .unresolved_report_count = 1;
+    expected_sara_report_view.counts.unresolved_report_count = 1;
     expected_jessica_report_view_after_resolve.resolver = Some(Person {
       id: inserted_timmy.id,
       name: inserted_timmy.name.clone(),

--- a/crates/db_views/src/comment_view.rs
+++ b/crates/db_views/src/comment_view.rs
@@ -1065,6 +1065,8 @@ mod tests {
         child_count: 5,
         hot_rank: RANK_DEFAULT,
         controversy_rank: 0.0,
+        report_count: 0,
+        unresolved_report_count: 0,
       },
     })
   }

--- a/crates/db_views/src/post_view.rs
+++ b/crates/db_views/src/post_view.rs
@@ -1735,6 +1735,8 @@ mod tests {
         community_id: inserted_post.community_id,
         creator_id: inserted_post.creator_id,
         instance_id: data.inserted_instance.id,
+        report_count: 0,
+        unresolved_report_count: 0,
       },
       subscribed: SubscribedType::NotSubscribed,
       read: false,

--- a/migrations/2024-11-21-195004_add_report_count/down.sql
+++ b/migrations/2024-11-21-195004_add_report_count/down.sql
@@ -1,0 +1,8 @@
+ALTER TABLE post_aggregates
+    DROP COLUMN report_count,
+    DROP COLUMN unresolved_report_count;
+
+ALTER TABLE comment_aggregates
+    DROP COLUMN report_count,
+    DROP COLUMN unresolved_report_count;
+

--- a/migrations/2024-11-21-195004_add_report_count/up.sql
+++ b/migrations/2024-11-21-195004_add_report_count/up.sql
@@ -1,0 +1,10 @@
+-- Adding report_count and unresolved_report_count
+-- to the post and comment aggregate tables
+ALTER TABLE post_aggregates
+    ADD COLUMN report_count bigint NOT NULL DEFAULT 0,
+    ADD COLUMN unresolved_report_count bigint NOT NULL DEFAULT 0;
+
+ALTER TABLE comment_aggregates
+    ADD COLUMN report_count bigint NOT NULL DEFAULT 0,
+    ADD COLUMN unresolved_report_count bigint NOT NULL DEFAULT 0;
+

--- a/migrations/2024-11-21-195004_add_report_count/up.sql
+++ b/migrations/2024-11-21-195004_add_report_count/up.sql
@@ -1,12 +1,12 @@
 -- Adding report_count and unresolved_report_count
 -- to the post and comment aggregate tables
 ALTER TABLE post_aggregates
-    ADD COLUMN report_count bigint NOT NULL DEFAULT 0,
-    ADD COLUMN unresolved_report_count bigint NOT NULL DEFAULT 0;
+    ADD COLUMN report_count smallint NOT NULL DEFAULT 0,
+    ADD COLUMN unresolved_report_count smallint NOT NULL DEFAULT 0;
 
 ALTER TABLE comment_aggregates
-    ADD COLUMN report_count bigint NOT NULL DEFAULT 0,
-    ADD COLUMN unresolved_report_count bigint NOT NULL DEFAULT 0;
+    ADD COLUMN report_count smallint NOT NULL DEFAULT 0,
+    ADD COLUMN unresolved_report_count smallint NOT NULL DEFAULT 0;
 
 -- Update the historical counts
 -- Posts

--- a/migrations/2024-11-21-195004_add_report_count/up.sql
+++ b/migrations/2024-11-21-195004_add_report_count/up.sql
@@ -8,3 +8,72 @@ ALTER TABLE comment_aggregates
     ADD COLUMN report_count bigint NOT NULL DEFAULT 0,
     ADD COLUMN unresolved_report_count bigint NOT NULL DEFAULT 0;
 
+-- Update the historical counts
+-- Posts
+UPDATE
+    post_aggregates AS a
+SET
+    report_count = cnt.count
+FROM (
+    SELECT
+        post_id,
+        count(*) AS count
+    FROM
+        post_report
+    GROUP BY
+        post_id) cnt
+WHERE
+    a.post_id = cnt.post_id;
+
+-- The unresolved
+UPDATE
+    post_aggregates AS a
+SET
+    unresolved_report_count = cnt.count
+FROM (
+    SELECT
+        post_id,
+        count(*) AS count
+    FROM
+        post_report
+    WHERE
+        resolved = 'f'
+    GROUP BY
+        post_id) cnt
+WHERE
+    a.post_id = cnt.post_id;
+
+-- Comments
+UPDATE
+    comment_aggregates AS a
+SET
+    report_count = cnt.count
+FROM (
+    SELECT
+        comment_id,
+        count(*) AS count
+    FROM
+        comment_report
+    GROUP BY
+        comment_id) cnt
+WHERE
+    a.comment_id = cnt.comment_id;
+
+-- The unresolved
+UPDATE
+    comment_aggregates AS a
+SET
+    unresolved_report_count = cnt.count
+FROM (
+    SELECT
+        comment_id,
+        count(*) AS count
+    FROM
+        comment_report
+    WHERE
+        resolved = 'f'
+    GROUP BY
+        comment_id) cnt
+WHERE
+    a.comment_id = cnt.comment_id;
+


### PR DESCRIPTION
- This adds a report_count and unresolved_report_count to the post and comment aggregate tables.
- Useful for front-ends wishing to show report links.
- Fixes #4163