### PR TITLE
Hash check and retry for pictrs binary

### DIFF
--- a/api_tests/prepare-drone-federation-test.sh
+++ b/api_tests/prepare-drone-federation-test.sh
@@ -13,13 +13,23 @@ export RUST_LOG="warn,lemmy_server=$LEMMY_LOG_LEVEL,lemmy_federate=$LEMMY_LOG_LE
 
 export LEMMY_TEST_FAST_FEDERATION=1 # by default, the persistent federation queue has delays in the scale of 30s-5min
 
+PICTRS_PATH="api_tests/pict-rs"
+PICTRS_EXPECTED_HASH="8feb52c0dee1dd0b41caa0e92afd9d5e597fbb4d7174d7bba22a1ba72fa01dbc  pict-rs"
+
 # pictrs setup
-if [ ! -f "api_tests/pict-rs" ]; then
-  # This one sometimes goes down
-  # curl "https://git.asonix.dog/asonix/pict-rs/releases/download/v0.5.16/pict-rs-linux-amd64" -o api_tests/pict-rs
-  curl "https://codeberg.org/asonix/pict-rs/releases/download/v0.5.6/pict-rs-linux-amd64" -o api_tests/pict-rs
-  chmod +x api_tests/pict-rs
+if [ ! -f "$PICTRS_PATH" ]; then
+  retry=true
+  while $retry
+  do
+    # This one sometimes goes down
+    # curl "https://git.asonix.dog/asonix/pict-rs/releases/download/v0.5.16/pict-rs-linux-amd64" -o "$PICTRS_PATH"
+    curl "https://codeberg.org/asonix/pict-rs/releases/download/v0.5.6/pict-rs-linux-amd64" -o "$PICTRS_PATH"
+    PICTRS_HASH=$(sha256sum "$PICTRS_PATH")
+    [[ "$PICTRS_HASH" != "$PICTRS_EXPECTED_HASH" ]] && retry=true || retry=false
+  done
+  chmod +x "$PICTRS_PATH"
 fi
+
 ./api_tests/pict-rs \
   run -a 0.0.0.0:8080 \
   --danger-dummy-mode \

--- a/api_tests/prepare-drone-federation-test.sh
+++ b/api_tests/prepare-drone-federation-test.sh
@@ -16,16 +16,18 @@ export LEMMY_TEST_FAST_FEDERATION=1 # by default, the persistent federation queu
 PICTRS_PATH="api_tests/pict-rs"
 PICTRS_EXPECTED_HASH="8feb52c0dee1dd0b41caa0e92afd9d5e597fbb4d7174d7bba22a1ba72fa01dbc  pict-rs"
 
-# pictrs setup
+# Pictrs setup. Download file with hash check and up to 3 retries. 
 if [ ! -f "$PICTRS_PATH" ]; then
   retry=true
-  while $retry
+  count=0
+  while $retry && [ "$count" -lt 3 ]
   do
     # This one sometimes goes down
     # curl "https://git.asonix.dog/asonix/pict-rs/releases/download/v0.5.16/pict-rs-linux-amd64" -o "$PICTRS_PATH"
-    curl "https://codeberg.org/asonix/pict-rs/releases/download/v0.5.6/pict-rs-linux-amd64" -o "$PICTRS_PATH"
+    curl "https://codeberg.org/asonix/pict-rs/releases/download/v0.5.5/pict-rs-linux-amd64" -o "$PICTRS_PATH"
     PICTRS_HASH=$(sha256sum "$PICTRS_PATH")
     [[ "$PICTRS_HASH" != "$PICTRS_EXPECTED_HASH" ]] && retry=true || retry=false
+    let count=count+1
   done
   chmod +x "$PICTRS_PATH"
 fi


### PR DESCRIPTION
I was consistently getting api test failures on image tests, until I deleted the pictrs binary and it was redownloaded, when tests passed again. The same errors also happen sometimes in CI. So we should check that the binary hash is correct, and redownload it if wrong. This is also more secure.