### PR TITLE
Remove instrument macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2633,7 +2633,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "tracing",
  "url",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ actix-web = { version = "4.9.0", default-features = false, features = [
   "macros",
   "rustls-0_23",
 ] }
-tracing = "0.1.41"
+tracing = { version = "0.1.41", default-features = false }
 tracing-actix-web = { version = "0.7.15", default-features = false }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 url = { version = "2.5.4", features = ["serde"] }

--- a/api_tests/run-federation-test.sh
+++ b/api_tests/run-federation-test.sh
@@ -11,7 +11,7 @@ killall -s1 lemmy_server || true
 popd
 
 pnpm i
-pnpm api-test || true
+pnpm api-test-post || true
 
 killall -s1 lemmy_server || true
 killall -s1 pict-rs || true

--- a/api_tests/run-federation-test.sh
+++ b/api_tests/run-federation-test.sh
@@ -11,7 +11,7 @@ killall -s1 lemmy_server || true
 popd
 
 pnpm i
-pnpm api-test-post || true
+pnpm api-test || true
 
 killall -s1 lemmy_server || true
 killall -s1 pict-rs || true

--- a/crates/api/src/comment/distinguish.rs
+++ b/crates/api/src/comment/distinguish.rs
@@ -11,7 +11,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::{CommentView, LocalUserView};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn distinguish_comment(
   data: Json<DistinguishComment>,
   context: Data<LemmyContext>,

--- a/crates/api/src/comment/like.rs
+++ b/crates/api/src/comment/like.rs
@@ -20,7 +20,6 @@ use lemmy_db_views::structs::{CommentView, LocalUserView};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 use std::ops::Deref;
 
-#[tracing::instrument(skip(context))]
 pub async fn like_comment(
   data: Json<CreateCommentLike>,
   context: Data<LemmyContext>,

--- a/crates/api/src/comment/list_comment_likes.rs
+++ b/crates/api/src/comment/list_comment_likes.rs
@@ -8,7 +8,6 @@ use lemmy_db_views::structs::{CommentView, LocalUserView, VoteView};
 use lemmy_utils::error::LemmyResult;
 
 /// Lists likes for a comment
-
 pub async fn list_comment_likes(
   data: Query<ListCommentLikes>,
   context: Data<LemmyContext>,

--- a/crates/api/src/comment/list_comment_likes.rs
+++ b/crates/api/src/comment/list_comment_likes.rs
@@ -8,7 +8,7 @@ use lemmy_db_views::structs::{CommentView, LocalUserView, VoteView};
 use lemmy_utils::error::LemmyResult;
 
 /// Lists likes for a comment
-#[tracing::instrument(skip(context))]
+
 pub async fn list_comment_likes(
   data: Query<ListCommentLikes>,
   context: Data<LemmyContext>,

--- a/crates/api/src/comment/save.rs
+++ b/crates/api/src/comment/save.rs
@@ -10,7 +10,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::{CommentView, LocalUserView};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn save_comment(
   data: Json<SaveComment>,
   context: Data<LemmyContext>,

--- a/crates/api/src/community/add_mod.rs
+++ b/crates/api/src/community/add_mod.rs
@@ -17,7 +17,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::{CommunityModeratorView, LocalUserView};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn add_mod_to_community(
   data: Json<AddModToCommunity>,
   context: Data<LemmyContext>,

--- a/crates/api/src/community/ban.rs
+++ b/crates/api/src/community/ban.rs
@@ -30,7 +30,6 @@ use lemmy_utils::{
   utils::validation::is_valid_body_field,
 };
 
-#[tracing::instrument(skip(context))]
 pub async fn ban_from_community(
   data: Json<BanFromCommunity>,
   context: Data<LemmyContext>,

--- a/crates/api/src/community/block.rs
+++ b/crates/api/src/community/block.rs
@@ -15,7 +15,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::{CommunityView, LocalUserView};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn user_block_community(
   data: Json<BlockCommunity>,
   context: Data<LemmyContext>,

--- a/crates/api/src/community/follow.rs
+++ b/crates/api/src/community/follow.rs
@@ -17,7 +17,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::{CommunityPersonBanView, CommunityView, LocalUserView};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn follow_community(
   data: Json<FollowCommunity>,
   context: Data<LemmyContext>,

--- a/crates/api/src/community/hide.rs
+++ b/crates/api/src/community/hide.rs
@@ -17,7 +17,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn hide_community(
   data: Json<HideCommunity>,
   context: Data<LemmyContext>,

--- a/crates/api/src/community/random.rs
+++ b/crates/api/src/community/random.rs
@@ -13,7 +13,6 @@ use lemmy_db_schema::source::{
 use lemmy_db_views::structs::{CommunityView, LocalUserView};
 use lemmy_utils::error::LemmyResult;
 
-#[tracing::instrument(skip(context))]
 pub async fn get_random_community(
   data: Query<GetRandomCommunity>,
   context: Data<LemmyContext>,

--- a/crates/api/src/community/transfer.rs
+++ b/crates/api/src/community/transfer.rs
@@ -20,7 +20,7 @@ use lemmy_utils::{
 
 // TODO: we dont do anything for federation here, it should be updated the next time the community
 //       gets fetched. i hope we can get rid of the community creator role soon.
-#[tracing::instrument(skip(context))]
+
 pub async fn transfer_community(
   data: Json<TransferCommunity>,
   context: Data<LemmyContext>,

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -146,7 +146,7 @@ fn build_totp_2fa(hostname: &str, username: &str, secret: &str) -> LemmyResult<T
 /// So when doing a site ban for a non-local user, you need to federate/send a
 /// community ban for every local community they've participated in.
 /// See https://github.com/LemmyNet/lemmy/issues/4118
-#[tracing::instrument(skip_all)]
+
 pub(crate) async fn ban_nonlocal_user_from_local_communities(
   local_user_view: &LocalUserView,
   target: &Person,

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -146,7 +146,6 @@ fn build_totp_2fa(hostname: &str, username: &str, secret: &str) -> LemmyResult<T
 /// So when doing a site ban for a non-local user, you need to federate/send a
 /// community ban for every local community they've participated in.
 /// See https://github.com/LemmyNet/lemmy/issues/4118
-
 pub(crate) async fn ban_nonlocal_user_from_local_communities(
   local_user_view: &LocalUserView,
   target: &Person,

--- a/crates/api/src/local_user/add_admin.rs
+++ b/crates/api/src/local_user/add_admin.rs
@@ -14,7 +14,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::{LocalUserView, PersonView};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn add_admin(
   data: Json<AddAdmin>,
   context: Data<LemmyContext>,

--- a/crates/api/src/local_user/ban_person.rs
+++ b/crates/api/src/local_user/ban_person.rs
@@ -22,7 +22,6 @@ use lemmy_utils::{
   utils::validation::is_valid_body_field,
 };
 
-#[tracing::instrument(skip(context))]
 pub async fn ban_from_site(
   data: Json<BanPerson>,
   context: Data<LemmyContext>,

--- a/crates/api/src/local_user/block.rs
+++ b/crates/api/src/local_user/block.rs
@@ -10,7 +10,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::{LocalUserView, PersonView};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn user_block_person(
   data: Json<BlockPerson>,
   context: Data<LemmyContext>,

--- a/crates/api/src/local_user/change_password.rs
+++ b/crates/api/src/local_user/change_password.rs
@@ -13,7 +13,6 @@ use lemmy_db_schema::source::{local_user::LocalUser, login_token::LoginToken};
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::{LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn change_password(
   data: Json<ChangePassword>,
   req: HttpRequest,

--- a/crates/api/src/local_user/change_password_after_reset.rs
+++ b/crates/api/src/local_user/change_password_after_reset.rs
@@ -12,7 +12,6 @@ use lemmy_db_schema::source::{
 };
 use lemmy_utils::error::{LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn change_password_after_reset(
   data: Json<PasswordChangeAfterReset>,
   context: Data<LemmyContext>,

--- a/crates/api/src/local_user/generate_totp_secret.rs
+++ b/crates/api/src/local_user/generate_totp_secret.rs
@@ -11,7 +11,7 @@ use lemmy_utils::error::{LemmyErrorType, LemmyResult};
 
 /// Generate a new secret for two-factor-authentication. Afterwards you need to call [toggle_totp]
 /// to enable it. This can only be called if 2FA is currently disabled.
-#[tracing::instrument(skip(context))]
+
 pub async fn generate_totp_secret(
   local_user_view: LocalUserView,
   context: Data<LemmyContext>,

--- a/crates/api/src/local_user/generate_totp_secret.rs
+++ b/crates/api/src/local_user/generate_totp_secret.rs
@@ -11,7 +11,6 @@ use lemmy_utils::error::{LemmyErrorType, LemmyResult};
 
 /// Generate a new secret for two-factor-authentication. Afterwards you need to call [toggle_totp]
 /// to enable it. This can only be called if 2FA is currently disabled.
-
 pub async fn generate_totp_secret(
   local_user_view: LocalUserView,
   context: Data<LemmyContext>,

--- a/crates/api/src/local_user/get_captcha.rs
+++ b/crates/api/src/local_user/get_captcha.rs
@@ -20,7 +20,6 @@ use lemmy_db_schema::source::{
 };
 use lemmy_utils::error::LemmyResult;
 
-#[tracing::instrument(skip(context))]
 pub async fn get_captcha(context: Data<LemmyContext>) -> LemmyResult<HttpResponse> {
   let local_site = LocalSite::read(&mut context.pool()).await?;
   let mut res = HttpResponseBuilder::new(StatusCode::OK);

--- a/crates/api/src/local_user/list_media.rs
+++ b/crates/api/src/local_user/list_media.rs
@@ -6,7 +6,6 @@ use lemmy_api_common::{
 use lemmy_db_views::structs::{LocalImageView, LocalUserView};
 use lemmy_utils::error::LemmyResult;
 
-#[tracing::instrument(skip(context))]
 pub async fn list_media(
   data: Query<ListMedia>,
   context: Data<LemmyContext>,

--- a/crates/api/src/local_user/list_saved.rs
+++ b/crates/api/src/local_user/list_saved.rs
@@ -11,7 +11,6 @@ use lemmy_db_views::{
 };
 use lemmy_utils::error::LemmyResult;
 
-#[tracing::instrument(skip(context))]
 pub async fn list_person_saved(
   data: Query<ListPersonSaved>,
   context: Data<LemmyContext>,

--- a/crates/api/src/local_user/login.rs
+++ b/crates/api/src/local_user/login.rs
@@ -13,7 +13,6 @@ use lemmy_api_common::{
 use lemmy_db_views::structs::{LocalUserView, SiteView};
 use lemmy_utils::error::{LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn login(
   data: Json<Login>,
   req: HttpRequest,

--- a/crates/api/src/local_user/logout.rs
+++ b/crates/api/src/local_user/logout.rs
@@ -9,7 +9,6 @@ use lemmy_db_schema::source::login_token::LoginToken;
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::{LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn logout(
   req: HttpRequest,
   // require login

--- a/crates/api/src/local_user/notifications/list_inbox.rs
+++ b/crates/api/src/local_user/notifications/list_inbox.rs
@@ -6,7 +6,6 @@ use lemmy_api_common::{
 use lemmy_db_views::{combined::inbox_combined_view::InboxCombinedQuery, structs::LocalUserView};
 use lemmy_utils::error::LemmyResult;
 
-#[tracing::instrument(skip(context))]
 pub async fn list_inbox(
   data: Query<ListInbox>,
   context: Data<LemmyContext>,

--- a/crates/api/src/local_user/notifications/mark_all_read.rs
+++ b/crates/api/src/local_user/notifications/mark_all_read.rs
@@ -9,7 +9,6 @@ use lemmy_db_schema::source::{
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn mark_all_notifications_read(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,

--- a/crates/api/src/local_user/notifications/mark_comment_mention_read.rs
+++ b/crates/api/src/local_user/notifications/mark_comment_mention_read.rs
@@ -11,7 +11,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn mark_comment_mention_as_read(
   data: Json<MarkPersonCommentMentionAsRead>,
   context: Data<LemmyContext>,

--- a/crates/api/src/local_user/notifications/mark_post_mention_read.rs
+++ b/crates/api/src/local_user/notifications/mark_post_mention_read.rs
@@ -11,7 +11,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn mark_post_mention_as_read(
   data: Json<MarkPersonPostMentionAsRead>,
   context: Data<LemmyContext>,

--- a/crates/api/src/local_user/notifications/mark_reply_read.rs
+++ b/crates/api/src/local_user/notifications/mark_reply_read.rs
@@ -7,7 +7,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn mark_reply_as_read(
   data: Json<MarkCommentReplyAsRead>,
   context: Data<LemmyContext>,

--- a/crates/api/src/local_user/notifications/unread_count.rs
+++ b/crates/api/src/local_user/notifications/unread_count.rs
@@ -3,7 +3,6 @@ use lemmy_api_common::{context::LemmyContext, person::GetUnreadCountResponse};
 use lemmy_db_views::structs::{InboxCombinedViewInternal, LocalUserView};
 use lemmy_utils::error::LemmyResult;
 
-#[tracing::instrument(skip(context))]
 pub async fn unread_count(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,

--- a/crates/api/src/local_user/report_count.rs
+++ b/crates/api/src/local_user/report_count.rs
@@ -7,7 +7,6 @@ use lemmy_api_common::{
 use lemmy_db_views::structs::{LocalUserView, ReportCombinedViewInternal};
 use lemmy_utils::error::LemmyResult;
 
-#[tracing::instrument(skip(context))]
 pub async fn report_count(
   data: Query<GetReportCount>,
   context: Data<LemmyContext>,

--- a/crates/api/src/local_user/reset_password.rs
+++ b/crates/api/src/local_user/reset_password.rs
@@ -9,7 +9,6 @@ use lemmy_db_views::structs::{LocalUserView, SiteView};
 use lemmy_utils::error::LemmyResult;
 use tracing::error;
 
-#[tracing::instrument(skip(context))]
 pub async fn reset_password(
   data: Json<PasswordReset>,
   context: Data<LemmyContext>,

--- a/crates/api/src/local_user/save_settings.rs
+++ b/crates/api/src/local_user/save_settings.rs
@@ -28,7 +28,6 @@ use lemmy_utils::{
 };
 use std::ops::Deref;
 
-#[tracing::instrument(skip(context))]
 pub async fn save_user_settings(
   data: Json<SaveUserSettings>,
   context: Data<LemmyContext>,

--- a/crates/api/src/local_user/update_totp.rs
+++ b/crates/api/src/local_user/update_totp.rs
@@ -16,7 +16,6 @@ use lemmy_utils::error::LemmyResult;
 ///
 /// Disabling is only possible if 2FA was previously enabled. Again it is necessary to pass a valid
 /// token.
-
 pub async fn update_totp(
   data: Json<UpdateTotp>,
   local_user_view: LocalUserView,

--- a/crates/api/src/local_user/update_totp.rs
+++ b/crates/api/src/local_user/update_totp.rs
@@ -16,7 +16,7 @@ use lemmy_utils::error::LemmyResult;
 ///
 /// Disabling is only possible if 2FA was previously enabled. Again it is necessary to pass a valid
 /// token.
-#[tracing::instrument(skip(context))]
+
 pub async fn update_totp(
   data: Json<UpdateTotp>,
   local_user_view: LocalUserView,

--- a/crates/api/src/local_user/user_block_instance.rs
+++ b/crates/api/src/local_user/user_block_instance.rs
@@ -8,7 +8,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn user_block_instance(
   data: Json<UserBlockInstanceParams>,
   local_user_view: LocalUserView,

--- a/crates/api/src/local_user/validate_auth.rs
+++ b/crates/api/src/local_user/validate_auth.rs
@@ -11,7 +11,7 @@ use lemmy_utils::error::{LemmyErrorType, LemmyResult};
 
 /// Returns an error message if the auth token is invalid for any reason. Necessary because other
 /// endpoints silently treat any call with invalid auth as unauthenticated.
-#[tracing::instrument(skip(context))]
+
 pub async fn validate_auth(
   req: HttpRequest,
   context: Data<LemmyContext>,

--- a/crates/api/src/local_user/validate_auth.rs
+++ b/crates/api/src/local_user/validate_auth.rs
@@ -11,7 +11,6 @@ use lemmy_utils::error::{LemmyErrorType, LemmyResult};
 
 /// Returns an error message if the auth token is invalid for any reason. Necessary because other
 /// endpoints silently treat any call with invalid auth as unauthenticated.
-
 pub async fn validate_auth(
   req: HttpRequest,
   context: Data<LemmyContext>,

--- a/crates/api/src/post/feature.rs
+++ b/crates/api/src/post/feature.rs
@@ -19,7 +19,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::LemmyResult;
 
-#[tracing::instrument(skip(context))]
 pub async fn feature_post(
   data: Json<FeaturePost>,
   context: Data<LemmyContext>,

--- a/crates/api/src/post/get_link_metadata.rs
+++ b/crates/api/src/post/get_link_metadata.rs
@@ -8,7 +8,6 @@ use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 use url::Url;
 
-#[tracing::instrument(skip(context))]
 pub async fn get_link_metadata(
   data: Query<GetSiteMetadata>,
   context: Data<LemmyContext>,

--- a/crates/api/src/post/hide.rs
+++ b/crates/api/src/post/hide.rs
@@ -7,7 +7,6 @@ use lemmy_db_schema::source::post::PostHide;
 use lemmy_db_views::structs::{LocalUserView, PostView};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn hide_post(
   data: Json<HidePost>,
   context: Data<LemmyContext>,

--- a/crates/api/src/post/like.rs
+++ b/crates/api/src/post/like.rs
@@ -19,7 +19,6 @@ use lemmy_db_views::structs::{LocalUserView, PostView};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 use std::ops::Deref;
 
-#[tracing::instrument(skip(context))]
 pub async fn like_post(
   data: Json<CreatePostLike>,
   context: Data<LemmyContext>,

--- a/crates/api/src/post/list_post_likes.rs
+++ b/crates/api/src/post/list_post_likes.rs
@@ -9,7 +9,6 @@ use lemmy_db_views::structs::{LocalUserView, VoteView};
 use lemmy_utils::error::LemmyResult;
 
 /// Lists likes for a post
-
 pub async fn list_post_likes(
   data: Query<ListPostLikes>,
   context: Data<LemmyContext>,

--- a/crates/api/src/post/list_post_likes.rs
+++ b/crates/api/src/post/list_post_likes.rs
@@ -9,7 +9,7 @@ use lemmy_db_views::structs::{LocalUserView, VoteView};
 use lemmy_utils::error::LemmyResult;
 
 /// Lists likes for a post
-#[tracing::instrument(skip(context))]
+
 pub async fn list_post_likes(
   data: Query<ListPostLikes>,
   context: Data<LemmyContext>,

--- a/crates/api/src/post/lock.rs
+++ b/crates/api/src/post/lock.rs
@@ -17,7 +17,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::{LocalUserView, PostView};
 use lemmy_utils::error::LemmyResult;
 
-#[tracing::instrument(skip(context))]
 pub async fn lock_post(
   data: Json<LockPost>,
   context: Data<LemmyContext>,

--- a/crates/api/src/post/mark_many_read.rs
+++ b/crates/api/src/post/mark_many_read.rs
@@ -4,7 +4,6 @@ use lemmy_db_schema::source::post::PostRead;
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::{LemmyErrorType, LemmyResult, MAX_API_PARAM_ELEMENTS};
 
-#[tracing::instrument(skip(context))]
 pub async fn mark_posts_as_read(
   data: Json<MarkManyPostsAsRead>,
   context: Data<LemmyContext>,

--- a/crates/api/src/post/mark_read.rs
+++ b/crates/api/src/post/mark_read.rs
@@ -7,7 +7,6 @@ use lemmy_db_schema::source::post::{PostRead, PostReadForm};
 use lemmy_db_views::structs::{LocalUserView, PostView};
 use lemmy_utils::error::LemmyResult;
 
-#[tracing::instrument(skip(context))]
 pub async fn mark_post_as_read(
   data: Json<MarkPostAsRead>,
   context: Data<LemmyContext>,

--- a/crates/api/src/post/save.rs
+++ b/crates/api/src/post/save.rs
@@ -10,7 +10,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::{LocalUserView, PostView};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn save_post(
   data: Json<SavePost>,
   context: Data<LemmyContext>,

--- a/crates/api/src/private_message/mark_read.rs
+++ b/crates/api/src/private_message/mark_read.rs
@@ -11,7 +11,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn mark_pm_as_read(
   data: Json<MarkPrivateMessageAsRead>,
   context: Data<LemmyContext>,

--- a/crates/api/src/reports/comment_report/create.rs
+++ b/crates/api/src/reports/comment_report/create.rs
@@ -22,7 +22,7 @@ use lemmy_db_views::structs::{CommentReportView, CommentView, LocalUserView};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 /// Creates a comment report and notifies the moderators of the community
-#[tracing::instrument(skip(context))]
+
 pub async fn create_comment_report(
   data: Json<CreateCommentReport>,
   context: Data<LemmyContext>,

--- a/crates/api/src/reports/comment_report/create.rs
+++ b/crates/api/src/reports/comment_report/create.rs
@@ -22,7 +22,6 @@ use lemmy_db_views::structs::{CommentReportView, CommentView, LocalUserView};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 /// Creates a comment report and notifies the moderators of the community
-
 pub async fn create_comment_report(
   data: Json<CreateCommentReport>,
   context: Data<LemmyContext>,

--- a/crates/api/src/reports/comment_report/resolve.rs
+++ b/crates/api/src/reports/comment_report/resolve.rs
@@ -9,7 +9,7 @@ use lemmy_db_views::structs::{CommentReportView, LocalUserView};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 /// Resolves or unresolves a comment report and notifies the moderators of the community
-#[tracing::instrument(skip(context))]
+
 pub async fn resolve_comment_report(
   data: Json<ResolveCommentReport>,
   context: Data<LemmyContext>,

--- a/crates/api/src/reports/comment_report/resolve.rs
+++ b/crates/api/src/reports/comment_report/resolve.rs
@@ -9,7 +9,6 @@ use lemmy_db_views::structs::{CommentReportView, LocalUserView};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 /// Resolves or unresolves a comment report and notifies the moderators of the community
-
 pub async fn resolve_comment_report(
   data: Json<ResolveCommentReport>,
   context: Data<LemmyContext>,

--- a/crates/api/src/reports/post_report/create.rs
+++ b/crates/api/src/reports/post_report/create.rs
@@ -22,7 +22,7 @@ use lemmy_db_views::structs::{LocalUserView, PostReportView, PostView};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 /// Creates a post report and notifies the moderators of the community
-#[tracing::instrument(skip(context))]
+
 pub async fn create_post_report(
   data: Json<CreatePostReport>,
   context: Data<LemmyContext>,

--- a/crates/api/src/reports/post_report/create.rs
+++ b/crates/api/src/reports/post_report/create.rs
@@ -22,7 +22,6 @@ use lemmy_db_views::structs::{LocalUserView, PostReportView, PostView};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 /// Creates a post report and notifies the moderators of the community
-
 pub async fn create_post_report(
   data: Json<CreatePostReport>,
   context: Data<LemmyContext>,

--- a/crates/api/src/reports/post_report/resolve.rs
+++ b/crates/api/src/reports/post_report/resolve.rs
@@ -9,7 +9,7 @@ use lemmy_db_views::structs::{LocalUserView, PostReportView};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 /// Resolves or unresolves a post report and notifies the moderators of the community
-#[tracing::instrument(skip(context))]
+
 pub async fn resolve_post_report(
   data: Json<ResolvePostReport>,
   context: Data<LemmyContext>,

--- a/crates/api/src/reports/post_report/resolve.rs
+++ b/crates/api/src/reports/post_report/resolve.rs
@@ -9,7 +9,6 @@ use lemmy_db_views::structs::{LocalUserView, PostReportView};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 /// Resolves or unresolves a post report and notifies the moderators of the community
-
 pub async fn resolve_post_report(
   data: Json<ResolvePostReport>,
   context: Data<LemmyContext>,

--- a/crates/api/src/reports/private_message_report/create.rs
+++ b/crates/api/src/reports/private_message_report/create.rs
@@ -16,7 +16,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::{LocalUserView, PrivateMessageReportView};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn create_pm_report(
   data: Json<CreatePrivateMessageReport>,
   context: Data<LemmyContext>,

--- a/crates/api/src/reports/private_message_report/resolve.rs
+++ b/crates/api/src/reports/private_message_report/resolve.rs
@@ -8,7 +8,6 @@ use lemmy_db_schema::{source::private_message_report::PrivateMessageReport, trai
 use lemmy_db_views::structs::{LocalUserView, PrivateMessageReportView};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn resolve_pm_report(
   data: Json<ResolvePrivateMessageReport>,
   context: Data<LemmyContext>,

--- a/crates/api/src/reports/report_combined/list.rs
+++ b/crates/api/src/reports/report_combined/list.rs
@@ -9,7 +9,7 @@ use lemmy_utils::error::LemmyResult;
 
 /// Lists reports for a community if an id is supplied
 /// or returns all reports for communities a user moderates
-#[tracing::instrument(skip(context))]
+
 pub async fn list_reports(
   data: Query<ListReports>,
   context: Data<LemmyContext>,

--- a/crates/api/src/reports/report_combined/list.rs
+++ b/crates/api/src/reports/report_combined/list.rs
@@ -9,7 +9,6 @@ use lemmy_utils::error::LemmyResult;
 
 /// Lists reports for a community if an id is supplied
 /// or returns all reports for communities a user moderates
-
 pub async fn list_reports(
   data: Query<ListReports>,
   context: Data<LemmyContext>,

--- a/crates/api/src/site/admin_allow_instance.rs
+++ b/crates/api/src/site/admin_allow_instance.rs
@@ -18,7 +18,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::LemmyResult;
 
-#[tracing::instrument(skip(context))]
 pub async fn admin_allow_instance(
   data: Json<AdminAllowInstanceParams>,
   local_user_view: LocalUserView,

--- a/crates/api/src/site/admin_block_instance.rs
+++ b/crates/api/src/site/admin_block_instance.rs
@@ -18,7 +18,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::LemmyResult;
 
-#[tracing::instrument(skip(context))]
 pub async fn admin_block_instance(
   data: Json<AdminBlockInstanceParams>,
   local_user_view: LocalUserView,

--- a/crates/api/src/site/federated_instances.rs
+++ b/crates/api/src/site/federated_instances.rs
@@ -7,7 +7,6 @@ use lemmy_api_common::{
 use lemmy_db_views::structs::SiteView;
 use lemmy_utils::error::LemmyResult;
 
-#[tracing::instrument(skip(context))]
 pub async fn get_federated_instances(
   context: Data<LemmyContext>,
 ) -> LemmyResult<Json<GetFederatedInstancesResponse>> {

--- a/crates/api/src/site/leave_admin.rs
+++ b/crates/api/src/site/leave_admin.rs
@@ -18,7 +18,6 @@ use lemmy_utils::{
   VERSION,
 };
 
-#[tracing::instrument(skip(context))]
 pub async fn leave_admin(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,

--- a/crates/api/src/site/list_all_media.rs
+++ b/crates/api/src/site/list_all_media.rs
@@ -7,7 +7,6 @@ use lemmy_api_common::{
 use lemmy_db_views::structs::{LocalImageView, LocalUserView};
 use lemmy_utils::error::LemmyResult;
 
-#[tracing::instrument(skip(context))]
 pub async fn list_all_media(
   data: Query<ListMedia>,
   context: Data<LemmyContext>,

--- a/crates/api/src/site/mod_log.rs
+++ b/crates/api/src/site/mod_log.rs
@@ -8,7 +8,6 @@ use lemmy_db_schema::source::local_site::LocalSite;
 use lemmy_db_views::{combined::modlog_combined_view::ModlogCombinedQuery, structs::LocalUserView};
 use lemmy_utils::error::LemmyResult;
 
-#[tracing::instrument(skip(context))]
 pub async fn get_mod_log(
   data: Query<GetModlog>,
   context: Data<LemmyContext>,

--- a/crates/api/src/site/purge/comment.rs
+++ b/crates/api/src/site/purge/comment.rs
@@ -18,7 +18,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::{CommentView, LocalUserView};
 use lemmy_utils::error::LemmyResult;
 
-#[tracing::instrument(skip(context))]
 pub async fn purge_comment(
   data: Json<PurgeComment>,
   context: Data<LemmyContext>,

--- a/crates/api/src/site/purge/community.rs
+++ b/crates/api/src/site/purge/community.rs
@@ -20,7 +20,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::{CommunityModeratorView, LocalUserView};
 use lemmy_utils::error::LemmyResult;
 
-#[tracing::instrument(skip(context))]
 pub async fn purge_community(
   data: Json<PurgeCommunity>,
   context: Data<LemmyContext>,

--- a/crates/api/src/site/purge/person.rs
+++ b/crates/api/src/site/purge/person.rs
@@ -19,7 +19,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::LemmyResult;
 
-#[tracing::instrument(skip(context))]
 pub async fn purge_person(
   data: Json<PurgePerson>,
   context: Data<LemmyContext>,

--- a/crates/api/src/site/purge/post.rs
+++ b/crates/api/src/site/purge/post.rs
@@ -19,7 +19,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::LemmyResult;
 
-#[tracing::instrument(skip(context))]
 pub async fn purge_post(
   data: Json<PurgePost>,
   context: Data<LemmyContext>,

--- a/crates/api_common/src/build_response.rs
+++ b/crates/api_common/src/build_response.rs
@@ -91,7 +91,7 @@ pub async fn build_post_response(
 }
 
 // TODO: this function is a mess and should be split up to handle email separately
-#[tracing::instrument(skip_all)]
+
 pub async fn send_local_notifs(
   mentions: Vec<MentionData>,
   post_or_comment_id: PostOrCommentId,

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -49,7 +49,6 @@ pub fn client_builder(settings: &Settings) -> ClientBuilder {
 }
 
 /// Fetches metadata for the given link and optionally generates thumbnail.
-#[tracing::instrument(skip_all)]
 pub async fn fetch_link_metadata(
   url: &Url,
   context: &LemmyContext,
@@ -422,7 +421,7 @@ pub async fn delete_image_from_pictrs(alias: &str, context: &LemmyContext) -> Le
 }
 
 /// Retrieves the image with local pict-rs and generates a thumbnail. Returns the thumbnail url.
-#[tracing::instrument(skip_all)]
+
 async fn generate_pictrs_thumbnail(image_url: &Url, context: &LemmyContext) -> LemmyResult<Url> {
   let pictrs_config = context.settings().pictrs()?;
 
@@ -476,7 +475,7 @@ async fn generate_pictrs_thumbnail(image_url: &Url, context: &LemmyContext) -> L
 /// Fetches the image details for pictrs proxied images
 ///
 /// We don't need to check for image mode, as that's already been done
-#[tracing::instrument(skip_all)]
+
 pub async fn fetch_pictrs_proxied_image_details(
   image_url: &Url,
   context: &LemmyContext,
@@ -512,7 +511,7 @@ pub async fn fetch_pictrs_proxied_image_details(
 }
 
 // TODO: get rid of this by reading content type from db
-#[tracing::instrument(skip_all)]
+
 async fn is_image_content_type(client: &ClientWithMiddleware, url: &Url) -> LemmyResult<()> {
   let response = client.get(url.as_str()).send().await?;
   if response

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -421,7 +421,6 @@ pub async fn delete_image_from_pictrs(alias: &str, context: &LemmyContext) -> Le
 }
 
 /// Retrieves the image with local pict-rs and generates a thumbnail. Returns the thumbnail url.
-
 async fn generate_pictrs_thumbnail(image_url: &Url, context: &LemmyContext) -> LemmyResult<Url> {
   let pictrs_config = context.settings().pictrs()?;
 
@@ -475,7 +474,6 @@ async fn generate_pictrs_thumbnail(image_url: &Url, context: &LemmyContext) -> L
 /// Fetches the image details for pictrs proxied images
 ///
 /// We don't need to check for image mode, as that's already been done
-
 pub async fn fetch_pictrs_proxied_image_details(
   image_url: &Url,
   context: &LemmyContext,

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -114,7 +114,6 @@ pub async fn is_mod_or_admin_opt(
 /// Check that a person is either a mod of any community, or an admin
 ///
 /// Should only be used for read operations
-
 pub async fn check_community_mod_of_any_or_admin_action(
   local_user_view: &LocalUserView,
   pool: &mut DbPool<'_>,
@@ -152,7 +151,6 @@ pub fn is_top_mod(
 }
 
 /// Updates the read comment count for a post. Usually done when reading or creating a new comment.
-
 pub async fn update_read_comments(
   person_id: PersonId,
   post_id: PostId,
@@ -324,7 +322,6 @@ pub async fn check_local_vote_mode(
 }
 
 /// Dont allow bots to do certain actions, like voting
-
 pub fn check_bot_account(person: &Person) -> LemmyResult<()> {
   if person.bot_account {
     Err(LemmyErrorType::InvalidBotAction)?
@@ -345,7 +342,6 @@ pub fn check_private_instance(
 }
 
 /// If private messages are disabled, dont allow them to be sent / received
-
 pub fn check_private_messages_enabled(local_user_view: &LocalUserView) -> Result<(), LemmyError> {
   if !local_user_view.local_user.enable_private_messages {
     Err(LemmyErrorType::CouldntCreatePrivateMessage)?

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -86,7 +86,6 @@ use webmention::{Webmention, WebmentionError};
 
 pub const AUTH_COOKIE_NAME: &str = "jwt";
 
-#[tracing::instrument(skip_all)]
 pub async fn is_mod_or_admin(
   pool: &mut DbPool<'_>,
   person: &Person,
@@ -96,7 +95,6 @@ pub async fn is_mod_or_admin(
   CommunityView::check_is_mod_or_admin(pool, person.id, community_id).await
 }
 
-#[tracing::instrument(skip_all)]
 pub async fn is_mod_or_admin_opt(
   pool: &mut DbPool<'_>,
   local_user_view: Option<&LocalUserView>,
@@ -116,7 +114,7 @@ pub async fn is_mod_or_admin_opt(
 /// Check that a person is either a mod of any community, or an admin
 ///
 /// Should only be used for read operations
-#[tracing::instrument(skip_all)]
+
 pub async fn check_community_mod_of_any_or_admin_action(
   local_user_view: &LocalUserView,
   pool: &mut DbPool<'_>,
@@ -154,7 +152,7 @@ pub fn is_top_mod(
 }
 
 /// Updates the read comment count for a post. Usually done when reading or creating a new comment.
-#[tracing::instrument(skip_all)]
+
 pub async fn update_read_comments(
   person_id: PersonId,
   post_id: PostId,
@@ -285,7 +283,6 @@ pub fn check_comment_deleted_or_removed(comment: &Comment) -> LemmyResult<()> {
   }
 }
 
-#[tracing::instrument(skip_all)]
 pub async fn check_person_instance_community_block(
   my_id: PersonId,
   potential_blocker_id: PersonId,
@@ -299,7 +296,6 @@ pub async fn check_person_instance_community_block(
   Ok(())
 }
 
-#[tracing::instrument(skip_all)]
 pub async fn check_local_vote_mode(
   score: i16,
   post_or_comment_id: PostOrCommentId,
@@ -328,7 +324,7 @@ pub async fn check_local_vote_mode(
 }
 
 /// Dont allow bots to do certain actions, like voting
-#[tracing::instrument(skip_all)]
+
 pub fn check_bot_account(person: &Person) -> LemmyResult<()> {
   if person.bot_account {
     Err(LemmyErrorType::InvalidBotAction)?
@@ -337,7 +333,6 @@ pub fn check_bot_account(person: &Person) -> LemmyResult<()> {
   }
 }
 
-#[tracing::instrument(skip_all)]
 pub fn check_private_instance(
   local_user_view: &Option<LocalUserView>,
   local_site: &LocalSite,
@@ -350,7 +345,7 @@ pub fn check_private_instance(
 }
 
 /// If private messages are disabled, dont allow them to be sent / received
-#[tracing::instrument(skip_all)]
+
 pub fn check_private_messages_enabled(local_user_view: &LocalUserView) -> Result<(), LemmyError> {
   if !local_user_view.local_user.enable_private_messages {
     Err(LemmyErrorType::CouldntCreatePrivateMessage)?
@@ -359,7 +354,6 @@ pub fn check_private_messages_enabled(local_user_view: &LocalUserView) -> Result
   }
 }
 
-#[tracing::instrument(skip_all)]
 pub async fn build_federated_instances(
   local_site: &LocalSite,
   pool: &mut DbPool<'_>,
@@ -1037,7 +1031,6 @@ fn limit_expire_time(expires: DateTime<Utc>) -> LemmyResult<Option<DateTime<Utc>
   }
 }
 
-#[tracing::instrument(skip_all)]
 pub fn check_conflicting_like_filters(
   liked_only: Option<bool>,
   disliked_only: Option<bool>,
@@ -1153,7 +1146,6 @@ fn build_proxied_image_url(
   ))
 }
 
-#[tracing::instrument(skip_all)]
 pub async fn local_user_view_from_jwt(
   jwt: &str,
   context: &LemmyContext,

--- a/crates/api_crud/Cargo.toml
+++ b/crates/api_crud/Cargo.toml
@@ -20,7 +20,6 @@ lemmy_api_common = { workspace = true, features = ["full"] }
 activitypub_federation = { workspace = true }
 bcrypt = { workspace = true }
 actix-web = { workspace = true }
-tracing = { workspace = true }
 url = { workspace = true }
 futures.workspace = true
 uuid = { workspace = true }

--- a/crates/api_crud/src/comment/create.rs
+++ b/crates/api_crud/src/comment/create.rs
@@ -33,7 +33,6 @@ use lemmy_utils::{
   MAX_COMMENT_DEPTH_LIMIT,
 };
 
-#[tracing::instrument(skip(context))]
 pub async fn create_comment(
   data: Json<CreateComment>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/comment/delete.rs
+++ b/crates/api_crud/src/comment/delete.rs
@@ -15,7 +15,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::{CommentView, LocalUserView};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn delete_comment(
   data: Json<DeleteComment>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/comment/read.rs
+++ b/crates/api_crud/src/comment/read.rs
@@ -9,7 +9,6 @@ use lemmy_db_schema::source::local_site::LocalSite;
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::LemmyResult;
 
-#[tracing::instrument(skip(context))]
 pub async fn get_comment(
   data: Query<GetComment>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/comment/remove.rs
+++ b/crates/api_crud/src/comment/remove.rs
@@ -20,7 +20,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::{CommentView, LocalUserView};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn remove_comment(
   data: Json<RemoveComment>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/comment/update.rs
+++ b/crates/api_crud/src/comment/update.rs
@@ -28,7 +28,6 @@ use lemmy_utils::{
   utils::{mention::scrape_text_for_mentions, validation::is_valid_body_field},
 };
 
-#[tracing::instrument(skip(context))]
 pub async fn update_comment(
   data: Json<EditComment>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/community/create.rs
+++ b/crates/api_crud/src/community/create.rs
@@ -44,7 +44,6 @@ use lemmy_utils::{
   },
 };
 
-#[tracing::instrument(skip(context))]
 pub async fn create_community(
   data: Json<CreateCommunity>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/community/delete.rs
+++ b/crates/api_crud/src/community/delete.rs
@@ -14,7 +14,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::{CommunityModeratorView, LocalUserView};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn delete_community(
   data: Json<DeleteCommunity>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/community/list.rs
+++ b/crates/api_crud/src/community/list.rs
@@ -10,7 +10,6 @@ use lemmy_db_views::{
 };
 use lemmy_utils::error::LemmyResult;
 
-#[tracing::instrument(skip(context))]
 pub async fn list_communities(
   data: Query<ListCommunities>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/community/remove.rs
+++ b/crates/api_crud/src/community/remove.rs
@@ -17,7 +17,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn remove_community(
   data: Json<RemoveCommunity>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/community/update.rs
+++ b/crates/api_crud/src/community/update.rs
@@ -29,7 +29,6 @@ use lemmy_utils::{
   utils::{slurs::check_slurs_opt, validation::is_valid_body_field},
 };
 
-#[tracing::instrument(skip(context))]
 pub async fn update_community(
   data: Json<EditCommunity>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/custom_emoji/create.rs
+++ b/crates/api_crud/src/custom_emoji/create.rs
@@ -15,7 +15,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::{CustomEmojiView, LocalUserView};
 use lemmy_utils::error::LemmyResult;
 
-#[tracing::instrument(skip(context))]
 pub async fn create_custom_emoji(
   data: Json<CreateCustomEmoji>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/custom_emoji/delete.rs
+++ b/crates/api_crud/src/custom_emoji/delete.rs
@@ -10,7 +10,6 @@ use lemmy_db_schema::{source::custom_emoji::CustomEmoji, traits::Crud};
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::LemmyResult;
 
-#[tracing::instrument(skip(context))]
 pub async fn delete_custom_emoji(
   data: Json<DeleteCustomEmoji>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/custom_emoji/list.rs
+++ b/crates/api_crud/src/custom_emoji/list.rs
@@ -3,13 +3,11 @@ use lemmy_api_common::{
   context::LemmyContext,
   custom_emoji::{ListCustomEmojis, ListCustomEmojisResponse},
 };
-use lemmy_db_views::structs::{CustomEmojiView, LocalUserView};
+use lemmy_db_views::structs::CustomEmojiView;
 use lemmy_utils::error::LemmyError;
 
-#[tracing::instrument(skip(context))]
 pub async fn list_custom_emojis(
   data: Query<ListCustomEmojis>,
-  local_user_view: Option<LocalUserView>,
   context: Data<LemmyContext>,
 ) -> Result<Json<ListCustomEmojisResponse>, LemmyError> {
   let custom_emojis = CustomEmojiView::list(

--- a/crates/api_crud/src/custom_emoji/update.rs
+++ b/crates/api_crud/src/custom_emoji/update.rs
@@ -15,7 +15,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::{CustomEmojiView, LocalUserView};
 use lemmy_utils::error::LemmyResult;
 
-#[tracing::instrument(skip(context))]
 pub async fn update_custom_emoji(
   data: Json<EditCustomEmoji>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/oauth_provider/create.rs
+++ b/crates/api_crud/src/oauth_provider/create.rs
@@ -13,7 +13,6 @@ use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::LemmyError;
 use url::Url;
 
-#[tracing::instrument(skip(context))]
 pub async fn create_oauth_provider(
   data: Json<CreateOAuthProvider>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/oauth_provider/delete.rs
+++ b/crates/api_crud/src/oauth_provider/delete.rs
@@ -10,7 +10,6 @@ use lemmy_db_schema::{source::oauth_provider::OAuthProvider, traits::Crud};
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::{LemmyError, LemmyErrorExt, LemmyErrorType};
 
-#[tracing::instrument(skip(context))]
 pub async fn delete_oauth_provider(
   data: Json<DeleteOAuthProvider>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/oauth_provider/update.rs
+++ b/crates/api_crud/src/oauth_provider/update.rs
@@ -10,7 +10,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::LemmyError;
 
-#[tracing::instrument(skip(context))]
 pub async fn update_oauth_provider(
   data: Json<EditOAuthProvider>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/post/create.rs
+++ b/crates/api_crud/src/post/create.rs
@@ -43,7 +43,6 @@ use lemmy_utils::{
   },
 };
 
-#[tracing::instrument(skip(context))]
 pub async fn create_post(
   data: Json<CreatePost>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/post/delete.rs
+++ b/crates/api_crud/src/post/delete.rs
@@ -17,7 +17,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::{LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn delete_post(
   data: Json<DeletePost>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/post/read.rs
+++ b/crates/api_crud/src/post/read.rs
@@ -17,7 +17,6 @@ use lemmy_db_views::{
 };
 use lemmy_utils::error::{LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn get_post(
   data: Query<GetPost>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/post/remove.rs
+++ b/crates/api_crud/src/post/remove.rs
@@ -20,7 +20,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::LemmyResult;
 
-#[tracing::instrument(skip(context))]
 pub async fn remove_post(
   data: Json<RemovePost>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/post/update.rs
+++ b/crates/api_crud/src/post/update.rs
@@ -44,7 +44,6 @@ use lemmy_utils::{
 };
 use std::ops::Deref;
 
-#[tracing::instrument(skip(context))]
 pub async fn update_post(
   data: Json<EditPost>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/private_message/create.rs
+++ b/crates/api_crud/src/private_message/create.rs
@@ -27,7 +27,6 @@ use lemmy_utils::{
   utils::{markdown::markdown_to_html, validation::is_valid_body_field},
 };
 
-#[tracing::instrument(skip(context))]
 pub async fn create_private_message(
   data: Json<CreatePrivateMessage>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/private_message/delete.rs
+++ b/crates/api_crud/src/private_message/delete.rs
@@ -12,7 +12,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::{LocalUserView, PrivateMessageView};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn delete_private_message(
   data: Json<DeletePrivateMessage>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/private_message/update.rs
+++ b/crates/api_crud/src/private_message/update.rs
@@ -20,7 +20,6 @@ use lemmy_utils::{
   utils::validation::is_valid_body_field,
 };
 
-#[tracing::instrument(skip(context))]
 pub async fn update_private_message(
   data: Json<EditPrivateMessage>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/site/create.rs
+++ b/crates/api_crud/src/site/create.rs
@@ -41,7 +41,6 @@ use lemmy_utils::{
 };
 use url::Url;
 
-#[tracing::instrument(skip(context))]
 pub async fn create_site(
   data: Json<CreateSite>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/site/read.rs
+++ b/crates/api_crud/src/site/read.rs
@@ -12,7 +12,6 @@ use lemmy_db_views::structs::{LocalUserView, PersonView, SiteView};
 use lemmy_utils::{build_cache, error::LemmyResult, CacheLock, VERSION};
 use std::sync::LazyLock;
 
-#[tracing::instrument(skip(context))]
 pub async fn get_site_v3(
   local_user_view: Option<LocalUserView>,
   context: Data<LemmyContext>,
@@ -24,7 +23,6 @@ pub async fn get_site_v3(
   Ok(site)
 }
 
-#[tracing::instrument(skip(context))]
 pub async fn get_site_v4(
   local_user_view: Option<LocalUserView>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/site/update.rs
+++ b/crates/api_crud/src/site/update.rs
@@ -43,7 +43,6 @@ use lemmy_utils::{
   },
 };
 
-#[tracing::instrument(skip(context))]
 pub async fn update_site(
   data: Json<EditSite>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/tagline/create.rs
+++ b/crates/api_crud/src/tagline/create.rs
@@ -15,7 +15,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::LemmyError;
 
-#[tracing::instrument(skip(context))]
 pub async fn create_tagline(
   data: Json<CreateTagline>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/tagline/delete.rs
+++ b/crates/api_crud/src/tagline/delete.rs
@@ -10,7 +10,6 @@ use lemmy_db_schema::{source::tagline::Tagline, traits::Crud};
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::LemmyError;
 
-#[tracing::instrument(skip(context))]
 pub async fn delete_tagline(
   data: Json<DeleteTagline>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/tagline/list.rs
+++ b/crates/api_crud/src/tagline/list.rs
@@ -4,13 +4,10 @@ use lemmy_api_common::{
   tagline::{ListTaglines, ListTaglinesResponse},
 };
 use lemmy_db_schema::source::tagline::Tagline;
-use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::LemmyError;
 
-#[tracing::instrument(skip(context))]
 pub async fn list_taglines(
   data: Query<ListTaglines>,
-  local_user_view: Option<LocalUserView>,
   context: Data<LemmyContext>,
 ) -> Result<Json<ListTaglinesResponse>, LemmyError> {
   let taglines = Tagline::list(&mut context.pool(), data.page, data.limit).await?;

--- a/crates/api_crud/src/tagline/update.rs
+++ b/crates/api_crud/src/tagline/update.rs
@@ -16,7 +16,6 @@ use lemmy_db_schema::{
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::LemmyError;
 
-#[tracing::instrument(skip(context))]
 pub async fn update_tagline(
   data: Json<UpdateTagline>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/user/create.rs
+++ b/crates/api_crud/src/user/create.rs
@@ -403,7 +403,7 @@ pub async fn authenticate_with_oauth(
     login_response.jwt = Some(jwt);
   }
 
-  return Ok(Json(login_response));
+  Ok(Json(login_response))
 }
 
 async fn create_person(

--- a/crates/api_crud/src/user/create.rs
+++ b/crates/api_crud/src/user/create.rs
@@ -193,7 +193,6 @@ pub async fn register(
   Ok(Json(login_response))
 }
 
-#[tracing::instrument(skip(context))]
 pub async fn authenticate_with_oauth(
   data: Json<AuthenticateWithOauth>,
   req: HttpRequest,

--- a/crates/api_crud/src/user/delete.rs
+++ b/crates/api_crud/src/user/delete.rs
@@ -16,7 +16,6 @@ use lemmy_db_schema::source::{
 use lemmy_db_views::structs::LocalUserView;
 use lemmy_utils::error::{LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn delete_account(
   data: Json<DeleteAccount>,
   context: Data<LemmyContext>,

--- a/crates/api_crud/src/user/my_user.rs
+++ b/crates/api_crud/src/user/my_user.rs
@@ -9,7 +9,6 @@ use lemmy_db_schema::source::{
 use lemmy_db_views::structs::{CommunityFollowerView, CommunityModeratorView, LocalUserView};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn get_my_user(
   local_user_view: LocalUserView,
   context: Data<LemmyContext>,

--- a/crates/apub/src/activities/block/block_user.rs
+++ b/crates/apub/src/activities/block/block_user.rs
@@ -72,7 +72,6 @@ impl BlockUser {
     })
   }
 
-  #[tracing::instrument(skip_all)]
   pub async fn send(
     target: &SiteOrCommunity,
     user: &ApubPerson,
@@ -120,7 +119,6 @@ impl ActivityHandler for BlockUser {
     self.actor.inner()
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(&self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     match self.target.dereference(context).await? {
       SiteOrCommunity::Site(site) => {
@@ -148,7 +146,6 @@ impl ActivityHandler for BlockUser {
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn receive(self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     let expires = self.end_time;

--- a/crates/apub/src/activities/block/mod.rs
+++ b/crates/apub/src/activities/block/mod.rs
@@ -49,7 +49,6 @@ impl Object for SiteOrCommunity {
   type Kind = InstanceOrGroup;
   type Error = LemmyError;
 
-  #[tracing::instrument(skip_all)]
   fn last_refreshed_at(&self) -> Option<DateTime<Utc>> {
     Some(match self {
       SiteOrCommunity::Site(i) => i.last_refreshed_at,
@@ -57,7 +56,6 @@ impl Object for SiteOrCommunity {
     })
   }
 
-  #[tracing::instrument(skip_all)]
   async fn read_from_id(object_id: Url, data: &Data<Self::DataType>) -> LemmyResult<Option<Self>>
   where
     Self: Sized,
@@ -85,7 +83,6 @@ impl Object for SiteOrCommunity {
     })
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(
     apub: &Self::Kind,
     expected_domain: &Url,
@@ -97,7 +94,6 @@ impl Object for SiteOrCommunity {
     }
   }
 
-  #[tracing::instrument(skip_all)]
   async fn from_json(apub: Self::Kind, data: &Data<Self::DataType>) -> LemmyResult<Self>
   where
     Self: Sized,

--- a/crates/apub/src/activities/block/undo_block_user.rs
+++ b/crates/apub/src/activities/block/undo_block_user.rs
@@ -36,7 +36,6 @@ use lemmy_utils::error::{LemmyError, LemmyResult};
 use url::Url;
 
 impl UndoBlockUser {
-  #[tracing::instrument(skip_all)]
   pub async fn send(
     target: &SiteOrCommunity,
     user: &ApubPerson,
@@ -89,14 +88,12 @@ impl ActivityHandler for UndoBlockUser {
     self.actor.inner()
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(&self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     verify_domains_match(self.actor.inner(), self.object.actor.inner())?;
     self.object.verify(context).await?;
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn receive(self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     let expires = self.object.end_time;

--- a/crates/apub/src/activities/community/announce.rs
+++ b/crates/apub/src/activities/community/announce.rs
@@ -44,12 +44,10 @@ impl ActivityHandler for RawAnnouncableActivities {
     &self.actor
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(&self, _data: &Data<Self::DataType>) -> Result<(), Self::Error> {
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn receive(self, context: &Data<Self::DataType>) -> Result<(), Self::Error> {
     let activity: AnnouncableActivities = self.clone().try_into()?;
 
@@ -107,7 +105,6 @@ impl AnnounceActivity {
     })
   }
 
-  #[tracing::instrument(skip_all)]
   pub async fn send(
     object: RawAnnouncableActivities,
     community: &ApubCommunity,
@@ -154,12 +151,10 @@ impl ActivityHandler for AnnounceActivity {
     self.actor.inner()
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(&self, _context: &Data<Self::DataType>) -> LemmyResult<()> {
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn receive(self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     let object: AnnouncableActivities = self.object.object(context).await?.try_into()?;

--- a/crates/apub/src/activities/community/collection_add.rs
+++ b/crates/apub/src/activities/community/collection_add.rs
@@ -41,7 +41,6 @@ use lemmy_utils::error::{LemmyError, LemmyResult};
 use url::Url;
 
 impl CollectionAdd {
-  #[tracing::instrument(skip_all)]
   pub async fn send_add_mod(
     community: &ApubCommunity,
     added_mod: &ApubPerson,
@@ -112,7 +111,6 @@ impl ActivityHandler for CollectionAdd {
     self.actor.inner()
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(&self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     let community = self.community(context).await?;
     verify_visibility(&self.to, &self.cc, &community)?;
@@ -121,7 +119,6 @@ impl ActivityHandler for CollectionAdd {
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn receive(self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     let (community, collection_type) =

--- a/crates/apub/src/activities/community/collection_remove.rs
+++ b/crates/apub/src/activities/community/collection_remove.rs
@@ -36,7 +36,6 @@ use lemmy_utils::error::{LemmyError, LemmyResult};
 use url::Url;
 
 impl CollectionRemove {
-  #[tracing::instrument(skip_all)]
   pub async fn send_remove_mod(
     community: &ApubCommunity,
     removed_mod: &ApubPerson,
@@ -107,7 +106,6 @@ impl ActivityHandler for CollectionRemove {
     self.actor.inner()
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(&self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     let community = self.community(context).await?;
     verify_visibility(&self.to, &self.cc, &community)?;
@@ -116,7 +114,6 @@ impl ActivityHandler for CollectionRemove {
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn receive(self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     let (community, collection_type) =

--- a/crates/apub/src/activities/community/report.rs
+++ b/crates/apub/src/activities/community/report.rs
@@ -101,14 +101,12 @@ impl ActivityHandler for Report {
     self.actor.inner()
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(&self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     let community = self.community(context).await?;
     verify_person_in_community(&self.actor, &community, context).await?;
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn receive(self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     let actor = self.actor.dereference(context).await?;

--- a/crates/apub/src/activities/community/update.rs
+++ b/crates/apub/src/activities/community/update.rs
@@ -75,7 +75,6 @@ impl ActivityHandler for UpdateCommunity {
     self.actor.inner()
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(&self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     let community = self.community(context).await?;
     verify_visibility(&self.to, &self.cc, &community)?;
@@ -85,7 +84,6 @@ impl ActivityHandler for UpdateCommunity {
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn receive(self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     let community = self.community(context).await?;

--- a/crates/apub/src/activities/create_or_update/comment.rs
+++ b/crates/apub/src/activities/create_or_update/comment.rs
@@ -47,7 +47,6 @@ use serde_json::{from_value, to_value};
 use url::Url;
 
 impl CreateOrUpdateNote {
-  #[tracing::instrument(skip(comment, person_id, kind, context))]
   pub(crate) async fn send(
     comment: Comment,
     person_id: PersonId,
@@ -120,7 +119,6 @@ impl ActivityHandler for CreateOrUpdateNote {
     self.actor.inner()
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(&self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     let post = self.object.get_parents(context).await?.0;
     let community = self.community(context).await?;
@@ -136,7 +134,6 @@ impl ActivityHandler for CreateOrUpdateNote {
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn receive(self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     // Need to do this check here instead of Note::from_json because we need the person who

--- a/crates/apub/src/activities/create_or_update/note_wrapper.rs
+++ b/crates/apub/src/activities/create_or_update/note_wrapper.rs
@@ -31,13 +31,11 @@ impl ActivityHandler for CreateOrUpdateNoteWrapper {
     &self.actor
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(&self, _context: &Data<Self::DataType>) -> LemmyResult<()> {
     // Do everything in receive to avoid extra checks.
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn receive(self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     // Use serde to convert NoteWrapper either into Comment or PrivateMessage,
     // depending on conditions below. This works because NoteWrapper keeps all

--- a/crates/apub/src/activities/create_or_update/post.rs
+++ b/crates/apub/src/activities/create_or_update/post.rs
@@ -60,7 +60,6 @@ impl CreateOrUpdatePage {
     })
   }
 
-  #[tracing::instrument(skip_all)]
   pub(crate) async fn send(
     post: Post,
     person_id: PersonId,
@@ -102,7 +101,6 @@ impl ActivityHandler for CreateOrUpdatePage {
     self.actor.inner()
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(&self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     let community = self.community(context).await?;
     verify_visibility(&self.to, &self.cc, &community)?;
@@ -114,7 +112,6 @@ impl ActivityHandler for CreateOrUpdatePage {
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn receive(self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     let post = ApubPost::from_json(self.object, context).await?;

--- a/crates/apub/src/activities/create_or_update/private_message.rs
+++ b/crates/apub/src/activities/create_or_update/private_message.rs
@@ -56,7 +56,6 @@ impl ActivityHandler for CreateOrUpdatePrivateMessage {
     self.actor.inner()
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(&self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     verify_person(&self.actor, context).await?;
     verify_domains_match(self.actor.inner(), self.object.id.inner())?;
@@ -66,7 +65,6 @@ impl ActivityHandler for CreateOrUpdatePrivateMessage {
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn receive(self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     ApubPrivateMessage::from_json(self.object, context).await?;

--- a/crates/apub/src/activities/deletion/delete.rs
+++ b/crates/apub/src/activities/deletion/delete.rs
@@ -43,13 +43,11 @@ impl ActivityHandler for Delete {
     self.actor.inner()
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(&self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     verify_delete_activity(self, self.summary.is_some(), context).await?;
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn receive(self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     if let Some(reason) = self.summary {
@@ -107,7 +105,6 @@ impl Delete {
   }
 }
 
-#[tracing::instrument(skip_all)]
 pub(in crate::activities) async fn receive_remove_action(
   actor: &ApubPerson,
   object: &Url,

--- a/crates/apub/src/activities/deletion/mod.rs
+++ b/crates/apub/src/activities/deletion/mod.rs
@@ -49,7 +49,6 @@ pub mod undo_delete;
 
 /// Parameter `reason` being set indicates that this is a removal by a mod. If its unset, this
 /// action was done by a normal user.
-
 pub(crate) async fn send_apub_delete_in_community(
   actor: Person,
   community: Community,
@@ -233,7 +232,6 @@ async fn verify_delete_post_or_comment(
 }
 
 /// Write deletion or restoring of an object to the database, and send websocket message.
-
 async fn receive_delete_action(
   object: &Url,
   actor: &ObjectId<ApubPerson>,

--- a/crates/apub/src/activities/deletion/mod.rs
+++ b/crates/apub/src/activities/deletion/mod.rs
@@ -49,7 +49,7 @@ pub mod undo_delete;
 
 /// Parameter `reason` being set indicates that this is a removal by a mod. If its unset, this
 /// action was done by a normal user.
-#[tracing::instrument(skip_all)]
+
 pub(crate) async fn send_apub_delete_in_community(
   actor: Person,
   community: Community,
@@ -79,7 +79,6 @@ pub(crate) async fn send_apub_delete_in_community(
   .await
 }
 
-#[tracing::instrument(skip_all)]
 pub(crate) async fn send_apub_delete_private_message(
   actor: &ApubPerson,
   pm: DbPrivateMessage,
@@ -129,7 +128,6 @@ pub enum DeletableObjects {
 }
 
 impl DeletableObjects {
-  #[tracing::instrument(skip_all)]
   pub(crate) async fn read_from_db(
     ap_id: &Url,
     context: &Data<LemmyContext>,
@@ -163,7 +161,6 @@ impl DeletableObjects {
   }
 }
 
-#[tracing::instrument(skip_all)]
 pub(in crate::activities) async fn verify_delete_activity(
   activity: &Delete,
   is_mod_action: bool,
@@ -218,7 +215,6 @@ pub(in crate::activities) async fn verify_delete_activity(
   Ok(())
 }
 
-#[tracing::instrument(skip_all)]
 async fn verify_delete_post_or_comment(
   actor: &ObjectId<ApubPerson>,
   object_id: &Url,
@@ -237,7 +233,7 @@ async fn verify_delete_post_or_comment(
 }
 
 /// Write deletion or restoring of an object to the database, and send websocket message.
-#[tracing::instrument(skip_all)]
+
 async fn receive_delete_action(
   object: &Url,
   actor: &ObjectId<ApubPerson>,

--- a/crates/apub/src/activities/deletion/undo_delete.rs
+++ b/crates/apub/src/activities/deletion/undo_delete.rs
@@ -47,7 +47,6 @@ impl ActivityHandler for UndoDelete {
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn receive(self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     if self.object.summary.is_some() {
@@ -64,7 +63,6 @@ impl ActivityHandler for UndoDelete {
 }
 
 impl UndoDelete {
-  #[tracing::instrument(skip_all)]
   pub(in crate::activities::deletion) fn new(
     actor: &ApubPerson,
     object: DeletableObjects,
@@ -90,7 +88,6 @@ impl UndoDelete {
     })
   }
 
-  #[tracing::instrument(skip_all)]
   pub(in crate::activities) async fn receive_undo_remove_action(
     actor: &ApubPerson,
     object: &Url,

--- a/crates/apub/src/activities/following/accept.rs
+++ b/crates/apub/src/activities/following/accept.rs
@@ -18,7 +18,6 @@ use lemmy_utils::error::{LemmyError, LemmyResult};
 use url::Url;
 
 impl AcceptFollow {
-  #[tracing::instrument(skip_all)]
   pub async fn send(follow: Follow, context: &Data<LemmyContext>) -> LemmyResult<()> {
     let user_or_community = follow.object.dereference_local(context).await?;
     let person = follow.actor.clone().dereference(context).await?;
@@ -51,7 +50,6 @@ impl ActivityHandler for AcceptFollow {
     self.actor.inner()
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(&self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     verify_urls_match(self.actor.inner(), self.object.object.inner())?;
     self.object.verify(context).await?;
@@ -61,7 +59,6 @@ impl ActivityHandler for AcceptFollow {
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn receive(self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     let community = self.actor.dereference(context).await?;

--- a/crates/apub/src/activities/following/follow.rs
+++ b/crates/apub/src/activities/following/follow.rs
@@ -47,7 +47,6 @@ impl Follow {
     })
   }
 
-  #[tracing::instrument(skip_all)]
   pub async fn send(
     actor: &ApubPerson,
     community: &ApubCommunity,
@@ -76,7 +75,6 @@ impl ActivityHandler for Follow {
     self.actor.inner()
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(&self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     verify_person(&self.actor, context).await?;
     let object = self.object.dereference(context).await?;
@@ -89,7 +87,6 @@ impl ActivityHandler for Follow {
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn receive(self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     let actor = self.actor.dereference(context).await?;

--- a/crates/apub/src/activities/following/reject.rs
+++ b/crates/apub/src/activities/following/reject.rs
@@ -21,7 +21,6 @@ use lemmy_utils::error::{LemmyError, LemmyResult};
 use url::Url;
 
 impl RejectFollow {
-  #[tracing::instrument(skip_all)]
   pub async fn send(follow: Follow, context: &Data<LemmyContext>) -> LemmyResult<()> {
     let user_or_community = follow.object.dereference_local(context).await?;
     let person = follow.actor.clone().dereference(context).await?;
@@ -54,7 +53,6 @@ impl ActivityHandler for RejectFollow {
     self.actor.inner()
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(&self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     verify_urls_match(self.actor.inner(), self.object.object.inner())?;
     self.object.verify(context).await?;
@@ -64,7 +62,6 @@ impl ActivityHandler for RejectFollow {
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn receive(self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     let community = self.actor.dereference(context).await?;

--- a/crates/apub/src/activities/following/undo_follow.rs
+++ b/crates/apub/src/activities/following/undo_follow.rs
@@ -24,7 +24,6 @@ use lemmy_utils::error::{LemmyError, LemmyResult};
 use url::Url;
 
 impl UndoFollow {
-  #[tracing::instrument(skip_all)]
   pub async fn send(
     actor: &ApubPerson,
     community: &ApubCommunity,
@@ -63,7 +62,6 @@ impl ActivityHandler for UndoFollow {
     self.actor.inner()
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(&self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     verify_urls_match(self.actor.inner(), self.object.actor.inner())?;
     verify_person(&self.actor, context).await?;
@@ -74,7 +72,6 @@ impl ActivityHandler for UndoFollow {
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn receive(self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     let person = self.actor.dereference(context).await?;

--- a/crates/apub/src/activities/mod.rs
+++ b/crates/apub/src/activities/mod.rs
@@ -59,7 +59,6 @@ pub mod voting;
 
 /// Checks that the specified Url actually identifies a Person (by fetching it), and that the person
 /// doesn't have a site ban.
-
 async fn verify_person(
   person_id: &ObjectId<ApubPerson>,
   context: &Data<LemmyContext>,
@@ -75,7 +74,6 @@ async fn verify_person(
 
 /// Fetches the person and community to verify their type, then checks if person is banned from site
 /// or community.
-
 pub(crate) async fn verify_person_in_community(
   person_id: &ObjectId<ApubPerson>,
   community: &ApubCommunity,
@@ -97,7 +95,6 @@ pub(crate) async fn verify_person_in_community(
 /// * `mod_id` - Activitypub ID of the mod or admin who performed the action
 /// * `object_id` - Activitypub ID of the actor or object that is being moderated
 /// * `community` - The community inside which moderation is happening
-
 pub(crate) async fn verify_mod_action(
   mod_id: &ObjectId<ApubPerson>,
   community: &Community,

--- a/crates/apub/src/activities/mod.rs
+++ b/crates/apub/src/activities/mod.rs
@@ -59,7 +59,7 @@ pub mod voting;
 
 /// Checks that the specified Url actually identifies a Person (by fetching it), and that the person
 /// doesn't have a site ban.
-#[tracing::instrument(skip_all)]
+
 async fn verify_person(
   person_id: &ObjectId<ApubPerson>,
   context: &Data<LemmyContext>,
@@ -75,7 +75,7 @@ async fn verify_person(
 
 /// Fetches the person and community to verify their type, then checks if person is banned from site
 /// or community.
-#[tracing::instrument(skip_all)]
+
 pub(crate) async fn verify_person_in_community(
   person_id: &ObjectId<ApubPerson>,
   community: &ApubCommunity,
@@ -97,7 +97,7 @@ pub(crate) async fn verify_person_in_community(
 /// * `mod_id` - Activitypub ID of the mod or admin who performed the action
 /// * `object_id` - Activitypub ID of the actor or object that is being moderated
 /// * `community` - The community inside which moderation is happening
-#[tracing::instrument(skip_all)]
+
 pub(crate) async fn verify_mod_action(
   mod_id: &ObjectId<ApubPerson>,
   community: &Community,
@@ -190,7 +190,6 @@ pub(crate) trait GetActorType {
   fn actor_type(&self) -> ActorType;
 }
 
-#[tracing::instrument(skip_all)]
 async fn send_lemmy_activity<Activity, ActorT>(
   data: &Data<LemmyContext>,
   activity: Activity,

--- a/crates/apub/src/activities/voting/mod.rs
+++ b/crates/apub/src/activities/voting/mod.rs
@@ -52,7 +52,6 @@ pub(crate) async fn send_like_activity(
   }
 }
 
-#[tracing::instrument(skip_all)]
 async fn vote_comment(
   vote_type: &VoteType,
   actor: ApubPerson,
@@ -71,7 +70,6 @@ async fn vote_comment(
   Ok(())
 }
 
-#[tracing::instrument(skip_all)]
 async fn vote_post(
   vote_type: &VoteType,
   actor: ApubPerson,
@@ -86,7 +84,6 @@ async fn vote_post(
   Ok(())
 }
 
-#[tracing::instrument(skip_all)]
 async fn undo_vote_comment(
   actor: ApubPerson,
   comment: &ApubComment,
@@ -98,7 +95,6 @@ async fn undo_vote_comment(
   Ok(())
 }
 
-#[tracing::instrument(skip_all)]
 async fn undo_vote_post(
   actor: ApubPerson,
   post: &ApubPost,

--- a/crates/apub/src/activities/voting/undo_vote.rs
+++ b/crates/apub/src/activities/voting/undo_vote.rs
@@ -53,7 +53,6 @@ impl ActivityHandler for UndoVote {
     self.actor.inner()
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(&self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     let community = self.community(context).await?;
     verify_person_in_community(&self.actor, &community, context).await?;
@@ -62,7 +61,6 @@ impl ActivityHandler for UndoVote {
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn receive(self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     let actor = self.actor.dereference(context).await?;

--- a/crates/apub/src/activities/voting/vote.rs
+++ b/crates/apub/src/activities/voting/vote.rs
@@ -51,14 +51,12 @@ impl ActivityHandler for Vote {
     self.actor.inner()
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(&self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     let community = self.community(context).await?;
     verify_person_in_community(&self.actor, &community, context).await?;
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn receive(self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     insert_received_activity(&self.id, context).await?;
     let actor = self.actor.dereference(context).await?;

--- a/crates/apub/src/activity_lists.rs
+++ b/crates/apub/src/activity_lists.rs
@@ -73,7 +73,6 @@ pub enum AnnouncableActivities {
 
 #[async_trait::async_trait]
 impl InCommunity for AnnouncableActivities {
-  #[tracing::instrument(skip(self, context))]
   async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     use AnnouncableActivities::*;
     match self {

--- a/crates/apub/src/api/list_comments.rs
+++ b/crates/apub/src/api/list_comments.rs
@@ -22,7 +22,6 @@ use lemmy_db_views::{
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 /// A common fetcher for both the CommentView, and CommentSlimView.
-
 async fn list_comments_common(
   data: Query<GetComments>,
   context: Data<LemmyContext>,

--- a/crates/apub/src/api/list_comments.rs
+++ b/crates/apub/src/api/list_comments.rs
@@ -22,7 +22,7 @@ use lemmy_db_views::{
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 /// A common fetcher for both the CommentView, and CommentSlimView.
-#[tracing::instrument(skip(context))]
+
 async fn list_comments_common(
   data: Query<GetComments>,
   context: Data<LemmyContext>,
@@ -93,7 +93,6 @@ async fn list_comments_common(
   .with_lemmy_type(LemmyErrorType::CouldntGetComments)
 }
 
-#[tracing::instrument(skip(context))]
 pub async fn list_comments(
   data: Query<GetComments>,
   context: Data<LemmyContext>,
@@ -104,7 +103,6 @@ pub async fn list_comments(
   Ok(Json(GetCommentsResponse { comments }))
 }
 
-#[tracing::instrument(skip(context))]
 pub async fn list_comments_slim(
   data: Query<GetComments>,
   context: Data<LemmyContext>,

--- a/crates/apub/src/api/list_person_content.rs
+++ b/crates/apub/src/api/list_person_content.rs
@@ -12,7 +12,6 @@ use lemmy_db_views::{
 };
 use lemmy_utils::error::LemmyResult;
 
-#[tracing::instrument(skip(context))]
 pub async fn list_person_content(
   data: Query<ListPersonContent>,
   context: Data<LemmyContext>,

--- a/crates/apub/src/api/list_posts.rs
+++ b/crates/apub/src/api/list_posts.rs
@@ -20,7 +20,6 @@ use lemmy_db_views::{
 };
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn list_posts(
   data: Query<GetPosts>,
   context: Data<LemmyContext>,

--- a/crates/apub/src/api/read_community.rs
+++ b/crates/apub/src/api/read_community.rs
@@ -14,7 +14,6 @@ use lemmy_db_schema::source::{
 use lemmy_db_views::structs::{CommunityModeratorView, CommunityView, LocalUserView};
 use lemmy_utils::error::{LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn get_community(
   data: Query<GetCommunity>,
   context: Data<LemmyContext>,

--- a/crates/apub/src/api/read_person.rs
+++ b/crates/apub/src/api/read_person.rs
@@ -9,7 +9,6 @@ use lemmy_api_common::{
 use lemmy_db_views::structs::{CommunityModeratorView, LocalUserView, PersonView, SiteView};
 use lemmy_utils::error::LemmyResult;
 
-#[tracing::instrument(skip(context))]
 pub async fn read_person(
   data: Query<GetPersonDetails>,
   context: Data<LemmyContext>,

--- a/crates/apub/src/api/resolve_object.rs
+++ b/crates/apub/src/api/resolve_object.rs
@@ -14,7 +14,6 @@ use lemmy_db_schema::{source::local_site::LocalSite, utils::DbPool};
 use lemmy_db_views::structs::{CommentView, CommunityView, LocalUserView, PersonView, PostView};
 use lemmy_utils::error::{LemmyErrorExt2, LemmyErrorType, LemmyResult};
 
-#[tracing::instrument(skip(context))]
 pub async fn resolve_object(
   data: Query<ResolveObject>,
   context: Data<LemmyContext>,

--- a/crates/apub/src/api/search.rs
+++ b/crates/apub/src/api/search.rs
@@ -13,7 +13,6 @@ use lemmy_db_views::{
 };
 use lemmy_utils::error::LemmyResult;
 
-#[tracing::instrument(skip(context))]
 pub async fn search(
   data: Query<Search>,
   context: Data<LemmyContext>,

--- a/crates/apub/src/api/user_settings_backup.rs
+++ b/crates/apub/src/api/user_settings_backup.rs
@@ -70,7 +70,6 @@ pub struct UserSettingsBackup {
   pub blocked_instances: Vec<String>,
 }
 
-#[tracing::instrument(skip(context))]
 pub async fn export_settings(
   local_user_view: LocalUserView,
   context: Data<LemmyContext>,
@@ -96,7 +95,6 @@ pub async fn export_settings(
   }))
 }
 
-#[tracing::instrument(skip(context))]
 pub async fn import_settings(
   data: Json<UserSettingsBackup>,
   local_user_view: LocalUserView,

--- a/crates/apub/src/collections/community_moderators.rs
+++ b/crates/apub/src/collections/community_moderators.rs
@@ -28,7 +28,6 @@ impl Collection for ApubCommunityModerators {
   type Kind = GroupModerators;
   type Error = LemmyError;
 
-  #[tracing::instrument(skip_all)]
   async fn read_local(owner: &Self::Owner, data: &Data<Self::DataType>) -> LemmyResult<Self::Kind> {
     let moderators = CommunityModeratorView::for_community(&mut data.pool(), owner.id).await?;
     let ordered_items = moderators
@@ -42,7 +41,6 @@ impl Collection for ApubCommunityModerators {
     })
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(
     group_moderators: &GroupModerators,
     expected_domain: &Url,
@@ -52,7 +50,6 @@ impl Collection for ApubCommunityModerators {
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn from_json(
     apub: Self::Kind,
     owner: &Self::Owner,

--- a/crates/apub/src/collections/community_outbox.rs
+++ b/crates/apub/src/collections/community_outbox.rs
@@ -33,7 +33,6 @@ impl Collection for ApubCommunityOutbox {
   type Kind = GroupOutbox;
   type Error = LemmyError;
 
-  #[tracing::instrument(skip_all)]
   async fn read_local(owner: &Self::Owner, data: &Data<Self::DataType>) -> LemmyResult<Self::Kind> {
     let site = Site::read_local(&mut data.pool()).await?;
 
@@ -69,7 +68,6 @@ impl Collection for ApubCommunityOutbox {
     })
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(
     group_outbox: &GroupOutbox,
     expected_domain: &Url,
@@ -79,7 +77,6 @@ impl Collection for ApubCommunityOutbox {
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn from_json(
     apub: Self::Kind,
     _owner: &Self::Owner,

--- a/crates/apub/src/fetcher/mod.rs
+++ b/crates/apub/src/fetcher/mod.rs
@@ -20,7 +20,6 @@ pub mod user_or_community;
 ///
 /// In case the requesting user is logged in and the object was not found locally, it is attempted
 /// to fetch via webfinger from the original instance.
-
 pub async fn resolve_actor_identifier<ActorType, DbActor>(
   identifier: &str,
   context: &Data<LemmyContext>,

--- a/crates/apub/src/fetcher/mod.rs
+++ b/crates/apub/src/fetcher/mod.rs
@@ -20,7 +20,7 @@ pub mod user_or_community;
 ///
 /// In case the requesting user is logged in and the object was not found locally, it is attempted
 /// to fetch via webfinger from the original instance.
-#[tracing::instrument(skip_all)]
+
 pub async fn resolve_actor_identifier<ActorType, DbActor>(
   identifier: &str,
   context: &Data<LemmyContext>,

--- a/crates/apub/src/fetcher/post_or_comment.rs
+++ b/crates/apub/src/fetcher/post_or_comment.rs
@@ -39,7 +39,6 @@ impl Object for PostOrComment {
     None
   }
 
-  #[tracing::instrument(skip_all)]
   async fn read_from_id(object_id: Url, data: &Data<Self::DataType>) -> LemmyResult<Option<Self>> {
     let post = ApubPost::read_from_id(object_id.clone(), data).await?;
     Ok(match post {
@@ -50,7 +49,6 @@ impl Object for PostOrComment {
     })
   }
 
-  #[tracing::instrument(skip_all)]
   async fn delete(self, data: &Data<Self::DataType>) -> LemmyResult<()> {
     match self {
       PostOrComment::Post(p) => p.delete(data).await,
@@ -65,7 +63,6 @@ impl Object for PostOrComment {
     })
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(
     apub: &Self::Kind,
     expected_domain: &Url,
@@ -77,7 +74,6 @@ impl Object for PostOrComment {
     }
   }
 
-  #[tracing::instrument(skip_all)]
   async fn from_json(apub: PageOrNote, context: &Data<LemmyContext>) -> LemmyResult<Self> {
     Ok(match apub {
       PageOrNote::Page(p) => PostOrComment::Post(ApubPost::from_json(*p, context).await?),

--- a/crates/apub/src/fetcher/search.rs
+++ b/crates/apub/src/fetcher/search.rs
@@ -14,7 +14,7 @@ use url::Url;
 /// Converts search query to object id. The query can either be an URL, which will be treated as
 /// ObjectId directly, or a webfinger identifier (@user@example.com or !community@example.com)
 /// which gets resolved to an URL.
-#[tracing::instrument(skip_all)]
+
 pub(crate) async fn search_query_to_object_id(
   mut query: String,
   context: &Data<LemmyContext>,
@@ -39,7 +39,7 @@ pub(crate) async fn search_query_to_object_id(
 /// Converts a search query to an object id.  The query MUST bbe a URL which will bbe treated
 /// as the ObjectId directly.  If the query is a webfinger identifier (@user@example.com or
 /// !community@example.com) this method will return an error.
-#[tracing::instrument(skip_all)]
+
 pub(crate) async fn search_query_to_object_id_local(
   query: &str,
   context: &Data<LemmyContext>,
@@ -80,7 +80,7 @@ impl Object for SearchableObjects {
   //       a single query.
   //       we could skip this and always return an error, but then it would always fetch objects
   //       over http, and not be able to mark objects as deleted that were deleted by remote server.
-  #[tracing::instrument(skip_all)]
+
   async fn read_from_id(
     object_id: Url,
     context: &Data<Self::DataType>,
@@ -96,7 +96,6 @@ impl Object for SearchableObjects {
     Ok(None)
   }
 
-  #[tracing::instrument(skip_all)]
   async fn delete(self, data: &Data<Self::DataType>) -> LemmyResult<()> {
     match self {
       SearchableObjects::PostOrComment(pc) => pc.delete(data).await,
@@ -112,7 +111,6 @@ impl Object for SearchableObjects {
     })
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(
     apub: &Self::Kind,
     expected_domain: &Url,
@@ -125,7 +123,6 @@ impl Object for SearchableObjects {
     }
   }
 
-  #[tracing::instrument(skip_all)]
   async fn from_json(apub: Self::Kind, context: &Data<LemmyContext>) -> LemmyResult<Self> {
     use SearchableKinds::*;
     use SearchableObjects as SO;

--- a/crates/apub/src/fetcher/search.rs
+++ b/crates/apub/src/fetcher/search.rs
@@ -14,7 +14,6 @@ use url::Url;
 /// Converts search query to object id. The query can either be an URL, which will be treated as
 /// ObjectId directly, or a webfinger identifier (@user@example.com or !community@example.com)
 /// which gets resolved to an URL.
-
 pub(crate) async fn search_query_to_object_id(
   mut query: String,
   context: &Data<LemmyContext>,
@@ -39,7 +38,6 @@ pub(crate) async fn search_query_to_object_id(
 /// Converts a search query to an object id.  The query MUST bbe a URL which will bbe treated
 /// as the ObjectId directly.  If the query is a webfinger identifier (@user@example.com or
 /// !community@example.com) this method will return an error.
-
 pub(crate) async fn search_query_to_object_id_local(
   query: &str,
   context: &Data<LemmyContext>,
@@ -80,7 +78,6 @@ impl Object for SearchableObjects {
   //       a single query.
   //       we could skip this and always return an error, but then it would always fetch objects
   //       over http, and not be able to mark objects as deleted that were deleted by remote server.
-
   async fn read_from_id(
     object_id: Url,
     context: &Data<Self::DataType>,

--- a/crates/apub/src/fetcher/site_or_community_or_user.rs
+++ b/crates/apub/src/fetcher/site_or_community_or_user.rs
@@ -41,7 +41,6 @@ impl Object for SiteOrCommunityOrUser {
     })
   }
 
-  #[tracing::instrument(skip_all)]
   async fn read_from_id(object_id: Url, data: &Data<Self::DataType>) -> LemmyResult<Option<Self>> {
     let site = ApubSite::read_from_id(object_id.clone(), data).await?;
     Ok(match site {
@@ -52,7 +51,6 @@ impl Object for SiteOrCommunityOrUser {
     })
   }
 
-  #[tracing::instrument(skip_all)]
   async fn delete(self, data: &Data<Self::DataType>) -> LemmyResult<()> {
     match self {
       SiteOrCommunityOrUser::Site(p) => p.delete(data).await,
@@ -69,7 +67,6 @@ impl Object for SiteOrCommunityOrUser {
     })
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(
     apub: &Self::Kind,
     expected_domain: &Url,
@@ -83,7 +80,6 @@ impl Object for SiteOrCommunityOrUser {
     }
   }
 
-  #[tracing::instrument(skip_all)]
   async fn from_json(apub: Self::Kind, data: &Data<Self::DataType>) -> LemmyResult<Self> {
     Ok(match apub {
       SiteOrPersonOrGroup::Instance(a) => {

--- a/crates/apub/src/fetcher/user_or_community.rs
+++ b/crates/apub/src/fetcher/user_or_community.rs
@@ -46,7 +46,6 @@ impl Object for UserOrCommunity {
     })
   }
 
-  #[tracing::instrument(skip_all)]
   async fn read_from_id(object_id: Url, data: &Data<Self::DataType>) -> LemmyResult<Option<Self>> {
     let person = ApubPerson::read_from_id(object_id.clone(), data).await?;
     Ok(match person {
@@ -57,7 +56,6 @@ impl Object for UserOrCommunity {
     })
   }
 
-  #[tracing::instrument(skip_all)]
   async fn delete(self, data: &Data<Self::DataType>) -> LemmyResult<()> {
     match self {
       UserOrCommunity::User(p) => p.delete(data).await,
@@ -72,7 +70,6 @@ impl Object for UserOrCommunity {
     })
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(
     apub: &Self::Kind,
     expected_domain: &Url,
@@ -84,7 +81,6 @@ impl Object for UserOrCommunity {
     }
   }
 
-  #[tracing::instrument(skip_all)]
   async fn from_json(apub: Self::Kind, data: &Data<Self::DataType>) -> LemmyResult<Self> {
     Ok(match apub {
       PersonOrGroup::Person(p) => UserOrCommunity::User(ApubPerson::from_json(p, data).await?),

--- a/crates/apub/src/http/comment.rs
+++ b/crates/apub/src/http/comment.rs
@@ -20,7 +20,7 @@ pub(crate) struct CommentQuery {
 }
 
 /// Return the ActivityPub json representation of a local comment over HTTP.
-#[tracing::instrument(skip_all)]
+
 pub(crate) async fn get_apub_comment(
   info: Path<CommentQuery>,
   context: Data<LemmyContext>,

--- a/crates/apub/src/http/comment.rs
+++ b/crates/apub/src/http/comment.rs
@@ -20,7 +20,6 @@ pub(crate) struct CommentQuery {
 }
 
 /// Return the ActivityPub json representation of a local comment over HTTP.
-
 pub(crate) async fn get_apub_comment(
   info: Path<CommentQuery>,
   context: Data<LemmyContext>,

--- a/crates/apub/src/http/community.rs
+++ b/crates/apub/src/http/community.rs
@@ -38,7 +38,6 @@ pub struct CommunityIsFollowerQuery {
 }
 
 /// Return the ActivityPub json representation of a local community over HTTP.
-
 pub(crate) async fn get_apub_community_http(
   info: Path<CommunityPath>,
   context: Data<LemmyContext>,

--- a/crates/apub/src/http/community.rs
+++ b/crates/apub/src/http/community.rs
@@ -38,7 +38,7 @@ pub struct CommunityIsFollowerQuery {
 }
 
 /// Return the ActivityPub json representation of a local community over HTTP.
-#[tracing::instrument(skip_all)]
+
 pub(crate) async fn get_apub_community_http(
   info: Path<CommunityPath>,
   context: Data<LemmyContext>,
@@ -126,7 +126,6 @@ pub(crate) async fn get_apub_community_outbox(
   create_apub_response(&outbox)
 }
 
-#[tracing::instrument(skip_all)]
 pub(crate) async fn get_apub_community_moderators(
   info: Path<CommunityPath>,
   context: Data<LemmyContext>,

--- a/crates/apub/src/http/mod.rs
+++ b/crates/apub/src/http/mod.rs
@@ -95,7 +95,6 @@ pub struct ActivityQuery {
 }
 
 /// Return the ActivityPub json representation of a local activity over HTTP.
-
 pub(crate) async fn get_activity(
   info: web::Path<ActivityQuery>,
   context: web::Data<LemmyContext>,

--- a/crates/apub/src/http/mod.rs
+++ b/crates/apub/src/http/mod.rs
@@ -95,7 +95,7 @@ pub struct ActivityQuery {
 }
 
 /// Return the ActivityPub json representation of a local activity over HTTP.
-#[tracing::instrument(skip_all)]
+
 pub(crate) async fn get_activity(
   info: web::Path<ActivityQuery>,
   context: web::Data<LemmyContext>,

--- a/crates/apub/src/http/person.rs
+++ b/crates/apub/src/http/person.rs
@@ -16,7 +16,6 @@ pub struct PersonQuery {
 }
 
 /// Return the ActivityPub json representation of a local person over HTTP.
-
 pub(crate) async fn get_apub_person_http(
   info: web::Path<PersonQuery>,
   context: Data<LemmyContext>,

--- a/crates/apub/src/http/person.rs
+++ b/crates/apub/src/http/person.rs
@@ -16,7 +16,7 @@ pub struct PersonQuery {
 }
 
 /// Return the ActivityPub json representation of a local person over HTTP.
-#[tracing::instrument(skip_all)]
+
 pub(crate) async fn get_apub_person_http(
   info: web::Path<PersonQuery>,
   context: Data<LemmyContext>,
@@ -37,7 +37,6 @@ pub(crate) async fn get_apub_person_http(
   }
 }
 
-#[tracing::instrument(skip_all)]
 pub(crate) async fn get_apub_person_outbox(
   info: web::Path<PersonQuery>,
   context: Data<LemmyContext>,

--- a/crates/apub/src/http/post.rs
+++ b/crates/apub/src/http/post.rs
@@ -20,7 +20,7 @@ pub(crate) struct PostQuery {
 }
 
 /// Return the ActivityPub json representation of a local post over HTTP.
-#[tracing::instrument(skip_all)]
+
 pub(crate) async fn get_apub_post(
   info: web::Path<PostQuery>,
   context: Data<LemmyContext>,

--- a/crates/apub/src/http/post.rs
+++ b/crates/apub/src/http/post.rs
@@ -20,7 +20,6 @@ pub(crate) struct PostQuery {
 }
 
 /// Return the ActivityPub json representation of a local post over HTTP.
-
 pub(crate) async fn get_apub_post(
   info: web::Path<PostQuery>,
   context: Data<LemmyContext>,

--- a/crates/apub/src/http/site.rs
+++ b/crates/apub/src/http/site.rs
@@ -17,7 +17,6 @@ pub(crate) async fn get_apub_site_http(context: Data<LemmyContext>) -> LemmyResu
   create_apub_response(&apub)
 }
 
-#[tracing::instrument(skip_all)]
 pub(crate) async fn get_apub_site_outbox(context: Data<LemmyContext>) -> LemmyResult<HttpResponse> {
   let outbox_id = format!(
     "{}/site_outbox",

--- a/crates/apub/src/lib.rs
+++ b/crates/apub/src/lib.rs
@@ -89,7 +89,6 @@ impl UrlVerifier for VerifyUrlData {
 /// - the correct scheme (either http or https)
 /// - URL being in the allowlist (if it is active)
 /// - URL not being in the blocklist (if it is active)
-#[tracing::instrument(skip(local_site_data))]
 fn check_apub_id_valid(apub_id: &Url, local_site_data: &LocalSiteData) -> LemmyResult<()> {
   let domain = apub_id
     .domain()
@@ -213,7 +212,6 @@ pub(crate) async fn check_apub_id_valid_with_strictness(
 ///
 /// This ensures that the same activity doesn't get received and processed more than once, which
 /// would be a waste of resources.
-#[tracing::instrument(skip(data))]
 async fn insert_received_activity(ap_id: &Url, data: &Data<LemmyContext>) -> LemmyResult<()> {
   ReceivedActivity::create(&mut data.pool(), &ap_id.clone().into()).await?;
   Ok(())

--- a/crates/apub/src/mentions.rs
+++ b/crates/apub/src/mentions.rs
@@ -42,7 +42,6 @@ pub struct MentionsAndAddresses {
 /// This takes a comment, and builds a list of to_addresses, inboxes,
 /// and mention tags, so they know where to be sent to.
 /// Addresses are the persons / addresses that go in the cc field.
-#[tracing::instrument(skip(comment, context))]
 pub async fn collect_non_local_mentions(
   comment: &ApubComment,
   context: &Data<LemmyContext>,
@@ -95,7 +94,6 @@ pub async fn collect_non_local_mentions(
 
 /// Returns the apub ID of the person this comment is responding to. Meaning, in case this is a
 /// top-level comment, the creator of the post, otherwise the creator of the parent comment.
-#[tracing::instrument(skip(pool, comment))]
 async fn get_comment_parent_creator(
   pool: &mut DbPool<'_>,
   comment: &Comment,

--- a/crates/apub/src/objects/comment.rs
+++ b/crates/apub/src/objects/comment.rs
@@ -130,7 +130,6 @@ impl Object for ApubComment {
 
   /// Recursively fetches all parent comments. This can lead to a stack overflow so we need to
   /// Box::pin all large futures on the heap.
-
   async fn verify(
     note: &Note,
     expected_domain: &Url,
@@ -170,7 +169,6 @@ impl Object for ApubComment {
   /// Converts a `Note` to `Comment`.
   ///
   /// If the parent community, post and comment(s) are not known locally, these are also fetched.
-
   async fn from_json(note: Note, context: &Data<LemmyContext>) -> LemmyResult<ApubComment> {
     let creator = note.attributed_to.dereference(context).await?;
     let (post, parent_comment) = note.get_parents(context).await?;

--- a/crates/apub/src/objects/comment.rs
+++ b/crates/apub/src/objects/comment.rs
@@ -67,7 +67,6 @@ impl Object for ApubComment {
     None
   }
 
-  #[tracing::instrument(skip_all)]
   async fn read_from_id(
     object_id: Url,
     context: &Data<Self::DataType>,
@@ -79,7 +78,6 @@ impl Object for ApubComment {
     )
   }
 
-  #[tracing::instrument(skip_all)]
   async fn delete(self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     if !self.deleted {
       let form = CommentUpdateForm {
@@ -91,7 +89,6 @@ impl Object for ApubComment {
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn into_json(self, context: &Data<Self::DataType>) -> LemmyResult<Note> {
     let creator_id = self.creator_id;
     let creator = Person::read(&mut context.pool(), creator_id).await?;
@@ -133,7 +130,7 @@ impl Object for ApubComment {
 
   /// Recursively fetches all parent comments. This can lead to a stack overflow so we need to
   /// Box::pin all large futures on the heap.
-  #[tracing::instrument(skip_all)]
+
   async fn verify(
     note: &Note,
     expected_domain: &Url,
@@ -173,7 +170,7 @@ impl Object for ApubComment {
   /// Converts a `Note` to `Comment`.
   ///
   /// If the parent community, post and comment(s) are not known locally, these are also fetched.
-  #[tracing::instrument(skip_all)]
+
   async fn from_json(note: Note, context: &Data<LemmyContext>) -> LemmyResult<ApubComment> {
     let creator = note.attributed_to.dereference(context).await?;
     let (post, parent_comment) = note.get_parents(context).await?;

--- a/crates/apub/src/objects/community.rs
+++ b/crates/apub/src/objects/community.rs
@@ -1,8 +1,6 @@
 use crate::{
   activities::GetActorType,
-  check_apub_id_valid,
   fetcher::markdown_links::markdown_rewrite_remote_links_opt,
-  local_site_data_cached,
   objects::{instance::fetch_instance_actor_for_object, read_from_string_or_source_opt},
   protocol::{
     objects::{group::Group, LanguageTag},
@@ -40,7 +38,6 @@ use lemmy_db_schema::{
   traits::{ApubActor, Crud},
   CommunityVisibility,
 };
-use lemmy_db_views::structs::CommunityFollowerView;
 use lemmy_utils::{
   error::{LemmyError, LemmyResult},
   spawn_try_task,
@@ -75,7 +72,6 @@ impl Object for ApubCommunity {
     Some(self.last_refreshed_at)
   }
 
-  #[tracing::instrument(skip_all)]
   async fn read_from_id(
     object_id: Url,
     context: &Data<Self::DataType>,
@@ -87,7 +83,6 @@ impl Object for ApubCommunity {
     )
   }
 
-  #[tracing::instrument(skip_all)]
   async fn delete(self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     let form = CommunityUpdateForm {
       deleted: Some(true),
@@ -97,7 +92,6 @@ impl Object for ApubCommunity {
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn into_json(self, data: &Data<Self::DataType>) -> LemmyResult<Group> {
     let community_id = self.id;
     let langs = CommunityLanguage::read(&mut data.pool(), community_id).await?;
@@ -131,7 +125,6 @@ impl Object for ApubCommunity {
     Ok(group)
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(
     group: &Group,
     expected_domain: &Url,
@@ -141,7 +134,7 @@ impl Object for ApubCommunity {
   }
 
   /// Converts a `Group` to `Community`, inserts it into the database and updates moderators.
-  #[tracing::instrument(skip_all)]
+
   async fn from_json(group: Group, context: &Data<Self::DataType>) -> LemmyResult<ApubCommunity> {
     let instance_id = fetch_instance_actor_for_object(&group.id, context).await?;
 
@@ -244,27 +237,6 @@ impl Actor for ApubCommunity {
 impl GetActorType for ApubCommunity {
   fn actor_type(&self) -> ActorType {
     ActorType::Community
-  }
-}
-
-impl ApubCommunity {
-  /// For a given community, returns the inboxes of all followers.
-  #[tracing::instrument(skip_all)]
-  pub(crate) async fn get_follower_inboxes(&self, context: &LemmyContext) -> LemmyResult<Vec<Url>> {
-    let id = self.id;
-
-    let local_site_data = local_site_data_cached(&mut context.pool()).await?;
-    let follows =
-      CommunityFollowerView::get_community_follower_inboxes(&mut context.pool(), id).await?;
-    let inboxes: Vec<Url> = follows
-      .into_iter()
-      .map(Into::into)
-      .filter(|inbox: &Url| inbox.host_str() != Some(&context.settings().hostname))
-      // Don't send to blocked instances
-      .filter(|inbox| check_apub_id_valid(inbox, &local_site_data).is_ok())
-      .collect();
-
-    Ok(inboxes)
   }
 }
 

--- a/crates/apub/src/objects/instance.rs
+++ b/crates/apub/src/objects/instance.rs
@@ -79,7 +79,6 @@ impl Object for ApubSite {
     Some(self.last_refreshed_at)
   }
 
-  #[tracing::instrument(skip_all)]
   async fn read_from_id(object_id: Url, data: &Data<Self::DataType>) -> LemmyResult<Option<Self>> {
     Ok(
       Site::read_from_apub_id(&mut data.pool(), &object_id.into())
@@ -92,7 +91,6 @@ impl Object for ApubSite {
     Err(FederationError::CantDeleteSite.into())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn into_json(self, data: &Data<Self::DataType>) -> LemmyResult<Self::Kind> {
     let site_id = self.id;
     let langs = SiteLanguage::read(&mut data.pool(), site_id).await?;
@@ -120,7 +118,6 @@ impl Object for ApubSite {
     Ok(instance)
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(
     apub: &Self::Kind,
     expected_domain: &Url,
@@ -138,7 +135,6 @@ impl Object for ApubSite {
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn from_json(apub: Self::Kind, context: &Data<Self::DataType>) -> LemmyResult<Self> {
     let domain = apub
       .id

--- a/crates/apub/src/objects/person.rs
+++ b/crates/apub/src/objects/person.rs
@@ -71,7 +71,6 @@ impl Object for ApubPerson {
     Some(self.last_refreshed_at)
   }
 
-  #[tracing::instrument(skip_all)]
   async fn read_from_id(
     object_id: Url,
     context: &Data<Self::DataType>,
@@ -83,7 +82,6 @@ impl Object for ApubPerson {
     )
   }
 
-  #[tracing::instrument(skip_all)]
   async fn delete(self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     let form = PersonUpdateForm {
       deleted: Some(true),
@@ -93,7 +91,6 @@ impl Object for ApubPerson {
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn into_json(self, _context: &Data<Self::DataType>) -> LemmyResult<Person> {
     let kind = if self.bot_account {
       UserTypes::Service
@@ -121,7 +118,6 @@ impl Object for ApubPerson {
     Ok(person)
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(
     person: &Person,
     expected_domain: &Url,
@@ -141,7 +137,6 @@ impl Object for ApubPerson {
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn from_json(person: Person, context: &Data<Self::DataType>) -> LemmyResult<ApubPerson> {
     let instance_id = fetch_instance_actor_for_object(&person.id, context).await?;
 

--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -81,7 +81,6 @@ impl Object for ApubPost {
     None
   }
 
-  #[tracing::instrument(skip_all)]
   async fn read_from_id(
     object_id: Url,
     context: &Data<Self::DataType>,
@@ -93,7 +92,6 @@ impl Object for ApubPost {
     )
   }
 
-  #[tracing::instrument(skip_all)]
   async fn delete(self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     if !self.deleted {
       let form = PostUpdateForm {
@@ -106,7 +104,7 @@ impl Object for ApubPost {
   }
 
   // Turn a Lemmy post into an ActivityPub page that can be sent out over the network.
-  #[tracing::instrument(skip_all)]
+
   async fn into_json(self, context: &Data<Self::DataType>) -> LemmyResult<Page> {
     let creator_id = self.creator_id;
     let creator = Person::read(&mut context.pool(), creator_id).await?;
@@ -154,7 +152,6 @@ impl Object for ApubPost {
     Ok(page)
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(
     page: &Page,
     expected_domain: &Url,
@@ -176,7 +173,6 @@ impl Object for ApubPost {
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn from_json(page: Page, context: &Data<Self::DataType>) -> LemmyResult<ApubPost> {
     let creator = page.creator()?.dereference(context).await?;
     let community = page.community(context).await?;

--- a/crates/apub/src/objects/private_message.rs
+++ b/crates/apub/src/objects/private_message.rs
@@ -70,7 +70,6 @@ impl Object for ApubPrivateMessage {
     None
   }
 
-  #[tracing::instrument(skip_all)]
   async fn read_from_id(
     object_id: Url,
     context: &Data<Self::DataType>,
@@ -87,7 +86,6 @@ impl Object for ApubPrivateMessage {
     Err(LemmyErrorType::NotFound.into())
   }
 
-  #[tracing::instrument(skip_all)]
   async fn into_json(self, context: &Data<Self::DataType>) -> LemmyResult<PrivateMessage> {
     let creator_id = self.creator_id;
     let creator = Person::read(&mut context.pool(), creator_id).await?;
@@ -120,7 +118,6 @@ impl Object for ApubPrivateMessage {
     Ok(note)
   }
 
-  #[tracing::instrument(skip_all)]
   async fn verify(
     note: &PrivateMessage,
     expected_domain: &Url,
@@ -141,7 +138,6 @@ impl Object for ApubPrivateMessage {
     }
   }
 
-  #[tracing::instrument(skip_all)]
   async fn from_json(
     note: PrivateMessage,
     context: &Data<Self::DataType>,

--- a/crates/db_views/src/community/community_follower_view.rs
+++ b/crates/db_views/src/community/community_follower_view.rs
@@ -53,22 +53,6 @@ impl CommunityFollowerView {
       .await
       .with_lemmy_type(LemmyErrorType::NotFound)
   }
-  pub async fn get_community_follower_inboxes(
-    pool: &mut DbPool<'_>,
-    community_id: CommunityId,
-  ) -> Result<Vec<DbUrl>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let res = action_query(community_actions::followed)
-      .filter(community_actions::community_id.eq(community_id))
-      .filter(not(person::local))
-      .inner_join(person::table.on(community_actions::person_id.eq(person::id)))
-      .select(person::inbox_url)
-      .distinct()
-      .load::<DbUrl>(conn)
-      .await?;
-
-    Ok(res)
-  }
   pub async fn count_community_followers(
     pool: &mut DbPool<'_>,
     community_id: CommunityId,

--- a/crates/routes/src/feeds.rs
+++ b/crates/routes/src/feeds.rs
@@ -90,7 +90,6 @@ static RSS_NAMESPACE: LazyLock<BTreeMap<String, String>> = LazyLock::new(|| {
   h
 });
 
-#[tracing::instrument(skip_all)]
 async fn get_all_feed(
   info: web::Query<Params>,
   context: web::Data<LemmyContext>,
@@ -107,7 +106,6 @@ async fn get_all_feed(
   )
 }
 
-#[tracing::instrument(skip_all)]
 async fn get_local_feed(
   info: web::Query<Params>,
   context: web::Data<LemmyContext>,
@@ -124,7 +122,6 @@ async fn get_local_feed(
   )
 }
 
-#[tracing::instrument(skip_all)]
 async fn get_feed_data(
   context: &LemmyContext,
   listing_type: ListingType,
@@ -168,7 +165,6 @@ async fn get_feed_data(
   )
 }
 
-#[tracing::instrument(skip_all)]
 async fn get_feed(
   req: HttpRequest,
   info: web::Query<Params>,
@@ -229,7 +225,6 @@ async fn get_feed(
   )
 }
 
-#[tracing::instrument(skip_all)]
 async fn get_feed_user(
   context: &LemmyContext,
   sort_type: &PostSortType,
@@ -267,7 +262,6 @@ async fn get_feed_user(
   Ok(channel)
 }
 
-#[tracing::instrument(skip_all)]
 async fn get_feed_community(
   context: &LemmyContext,
   sort_type: &PostSortType,
@@ -312,7 +306,6 @@ async fn get_feed_community(
   Ok(channel)
 }
 
-#[tracing::instrument(skip_all)]
 async fn get_feed_front(
   context: &LemmyContext,
   sort_type: &PostSortType,
@@ -353,7 +346,6 @@ async fn get_feed_front(
   Ok(channel)
 }
 
-#[tracing::instrument(skip_all)]
 async fn get_feed_inbox(context: &LemmyContext, jwt: &str) -> LemmyResult<Channel> {
   let site_view = SiteView::read_local(&mut context.pool()).await?;
   let local_user = local_user_view_from_jwt(jwt, context).await?;
@@ -387,7 +379,6 @@ async fn get_feed_inbox(context: &LemmyContext, jwt: &str) -> LemmyResult<Channe
   Ok(channel)
 }
 
-#[tracing::instrument(skip_all)]
 fn create_reply_and_mention_items(
   inbox: Vec<InboxCombinedView>,
   protocol_and_hostname: &str,
@@ -441,7 +432,6 @@ fn create_reply_and_mention_items(
   Ok(reply_items)
 }
 
-#[tracing::instrument(skip_all)]
 fn build_item(
   creator_name: &str,
   published: &DateTime<Utc>,
@@ -471,7 +461,6 @@ fn build_item(
   })
 }
 
-#[tracing::instrument(skip_all)]
 fn create_post_items(posts: Vec<PostView>, protocol_and_hostname: &str) -> LemmyResult<Vec<Item>> {
   let mut items: Vec<Item> = Vec::new();
 

--- a/crates/utils/src/request.rs
+++ b/crates/utils/src/request.rs
@@ -1,6 +1,5 @@
 use std::future::Future;
 
-#[tracing::instrument(skip_all)]
 pub async fn retry<F, Fut, T>(f: F) -> Result<T, reqwest_middleware::Error>
 where
   F: Fn() -> Fut,
@@ -9,7 +8,6 @@ where
   retry_custom(|| async { Ok((f)().await) }).await
 }
 
-#[tracing::instrument(skip_all)]
 #[allow(clippy::expect_used)]
 async fn retry_custom<F, Fut, T>(f: F) -> Result<T, reqwest_middleware::Error>
 where


### PR DESCRIPTION
Apparently these can be used to filter logs for specific functions, but I dont think that anyone is using it. So Im removing this as macros can also increase compilation time. This change also revealed some unused code.

https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html

https://docs.rs/tracing/latest/tracing/attr.instrument.html