### PR TITLE
Rate limit changes (fixes #5287)

### DIFF
--- a/api_tests/run-federation-test.sh
+++ b/api_tests/run-federation-test.sh
@@ -11,7 +11,7 @@ killall -s1 lemmy_server || true
 popd
 
 pnpm i
-pnpm api-test || true
+pnpm api-test-post || true
 
 killall -s1 lemmy_server || true
 killall -s1 pict-rs || true

--- a/api_tests/run-federation-test.sh
+++ b/api_tests/run-federation-test.sh
@@ -11,7 +11,7 @@ killall -s1 lemmy_server || true
 popd
 
 pnpm i
-pnpm api-test-post || true
+pnpm api-test || true
 
 killall -s1 lemmy_server || true
 killall -s1 pict-rs || true

--- a/src/api_routes_v3.rs
+++ b/src/api_routes_v3.rs
@@ -198,11 +198,10 @@ pub fn config(cfg: &mut ServiceConfig, rate_limit: &RateLimitCell) {
         )
         // Post
         .service(
-          // Handle POST to /post separately to add the post() rate limitter
-          resource("/post")
-            .guard(guard::Post())
+          scope("/post")
             .wrap(rate_limit.post())
-            .route(post().to(create_post)),
+            .route("", post().to(create_post))
+            .route("/site_metadata", get().to(get_link_metadata)),
         )
         .service(
           scope("/post")
@@ -220,8 +219,7 @@ pub fn config(cfg: &mut ServiceConfig, rate_limit: &RateLimitCell) {
             .route("/like/list", get().to(list_post_likes))
             .route("/save", put().to(save_post))
             .route("/report", post().to(create_post_report))
-            .route("/report/resolve", put().to(resolve_post_report))
-            .route("/site_metadata", get().to(get_link_metadata)),
+            .route("/report/resolve", put().to(resolve_post_report)),
         )
         // Comment
         .service(

--- a/src/api_routes_v3.rs
+++ b/src/api_routes_v3.rs
@@ -165,7 +165,7 @@ pub fn config(cfg: &mut ServiceConfig, rate_limit: &RateLimitCell) {
         )
         .service(
           resource("/resolve_object")
-            .wrap(rate_limit.message())
+            .wrap(rate_limit.search())
             .route(get().to(resolve_object)),
         )
         // Community

--- a/src/api_routes_v3.rs
+++ b/src/api_routes_v3.rs
@@ -198,10 +198,14 @@ pub fn config(cfg: &mut ServiceConfig, rate_limit: &RateLimitCell) {
         )
         // Post
         .service(
-          scope("/post")
+          resource("/post")
             .wrap(rate_limit.post())
-            .route("", post().to(create_post))
-            .route("/site_metadata", get().to(get_link_metadata)),
+            .route(post().to(create_post)),
+        )
+        .service(
+          resource("post/site_metadata")
+            .wrap(rate_limit.search())
+            .route(get().to(get_link_metadata)),
         )
         .service(
           scope("/post")

--- a/src/api_routes_v3.rs
+++ b/src/api_routes_v3.rs
@@ -137,9 +137,13 @@ pub fn config(cfg: &mut ServiceConfig, rate_limit: &RateLimitCell) {
         .wrap(rate_limit.image())
         .route(post().to(upload_image)),
     )
-    .service(resource("/pictrs/image/{filename}").route(get().to(get_image)))
-    .service(resource("/pictrs/image/delete/{token}/{filename}").route(get().to(delete_image)))
-    .service(resource("/pictrs/healthz").route(get().to(pictrs_health)))
+    .service(
+      scope("/pictrs")
+        .wrap(rate_limit.message())
+        .route("/image/{filename}", get().to(get_image))
+        .route("/image/delete/{token}/{filename}", get().to(delete_image))
+        .route("/healthz", get().to(pictrs_health)),
+    )
     .service(
       scope("/api/v3")
         .route("/image_proxy", get().to(image_proxy))

--- a/src/api_routes_v3.rs
+++ b/src/api_routes_v3.rs
@@ -203,11 +203,13 @@ pub fn config(cfg: &mut ServiceConfig, rate_limit: &RateLimitCell) {
         // Post
         .service(
           resource("/post")
+            // Handle POST to /post separately to add the post() rate limitter
+            .guard(guard::Post())
             .wrap(rate_limit.post())
             .route(post().to(create_post)),
         )
         .service(
-          resource("post/site_metadata")
+          resource("/post/site_metadata")
             .wrap(rate_limit.search())
             .route(get().to(get_link_metadata)),
         )

--- a/src/api_routes_v4.rs
+++ b/src/api_routes_v4.rs
@@ -232,10 +232,14 @@ pub fn config(cfg: &mut ServiceConfig, rate_limit: &RateLimitCell) {
       .route("/federated_instances", get().to(get_federated_instances))
       // Post
       .service(
-        scope("/post")
+        resource("/post")
           .wrap(rate_limit.post())
-          .route("", post().to(create_post))
-          .route("/site_metadata", get().to(get_link_metadata)),
+          .route(post().to(create_post)),
+      )
+      .service(
+        resource("post/site_metadata")
+          .wrap(rate_limit.search())
+          .route(get().to(get_link_metadata)),
       )
       .service(
         scope("/post")

--- a/src/api_routes_v4.rs
+++ b/src/api_routes_v4.rs
@@ -232,11 +232,10 @@ pub fn config(cfg: &mut ServiceConfig, rate_limit: &RateLimitCell) {
       .route("/federated_instances", get().to(get_federated_instances))
       // Post
       .service(
-        // Handle POST to /post separately to add the post() rate limitter
-        resource("/post")
-          .guard(guard::Post())
+        scope("/post")
           .wrap(rate_limit.post())
-          .route(post().to(create_post)),
+          .route("", post().to(create_post))
+          .route("/site_metadata", get().to(get_link_metadata)),
       )
       .service(
         scope("/post")
@@ -254,8 +253,7 @@ pub fn config(cfg: &mut ServiceConfig, rate_limit: &RateLimitCell) {
           .route("/like/list", get().to(list_post_likes))
           .route("/save", put().to(save_post))
           .route("/report", post().to(create_post_report))
-          .route("/report/resolve", put().to(resolve_post_report))
-          .route("/site_metadata", get().to(get_link_metadata)),
+          .route("/report/resolve", put().to(resolve_post_report)),
       )
       // Comment
       .service(

--- a/src/api_routes_v4.rs
+++ b/src/api_routes_v4.rs
@@ -237,11 +237,13 @@ pub fn config(cfg: &mut ServiceConfig, rate_limit: &RateLimitCell) {
       // Post
       .service(
         resource("/post")
+          // Handle POST to /post separately to add the post() rate limitter
+          .guard(guard::Post())
           .wrap(rate_limit.post())
           .route(post().to(create_post)),
       )
       .service(
-        resource("post/site_metadata")
+        resource("/post/site_metadata")
           .wrap(rate_limit.search())
           .route(get().to(get_link_metadata)),
       )

--- a/src/api_routes_v4.rs
+++ b/src/api_routes_v4.rs
@@ -196,7 +196,11 @@ pub fn config(cfg: &mut ServiceConfig, rate_limit: &RateLimitCell) {
           .wrap(rate_limit.search())
           .route(get().to(search)),
       )
-      .route("/resolve_object", get().to(resolve_object))
+      .service(
+        resource("/resolve_object")
+          .wrap(rate_limit.search())
+          .route(get().to(resolve_object)),
+      )
       // Community
       .service(
         resource("/community")


### PR DESCRIPTION
Using the same rate limit as create post because it belongs together and is less verbose this way (no need for a separate service). Tested and still works without the post guard.