### PR TITLE
Remove unused params on CreateSite/EditSite

### DIFF
--- a/crates/api_common/src/site.rs
+++ b/crates/api_common/src/site.rs
@@ -203,8 +203,6 @@ pub struct CreateSite {
   #[cfg_attr(feature = "full", ts(optional))]
   pub banner: Option<String>,
   #[cfg_attr(feature = "full", ts(optional))]
-  pub enable_nsfw: Option<bool>,
-  #[cfg_attr(feature = "full", ts(optional))]
   pub community_creation_admin_only: Option<bool>,
   #[cfg_attr(feature = "full", ts(optional))]
   pub require_email_verification: Option<bool>,
@@ -261,8 +259,6 @@ pub struct CreateSite {
   #[cfg_attr(feature = "full", ts(optional))]
   pub federation_enabled: Option<bool>,
   #[cfg_attr(feature = "full", ts(optional))]
-  pub federation_debug: Option<bool>,
-  #[cfg_attr(feature = "full", ts(optional))]
   pub captcha_enabled: Option<bool>,
   #[cfg_attr(feature = "full", ts(optional))]
   pub captcha_difficulty: Option<String>,
@@ -302,9 +298,6 @@ pub struct EditSite {
   /// A url for your site's banner.
   #[cfg_attr(feature = "full", ts(optional))]
   pub banner: Option<String>,
-  /// Whether to enable NSFW.
-  #[cfg_attr(feature = "full", ts(optional))]
-  pub enable_nsfw: Option<bool>,
   /// Limits community creation to admins only.
   #[cfg_attr(feature = "full", ts(optional))]
   pub community_creation_admin_only: Option<bool>,
@@ -383,9 +376,6 @@ pub struct EditSite {
   /// Whether to enable federation.
   #[cfg_attr(feature = "full", ts(optional))]
   pub federation_enabled: Option<bool>,
-  /// Enables federation debugging.
-  #[cfg_attr(feature = "full", ts(optional))]
-  pub federation_debug: Option<bool>,
   /// Whether to enable captchas for signups.
   #[cfg_attr(feature = "full", ts(optional))]
   pub captcha_enabled: Option<bool>,


### PR DESCRIPTION
Unfortunately there is no way to get automatic warnings about these unused parameters because the structs have to be public.