### PR TITLE
Updating to rasky's lemmy-cross-toolchain v0.5.0 for rust 1.81

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ ARG RUST_RELEASE_MODE=debug
 
 ARG AMD_BUILDER_IMAGE=rust:${RUST_VERSION}
 # Repo: https://github.com/raskyld/lemmy-cross-toolchains
-ARG ARM_BUILDER_IMAGE="ghcr.io/raskyld/aarch64-lemmy-linux-gnu:v0.4.0"
+ARG ARM_BUILDER_IMAGE="ghcr.io/raskyld/aarch64-lemmy-linux-gnu:v0.5.0"
 
 ARG AMD_RUNNER_IMAGE=debian:bookworm-slim
 ARG ARM_RUNNER_IMAGE=debian:bookworm-slim


### PR DESCRIPTION
- Fixes #5159