### PR TITLE
Add some url validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,8 +10,9 @@ checksum = "8f27d075294830fcab6f66e320dab524bc6d048f4a151698e153205559113772"
 
 [[package]]
 name = "activitypub_federation"
-version = "0.6.1"
-source = "git+https://github.com/LemmyNet/activitypub-federation-rust.git?branch=more-url-validation#7f2c303c36af3a24f8f72b5d7100d8d02ad7a961"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce5c105760d36108026acde9cb779d8ef4714d5e551f248a9e8e0369b6671b78"
 dependencies = [
  "activitystreams-kinds",
  "actix-web",
@@ -2956,7 +2957,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5765,7 +5766,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "8f27d075294830fcab6f66e320dab524bc6d048f4a151698e153205559113772"
 [[package]]
 name = "activitypub_federation"
 version = "0.6.1"
-source = "git+https://github.com/LemmyNet/activitypub-federation-rust.git?branch=more-url-validation#4991c1f9d99118da83d23ff4c9a1500a4293fccd"
+source = "git+https://github.com/LemmyNet/activitypub-federation-rust.git?branch=more-url-validation#686da0f03a17611eafdeb02db71ecbfcfc7262f5"
 dependencies = [
  "activitystreams-kinds",
  "actix-web",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "8f27d075294830fcab6f66e320dab524bc6d048f4a151698e153205559113772"
 [[package]]
 name = "activitypub_federation"
 version = "0.6.1"
-source = "git+https://github.com/LemmyNet/activitypub-federation-rust.git?branch=more-url-validation#686da0f03a17611eafdeb02db71ecbfcfc7262f5"
+source = "git+https://github.com/LemmyNet/activitypub-federation-rust.git?branch=more-url-validation#7f2c303c36af3a24f8f72b5d7100d8d02ad7a961"
 dependencies = [
  "activitystreams-kinds",
  "actix-web",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,8 +11,7 @@ checksum = "8f27d075294830fcab6f66e320dab524bc6d048f4a151698e153205559113772"
 [[package]]
 name = "activitypub_federation"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee819cada736b6e26c59706f9e6ff89a48060e635c0546ff984d84baefc8c13a"
+source = "git+https://github.com/LemmyNet/activitypub-federation-rust.git?branch=more-url-validation#4991c1f9d99118da83d23ff4c9a1500a4293fccd"
 dependencies = [
  "activitystreams-kinds",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ lemmy_db_views = { version = "=0.19.6-beta.7", path = "./crates/db_views" }
 lemmy_db_views_actor = { version = "=0.19.6-beta.7", path = "./crates/db_views_actor" }
 lemmy_db_views_moderator = { version = "=0.19.6-beta.7", path = "./crates/db_views_moderator" }
 lemmy_federate = { version = "=0.19.6-beta.7", path = "./crates/federate" }
-activitypub_federation = { git = "https://github.com/LemmyNet/activitypub-federation-rust.git", branch = "more-url-validation", default-features = false, features = [
+activitypub_federation = { version = "0.6.2", default-features = false, features = [
   "actix-web",
 ] }
 diesel = "2.2.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ lemmy_db_views = { version = "=0.19.6-beta.7", path = "./crates/db_views" }
 lemmy_db_views_actor = { version = "=0.19.6-beta.7", path = "./crates/db_views_actor" }
 lemmy_db_views_moderator = { version = "=0.19.6-beta.7", path = "./crates/db_views_moderator" }
 lemmy_federate = { version = "=0.19.6-beta.7", path = "./crates/federate" }
-activitypub_federation = { version = "0.6.1", default-features = false, features = [
+activitypub_federation = { git = "https://github.com/LemmyNet/activitypub-federation-rust.git", branch = "more-url-validation", default-features = false, features = [
   "actix-web",
 ] }
 diesel = "2.2.6"

--- a/api_tests/src/image.spec.ts
+++ b/api_tests/src/image.spec.ts
@@ -235,7 +235,6 @@ test("Thumbnail of remote image link is proxied if setting enabled", async () =>
   expect(post).toBeDefined();
 
   // remote image gets proxied after upload
-  console.log(post.thumbnail_url);
   expect(
     post.thumbnail_url?.startsWith(
       "http://lemmy-gamma:8561/api/v4/image/proxy?url",

--- a/api_tests/src/image.spec.ts
+++ b/api_tests/src/image.spec.ts
@@ -235,6 +235,7 @@ test("Thumbnail of remote image link is proxied if setting enabled", async () =>
   expect(post).toBeDefined();
 
   // remote image gets proxied after upload
+  console.log(post.thumbnail_url);
   expect(
     post.thumbnail_url?.startsWith(
       "http://lemmy-gamma:8561/api/v4/image/proxy?url",

--- a/crates/api/src/post/get_link_metadata.rs
+++ b/crates/api/src/post/get_link_metadata.rs
@@ -16,7 +16,7 @@ pub async fn get_link_metadata(
   _local_user_view: LocalUserView,
 ) -> LemmyResult<Json<GetSiteMetadataResponse>> {
   let url = Url::parse(&data.url).with_lemmy_type(LemmyErrorType::InvalidUrl)?;
-  let metadata = fetch_link_metadata(&url, &context).await?;
+  let metadata = fetch_link_metadata(&url, &context, false).await?;
 
   Ok(Json(GetSiteMetadataResponse { metadata }))
 }

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -542,7 +542,7 @@ mod tests {
   async fn test_link_metadata() -> LemmyResult<()> {
     let context = LemmyContext::init_test_context().await;
     let sample_url = Url::parse("https://gitlab.com/IzzyOnDroid/repo/-/wikis/FAQ")?;
-    let sample_res = fetch_link_metadata(&sample_url, &context).await?;
+    let sample_res = fetch_link_metadata(&sample_url, &context, false).await?;
     assert_eq!(
       Some("FAQ · Wiki · IzzyOnDroid / repo · GitLab".to_string()),
       sample_res.opengraph_data.title

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -55,6 +55,10 @@ pub async fn fetch_link_metadata(
   context: &LemmyContext,
   recursion: bool,
 ) -> LemmyResult<LinkMetadata> {
+  if url.scheme() != "http" && url.scheme() != "https" {
+    return Err(LemmyErrorType::InvalidUrl.into());
+  }
+
   // Resolve the domain and throw an error if it points to any internal IP,
   // using logic from nightly IpAddr::is_global.
   if !cfg!(debug_assertions) {

--- a/crates/apub/src/objects/comment.rs
+++ b/crates/apub/src/objects/comment.rs
@@ -3,7 +3,7 @@ use crate::{
   check_apub_id_valid_with_strictness,
   fetcher::markdown_links::markdown_rewrite_remote_links,
   mentions::collect_non_local_mentions,
-  objects::{append_attachments_to_comment, read_from_string_or_source, verify_is_remote_object},
+  objects::{append_attachments_to_comment, read_from_string_or_source},
   protocol::{
     objects::{note::Note, LanguageTag},
     InCommunity,
@@ -13,7 +13,10 @@ use crate::{
 use activitypub_federation::{
   config::Data,
   kinds::object::NoteType,
-  protocol::{values::MediaTypeMarkdownOrHtml, verification::verify_domains_match},
+  protocol::{
+    values::MediaTypeMarkdownOrHtml,
+    verification::{verify_domains_match, verify_is_remote_object},
+  },
   traits::Object,
 };
 use chrono::{DateTime, Utc};

--- a/crates/apub/src/objects/instance.rs
+++ b/crates/apub/src/objects/instance.rs
@@ -1,4 +1,3 @@
-use super::verify_is_remote_object;
 use crate::{
   activities::GetActorType,
   check_apub_id_valid_with_strictness,
@@ -15,7 +14,10 @@ use activitypub_federation::{
   config::Data,
   fetch::object_id::ObjectId,
   kinds::actor::ApplicationType,
-  protocol::{values::MediaTypeHtml, verification::verify_domains_match},
+  protocol::{
+    values::MediaTypeHtml,
+    verification::{verify_domains_match, verify_is_remote_object},
+  },
   traits::{Actor, Object},
 };
 use chrono::{DateTime, Utc};

--- a/crates/apub/src/objects/mod.rs
+++ b/crates/apub/src/objects/mod.rs
@@ -1,16 +1,8 @@
 use crate::protocol::{objects::page::Attachment, Source};
-use activitypub_federation::{
-  config::Data,
-  fetch::object_id::ObjectId,
-  protocol::values::MediaTypeMarkdownOrHtml,
-  traits::Object,
-};
-use anyhow::anyhow;
+use activitypub_federation::{config::Data, protocol::values::MediaTypeMarkdownOrHtml};
 use html2md::parse_html;
 use lemmy_api_common::context::LemmyContext;
 use lemmy_utils::error::LemmyResult;
-use serde::Deserialize;
-use std::fmt::Debug;
 
 pub mod comment;
 pub mod community;
@@ -61,23 +53,4 @@ pub(crate) async fn append_attachments_to_comment(
   }
 
   Ok(content)
-}
-
-/// When for example a Post is made in a remote community, the community will send it back,
-/// wrapped in Announce. If we simply receive this like any other federated object, overwrite the
-/// existing, local Post. In particular, it will set the field local = false, so that the object
-/// can't be fetched from the Activitypub HTTP endpoint anymore (which only serves local objects).
-pub(crate) fn verify_is_remote_object<T>(
-  id: &ObjectId<T>,
-  context: &Data<LemmyContext>,
-) -> LemmyResult<()>
-where
-  T: Object<DataType = LemmyContext> + Debug + Send + 'static,
-  for<'de2> <T as Object>::Kind: Deserialize<'de2>,
-{
-  if id.is_local(context) {
-    Err(anyhow!("cant accept local object from remote instance").into())
-  } else {
-    Ok(())
-  }
 }

--- a/crates/apub/src/objects/person.rs
+++ b/crates/apub/src/objects/person.rs
@@ -1,4 +1,3 @@
-use super::verify_is_remote_object;
 use crate::{
   activities::GetActorType,
   check_apub_id_valid_with_strictness,
@@ -13,7 +12,7 @@ use crate::{
 };
 use activitypub_federation::{
   config::Data,
-  protocol::verification::verify_domains_match,
+  protocol::verification::{verify_domains_match, verify_is_remote_object},
   traits::{Actor, Object},
 };
 use chrono::{DateTime, Utc};

--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -3,7 +3,7 @@ use crate::{
   check_apub_id_valid_with_strictness,
   fetcher::markdown_links::{markdown_rewrite_remote_links_opt, to_local_url},
   local_site_data_cached,
-  objects::{read_from_string_or_source_opt, verify_is_remote_object},
+  objects::read_from_string_or_source_opt,
   protocol::{
     objects::{
       page::{Attachment, AttributedTo, Hashtag, HashtagType, Page, PageType},
@@ -16,7 +16,10 @@ use crate::{
 };
 use activitypub_federation::{
   config::Data,
-  protocol::{values::MediaTypeMarkdownOrHtml, verification::verify_domains_match},
+  protocol::{
+    values::MediaTypeMarkdownOrHtml,
+    verification::{verify_domains_match, verify_is_remote_object},
+  },
   traits::Object,
 };
 use anyhow::anyhow;

--- a/crates/apub/src/objects/private_message.rs
+++ b/crates/apub/src/objects/private_message.rs
@@ -1,4 +1,3 @@
-use super::verify_is_remote_object;
 use crate::{
   check_apub_id_valid_with_strictness,
   fetcher::markdown_links::markdown_rewrite_remote_links,
@@ -10,7 +9,10 @@ use crate::{
 };
 use activitypub_federation::{
   config::Data,
-  protocol::{values::MediaTypeHtml, verification::verify_domains_match},
+  protocol::{
+    values::MediaTypeHtml,
+    verification::{verify_domains_match, verify_is_remote_object},
+  },
   traits::Object,
 };
 use chrono::{DateTime, Utc};


### PR DESCRIPTION
- In production mode check that `fetch_link_metadata()` doesnt connect to any private/internal IPs. To make this check work reliably, disable automatic redirects and manually follow a single redirect
- Includes extra validation mentioned in https://github.com/LemmyNet/activitypub-federation-rust/pull/134
- Move `verify_is_remote_object()` into activitypub library
- Only fetch metadata for http, https urls
