### PR TITLE
Use different counts for denominator in scaled rank for posts

### DIFF
--- a/crates/db_schema/replaceable_schema/utils.sql
+++ b/crates/db_schema/replaceable_schema/utils.sql
@@ -33,16 +33,16 @@ now() - published) < '7 days' THEN
         0.0
     END;
 
-CREATE FUNCTION r.scaled_rank (score numeric, published timestamp with time zone, users_active_month numeric)
+CREATE FUNCTION r.scaled_rank (score numeric, published timestamp with time zone, interactions_month numeric)
     RETURNS double precision
     LANGUAGE sql
     IMMUTABLE PARALLEL SAFE
     -- Add 2 to avoid divide by zero errors
     -- Default for score = 1, active users = 1, and now, is (0.1728 / log(2 + 1)) = 0.3621
-    -- There may need to be a scale factor multiplied to users_active_month, to make
+    -- There may need to be a scale factor multiplied to interactions_month, to make
     -- the log curve less pronounced. This can be tuned in the future.
     RETURN (
-        r.hot_rank (score, published) / log(2 + users_active_month)
+        r.hot_rank (score, published) / log(2 + interactions_month)
 );
 
 -- For tables with `deleted` and `removed` columns, this function determines which rows to include in a count.
@@ -209,6 +209,27 @@ BEGIN
             AND pe.bot_account = FALSE) a
 GROUP BY
     community_id;
+END;
+$$;
+
+-- Community aggregate function for adding up total number of interactions
+CREATE OR REPLACE FUNCTION r.community_aggregates_interactions (i text)
+    RETURNS TABLE (
+        count_ bigint,
+        community_id_ integer)
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    RETURN query
+    SELECT
+        COALESCE(sum(comments + upvotes + downvotes), 0) AS count_,
+        community_id AS community_id_
+    FROM
+        post_aggregates
+    WHERE
+        published >= (CURRENT_TIMESTAMP - i::interval)
+    GROUP BY
+        community_id;
 END;
 $$;
 

--- a/crates/db_schema/replaceable_schema/utils.sql
+++ b/crates/db_schema/replaceable_schema/utils.sql
@@ -222,7 +222,7 @@ CREATE OR REPLACE FUNCTION r.community_aggregates_interactions (i text)
 BEGIN
     RETURN query
     SELECT
-        COALESCE(sum(comments + upvotes + downvotes), 0) AS count_,
+        COALESCE(sum(comments + upvotes + downvotes)::bigint, 0) AS count_,
         community_id AS community_id_
     FROM
         post_aggregates

--- a/crates/db_schema/src/aggregates/post_aggregates.rs
+++ b/crates/db_schema/src/aggregates/post_aggregates.rs
@@ -22,9 +22,10 @@ impl PostAggregates {
 
     // Diesel can't update based on a join, which is necessary for the scaled_rank
     // https://github.com/diesel-rs/diesel/issues/1478
-    // Just select the users_active_month manually for now, since its a single post anyway
-    let users_active_month = community_aggregates::table
-      .select(community_aggregates::users_active_month)
+    // Just select the metrics we need manually, for now, since its a single post anyway
+
+    let interactions_month = community_aggregates::table
+      .select(community_aggregates::interactions_month)
       .inner_join(post::table.on(community_aggregates::community_id.eq(post::community_id)))
       .filter(post::id.eq(post_id))
       .first::<i64>(conn)
@@ -40,7 +41,7 @@ impl PostAggregates {
         post_aggregates::scaled_rank.eq(scaled_rank(
           post_aggregates::score,
           post_aggregates::published,
-          users_active_month,
+          interactions_month,
         )),
       ))
       .get_result::<Self>(conn)

--- a/crates/db_schema/src/aggregates/structs.rs
+++ b/crates/db_schema/src/aggregates/structs.rs
@@ -70,6 +70,9 @@ pub struct CommunityAggregates {
   pub users_active_month: i64,
   /// The number of users with any activity in the last year.
   pub users_active_half_year: i64,
+  /// Number of any interactions over the last month.
+  #[serde(skip)]
+  pub interactions_month: i64,
   #[serde(skip)]
   pub hot_rank: f64,
   pub subscribers_local: i64,

--- a/crates/db_schema/src/schema.rs
+++ b/crates/db_schema/src/schema.rs
@@ -252,6 +252,7 @@ diesel::table! {
         users_active_week -> Int8,
         users_active_month -> Int8,
         users_active_half_year -> Int8,
+        interactions_month -> Int8,
         hot_rank -> Float8,
         subscribers_local -> Int8,
         report_count -> Int2,

--- a/crates/db_schema/src/utils.rs
+++ b/crates/db_schema/src/utils.rs
@@ -531,7 +531,7 @@ pub mod functions {
 
   define_sql_function! {
     #[sql_name = "r.scaled_rank"]
-    fn scaled_rank(score: BigInt, time: Timestamptz, users_active_month: BigInt) -> Double;
+    fn scaled_rank(score: BigInt, time: Timestamptz, interactions_month: BigInt) -> Double;
   }
 
   define_sql_function! {

--- a/crates/routes/src/utils/scheduled_tasks.rs
+++ b/crates/routes/src/utils/scheduled_tasks.rs
@@ -278,8 +278,8 @@ async fn process_post_aggregates_ranks_in_batches(conn: &mut AsyncPgConnection) 
     .await
     .map_err(|e| {
       LemmyErrorType::Unknown(format!(
-        "Failed to update {} hot_ranks: {}",
-        "post_aggregates", e
+        "Failed to update post_aggregates hot_ranks: {}",
+        e
       ))
     })?;
 

--- a/crates/routes/src/utils/scheduled_tasks.rs
+++ b/crates/routes/src/utils/scheduled_tasks.rs
@@ -277,10 +277,7 @@ async fn process_post_aggregates_ranks_in_batches(conn: &mut AsyncPgConnection) 
     .get_results::<HotRanksUpdateResult>(conn)
     .await
     .map_err(|e| {
-      LemmyErrorType::Unknown(format!(
-        "Failed to update post_aggregates hot_ranks: {}",
-        e
-      ))
+      LemmyErrorType::Unknown(format!("Failed to update post_aggregates hot_ranks: {}", e))
     })?;
 
     processed_rows_count += updated_rows.len();

--- a/crates/routes/src/utils/scheduled_tasks.rs
+++ b/crates/routes/src/utils/scheduled_tasks.rs
@@ -256,24 +256,36 @@ async fn process_post_aggregates_ranks_in_batches(conn: &mut AsyncPgConnection) 
   while let Some(previous_batch_last_published) = previous_batch_result {
     let updated_rows = sql_query(
       r#"WITH batch AS (SELECT pa.post_id
-               FROM post_aggregates pa
-               WHERE pa.published > $1
-               AND (pa.hot_rank != 0 OR pa.hot_rank_active != 0)
-               ORDER BY pa.published
-               LIMIT $2
-               FOR UPDATE SKIP LOCKED)
-         UPDATE post_aggregates pa
-           SET hot_rank = r.hot_rank(pa.score, pa.published),
-           hot_rank_active = r.hot_rank(pa.score, pa.newest_comment_time_necro),
-           scaled_rank = r.scaled_rank(pa.score, pa.published, ca.users_active_month)
-         FROM batch, community_aggregates ca
-         WHERE pa.post_id = batch.post_id and pa.community_id = ca.community_id RETURNING pa.published;
-    "#,
+           FROM post_aggregates pa
+           WHERE pa.published > $1
+           AND (pa.hot_rank != 0 OR pa.hot_rank_active != 0)
+           ORDER BY pa.published
+           LIMIT $2
+          FOR UPDATE SKIP LOCKED),
+      community_interactions AS (
+          SELECT community_id, interactions_month
+          FROM community_aggregates
+          GROUP BY community_id)
+      UPDATE post_aggregates pa
+      SET hot_rank = r.hot_rank(pa.score, pa.published),
+          hot_rank_active = r.hot_rank(pa.score, pa.newest_comment_time_necro),
+          scaled_rank = r.scaled_rank(pa.score, pa.published, ci.interactions_month)
+      FROM batch, community_interactions ci
+      WHERE pa.post_id = batch.post_id
+      AND pa.community_id = ci.community_id
+      RETURNING pa.published;
+"#,
     )
     .bind::<Timestamptz, _>(previous_batch_last_published)
     .bind::<Integer, _>(update_batch_size)
     .get_results::<HotRanksUpdateResult>(conn)
-    .await.map_err(|e| LemmyErrorType::Unknown(format!("Failed to update {} hot_ranks: {}", "post_aggregates", e)))?;
+    .await
+    .map_err(|e| {
+      LemmyErrorType::Unknown(format!(
+        "Failed to update {} hot_ranks: {}",
+        "post_aggregates", e
+      ))
+    })?;
 
     processed_rows_count += updated_rows.len();
     previous_batch_result = updated_rows.last().map(|row| row.published);
@@ -371,7 +383,7 @@ async fn active_counts(pool: &mut DbPool<'_>) -> LemmyResult<()> {
 
   for (full_form, abbr) in &intervals {
     let update_site_stmt = format!(
-      "update site_aggregates set users_active_{} = (select * from r.site_aggregates_activity('{}')) where site_id = 1",
+      "update site_aggregates set users_active_{} = (select r.site_aggregates_activity('{}')) where site_id = 1",
       abbr, full_form
     );
     sql_query(update_site_stmt).execute(&mut conn).await?;
@@ -379,6 +391,11 @@ async fn active_counts(pool: &mut DbPool<'_>) -> LemmyResult<()> {
     let update_community_stmt = format!("update community_aggregates ca set users_active_{} = mv.count_ from r.community_aggregates_activity('{}') mv where ca.community_id = mv.community_id_", abbr, full_form);
     sql_query(update_community_stmt).execute(&mut conn).await?;
   }
+
+  let update_interactions_stmt = "update community_aggregates ca set interactions_month = mv.count_ from r.community_aggregates_interactions('1 month') mv where ca.community_id = mv.community_id_";
+  sql_query(update_interactions_stmt)
+    .execute(&mut conn)
+    .await?;
 
   info!("Done.");
   Ok(())

--- a/migrations/2025-01-21-000000_interactions_per_month_schema/down.sql
+++ b/migrations/2025-01-21-000000_interactions_per_month_schema/down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE community_aggregates
+    DROP COLUMN interactions_month;
+

--- a/migrations/2025-01-21-000000_interactions_per_month_schema/up.sql
+++ b/migrations/2025-01-21-000000_interactions_per_month_schema/up.sql
@@ -1,0 +1,4 @@
+-- Add the interactions_month column
+ALTER TABLE community_aggregates
+    ADD COLUMN interactions_month bigint NOT NULL DEFAULT 0;
+


### PR DESCRIPTION
In the discussion about a better "Scaled" sort in bug #5210, it was recommended that I make a new sort option to implement the different sorting I described.

Looking at the change, I don't think applying this PR is the right way. I think the complexity and UX issues are such that it would be better to just amend the "Scaled" sort option in-place instead of adding a new sort option. But, I'm submitting this for discussion and to move the process forward. Comments are welcome. Having the option visible for purposes of comparison may be useful, for purposes of evaluating the change.

To actually work, this PR needs to go in alongside some other changes in other repos:

* Add a translation for "Balanced" in `crates/utils/translations/translations/*.json`
* Add an option for the "Balanced" sort in `src/shared/components/common/sort-select.tsx` in lemmy-ui, around line 141

Comments welcome.