### PR TITLE
Remove getrandom dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2507,7 +2507,6 @@ dependencies = [
  "encoding_rs",
  "enum-map",
  "futures",
- "getrandom",
  "jsonwebtoken",
  "lemmy_db_schema",
  "lemmy_db_views",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ chrono = { version = "0.4.38", features = [
 ], default-features = false }
 serde_json = { version = "1.0.132", features = ["preserve_order"] }
 base64 = "0.22.1"
-uuid = { version = "1.11.0", features = ["serde", "v4"] }
+uuid = { version = "1.11.0", features = ["serde"] }
 async-trait = "0.1.83"
 captcha = "0.0.9"
 anyhow = { version = "1.0.93", features = [

--- a/crates/api_common/Cargo.toml
+++ b/crates/api_common/Cargo.toml
@@ -70,11 +70,6 @@ webpage = { version = "2.0", default-features = false, features = [
 ], optional = true }
 encoding_rs = { version = "0.8.35", optional = true }
 jsonwebtoken = { version = "9.3.0", optional = true }
-# necessary for wasmt compilation
-getrandom = { version = "0.2.15", features = ["js"] }
-
-[package.metadata.cargo-shear]
-ignored = ["getrandom"]
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/crates/api_common/Cargo.toml
+++ b/crates/api_common/Cargo.toml
@@ -36,6 +36,7 @@ full = [
   "futures",
   "jsonwebtoken",
   "mime",
+  "moka",
 ]
 
 [dependencies]
@@ -58,7 +59,7 @@ uuid = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
 ts-rs = { workspace = true, optional = true }
-moka.workspace = true
+moka = { workspace = true, optional = true }
 anyhow.workspace = true
 actix-web = { workspace = true, optional = true }
 enum-map = { workspace = true }

--- a/crates/db_schema/Cargo.toml
+++ b/crates/db_schema/Cargo.toml
@@ -75,7 +75,7 @@ tokio = { workspace = true, optional = true }
 tokio-postgres = { workspace = true, optional = true }
 tokio-postgres-rustls = { workspace = true, optional = true }
 rustls = { workspace = true, optional = true }
-uuid = { workspace = true, features = ["v4"] }
+uuid.workspace = true
 i-love-jesus = { workspace = true, optional = true }
 anyhow = { workspace = true }
 diesel-bind-if-some = { workspace = true, optional = true }


### PR DESCRIPTION
This dependency is needed to make `rand` compile on wasm targets ([see note in readme](https://github.com/rust-random/rand?tab=readme-ov-file#wasm-support)). However when compiling lemmy_api_common with default features, it doesnt pull in `rand` at all:
```
cargo tree -i rand -p lemmy_api_common
error: package ID specification `rand` did not match any packages

Did you mean `want`?
```

This means that it is unnecessary to specify the `getrandom` dependency.

cc @SleeplessOne1917 