### PR TITLE
Ignore follow requests from kbin, mbin for private communities

### DIFF
--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -186,6 +186,7 @@ pub enum FederationError {
   CantDeleteSite,
   ObjectIsNotPublic,
   ObjectIsNotPrivate,
+  PlatformLackingPrivateCommunitySupport,
   Unreachable,
 }
 


### PR DESCRIPTION
These platforms dont support privacy controls for votes, so they will most likely leak the content of private communities as well. Need to block them until support is implemented.

https://github.com/MbinOrg/mbin/issues/1115