### PR TITLE
Fixing person_content_combined migration uniques.

### DIFF
--- a/migrations/2024-12-05-233704_add_person_content_combined_table/up.sql
+++ b/migrations/2024-12-05-233704_add_person_content_combined_table/up.sql
@@ -33,8 +33,12 @@ CREATE TABLE person_saved_combined (
     id serial PRIMARY KEY,
     saved timestamptz NOT NULL,
     person_id int NOT NULL REFERENCES person ON UPDATE CASCADE ON DELETE CASCADE,
-    post_id int UNIQUE REFERENCES post ON UPDATE CASCADE ON DELETE CASCADE,
-    comment_id int UNIQUE REFERENCES COMMENT ON UPDATE CASCADE ON DELETE CASCADE,
+    post_id int REFERENCES post ON UPDATE CASCADE ON DELETE CASCADE,
+    comment_id int REFERENCES COMMENT ON UPDATE CASCADE ON DELETE CASCADE,
+    -- Unique constraints are different here, check for person AND item.
+    -- Otherwise you won't be able to add multiple posts
+    UNIQUE (person_id, post_id),
+    UNIQUE (person_id, comment_id),
     -- Make sure only one of the columns is not null
     CHECK (num_nonnulls (post_id, comment_id) = 1)
 );


### PR DESCRIPTION
Ran into this error when running with production data: 

`Error: LemmyError { message: Unknown("Failed to run 2024-12-05-233704_add_person_content_combined_table with: duplicate key value violates unique constraint \"person_saved_combined_post_id_key\""), inner: Failed to run 2024-12-05-233704_add_person_content_combined_table with: duplicate key value violates unique constraint "person_saved_combined_post_id_key"`

The unique constraints were wrong for the person_saved_combined table, so it couldn't add more than 1 post for different people.



For the record, this migration took ~13m with lemmy.ml production data.