### PR TITLE
Move up clippy and cargo test in CI.

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -91,6 +91,36 @@ steps:
     when:
       - event: pull_request
 
+  cargo_clippy:
+    image: *rust_image
+    environment:
+      CARGO_HOME: .cargo_home
+    commands:
+      - rustup component add clippy
+      - cargo clippy --workspace --tests --all-targets -- -D warnings
+    when: *slow_check_paths
+
+  cargo_test:
+    image: *rust_image
+    environment:
+      LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
+      RUST_BACKTRACE: "1"
+      CARGO_HOME: .cargo_home
+      LEMMY_TEST_FAST_FEDERATION: "1"
+      LEMMY_CONFIG_LOCATION: ../../config/config.hjson
+    commands:
+      - cargo test --workspace --no-fail-fast
+    when: *slow_check_paths
+
+  check_ts_bindings:
+    image: *rust_image
+    environment:
+      CARGO_HOME: .cargo_home
+    commands:
+      - ./scripts/ts_bindings_check.sh
+    when:
+      - event: pull_request
+
   # make sure api builds with default features (used by other crates relying on lemmy api)
   check_api_common_default_features:
     image: *rust_image
@@ -138,15 +168,6 @@ steps:
       - diff tmp.schema crates/db_schema/src/schema.rs
     when: *slow_check_paths
 
-  cargo_clippy:
-    image: *rust_image
-    environment:
-      CARGO_HOME: .cargo_home
-    commands:
-      - rustup component add clippy
-      - cargo clippy --workspace --tests --all-targets -- -D warnings
-    when: *slow_check_paths
-
   cargo_build:
     image: *rust_image
     environment:
@@ -155,27 +176,6 @@ steps:
       - cargo build
       - mv target/debug/lemmy_server target/lemmy_server
     when: *slow_check_paths
-
-  cargo_test:
-    image: *rust_image
-    environment:
-      LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
-      RUST_BACKTRACE: "1"
-      CARGO_HOME: .cargo_home
-      LEMMY_TEST_FAST_FEDERATION: "1"
-      LEMMY_CONFIG_LOCATION: ../../config/config.hjson
-    commands:
-      - cargo test --workspace --no-fail-fast
-    when: *slow_check_paths
-
-  check_ts_bindings:
-    image: *rust_image
-    environment:
-      CARGO_HOME: .cargo_home
-    commands:
-      - ./scripts/ts_bindings_check.sh
-    when:
-      - event: pull_request
 
   check_diesel_migration:
     # TODO: use willsquire/diesel-cli image when shared libraries become optional in lemmy_server


### PR DESCRIPTION
- Clippy and test areusually the most likely CI checks to fail, and it currently takes > 5m to reach it, wasting CPU resources.