### PR TITLE
refactor: avoid using format! when String creation is unnecessary

### DIFF
--- a/crates/apub/src/fetcher/markdown_links.rs
+++ b/crates/apub/src/fetcher/markdown_links.rs
@@ -42,7 +42,8 @@ pub async fn markdown_rewrite_remote_links(
       let mut local_url = local_url.to_string();
       // restore title
       if let Some(extra) = extra {
-        local_url = format!("{local_url} {extra}");
+        local_url.push(' ');
+        local_url.push_str(extra);
       }
       src.replace_range(start..end, local_url.as_str());
     }

--- a/crates/routes/src/feeds.rs
+++ b/crates/routes/src/feeds.rs
@@ -454,7 +454,6 @@ fn build_item(
   protocol_and_hostname: &str,
 ) -> LemmyResult<Item> {
   // TODO add images
-  let author_url = format!("{protocol_and_hostname}/u/{creator_name}");
   let guid = Some(Guid {
     permalink: true,
     value: url.to_owned(),
@@ -464,7 +463,8 @@ fn build_item(
   Ok(Item {
     title: Some(format!("Reply from {creator_name}")),
     author: Some(format!(
-      "/u/{creator_name} <a href=\"{author_url}\">(link)</a>"
+      "/u/{creator_name} <a href=\"{}\">(link)</a>",
+      format_args!("{protocol_and_hostname}/u/{creator_name}")
     )),
     pub_date: Some(published.to_rfc2822()),
     comments: Some(url.to_owned()),

--- a/crates/utils/src/utils/markdown/image_links.rs
+++ b/crates/utils/src/utils/markdown/image_links.rs
@@ -24,7 +24,8 @@ pub fn markdown_rewrite_image_links(mut src: String) -> (String, Vec<Url>) {
           );
           // restore custom emoji format
           if let Some(extra) = extra {
-            proxied = format!("{proxied} {extra}");
+            proxied.push(' ');
+            proxied.push_str(extra);
           }
           src.replace_range(start..end, &proxied);
         }

--- a/src/scheduled_tasks.rs
+++ b/src/scheduled_tasks.rs
@@ -190,10 +190,8 @@ async fn process_ranks_in_batches(
          UPDATE {aggregates_table} a {set_clause}
              FROM batch WHERE a.{id_column} = batch.{id_column} RETURNING a.published;
     "#,
-      id_column = format!("{table_name}_id"),
-      aggregates_table = format!("{table_name}_aggregates"),
-      set_clause = set_clause,
-      where_clause = where_clause
+      id_column = format_args!("{table_name}_id"),
+      aggregates_table = format_args!("{table_name}_aggregates"),
     ))
     .bind::<Timestamptz, _>(previous_batch_last_published)
     .bind::<Integer, _>(update_batch_size)


### PR DESCRIPTION
- When `String` creation is unnecessary, replace `format!()` with `format_args!()`, `push()` or `push_str()` to avoid overhead of heap allocation.