### PR TITLE
Add test cases for community with non-ascii name (ref #5239)

### DIFF
--- a/api_tests/run-federation-test.sh
+++ b/api_tests/run-federation-test.sh
@@ -11,7 +11,7 @@ killall -s1 lemmy_server || true
 popd
 
 pnpm i
-pnpm api-test-community || true
+pnpm api-test || true
 
 killall -s1 lemmy_server || true
 killall -s1 pict-rs || true

--- a/api_tests/run-federation-test.sh
+++ b/api_tests/run-federation-test.sh
@@ -11,7 +11,7 @@ killall -s1 lemmy_server || true
 popd
 
 pnpm i
-pnpm api-test || true
+pnpm api-test-community || true
 
 killall -s1 lemmy_server || true
 killall -s1 pict-rs || true

--- a/api_tests/src/community.spec.ts
+++ b/api_tests/src/community.spec.ts
@@ -578,7 +578,7 @@ test("Remote mods can edit communities", async () => {
 });
 
 test("Community name with non-ascii chars", async () => {
-    const name = "това_ме_ядосва" + Math.random().toString().slice(2, 6); 
+  const name = "това_ме_ядосва" + Math.random().toString().slice(2, 6);
   let communityRes = await createCommunity(alpha, name);
 
   let betaCommunity1 = await resolveCommunity(
@@ -586,7 +586,7 @@ test("Community name with non-ascii chars", async () => {
     communityRes.community_view.community.actor_id,
   );
   expect(betaCommunity1.community!.community.name).toBe(name);
-  
+
   let alphaCommunity2 = await getCommunityByName(alpha, name);
   expect(alphaCommunity2.community_view.community.name).toBe(name);
 
@@ -594,10 +594,7 @@ test("Community name with non-ascii chars", async () => {
   let betaCommunity2 = await getCommunityByName(beta, fediName);
   expect(betaCommunity2.community_view.community.name).toBe(name);
 
-  let postRes = await createPost(
-    beta,
-    betaCommunity1.community!.community.id,
-  );
+  let postRes = await createPost(beta, betaCommunity1.community!.community.id);
 
   let form: GetPosts = {
     community_name: fediName,

--- a/api_tests/src/community.spec.ts
+++ b/api_tests/src/community.spec.ts
@@ -35,7 +35,7 @@ import {
   userBlockInstance,
 } from "./shared";
 import { AdminAllowInstanceParams } from "lemmy-js-client/dist/types/AdminAllowInstanceParams";
-import { EditCommunity, EditSite } from "lemmy-js-client";
+import { EditCommunity, EditSite, GetPosts } from "lemmy-js-client";
 
 beforeAll(setupLogins);
 afterAll(unfollows);
@@ -575,4 +575,33 @@ test("Remote mods can edit communities", async () => {
   await expect(alphaCommunity.community_view.community.description).toBe(
     "Example description",
   );
+});
+
+test("Community name with non-ascii chars", async () => {
+    const name = "това_ме_ядосва" + Math.random().toString().slice(2, 6); 
+  let communityRes = await createCommunity(alpha, name);
+
+  let betaCommunity1 = await resolveCommunity(
+    beta,
+    communityRes.community_view.community.actor_id,
+  );
+  expect(betaCommunity1.community!.community.name).toBe(name);
+  
+  let alphaCommunity2 = await getCommunityByName(alpha, name);
+  expect(alphaCommunity2.community_view.community.name).toBe(name);
+
+  let fediName = `${communityRes.community_view.community.name}@LEMMY-ALPHA:8541`;
+  let betaCommunity2 = await getCommunityByName(beta, fediName);
+  expect(betaCommunity2.community_view.community.name).toBe(name);
+
+  let postRes = await createPost(
+    beta,
+    betaCommunity1.community!.community.id,
+  );
+
+  let form: GetPosts = {
+    community_name: fediName,
+  };
+  let posts = await beta.getPosts(form);
+  expect(posts.posts[0].post.name).toBe(postRes.post_view.post.name);
 });

--- a/api_tests/src/user.spec.ts
+++ b/api_tests/src/user.spec.ts
@@ -22,6 +22,7 @@ import {
   alphaImage,
   unfollows,
   saveUserSettingsBio,
+  getPersonDetails,
 } from "./shared";
 import {
   EditSite,
@@ -136,10 +137,11 @@ test("Requests with invalid auth should be treated as unauthenticated", async ()
 });
 
 test("Create user with Arabic name", async () => {
+  // less than actor_name_max_length
+    const name = "تجريب" + Math.random().toString().slice(2, 10); 
   let user = await registerUser(
     alpha,
-    alphaUrl,
-    "تجريب" + Math.random().toString().slice(2, 10), // less than actor_name_max_length
+    alphaUrl,name
   );
 
   let site = await getSite(user);
@@ -149,8 +151,11 @@ test("Create user with Arabic name", async () => {
   }
   apShortname = `${site.my_user.local_user_view.person.name}@lemmy-alpha:8541`;
 
-  let alphaPerson = (await resolvePerson(alpha, apShortname)).person;
-  expect(alphaPerson).toBeDefined();
+  let betaPerson1 = (await resolvePerson(beta, apShortname)).person;
+  expect(betaPerson1!.person.name).toBe(name);
+
+  let betaPerson2 = await getPersonDetails(beta, betaPerson1!.person.id);
+  expect(betaPerson2!.person_view.person.name).toBe(name);
 });
 
 test("Create user with accept-language", async () => {

--- a/api_tests/src/user.spec.ts
+++ b/api_tests/src/user.spec.ts
@@ -138,11 +138,8 @@ test("Requests with invalid auth should be treated as unauthenticated", async ()
 
 test("Create user with Arabic name", async () => {
   // less than actor_name_max_length
-    const name = "تجريب" + Math.random().toString().slice(2, 10); 
-  let user = await registerUser(
-    alpha,
-    alphaUrl,name
-  );
+  const name = "تجريب" + Math.random().toString().slice(2, 10);
+  let user = await registerUser(alpha, alphaUrl, name);
 
   let site = await getSite(user);
   expect(site.my_user).toBeDefined();


### PR DESCRIPTION
These are passing fine so there seems to be no problem in the backend, still its good to ensure it doesnt break in the future.