### PR TITLE
Use codeberg pictrs mirror to fix CI.

### DIFF
--- a/api_tests/prepare-drone-federation-test.sh
+++ b/api_tests/prepare-drone-federation-test.sh
@@ -15,7 +15,9 @@ export LEMMY_TEST_FAST_FEDERATION=1 # by default, the persistent federation queu
 
 # pictrs setup
 if [ ! -f "api_tests/pict-rs" ]; then
-  curl "https://git.asonix.dog/asonix/pict-rs/releases/download/v0.5.16/pict-rs-linux-amd64" -o api_tests/pict-rs
+  # This one sometimes goes down
+  # curl "https://git.asonix.dog/asonix/pict-rs/releases/download/v0.5.16/pict-rs-linux-amd64" -o api_tests/pict-rs
+  curl "https://codeberg.org/asonix/pict-rs/releases/download/v0.5.6/pict-rs-linux-amd64" -o api_tests/pict-rs
   chmod +x api_tests/pict-rs
 fi
 ./api_tests/pict-rs \


### PR DESCRIPTION
CI is currently broken because git.asonix.dog is down, with no ETA for fixing yet. This uses a codeberg mirror.