### PR TITLE
Use mimalloc as memory allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2832,6 +2832,7 @@ dependencies = [
  "lemmy_federate",
  "lemmy_routes",
  "lemmy_utils",
+ "mimalloc",
  "reqwest-middleware",
  "reqwest-tracing",
  "rustls 0.23.21",
@@ -2934,6 +2935,16 @@ name = "libm"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+
+[[package]]
+name = "libmimalloc-sys"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "linked-hash-map"
@@ -3223,6 +3234,15 @@ dependencies = [
  "migrations_internals",
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,3 +180,4 @@ serde_json = { workspace = true }
 rustls = { workspace = true }
 tokio.workspace = true
 clap = { workspace = true }
+mimalloc = "0.1.43"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,12 +52,16 @@ use lemmy_utils::{
   settings::{structs::Settings, SETTINGS},
   VERSION,
 };
+use mimalloc::MiMalloc;
 use reqwest_middleware::ClientBuilder;
 use reqwest_tracing::TracingMiddleware;
 use serde_json::json;
 use std::{ops::Deref, time::Duration};
 use tokio::signal::unix::SignalKind;
 use tracing_actix_web::{DefaultRootSpanBuilder, TracingLogger};
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 /// Timeout for HTTP requests while sending activities. A longer timeout provides better
 /// compatibility with other ActivityPub software that might allocate more time for synchronous


### PR DESCRIPTION
Rust uses the system memory allocator by default (glibc on linux). This allocator has problems with memory fragmentation, which means that in long-running processes, it cant always reuse memory and slowly increases memory usage over time. Performance may also be less than optimal. See the two threads below for details:

https://www.reddit.com/r/rust/comments/x9bq8k/bizarre_memory_leak_caused_by_tokio_runtime/ino8yz3/

https://www.reddit.com/r/rust/comments/1ifjzvv/picking_a_global_allocator/

The suggested alternatives are either mimalloc or jemalloc, and based on the information I found mimalloc is generally faster.