### PR TITLE
Only accept database connection by uri

### DIFF
--- a/config/defaults.hjson
+++ b/config/defaults.hjson
@@ -1,11 +1,7 @@
 {
   # settings related to the postgresql database
   database: {
-    # Configure the database by specifying a URI
-    # 
-    # This is the preferred method to specify database connection details since
-    # it is the most flexible.
-    # Connection URI pointing to a postgres instance
+    # Configure the database by specifying URI pointing to a postgres instance
     # 
     # This example uses peer authentication to obviate the need for creating,
     # configuring, and managing passwords.
@@ -14,25 +10,7 @@
     # PostgreSQL's documentation.
     # 
     # [0]: https://www.postgresql.org/docs/current/libpq-connect.html#id-1.7.3.8.3.6
-    uri: "postgresql:///lemmy?user=lemmy&host=/var/run/postgresql"
-
-    # or
-
-    # Configure the database by specifying parts of a URI
-    # 
-    # Note that specifying the `uri` field should be preferred since it provides
-    # greater control over how the connection is made. This merely exists for
-    # backwards-compatibility.
-    # Username to connect to postgres
-    user: "string"
-    # Password to connect to postgres
-    password: "string"
-    # Host where postgres is running
-    host: "string"
-    # Port where postgres can be accessed
-    port: 123
-    # Name of the postgres database for lemmy
-    database: "string"
+    connection: "postgres://lemmy:password@localhost:5432/lemmy"
     # Maximum number of active sql connections
     pool_size: 30
   }

--- a/crates/utils/src/settings/mod.rs
+++ b/crates/utils/src/settings/mod.rs
@@ -3,12 +3,10 @@ use anyhow::{anyhow, Context};
 use deser_hjson::from_str;
 use regex::Regex;
 use std::{env, fs, io::Error, sync::LazyLock};
+use structs::{PictrsConfig, PictrsImageMode, Settings};
 use url::Url;
-use urlencoding::encode;
 
 pub mod structs;
-
-use structs::{DatabaseConnection, PictrsConfig, PictrsImageMode, Settings};
 
 const DEFAULT_CONFIG_FILE: &str = "config/config.hjson";
 
@@ -52,19 +50,8 @@ impl Settings {
   pub fn get_database_url(&self) -> String {
     if let Ok(url) = env::var("LEMMY_DATABASE_URL") {
       return url;
-    }
-    match &self.database.connection {
-      DatabaseConnection::Uri { uri } => uri.clone(),
-      DatabaseConnection::Parts(parts) => {
-        format!(
-          "postgres://{}:{}@{}:{}/{}",
-          encode(&parts.user),
-          encode(&parts.password),
-          parts.host,
-          parts.port,
-          encode(&parts.database),
-        )
-      }
+    } else {
+      self.database.connection.clone()
     }
   }
 

--- a/crates/utils/src/settings/mod.rs
+++ b/crates/utils/src/settings/mod.rs
@@ -49,7 +49,7 @@ impl Settings {
 
   pub fn get_database_url(&self) -> String {
     if let Ok(url) = env::var("LEMMY_DATABASE_URL") {
-      return url;
+      url
     } else {
       self.database.connection.clone()
     }

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -132,62 +132,22 @@ pub enum PictrsImageMode {
 #[derive(Debug, Deserialize, Serialize, Clone, SmartDefault, Document)]
 #[serde(default)]
 pub struct DatabaseConfig {
-  #[serde(flatten, default)]
-  pub(crate) connection: DatabaseConnection,
+  /// Configure the database by specifying URI pointing to a postgres instance
+  ///
+  /// This example uses peer authentication to obviate the need for creating,
+  /// configuring, and managing passwords.
+  ///
+  /// For an explanation of how to use connection URIs, see [here][0] in
+  /// PostgreSQL's documentation.
+  ///
+  /// [0]: https://www.postgresql.org/docs/current/libpq-connect.html#id-1.7.3.8.3.6
+  #[default("postgres://lemmy:password@localhost:5432/lemmy")]
+  #[doku(example = "postgresql:///lemmy?user=lemmy&host=/var/run/postgresql")]
+  pub(crate) connection: String,
 
   /// Maximum number of active sql connections
   #[default(30)]
   pub pool_size: usize,
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone, SmartDefault, Document)]
-#[serde(untagged)]
-pub enum DatabaseConnection {
-  /// Configure the database by specifying a URI
-  ///
-  /// This is the preferred method to specify database connection details since
-  /// it is the most flexible.
-  Uri {
-    /// Connection URI pointing to a postgres instance
-    ///
-    /// This example uses peer authentication to obviate the need for creating,
-    /// configuring, and managing passwords.
-    ///
-    /// For an explanation of how to use connection URIs, see [here][0] in
-    /// PostgreSQL's documentation.
-    ///
-    /// [0]: https://www.postgresql.org/docs/current/libpq-connect.html#id-1.7.3.8.3.6
-    #[doku(example = "postgresql:///lemmy?user=lemmy&host=/var/run/postgresql")]
-    uri: String,
-  },
-
-  /// Configure the database by specifying parts of a URI
-  ///
-  /// Note that specifying the `uri` field should be preferred since it provides
-  /// greater control over how the connection is made. This merely exists for
-  /// backwards-compatibility.
-  #[default]
-  Parts(DatabaseConnectionParts),
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone, SmartDefault, Document)]
-#[serde(default)]
-pub struct DatabaseConnectionParts {
-  /// Username to connect to postgres
-  #[default("lemmy")]
-  pub(super) user: String,
-  /// Password to connect to postgres
-  #[default("password")]
-  pub(super) password: String,
-  #[default("localhost")]
-  /// Host where postgres is running
-  pub(super) host: String,
-  /// Port where postgres can be accessed
-  #[default(5432)]
-  pub(super) port: i32,
-  /// Name of the postgres database for lemmy
-  #[default("lemmy")]
-  pub(super) database: String,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Document, SmartDefault)]

--- a/docker/federation/lemmy_alpha.hjson
+++ b/docker/federation/lemmy_alpha.hjson
@@ -8,7 +8,7 @@
     site_name: lemmy-alpha
   }
   database: {
-    host: postgres_alpha
+    connection: "postgres://lemmy:password@postgres_alpha:5432/lemmy"
   }
   pictrs: {
     api_key: "my-pictrs-key"

--- a/docker/federation/lemmy_beta.hjson
+++ b/docker/federation/lemmy_beta.hjson
@@ -8,7 +8,7 @@
     site_name: lemmy-beta
   }
   database: {
-    host: postgres_beta
+    connection: "postgres://lemmy:password@postgres_beta:5432/lemmy"
   }
   pictrs: {
     api_key: "my-pictrs-key"

--- a/docker/federation/lemmy_delta.hjson
+++ b/docker/federation/lemmy_delta.hjson
@@ -8,6 +8,6 @@
     site_name: lemmy-delta
   }
   database: {
-    host: postgres_delta
+    connection: "postgres://lemmy:password@postgres_delta:5432/lemmy"
   }
 }

--- a/docker/federation/lemmy_epsilon.hjson
+++ b/docker/federation/lemmy_epsilon.hjson
@@ -8,7 +8,7 @@
     site_name: lemmy-epsilon
   }
   database: {
-    host: postgres_epsilon
+    connection: "postgres://lemmy:password@postgres_epsilon:5432/lemmy"
   }
   pictrs: {
     api_key: "my-pictrs-key"

--- a/docker/federation/lemmy_gamma.hjson
+++ b/docker/federation/lemmy_gamma.hjson
@@ -8,7 +8,7 @@
     site_name: lemmy-gamma
   }
   database: {
-    host: postgres_gamma
+    connection: "postgres://lemmy:password@postgres_gamma:5432/lemmy"
   }
   pictrs: {
     api_key: "my-pictrs-key"

--- a/docker/lemmy.hjson
+++ b/docker/lemmy.hjson
@@ -11,7 +11,7 @@
     site_name: "lemmy-dev"
   }
   database: {
-    host: postgres
+    connection: "postgres://lemmy:password@postgres:5432/lemmy"
   }
 
   hostname: "localhost"


### PR DESCRIPTION
We can get rid of database connection config by parts, as there is no reason to provide two ways. Anyway uri is more flexible, and it also simplifies the code.