### PR TITLE
Upgrade to edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace.package]
 version = "1.0.0-alpha.0"
-edition = "2021"
+edition = "2024"
 description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
 homepage = "https://join-lemmy.org/"

--- a/crates/api/src/local_user/get_captcha.rs
+++ b/crates/api/src/local_user/get_captcha.rs
@@ -8,7 +8,7 @@ use actix_web::{
   HttpResponse,
   HttpResponseBuilder,
 };
-use captcha::{gen, Difficulty};
+use captcha::{r#gen as generate, Difficulty};
 use lemmy_api_common::{
   context::LemmyContext,
   person::{CaptchaResponse, GetCaptchaResponse},
@@ -29,7 +29,7 @@ pub async fn get_captcha(context: Data<LemmyContext>) -> LemmyResult<HttpRespons
     return Ok(res.json(Json(GetCaptchaResponse { ok: None })));
   }
 
-  let captcha = gen(match local_site.captcha_difficulty.as_str() {
+  let captcha = generate(match local_site.captcha_difficulty.as_str() {
     "easy" => Difficulty::Easy,
     "hard" => Difficulty::Hard,
     _ => Difficulty::Medium,


### PR DESCRIPTION
https://blog.rust-lang.org/2025/02/20/Rust-1.85.0.html

Wanted to see how easy or hard this it, and it turned out very simple. Only problem was `gen` being used as function name by a library which is a reserved keyword now (https://github.com/daniel-e/captcha/issues/30). There are also many [formatting changes](https://doc.rust-lang.org/edition-guide/rust-2024/rustfmt-formatting-fixes.html), with imports got reordered and multiple lines merged into one. I havent included those in the PR yet to avoid conflicts so CI is currently failing.

This requires Rust 1.85 so lets wait a while before merging.