### PR TITLE
Show posts/comments from followed communities despite instance block

### DIFF
--- a/crates/db_views/src/comment/comment_view.rs
+++ b/crates/db_views/src/comment/comment_view.rs
@@ -1,4 +1,7 @@
-use crate::structs::{CommentSlimView, CommentView};
+use crate::{
+  post::post_view::filter_blocked,
+  structs::{CommentSlimView, CommentView},
+};
 use diesel::{
   dsl::exists,
   result::Error,
@@ -233,11 +236,7 @@ impl CommentQuery<'_> {
         ),
       ));
 
-      // Don't show blocked communities or persons
-      query = query
-        .filter(instance_actions::blocked.is_null())
-        .filter(community_actions::blocked.is_null())
-        .filter(person_actions::blocked.is_null());
+      query = query.filter(filter_blocked());
     };
 
     if !o.local_user.show_nsfw(site) {

--- a/crates/db_views/src/comment/comment_view.rs
+++ b/crates/db_views/src/comment/comment_view.rs
@@ -1,6 +1,6 @@
 use crate::{
-  post::post_view::filter_blocked,
   structs::{CommentSlimView, CommentView},
+  utils::filter_blocked,
 };
 use diesel::{
   dsl::exists,

--- a/crates/db_views/src/lib.rs
+++ b/crates/db_views/src/lib.rs
@@ -22,3 +22,5 @@ pub mod reports;
 #[cfg(feature = "full")]
 pub mod site;
 pub mod structs;
+#[cfg(feature = "full")]
+pub mod utils;

--- a/crates/db_views/src/post/post_view.rs
+++ b/crates/db_views/src/post/post_view.rs
@@ -1,4 +1,7 @@
-use crate::structs::{PaginationCursor, PostView};
+use crate::{
+  structs::{PaginationCursor, PostView},
+  utils::filter_blocked,
+};
 use diesel::{
   debug_query,
   dsl::{exists, not},
@@ -647,17 +650,6 @@ impl<'a> PostQuery<'a> {
       .load::<PostView>(conn)
       .await
   }
-}
-
-/// Hide all content from blocked communities and persons. Content from blocked instances is also
-/// hidden, unless the user followed the community explicitly.
-#[diesel::dsl::auto_type]
-pub(crate) fn filter_blocked() -> _ {
-  instance_actions::blocked
-    .is_null()
-    .or(community_actions::followed.is_not_null())
-    .and(community_actions::blocked.is_null())
-    .and(person_actions::blocked.is_null())
 }
 
 #[allow(clippy::indexing_slicing)]

--- a/crates/db_views/src/utils.rs
+++ b/crates/db_views/src/utils.rs
@@ -1,0 +1,13 @@
+use diesel::{BoolExpressionMethods, ExpressionMethods};
+use lemmy_db_schema::schema::{community_actions, instance_actions, person_actions};
+
+/// Hide all content from blocked communities and persons. Content from blocked instances is also
+/// hidden, unless the user followed the community explicitly.
+#[diesel::dsl::auto_type]
+pub(crate) fn filter_blocked() -> _ {
+  instance_actions::blocked
+    .is_null()
+    .or(community_actions::followed.is_not_null())
+    .and(community_actions::blocked.is_null())
+    .and(person_actions::blocked.is_null())
+}


### PR DESCRIPTION
With this change you can block an instance like lemmy.world to prevent it from flooding the All feed, while still being able to see posts from subscribed communities on that instance.

Another option would be to ignore instance blocks in case `listing_type == Subscribed`, but that would be more complicated and have basically the same end result.