### PR TITLE
Reduce usage of async_trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2695,7 +2695,6 @@ version = "1.0.0-alpha.0"
 dependencies = [
  "activitypub_federation",
  "anyhow",
- "async-trait",
  "bcrypt",
  "chrono",
  "deadpool",
@@ -2760,7 +2759,6 @@ dependencies = [
  "activitypub_federation",
  "actix-web",
  "anyhow",
- "async-trait",
  "chrono",
  "diesel",
  "diesel-async",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,6 @@ chrono = { version = "0.4.39", features = [
 serde_json = { version = "1.0.138", features = ["preserve_order"] }
 base64 = "0.22.1"
 uuid = { version = "1.13.1", features = ["serde"] }
-async-trait = "0.1.86"
 captcha = "0.0.9"
 anyhow = { version = "1.0.95", features = ["backtrace"] }
 diesel_ltree = "0.4.0"

--- a/crates/apub/Cargo.toml
+++ b/crates/apub/Cargo.toml
@@ -35,7 +35,7 @@ url = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
 uuid = { workspace = true }
-async-trait = { workspace = true }
+async-trait = "0.1.86"
 anyhow = { workspace = true }
 reqwest = { workspace = true }
 moka.workspace = true

--- a/crates/apub/src/activities/create_or_update/note_wrapper.rs
+++ b/crates/apub/src/activities/create_or_update/note_wrapper.rs
@@ -61,7 +61,6 @@ impl ActivityHandler for CreateOrUpdateNoteWrapper {
   }
 }
 
-#[async_trait::async_trait]
 impl InCommunity for CreateOrUpdateNoteWrapper {
   async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     // Same logic as in receive. In case this is a private message, an error is returned.

--- a/crates/apub/src/activity_lists.rs
+++ b/crates/apub/src/activity_lists.rs
@@ -75,7 +75,6 @@ pub enum AnnouncableActivities {
   Page(Page),
 }
 
-#[async_trait::async_trait]
 impl InCommunity for AnnouncableActivities {
   async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     use AnnouncableActivities::*;

--- a/crates/apub/src/fetcher/post_or_comment.rs
+++ b/crates/apub/src/fetcher/post_or_comment.rs
@@ -82,7 +82,6 @@ impl Object for PostOrComment {
   }
 }
 
-#[async_trait::async_trait]
 impl InCommunity for PostOrComment {
   async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let cid = match self {

--- a/crates/apub/src/protocol/activities/block/block_user.rs
+++ b/crates/apub/src/protocol/activities/block/block_user.rs
@@ -40,7 +40,6 @@ pub struct BlockUser {
   pub(crate) end_time: Option<DateTime<Utc>>,
 }
 
-#[async_trait::async_trait]
 impl InCommunity for BlockUser {
   async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let target = self.target.dereference(context).await?;

--- a/crates/apub/src/protocol/activities/block/undo_block_user.rs
+++ b/crates/apub/src/protocol/activities/block/undo_block_user.rs
@@ -33,7 +33,6 @@ pub struct UndoBlockUser {
   pub(crate) restore_data: Option<bool>,
 }
 
-#[async_trait::async_trait]
 impl InCommunity for UndoBlockUser {
   async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let community = self.object.community(context).await?;

--- a/crates/apub/src/protocol/activities/community/collection_add.rs
+++ b/crates/apub/src/protocol/activities/community/collection_add.rs
@@ -29,7 +29,6 @@ pub struct CollectionAdd {
   pub(crate) id: Url,
 }
 
-#[async_trait::async_trait]
 impl InCommunity for CollectionAdd {
   async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let (community, _) =

--- a/crates/apub/src/protocol/activities/community/collection_remove.rs
+++ b/crates/apub/src/protocol/activities/community/collection_remove.rs
@@ -29,7 +29,6 @@ pub struct CollectionRemove {
   pub(crate) id: Url,
 }
 
-#[async_trait::async_trait]
 impl InCommunity for CollectionRemove {
   async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let (community, _) =

--- a/crates/apub/src/protocol/activities/community/lock_page.rs
+++ b/crates/apub/src/protocol/activities/community/lock_page.rs
@@ -48,7 +48,6 @@ pub struct UndoLockPage {
   pub(crate) id: Url,
 }
 
-#[async_trait::async_trait]
 impl InCommunity for LockPage {
   async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let post = self.object.dereference(context).await?;
@@ -57,7 +56,6 @@ impl InCommunity for LockPage {
   }
 }
 
-#[async_trait::async_trait]
 impl InCommunity for UndoLockPage {
   async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let community = self.object.community(context).await?;

--- a/crates/apub/src/protocol/activities/community/report.rs
+++ b/crates/apub/src/protocol/activities/community/report.rs
@@ -91,7 +91,6 @@ impl ReportObject {
   }
 }
 
-#[async_trait::async_trait]
 impl InCommunity for Report {
   async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let community = self.to[0].dereference(context).await?;

--- a/crates/apub/src/protocol/activities/community/resolve_report.rs
+++ b/crates/apub/src/protocol/activities/community/resolve_report.rs
@@ -31,7 +31,6 @@ pub struct ResolveReport {
   pub(crate) id: Url,
 }
 
-#[async_trait::async_trait]
 impl InCommunity for ResolveReport {
   async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     self.object.community(context).await

--- a/crates/apub/src/protocol/activities/community/update.rs
+++ b/crates/apub/src/protocol/activities/community/update.rs
@@ -30,7 +30,6 @@ pub struct UpdateCommunity {
   pub(crate) id: Url,
 }
 
-#[async_trait::async_trait]
 impl InCommunity for UpdateCommunity {
   async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let community: ApubCommunity = self.object.id.clone().dereference(context).await?;

--- a/crates/apub/src/protocol/activities/create_or_update/note.rs
+++ b/crates/apub/src/protocol/activities/create_or_update/note.rs
@@ -30,7 +30,6 @@ pub struct CreateOrUpdateNote {
   pub(crate) id: Url,
 }
 
-#[async_trait::async_trait]
 impl InCommunity for CreateOrUpdateNote {
   async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let post = self.object.get_parents(context).await?.0;

--- a/crates/apub/src/protocol/activities/create_or_update/page.rs
+++ b/crates/apub/src/protocol/activities/create_or_update/page.rs
@@ -26,7 +26,6 @@ pub struct CreateOrUpdatePage {
   pub(crate) id: Url,
 }
 
-#[async_trait::async_trait]
 impl InCommunity for CreateOrUpdatePage {
   async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let community = self.object.community(context).await?;

--- a/crates/apub/src/protocol/activities/deletion/delete.rs
+++ b/crates/apub/src/protocol/activities/deletion/delete.rs
@@ -44,7 +44,6 @@ pub struct Delete {
   pub(crate) remove_data: Option<bool>,
 }
 
-#[async_trait::async_trait]
 impl InCommunity for Delete {
   async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let community_id = match DeletableObjects::read_from_db(self.object.id(), context).await? {

--- a/crates/apub/src/protocol/activities/deletion/undo_delete.rs
+++ b/crates/apub/src/protocol/activities/deletion/undo_delete.rs
@@ -31,7 +31,6 @@ pub struct UndoDelete {
   pub(crate) cc: Vec<Url>,
 }
 
-#[async_trait::async_trait]
 impl InCommunity for UndoDelete {
   async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let community = self.object.community(context).await?;

--- a/crates/apub/src/protocol/activities/voting/undo_vote.rs
+++ b/crates/apub/src/protocol/activities/voting/undo_vote.rs
@@ -18,7 +18,6 @@ pub struct UndoVote {
   pub(crate) id: Url,
 }
 
-#[async_trait::async_trait]
 impl InCommunity for UndoVote {
   async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let community = self.object.community(context).await?;

--- a/crates/apub/src/protocol/activities/voting/vote.rs
+++ b/crates/apub/src/protocol/activities/voting/vote.rs
@@ -47,7 +47,6 @@ impl From<&VoteType> for i16 {
   }
 }
 
-#[async_trait::async_trait]
 impl InCommunity for Vote {
   async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let community = self

--- a/crates/apub/src/protocol/mod.rs
+++ b/crates/apub/src/protocol/mod.rs
@@ -80,9 +80,11 @@ impl<Kind: Id + DeserializeOwned + Send> IdOrNestedObject<Kind> {
   }
 }
 
-#[async_trait::async_trait]
 pub trait InCommunity {
-  async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity>;
+  fn community(
+    &self,
+    context: &Data<LemmyContext>,
+  ) -> impl std::future::Future<Output = LemmyResult<ApubCommunity>> + Send;
 }
 
 #[cfg(test)]

--- a/crates/apub/src/protocol/mod.rs
+++ b/crates/apub/src/protocol/mod.rs
@@ -9,7 +9,7 @@ use lemmy_api_common::context::LemmyContext;
 use lemmy_db_schema::newtypes::DbUrl;
 use lemmy_utils::error::LemmyResult;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{collections::HashMap, future::Future};
 use url::Url;
 
 pub mod activities;
@@ -84,7 +84,7 @@ pub trait InCommunity {
   fn community(
     &self,
     context: &Data<LemmyContext>,
-  ) -> impl std::future::Future<Output = LemmyResult<ApubCommunity>> + Send;
+  ) -> impl Future<Output = LemmyResult<ApubCommunity>> + Send;
 }
 
 #[cfg(test)]

--- a/crates/apub/src/protocol/objects/note.rs
+++ b/crates/apub/src/protocol/objects/note.rs
@@ -87,7 +87,6 @@ impl Note {
   }
 }
 
-#[async_trait::async_trait]
 impl InCommunity for Note {
   async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let (post, _) = self.get_parents(context).await?;

--- a/crates/apub/src/protocol/objects/page.rs
+++ b/crates/apub/src/protocol/objects/page.rs
@@ -226,7 +226,6 @@ impl ActivityHandler for Page {
   }
 }
 
-#[async_trait::async_trait]
 impl InCommunity for Page {
   async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     let community = match &self.attributed_to {

--- a/crates/db_schema/Cargo.toml
+++ b/crates/db_schema/Cargo.toml
@@ -65,7 +65,6 @@ diesel-async = { workspace = true, features = [
 ], optional = true }
 regex = { workspace = true, optional = true }
 diesel_ltree = { workspace = true, optional = true }
-async-trait = { workspace = true }
 tracing = { workspace = true }
 deadpool = { version = "0.12.2", optional = true, features = ["rt_tokio_1"] }
 ts-rs = { workspace = true, optional = true }

--- a/crates/db_schema/src/impls/comment.rs
+++ b/crates/db_schema/src/impls/comment.rs
@@ -153,7 +153,6 @@ pub fn comment_select_remove_deletes() -> _ {
   )
 }
 
-#[async_trait]
 impl Crud for Comment {
   type InsertForm = CommentInsertForm;
   type UpdateForm = CommentUpdateForm;
@@ -178,7 +177,6 @@ impl Crud for Comment {
   }
 }
 
-#[async_trait]
 impl Likeable for CommentLike {
   type Form = CommentLikeForm;
   type IdType = CommentId;
@@ -211,7 +209,6 @@ impl Likeable for CommentLike {
   }
 }
 
-#[async_trait]
 impl Saveable for CommentSaved {
   type Form = CommentSavedForm;
   async fn save(

--- a/crates/db_schema/src/impls/comment_reply.rs
+++ b/crates/db_schema/src/impls/comment_reply.rs
@@ -9,7 +9,6 @@ use crate::{
 use diesel::{dsl::insert_into, result::Error, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 
-#[async_trait]
 impl Crud for CommentReply {
   type InsertForm = CommentReplyInsertForm;
   type UpdateForm = CommentReplyUpdateForm;

--- a/crates/db_schema/src/impls/comment_report.rs
+++ b/crates/db_schema/src/impls/comment_report.rs
@@ -16,7 +16,6 @@ use diesel::{
 use diesel_async::RunQueryDsl;
 use lemmy_utils::error::LemmyResult;
 
-#[async_trait]
 impl Reportable for CommentReport {
   type Form = CommentReportForm;
   type IdType = CommentReportId;

--- a/crates/db_schema/src/impls/community.rs
+++ b/crates/db_schema/src/impls/community.rs
@@ -53,7 +53,6 @@ use lemmy_utils::{
 };
 use url::Url;
 
-#[async_trait]
 impl Crud for Community {
   type InsertForm = CommunityInsertForm;
   type UpdateForm = CommunityUpdateForm;
@@ -86,7 +85,6 @@ impl Crud for Community {
   }
 }
 
-#[async_trait]
 impl Joinable for CommunityModerator {
   type Form = CommunityModeratorForm;
   async fn join(
@@ -356,7 +354,6 @@ impl CommunityModerator {
   }
 }
 
-#[async_trait]
 impl Bannable for CommunityPersonBan {
   type Form = CommunityPersonBanForm;
   async fn ban(
@@ -458,7 +455,6 @@ impl Queryable<sql_types::Nullable<crate::schema::sql_types::CommunityFollowerSt
   }
 }
 
-#[async_trait]
 impl Followable for CommunityFollower {
   type Form = CommunityFollowerForm;
   async fn follow(pool: &mut DbPool<'_>, form: &CommunityFollowerForm) -> Result<Self, Error> {
@@ -505,7 +501,6 @@ impl Followable for CommunityFollower {
   }
 }
 
-#[async_trait]
 impl ApubActor for Community {
   async fn read_from_apub_id(
     pool: &mut DbPool<'_>,

--- a/crates/db_schema/src/impls/community_block.rs
+++ b/crates/db_schema/src/impls/community_block.rs
@@ -55,7 +55,6 @@ impl CommunityBlock {
   }
 }
 
-#[async_trait]
 impl Blockable for CommunityBlock {
   type Form = CommunityBlockForm;
   async fn block(pool: &mut DbPool<'_>, community_block_form: &Self::Form) -> Result<Self, Error> {

--- a/crates/db_schema/src/impls/community_report.rs
+++ b/crates/db_schema/src/impls/community_report.rs
@@ -16,7 +16,6 @@ use diesel::{
 use diesel_async::RunQueryDsl;
 use lemmy_utils::error::LemmyResult;
 
-#[async_trait]
 impl Reportable for CommunityReport {
   type Form = CommunityReportForm;
   type IdType = CommunityReportId;

--- a/crates/db_schema/src/impls/custom_emoji.rs
+++ b/crates/db_schema/src/impls/custom_emoji.rs
@@ -14,7 +14,6 @@ use crate::{
 use diesel::{dsl::insert_into, result::Error, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 
-#[async_trait]
 impl Crud for CustomEmoji {
   type InsertForm = CustomEmojiInsertForm;
   type UpdateForm = CustomEmojiUpdateForm;

--- a/crates/db_schema/src/impls/instance_block.rs
+++ b/crates/db_schema/src/impls/instance_block.rs
@@ -53,7 +53,6 @@ impl InstanceBlock {
   }
 }
 
-#[async_trait]
 impl Blockable for InstanceBlock {
   type Form = InstanceBlockForm;
   async fn block(pool: &mut DbPool<'_>, instance_block_form: &Self::Form) -> Result<Self, Error> {

--- a/crates/db_schema/src/impls/mod_log/admin.rs
+++ b/crates/db_schema/src/impls/mod_log/admin.rs
@@ -35,7 +35,6 @@ use crate::{
 use diesel::{dsl::insert_into, result::Error, QueryDsl};
 use diesel_async::RunQueryDsl;
 
-#[async_trait]
 impl Crud for AdminPurgePerson {
   type InsertForm = AdminPurgePersonForm;
   type UpdateForm = AdminPurgePersonForm;
@@ -62,7 +61,6 @@ impl Crud for AdminPurgePerson {
   }
 }
 
-#[async_trait]
 impl Crud for AdminPurgeCommunity {
   type InsertForm = AdminPurgeCommunityForm;
   type UpdateForm = AdminPurgeCommunityForm;
@@ -89,7 +87,6 @@ impl Crud for AdminPurgeCommunity {
   }
 }
 
-#[async_trait]
 impl Crud for AdminPurgePost {
   type InsertForm = AdminPurgePostForm;
   type UpdateForm = AdminPurgePostForm;
@@ -116,7 +113,6 @@ impl Crud for AdminPurgePost {
   }
 }
 
-#[async_trait]
 impl Crud for AdminPurgeComment {
   type InsertForm = AdminPurgeCommentForm;
   type UpdateForm = AdminPurgeCommentForm;
@@ -143,7 +139,6 @@ impl Crud for AdminPurgeComment {
   }
 }
 
-#[async_trait]
 impl Crud for AdminAllowInstance {
   type InsertForm = AdminAllowInstanceForm;
   type UpdateForm = AdminAllowInstanceForm;
@@ -170,7 +165,6 @@ impl Crud for AdminAllowInstance {
   }
 }
 
-#[async_trait]
 impl Crud for AdminBlockInstance {
   type InsertForm = AdminBlockInstanceForm;
   type UpdateForm = AdminBlockInstanceForm;

--- a/crates/db_schema/src/impls/mod_log/moderator.rs
+++ b/crates/db_schema/src/impls/mod_log/moderator.rs
@@ -55,7 +55,6 @@ use crate::{
 use diesel::{dsl::insert_into, result::Error, QueryDsl};
 use diesel_async::RunQueryDsl;
 
-#[async_trait]
 impl Crud for ModRemovePost {
   type InsertForm = ModRemovePostForm;
   type UpdateForm = ModRemovePostForm;
@@ -95,7 +94,6 @@ impl ModRemovePost {
   }
 }
 
-#[async_trait]
 impl Crud for ModLockPost {
   type InsertForm = ModLockPostForm;
   type UpdateForm = ModLockPostForm;
@@ -122,7 +120,6 @@ impl Crud for ModLockPost {
   }
 }
 
-#[async_trait]
 impl Crud for ModFeaturePost {
   type InsertForm = ModFeaturePostForm;
   type UpdateForm = ModFeaturePostForm;
@@ -149,7 +146,6 @@ impl Crud for ModFeaturePost {
   }
 }
 
-#[async_trait]
 impl Crud for ModRemoveComment {
   type InsertForm = ModRemoveCommentForm;
   type UpdateForm = ModRemoveCommentForm;
@@ -189,7 +185,6 @@ impl ModRemoveComment {
   }
 }
 
-#[async_trait]
 impl Crud for ModRemoveCommunity {
   type InsertForm = ModRemoveCommunityForm;
   type UpdateForm = ModRemoveCommunityForm;
@@ -216,7 +211,6 @@ impl Crud for ModRemoveCommunity {
   }
 }
 
-#[async_trait]
 impl Crud for ModBanFromCommunity {
   type InsertForm = ModBanFromCommunityForm;
   type UpdateForm = ModBanFromCommunityForm;
@@ -243,7 +237,6 @@ impl Crud for ModBanFromCommunity {
   }
 }
 
-#[async_trait]
 impl Crud for ModBan {
   type InsertForm = ModBanForm;
   type UpdateForm = ModBanForm;
@@ -270,7 +263,6 @@ impl Crud for ModBan {
   }
 }
 
-#[async_trait]
 impl Crud for ModHideCommunity {
   type InsertForm = ModHideCommunityForm;
   type UpdateForm = ModHideCommunityForm;
@@ -297,7 +289,6 @@ impl Crud for ModHideCommunity {
   }
 }
 
-#[async_trait]
 impl Crud for ModAddCommunity {
   type InsertForm = ModAddCommunityForm;
   type UpdateForm = ModAddCommunityForm;
@@ -324,7 +315,6 @@ impl Crud for ModAddCommunity {
   }
 }
 
-#[async_trait]
 impl Crud for ModTransferCommunity {
   type InsertForm = ModTransferCommunityForm;
   type UpdateForm = ModTransferCommunityForm;
@@ -351,7 +341,6 @@ impl Crud for ModTransferCommunity {
   }
 }
 
-#[async_trait]
 impl Crud for ModAdd {
   type InsertForm = ModAddForm;
   type UpdateForm = ModAddForm;

--- a/crates/db_schema/src/impls/oauth_provider.rs
+++ b/crates/db_schema/src/impls/oauth_provider.rs
@@ -13,7 +13,6 @@ use crate::{
 use diesel::{dsl::insert_into, result::Error, QueryDsl};
 use diesel_async::RunQueryDsl;
 
-#[async_trait]
 impl Crud for OAuthProvider {
   type InsertForm = OAuthProviderInsertForm;
   type UpdateForm = OAuthProviderUpdateForm;

--- a/crates/db_schema/src/impls/person.rs
+++ b/crates/db_schema/src/impls/person.rs
@@ -30,7 +30,6 @@ use lemmy_utils::{
 };
 use url::Url;
 
-#[async_trait]
 impl Crud for Person {
   type InsertForm = PersonInsertForm;
   type UpdateForm = PersonUpdateForm;
@@ -155,7 +154,6 @@ impl PersonInsertForm {
   }
 }
 
-#[async_trait]
 impl ApubActor for Person {
   async fn read_from_apub_id(
     pool: &mut DbPool<'_>,
@@ -204,7 +202,6 @@ impl ApubActor for Person {
   }
 }
 
-#[async_trait]
 impl Followable for PersonFollower {
   type Form = PersonFollowerForm;
   async fn follow(pool: &mut DbPool<'_>, form: &PersonFollowerForm) -> Result<Self, Error> {

--- a/crates/db_schema/src/impls/person_block.rs
+++ b/crates/db_schema/src/impls/person_block.rs
@@ -60,7 +60,6 @@ impl PersonBlock {
   }
 }
 
-#[async_trait]
 impl Blockable for PersonBlock {
   type Form = PersonBlockForm;
   async fn block(

--- a/crates/db_schema/src/impls/person_comment_mention.rs
+++ b/crates/db_schema/src/impls/person_comment_mention.rs
@@ -13,7 +13,6 @@ use crate::{
 use diesel::{dsl::insert_into, result::Error, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 
-#[async_trait]
 impl Crud for PersonCommentMention {
   type InsertForm = PersonCommentMentionInsertForm;
   type UpdateForm = PersonCommentMentionUpdateForm;

--- a/crates/db_schema/src/impls/person_post_mention.rs
+++ b/crates/db_schema/src/impls/person_post_mention.rs
@@ -13,7 +13,6 @@ use crate::{
 use diesel::{dsl::insert_into, result::Error, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 
-#[async_trait]
 impl Crud for PersonPostMention {
   type InsertForm = PersonPostMentionInsertForm;
   type UpdateForm = PersonPostMentionUpdateForm;

--- a/crates/db_schema/src/impls/post.rs
+++ b/crates/db_schema/src/impls/post.rs
@@ -46,7 +46,6 @@ use lemmy_utils::{
   settings::structs::Settings,
 };
 
-#[async_trait]
 impl Crud for Post {
   type InsertForm = PostInsertForm;
   type UpdateForm = PostUpdateForm;
@@ -280,7 +279,6 @@ impl Post {
   }
 }
 
-#[async_trait]
 impl Likeable for PostLike {
   type Form = PostLikeForm;
   type IdType = PostId;
@@ -309,7 +307,6 @@ impl Likeable for PostLike {
   }
 }
 
-#[async_trait]
 impl Saveable for PostSaved {
   type Form = PostSavedForm;
   async fn save(pool: &mut DbPool<'_>, post_saved_form: &PostSavedForm) -> Result<Self, Error> {

--- a/crates/db_schema/src/impls/post_report.rs
+++ b/crates/db_schema/src/impls/post_report.rs
@@ -16,7 +16,6 @@ use diesel::{
 use diesel_async::RunQueryDsl;
 use lemmy_utils::error::LemmyResult;
 
-#[async_trait]
 impl Reportable for PostReport {
   type Form = PostReportForm;
   type IdType = PostReportId;

--- a/crates/db_schema/src/impls/private_message.rs
+++ b/crates/db_schema/src/impls/private_message.rs
@@ -12,7 +12,6 @@ use diesel_async::RunQueryDsl;
 use lemmy_utils::{error::LemmyResult, settings::structs::Settings};
 use url::Url;
 
-#[async_trait]
 impl Crud for PrivateMessage {
   type InsertForm = PrivateMessageInsertForm;
   type UpdateForm = PrivateMessageUpdateForm;

--- a/crates/db_schema/src/impls/private_message_report.rs
+++ b/crates/db_schema/src/impls/private_message_report.rs
@@ -15,7 +15,6 @@ use diesel::{
 use diesel_async::RunQueryDsl;
 use lemmy_utils::error::{FederationError, LemmyResult};
 
-#[async_trait]
 impl Reportable for PrivateMessageReport {
   type Form = PrivateMessageReportForm;
   type IdType = PrivateMessageReportId;

--- a/crates/db_schema/src/impls/registration_application.rs
+++ b/crates/db_schema/src/impls/registration_application.rs
@@ -12,7 +12,6 @@ use crate::{
 use diesel::{insert_into, result::Error, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 
-#[async_trait]
 impl Crud for RegistrationApplication {
   type InsertForm = RegistrationApplicationInsertForm;
   type UpdateForm = RegistrationApplicationUpdateForm;

--- a/crates/db_schema/src/impls/site.rs
+++ b/crates/db_schema/src/impls/site.rs
@@ -13,7 +13,6 @@ use diesel_async::RunQueryDsl;
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 use url::Url;
 
-#[async_trait]
 impl Crud for Site {
   type InsertForm = SiteInsertForm;
   type UpdateForm = SiteUpdateForm;

--- a/crates/db_schema/src/impls/tag.rs
+++ b/crates/db_schema/src/impls/tag.rs
@@ -9,7 +9,6 @@ use diesel::{insert_into, result::Error, QueryDsl};
 use diesel_async::RunQueryDsl;
 use lemmy_utils::error::LemmyResult;
 
-#[async_trait]
 impl Crud for Tag {
   type InsertForm = TagInsertForm;
 

--- a/crates/db_schema/src/impls/tagline.rs
+++ b/crates/db_schema/src/impls/tagline.rs
@@ -8,7 +8,6 @@ use crate::{
 use diesel::{insert_into, result::Error, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 
-#[async_trait]
 impl Crud for Tagline {
   type InsertForm = TaglineInsertForm;
   type UpdateForm = TaglineUpdateForm;

--- a/crates/db_schema/src/lib.rs
+++ b/crates/db_schema/src/lib.rs
@@ -9,10 +9,6 @@ extern crate diesel_derive_newtype;
 #[macro_use]
 extern crate diesel_derive_enum;
 
-#[cfg(feature = "full")]
-#[macro_use]
-extern crate async_trait;
-
 pub mod aggregates;
 #[cfg(feature = "full")]
 pub mod impls;
@@ -40,14 +36,10 @@ pub mod utils;
 #[cfg(feature = "full")]
 pub mod schema_setup;
 
-#[cfg(feature = "full")]
-use diesel::query_source::AliasedField;
-#[cfg(feature = "full")]
-use schema::person;
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString};
 #[cfg(feature = "full")]
-use ts_rs::TS;
+use {diesel::query_source::AliasedField, schema::person, ts_rs::TS};
 
 #[derive(
   EnumString, Display, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Default, Hash,

--- a/crates/db_schema/src/traits.rs
+++ b/crates/db_schema/src/traits.rs
@@ -16,6 +16,7 @@ use diesel_async::{
   RunQueryDsl,
 };
 use lemmy_utils::error::LemmyResult;
+use std::future::Future;
 
 /// Returned by `diesel::delete`
 pub type Delete<T> = DeleteStatement<<T as HasTable>::Table, <T as IntoUpdateTarget>::WhereClause>;
@@ -43,12 +44,12 @@ where
   fn create(
     pool: &mut DbPool<'_>,
     form: &Self::InsertForm,
-  ) -> impl std::future::Future<Output = Result<Self, Error>> + Send;
+  ) -> impl Future<Output = Result<Self, Error>> + Send;
 
   fn read(
     pool: &mut DbPool<'_>,
     id: Self::IdType,
-  ) -> impl std::future::Future<Output = Result<Self, Error>> + Send
+  ) -> impl Future<Output = Result<Self, Error>> + Send
   where
     Self: Send,
   {
@@ -65,12 +66,12 @@ where
     pool: &mut DbPool<'_>,
     id: Self::IdType,
     form: &Self::UpdateForm,
-  ) -> impl std::future::Future<Output = Result<Self, Error>> + Send;
+  ) -> impl Future<Output = Result<Self, Error>> + Send;
 
   fn delete(
     pool: &mut DbPool<'_>,
     id: Self::IdType,
-  ) -> impl std::future::Future<Output = Result<usize, Error>> + Send {
+  ) -> impl Future<Output = Result<usize, Error>> + Send {
     async {
       let query: Delete<Find<Self>> = diesel::delete(Self::table().find(id));
       let conn = &mut *get_conn(pool).await?;
@@ -84,20 +85,20 @@ pub trait Followable {
   fn follow(
     pool: &mut DbPool<'_>,
     form: &Self::Form,
-  ) -> impl std::future::Future<Output = Result<Self, Error>> + Send
+  ) -> impl Future<Output = Result<Self, Error>> + Send
   where
     Self: Sized;
   fn follow_accepted(
     pool: &mut DbPool<'_>,
     community_id: CommunityId,
     person_id: PersonId,
-  ) -> impl std::future::Future<Output = Result<Self, Error>> + Send
+  ) -> impl Future<Output = Result<Self, Error>> + Send
   where
     Self: Sized;
   fn unfollow(
     pool: &mut DbPool<'_>,
     form: &Self::Form,
-  ) -> impl std::future::Future<Output = Result<uplete::Count, Error>> + Send
+  ) -> impl Future<Output = Result<uplete::Count, Error>> + Send
   where
     Self: Sized;
 }
@@ -107,13 +108,13 @@ pub trait Joinable {
   fn join(
     pool: &mut DbPool<'_>,
     form: &Self::Form,
-  ) -> impl std::future::Future<Output = Result<Self, Error>> + Send
+  ) -> impl Future<Output = Result<Self, Error>> + Send
   where
     Self: Sized;
   fn leave(
     pool: &mut DbPool<'_>,
     form: &Self::Form,
-  ) -> impl std::future::Future<Output = Result<uplete::Count, Error>> + Send
+  ) -> impl Future<Output = Result<uplete::Count, Error>> + Send
   where
     Self: Sized;
 }
@@ -124,14 +125,14 @@ pub trait Likeable {
   fn like(
     pool: &mut DbPool<'_>,
     form: &Self::Form,
-  ) -> impl std::future::Future<Output = Result<Self, Error>> + Send
+  ) -> impl Future<Output = Result<Self, Error>> + Send
   where
     Self: Sized;
   fn remove(
     pool: &mut DbPool<'_>,
     person_id: PersonId,
     item_id: Self::IdType,
-  ) -> impl std::future::Future<Output = Result<uplete::Count, Error>> + Send
+  ) -> impl Future<Output = Result<uplete::Count, Error>> + Send
   where
     Self: Sized;
 }
@@ -141,13 +142,13 @@ pub trait Bannable {
   fn ban(
     pool: &mut DbPool<'_>,
     form: &Self::Form,
-  ) -> impl std::future::Future<Output = Result<Self, Error>> + Send
+  ) -> impl Future<Output = Result<Self, Error>> + Send
   where
     Self: Sized;
   fn unban(
     pool: &mut DbPool<'_>,
     form: &Self::Form,
-  ) -> impl std::future::Future<Output = Result<uplete::Count, Error>> + Send
+  ) -> impl Future<Output = Result<uplete::Count, Error>> + Send
   where
     Self: Sized;
 }
@@ -157,13 +158,13 @@ pub trait Saveable {
   fn save(
     pool: &mut DbPool<'_>,
     form: &Self::Form,
-  ) -> impl std::future::Future<Output = Result<Self, Error>> + Send
+  ) -> impl Future<Output = Result<Self, Error>> + Send
   where
     Self: Sized;
   fn unsave(
     pool: &mut DbPool<'_>,
     form: &Self::Form,
-  ) -> impl std::future::Future<Output = Result<uplete::Count, Error>> + Send
+  ) -> impl Future<Output = Result<uplete::Count, Error>> + Send
   where
     Self: Sized;
 }
@@ -173,13 +174,13 @@ pub trait Blockable {
   fn block(
     pool: &mut DbPool<'_>,
     form: &Self::Form,
-  ) -> impl std::future::Future<Output = Result<Self, Error>> + Send
+  ) -> impl Future<Output = Result<Self, Error>> + Send
   where
     Self: Sized;
   fn unblock(
     pool: &mut DbPool<'_>,
     form: &Self::Form,
-  ) -> impl std::future::Future<Output = Result<uplete::Count, Error>> + Send
+  ) -> impl Future<Output = Result<uplete::Count, Error>> + Send
   where
     Self: Sized;
 }
@@ -191,14 +192,14 @@ pub trait Reportable {
   fn report(
     pool: &mut DbPool<'_>,
     form: &Self::Form,
-  ) -> impl std::future::Future<Output = Result<Self, Error>> + Send
+  ) -> impl Future<Output = Result<Self, Error>> + Send
   where
     Self: Sized;
   fn resolve(
     pool: &mut DbPool<'_>,
     report_id: Self::IdType,
     resolver_id: PersonId,
-  ) -> impl std::future::Future<Output = Result<usize, Error>> + Send
+  ) -> impl Future<Output = Result<usize, Error>> + Send
   where
     Self: Sized;
   fn resolve_apub(
@@ -206,21 +207,21 @@ pub trait Reportable {
     object_id: Self::ObjectIdType,
     report_creator_id: PersonId,
     resolver_id: PersonId,
-  ) -> impl std::future::Future<Output = LemmyResult<usize>> + Send
+  ) -> impl Future<Output = LemmyResult<usize>> + Send
   where
     Self: Sized;
   fn resolve_all_for_object(
     pool: &mut DbPool<'_>,
     comment_id_: Self::ObjectIdType,
     by_resolver_id: PersonId,
-  ) -> impl std::future::Future<Output = Result<usize, Error>> + Send
+  ) -> impl Future<Output = Result<usize, Error>> + Send
   where
     Self: Sized;
   fn unresolve(
     pool: &mut DbPool<'_>,
     report_id: Self::IdType,
     resolver_id: PersonId,
-  ) -> impl std::future::Future<Output = Result<usize, Error>> + Send
+  ) -> impl Future<Output = Result<usize, Error>> + Send
   where
     Self: Sized;
 }
@@ -229,7 +230,7 @@ pub trait ApubActor {
   fn read_from_apub_id(
     pool: &mut DbPool<'_>,
     object_id: &DbUrl,
-  ) -> impl std::future::Future<Output = Result<Option<Self>, Error>> + Send
+  ) -> impl Future<Output = Result<Option<Self>, Error>> + Send
   where
     Self: Sized;
   /// - actor_name is the name of the community or user to read.
@@ -238,14 +239,14 @@ pub trait ApubActor {
     pool: &mut DbPool<'_>,
     actor_name: &str,
     include_deleted: bool,
-  ) -> impl std::future::Future<Output = Result<Option<Self>, Error>> + Send
+  ) -> impl Future<Output = Result<Option<Self>, Error>> + Send
   where
     Self: Sized;
   fn read_from_name_and_domain(
     pool: &mut DbPool<'_>,
     actor_name: &str,
     protocol_domain: &str,
-  ) -> impl std::future::Future<Output = Result<Option<Self>, Error>> + Send
+  ) -> impl Future<Output = Result<Option<Self>, Error>> + Send
   where
     Self: Sized;
 }

--- a/crates/db_schema/src/traits.rs
+++ b/crates/db_schema/src/traits.rs
@@ -27,7 +27,6 @@ pub type PrimaryKey<T> = <<T as HasTable>::Table as Table>::PrimaryKey;
 
 // Trying to create default implementations for `create` and `update` results in a lifetime mess and
 // weird compile errors. https://github.com/rust-lang/rust/issues/102211
-#[async_trait]
 pub trait Crud: HasTable + Sized
 where
   Self::Table: FindDsl<Self::IdType>,
@@ -41,168 +40,212 @@ where
   type UpdateForm;
   type IdType: Send;
 
-  async fn create(pool: &mut DbPool<'_>, form: &Self::InsertForm) -> Result<Self, Error>;
+  fn create(
+    pool: &mut DbPool<'_>,
+    form: &Self::InsertForm,
+  ) -> impl std::future::Future<Output = Result<Self, Error>> + Send;
 
-  async fn read(pool: &mut DbPool<'_>, id: Self::IdType) -> Result<Self, Error> {
-    let query: Find<Self> = Self::table().find(id);
-    let conn = &mut *get_conn(pool).await?;
-    query.first(conn).await
+  fn read(
+    pool: &mut DbPool<'_>,
+    id: Self::IdType,
+  ) -> impl std::future::Future<Output = Result<Self, Error>> + Send
+  where
+    Self: Send,
+  {
+    async {
+      let query: Find<Self> = Self::table().find(id);
+      let conn = &mut *get_conn(pool).await?;
+      query.first(conn).await
+    }
   }
 
   /// when you want to null out a column, you have to send Some(None)), since sending None means you
   /// just don't want to update that column.
-  async fn update(
+  fn update(
     pool: &mut DbPool<'_>,
     id: Self::IdType,
     form: &Self::UpdateForm,
-  ) -> Result<Self, Error>;
+  ) -> impl std::future::Future<Output = Result<Self, Error>> + Send;
 
-  async fn delete(pool: &mut DbPool<'_>, id: Self::IdType) -> Result<usize, Error> {
-    let query: Delete<Find<Self>> = diesel::delete(Self::table().find(id));
-    let conn = &mut *get_conn(pool).await?;
-    query.execute(conn).await
+  fn delete(
+    pool: &mut DbPool<'_>,
+    id: Self::IdType,
+  ) -> impl std::future::Future<Output = Result<usize, Error>> + Send {
+    async {
+      let query: Delete<Find<Self>> = diesel::delete(Self::table().find(id));
+      let conn = &mut *get_conn(pool).await?;
+      query.execute(conn).await
+    }
   }
 }
 
-#[async_trait]
 pub trait Followable {
   type Form;
-  async fn follow(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<Self, Error>
+  fn follow(
+    pool: &mut DbPool<'_>,
+    form: &Self::Form,
+  ) -> impl std::future::Future<Output = Result<Self, Error>> + Send
   where
     Self: Sized;
-  async fn follow_accepted(
+  fn follow_accepted(
     pool: &mut DbPool<'_>,
     community_id: CommunityId,
     person_id: PersonId,
-  ) -> Result<Self, Error>
+  ) -> impl std::future::Future<Output = Result<Self, Error>> + Send
   where
     Self: Sized;
-  async fn unfollow(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<uplete::Count, Error>
+  fn unfollow(
+    pool: &mut DbPool<'_>,
+    form: &Self::Form,
+  ) -> impl std::future::Future<Output = Result<uplete::Count, Error>> + Send
   where
     Self: Sized;
 }
 
-#[async_trait]
 pub trait Joinable {
   type Form;
-  async fn join(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<Self, Error>
+  fn join(
+    pool: &mut DbPool<'_>,
+    form: &Self::Form,
+  ) -> impl std::future::Future<Output = Result<Self, Error>> + Send
   where
     Self: Sized;
-  async fn leave(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<uplete::Count, Error>
+  fn leave(
+    pool: &mut DbPool<'_>,
+    form: &Self::Form,
+  ) -> impl std::future::Future<Output = Result<uplete::Count, Error>> + Send
   where
     Self: Sized;
 }
 
-#[async_trait]
 pub trait Likeable {
   type Form;
   type IdType;
-  async fn like(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<Self, Error>
+  fn like(
+    pool: &mut DbPool<'_>,
+    form: &Self::Form,
+  ) -> impl std::future::Future<Output = Result<Self, Error>> + Send
   where
     Self: Sized;
-  async fn remove(
+  fn remove(
     pool: &mut DbPool<'_>,
     person_id: PersonId,
     item_id: Self::IdType,
-  ) -> Result<uplete::Count, Error>
+  ) -> impl std::future::Future<Output = Result<uplete::Count, Error>> + Send
   where
     Self: Sized;
 }
 
-#[async_trait]
 pub trait Bannable {
   type Form;
-  async fn ban(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<Self, Error>
+  fn ban(
+    pool: &mut DbPool<'_>,
+    form: &Self::Form,
+  ) -> impl std::future::Future<Output = Result<Self, Error>> + Send
   where
     Self: Sized;
-  async fn unban(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<uplete::Count, Error>
+  fn unban(
+    pool: &mut DbPool<'_>,
+    form: &Self::Form,
+  ) -> impl std::future::Future<Output = Result<uplete::Count, Error>> + Send
   where
     Self: Sized;
 }
 
-#[async_trait]
 pub trait Saveable {
   type Form;
-  async fn save(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<Self, Error>
+  fn save(
+    pool: &mut DbPool<'_>,
+    form: &Self::Form,
+  ) -> impl std::future::Future<Output = Result<Self, Error>> + Send
   where
     Self: Sized;
-  async fn unsave(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<uplete::Count, Error>
+  fn unsave(
+    pool: &mut DbPool<'_>,
+    form: &Self::Form,
+  ) -> impl std::future::Future<Output = Result<uplete::Count, Error>> + Send
   where
     Self: Sized;
 }
 
-#[async_trait]
 pub trait Blockable {
   type Form;
-  async fn block(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<Self, Error>
+  fn block(
+    pool: &mut DbPool<'_>,
+    form: &Self::Form,
+  ) -> impl std::future::Future<Output = Result<Self, Error>> + Send
   where
     Self: Sized;
-  async fn unblock(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<uplete::Count, Error>
+  fn unblock(
+    pool: &mut DbPool<'_>,
+    form: &Self::Form,
+  ) -> impl std::future::Future<Output = Result<uplete::Count, Error>> + Send
   where
     Self: Sized;
 }
 
-#[async_trait]
 pub trait Reportable {
   type Form;
   type IdType;
   type ObjectIdType;
-  async fn report(pool: &mut DbPool<'_>, form: &Self::Form) -> Result<Self, Error>
+  fn report(
+    pool: &mut DbPool<'_>,
+    form: &Self::Form,
+  ) -> impl std::future::Future<Output = Result<Self, Error>> + Send
   where
     Self: Sized;
-  async fn resolve(
+  fn resolve(
     pool: &mut DbPool<'_>,
     report_id: Self::IdType,
     resolver_id: PersonId,
-  ) -> Result<usize, Error>
+  ) -> impl std::future::Future<Output = Result<usize, Error>> + Send
   where
     Self: Sized;
-  async fn resolve_apub(
+  fn resolve_apub(
     pool: &mut DbPool<'_>,
     object_id: Self::ObjectIdType,
     report_creator_id: PersonId,
     resolver_id: PersonId,
-  ) -> LemmyResult<usize>
+  ) -> impl std::future::Future<Output = LemmyResult<usize>> + Send
   where
     Self: Sized;
-  async fn resolve_all_for_object(
+  fn resolve_all_for_object(
     pool: &mut DbPool<'_>,
     comment_id_: Self::ObjectIdType,
     by_resolver_id: PersonId,
-  ) -> Result<usize, Error>
+  ) -> impl std::future::Future<Output = Result<usize, Error>> + Send
   where
     Self: Sized;
-  async fn unresolve(
+  fn unresolve(
     pool: &mut DbPool<'_>,
     report_id: Self::IdType,
     resolver_id: PersonId,
-  ) -> Result<usize, Error>
+  ) -> impl std::future::Future<Output = Result<usize, Error>> + Send
   where
     Self: Sized;
 }
 
-#[async_trait]
 pub trait ApubActor {
-  async fn read_from_apub_id(
+  fn read_from_apub_id(
     pool: &mut DbPool<'_>,
     object_id: &DbUrl,
-  ) -> Result<Option<Self>, Error>
+  ) -> impl std::future::Future<Output = Result<Option<Self>, Error>> + Send
   where
     Self: Sized;
   /// - actor_name is the name of the community or user to read.
   /// - include_deleted, if true, will return communities or users that were deleted/removed
-  async fn read_from_name(
+  fn read_from_name(
     pool: &mut DbPool<'_>,
     actor_name: &str,
     include_deleted: bool,
-  ) -> Result<Option<Self>, Error>
+  ) -> impl std::future::Future<Output = Result<Option<Self>, Error>> + Send
   where
     Self: Sized;
-  async fn read_from_name_and_domain(
+  fn read_from_name_and_domain(
     pool: &mut DbPool<'_>,
     actor_name: &str,
     protocol_domain: &str,
-  ) -> Result<Option<Self>, Error>
+  ) -> impl std::future::Future<Output = Result<Option<Self>, Error>> + Send
   where
     Self: Sized;
 }

--- a/crates/federate/Cargo.toml
+++ b/crates/federate/Cargo.toml
@@ -33,7 +33,6 @@ tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
 moka.workspace = true
 tokio-util = "0.7.13"
-async-trait.workspace = true
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/crates/federate/src/inboxes.rs
+++ b/crates/federate/src/inboxes.rs
@@ -1,5 +1,4 @@
 use crate::util::LEMMY_TEST_FAST_FEDERATION;
-use async_trait::async_trait;
 use chrono::{DateTime, TimeZone, Utc};
 use lemmy_db_schema::{
   newtypes::{CommunityId, DbUrl, InstanceId},
@@ -38,7 +37,6 @@ static FOLLOW_ADDITIONS_RECHECK_DELAY: LazyLock<chrono::TimeDelta> = LazyLock::n
 static FOLLOW_REMOVALS_RECHECK_DELAY: LazyLock<chrono::TimeDelta> =
   LazyLock::new(|| chrono::TimeDelta::try_hours(1).expect("TimeDelta out of bounds"));
 
-#[async_trait]
 pub trait DataSource: Send + Sync {
   async fn read_site_from_instance_id(&self, instance_id: InstanceId) -> LemmyResult<Site>;
   async fn get_instance_followed_community_inboxes(
@@ -57,7 +55,6 @@ impl DbDataSource {
   }
 }
 
-#[async_trait]
 impl DataSource for DbDataSource {
   async fn read_site_from_instance_id(&self, instance_id: InstanceId) -> LemmyResult<Site> {
     Site::read_from_instance_id(&mut DbPool::Pool(&self.pool), instance_id).await
@@ -231,7 +228,6 @@ mod tests {
   use serde_json::json;
   mock! {
       DataSource {}
-      #[async_trait]
       impl DataSource for DataSource {
           async fn read_site_from_instance_id(&self, instance_id: InstanceId) -> LemmyResult<Site>;
           async fn get_instance_followed_community_inboxes(


### PR DESCRIPTION
There is a lot of unnecessary usage of async_trait which can be replaced with [standard Rust functionality](https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html). This is preferable as less macro usage means faster compilation, and it uses static dispatch (meaning it chooses at compile time which code to execute, unlike async_trait macro which decides at runtime). However the trait definition is a little more verbose as it cannot use `async fn` but use fn with `-> impl Future`.