### PR TITLE
Fix triggers in remove aggregates tables pr

### DIFF
--- a/crates/db_schema/replaceable_schema/triggers.sql
+++ b/crates/db_schema/replaceable_schema/triggers.sql
@@ -164,7 +164,7 @@ FROM (
         AND post.published > ((comment).published - '2 days'::interval)) AS newest_comment_time_necro
 FROM
     select_old_and_new_rows AS old_and_new_rows
-        LEFT JOIN post ON post.id = (comment).post_id
+    LEFT JOIN post ON post.id = (comment).post_id
 WHERE
     r.is_counted (comment)
 GROUP BY

--- a/crates/db_schema/replaceable_schema/triggers.sql
+++ b/crates/db_schema/replaceable_schema/triggers.sql
@@ -418,14 +418,6 @@ BEGIN
     IF NEW.local THEN
         NEW.ap_id = coalesce(NEW.ap_id, r.local_url ('/comment/' || id));
     END IF;
-    -- Set community_id
-    NEW.community_id = (
-        SELECT
-            post.community_id
-        FROM
-            post
-        WHERE
-            post.id = NEW.post_id);
     RETURN NEW;
 END
 $$;

--- a/crates/db_schema/replaceable_schema/triggers.sql
+++ b/crates/db_schema/replaceable_schema/triggers.sql
@@ -300,11 +300,6 @@ END;
 
 $$);
 
-CREATE TRIGGER comment_count
-    AFTER UPDATE ON post REFERENCING OLD TABLE AS old_post NEW TABLE AS new_post
-    FOR EACH STATEMENT
-    EXECUTE FUNCTION r.update_comment_count_from_post ();
-
 -- Count subscribers for communities.
 -- subscribers should be updated only when a local community is followed by a local or remote person.
 -- subscribers_local should be updated only when a local person follows a local or remote community.

--- a/crates/db_schema/replaceable_schema/triggers.sql
+++ b/crates/db_schema/replaceable_schema/triggers.sql
@@ -27,53 +27,28 @@ BEGIN
         -- When a thing gets a vote, update its aggregates and its creator's aggregates
         CALL r.create_triggers ('thing_actions', $$
             BEGIN
-                /*IF (
-                    SELECT
-                        count(*)
-                FROM select_old_and_new_rows) = 0 THEN
-                    RETURN NULL;
-                END IF;*/
-                WITH thing_diff AS (
-                    UPDATE
+                WITH thing_diff AS ( UPDATE
                         thing AS a
                     SET
-                        score = a.score + diff.upvotes - diff.downvotes,
-                        upvotes = a.upvotes + diff.upvotes,
-                        downvotes = a.downvotes + diff.downvotes,
-                        controversy_rank = r.controversy_rank ((a.upvotes + diff.upvotes)::numeric, (a.downvotes + diff.downvotes)::numeric)
+                        score = a.score + diff.upvotes - diff.downvotes, upvotes = a.upvotes + diff.upvotes, downvotes = a.downvotes + diff.downvotes, controversy_rank = r.controversy_rank ((a.upvotes + diff.upvotes)::numeric, (a.downvotes + diff.downvotes)::numeric)
                     FROM (
                         SELECT
-                            (thing_actions).thing_id,
-                            coalesce(sum(count_diff) FILTER (WHERE (thing_actions).like_score = 1), 0) AS upvotes,
-                            coalesce(sum(count_diff) FILTER (WHERE (thing_actions).like_score != 1), 0) AS downvotes
-                        FROM
-                            select_old_and_new_rows AS old_and_new_rows
-                        WHERE (thing_actions).like_score IS NOT NULL
-                    GROUP BY
-                        (thing_actions).thing_id) AS diff
-                WHERE
-                    a.id = diff.thing_id
-                    AND (diff.upvotes,
-                        diff.downvotes) != (0,
-                        0)
+                            (thing_actions).thing_id, coalesce(sum(count_diff) FILTER (WHERE (thing_actions).like_score = 1), 0) AS upvotes, coalesce(sum(count_diff) FILTER (WHERE (thing_actions).like_score != 1), 0) AS downvotes FROM select_old_and_new_rows AS old_and_new_rows
+                WHERE (thing_actions).like_score IS NOT NULL GROUP BY (thing_actions).thing_id) AS diff
+            WHERE
+                a.id = diff.thing_id
+                    AND (diff.upvotes, diff.downvotes) != (0, 0)
                 RETURNING
-                    a.creator_id AS creator_id,
-                    diff.upvotes - diff.downvotes AS score)
-        UPDATE
-            person AS a
-        SET
-            thing_score = a.thing_score + diff.score
-        FROM (
-            SELECT
-                creator_id,
-                sum(score) AS score
-            FROM
-                thing_diff
-            GROUP BY
-                creator_id) AS diff
-    WHERE
-        a.id = diff.creator_id
-        AND diff.score != 0;
+                    a.creator_id AS creator_id, diff.upvotes - diff.downvotes AS score)
+            UPDATE
+                person AS a
+            SET
+                thing_score = a.thing_score + diff.score FROM (
+                    SELECT
+                        creator_id, sum(score) AS score FROM thing_diff GROUP BY creator_id) AS diff
+                WHERE
+                    a.id = diff.creator_id
+                    AND diff.score != 0;
                 RETURN NULL;
             END;
     $$);
@@ -109,8 +84,7 @@ BEGIN
     IF (
         SELECT
             count(*)
-FROM
-    select_old_and_new_rows) = 0 THEN
+    FROM select_old_and_new_rows) = 0 THEN
         RETURN NULL;
 
 END IF;
@@ -172,54 +146,36 @@ WHERE
     AND diff.child_count != 0;
 
 UPDATE
-        post AS a
-    SET
-        comments = a.comments + diff.comments,
-        newest_comment_time = GREATEST (a.newest_comment_time, diff.newest_comment_time),
-        newest_comment_time_necro = GREATEST (a.newest_comment_time_necro, diff.newest_comment_time_necro)
-    FROM (
-        SELECT
-            post.id AS post_id,
-            coalesce(sum(count_diff), 0) AS comments,
-            -- Old rows are excluded using `count_diff = 1`
-            max((comment).published) FILTER (WHERE count_diff = 1) AS newest_comment_time,
-            max((comment).published) FILTER (WHERE count_diff = 1
-                -- Ignore comments from the post's creator
-                AND post.creator_id != (comment).creator_id
-            -- Ignore comments on old posts
-            AND post.published > ((comment).published - '2 days'::interval)) AS newest_comment_time_necro
-    FROM
-        select_old_and_new_rows AS old_and_new_rows
-        INNER JOIN post ON post.id = (comment).post_id
-    WHERE
-        r.is_counted (comment)
-    GROUP BY
-        post.id) AS diff
-    WHERE
-        a.id = diff.post_id
-        AND (diff.comments,
-            GREATEST (a.newest_comment_time, diff.newest_comment_time),
-            GREATEST (a.newest_comment_time_necro, diff.newest_comment_time_necro)) != (0,
-            a.newest_comment_time,
-            a.newest_comment_time_necro);
-/*UPDATE
-    community AS a
+    post AS a
 SET
-    comments = a.comments + diff.comments
+    comments = a.comments + diff.comments,
+    newest_comment_time = GREATEST (a.newest_comment_time, diff.newest_comment_time),
+    newest_comment_time_necro = GREATEST (a.newest_comment_time_necro, diff.newest_comment_time_necro)
 FROM (
     SELECT
-        (comment).community_id,
-        coalesce(sum(count_diff), 0) AS comments
-    FROM
-        select_old_and_new_rows AS old_and_new_rows
+        post.id AS post_id,
+        coalesce(sum(count_diff), 0) AS comments,
+        -- Old rows are excluded using `count_diff = 1`
+        max((comment).published) FILTER (WHERE count_diff = 1) AS newest_comment_time,
+        max((comment).published) FILTER (WHERE count_diff = 1
+            -- Ignore comments from the post's creator
+            AND post.creator_id != (comment).creator_id
+        -- Ignore comments on old posts
+        AND post.published > ((comment).published - '2 days'::interval)) AS newest_comment_time_necro
+FROM
+    select_old_and_new_rows AS old_and_new_rows
         LEFT JOIN post ON post.id = (comment).post_id
-    WHERE
-        r.is_counted (comment) AND r.is_counted (post.*)
-    GROUP BY
-        (comment).community_id) AS diff
 WHERE
-    a.id = diff.community_id
-    AND diff.comments != 0;*/
+    r.is_counted (comment)
+GROUP BY
+    post.id) AS diff
+WHERE
+    a.id = diff.post_id
+    AND (diff.comments,
+        GREATEST (a.newest_comment_time, diff.newest_comment_time),
+        GREATEST (a.newest_comment_time_necro, diff.newest_comment_time_necro)) != (0,
+        a.newest_comment_time,
+        a.newest_comment_time_necro);
 
 UPDATE
     local_site AS a
@@ -244,32 +200,20 @@ $$);
 
 CALL r.create_triggers ('post', $$
 BEGIN
-    /*IF (
+    UPDATE
+        person AS a
+    SET
+        post_count = a.post_count + diff.post_count
+    FROM (
         SELECT
-            count(*)
-FROM
-    select_old_and_new_rows) = 0 THEN
-        RETURN NULL;
-
-END IF;*/
-
-UPDATE
-    person AS a
-SET
-    post_count = a.post_count + diff.post_count
-FROM (
-    SELECT
-        (post).creator_id,
-        coalesce(sum(count_diff), 0) AS post_count
-    FROM
-        select_old_and_new_rows AS old_and_new_rows
-    WHERE
-        r.is_counted (post)
-    GROUP BY
-        (post).creator_id) AS diff
+            (post).creator_id, coalesce(sum(count_diff), 0) AS post_count
+        FROM select_old_and_new_rows AS old_and_new_rows
+        WHERE
+            r.is_counted (post)
+        GROUP BY (post).creator_id) AS diff
 WHERE
     a.id = diff.creator_id
-    AND diff.post_count != 0;
+        AND diff.post_count != 0;
 
 UPDATE
     community AS a
@@ -289,7 +233,9 @@ FROM (
         (post).community_id) AS diff
 WHERE
     a.id = diff.community_id
-    AND (diff.posts, diff.comments) != (0, 0);
+    AND (diff.posts,
+        diff.comments) != (0,
+        0);
 
 UPDATE
     local_site AS a
@@ -314,27 +260,17 @@ $$);
 
 CALL r.create_triggers ('community', $$
 BEGIN
-    /*IF (
+    UPDATE
+        local_site AS a
+    SET
+        communities = a.communities + diff.communities
+    FROM (
         SELECT
-            count(*)
-FROM
-    select_old_and_new_rows) = 0 THEN
-        RETURN NULL;
-
-END IF;*/
-
-UPDATE
-    local_site AS a
-SET
-    communities = a.communities + diff.communities
-FROM (
-    SELECT
-        coalesce(sum(count_diff), 0) AS communities
-    FROM
-        select_old_and_new_rows AS old_and_new_rows
-    WHERE
-        r.is_counted (community)
-        AND (community).local) AS diff
+            coalesce(sum(count_diff), 0) AS communities
+        FROM select_old_and_new_rows AS old_and_new_rows
+        WHERE
+            r.is_counted (community)
+            AND (community).local) AS diff
 WHERE
     diff.communities != 0;
 
@@ -346,25 +282,15 @@ $$);
 
 CALL r.create_triggers ('person', $$
 BEGIN
-    /*IF (
+    UPDATE
+        local_site AS a
+    SET
+        users = a.users + diff.users
+    FROM (
         SELECT
-            count(*)
-FROM
-    select_old_and_new_rows) = 0 THEN
-        RETURN NULL;
-
-END IF;*/
-
-UPDATE
-    local_site AS a
-SET
-    users = a.users + diff.users
-FROM (
-    SELECT
-        coalesce(sum(count_diff), 0) AS users
-    FROM
-        select_old_and_new_rows AS old_and_new_rows
-    WHERE (person).local) AS diff
+            coalesce(sum(count_diff), 0) AS users
+        FROM select_old_and_new_rows AS old_and_new_rows
+        WHERE (person).local) AS diff
 WHERE
     diff.users != 0;
 
@@ -374,80 +300,31 @@ END;
 
 $$);
 
--- For community.comments, don't include comments of deleted or removed posts
-/*CREATE FUNCTION r.update_comment_count_from_post ()
-    RETURNS TRIGGER
-    LANGUAGE plpgsql
-    AS $$
-BEGIN
-    UPDATE
-        community AS a
-    SET
-        comments = a.comments + diff.comments
-    FROM (
-        SELECT
-            old_post.community_id,
-            sum((
-                CASE WHEN r.is_counted (new_post.*) THEN
-                    1
-                ELSE
-                    -1
-                END) * post.comments) AS comments
-        FROM
-            new_post
-            INNER JOIN old_post ON new_post.id = old_post.id
-                AND (r.is_counted (new_post.*) != r.is_counted (old_post.*))
-                INNER JOIN post ON post.id = new_post.id
-            GROUP BY
-                old_post.community_id) AS diff
-WHERE
-    a.id = diff.community_id
-        AND diff.comments != 0;
-    RETURN NULL;
-END;
-$$;
-
 CREATE TRIGGER comment_count
     AFTER UPDATE ON post REFERENCING OLD TABLE AS old_post NEW TABLE AS new_post
     FOR EACH STATEMENT
-    EXECUTE FUNCTION r.update_comment_count_from_post ();*/
+    EXECUTE FUNCTION r.update_comment_count_from_post ();
 
+/
 -- Count subscribers for communities.
 -- subscribers should be updated only when a local community is followed by a local or remote person.
 -- subscribers_local should be updated only when a local person follows a local or remote community.
 CALL r.create_triggers ('community_actions', $$
 BEGIN
-    /*IF (
+    UPDATE
+        community AS a
+    SET
+        subscribers = a.subscribers + diff.subscribers, subscribers_local = a.subscribers_local + diff.subscribers_local
+    FROM (
         SELECT
-            count(*)
-FROM
-    select_old_and_new_rows) = 0 THEN
-        RETURN NULL;
-
-END IF;*/
-
-UPDATE
-    community AS a
-SET
-    subscribers = a.subscribers + diff.subscribers,
-    subscribers_local = a.subscribers_local + diff.subscribers_local
-FROM (
-    SELECT
-        (community_actions).community_id,
-        coalesce(sum(count_diff) FILTER (WHERE community.local), 0) AS subscribers,
-        coalesce(sum(count_diff) FILTER (WHERE person.local), 0) AS subscribers_local
-    FROM
-        select_old_and_new_rows AS old_and_new_rows
+            (community_actions).community_id, coalesce(sum(count_diff) FILTER (WHERE community.local), 0) AS subscribers, coalesce(sum(count_diff) FILTER (WHERE person.local), 0) AS subscribers_local
+        FROM select_old_and_new_rows AS old_and_new_rows
     LEFT JOIN community ON community.id = (community_actions).community_id
     LEFT JOIN person ON person.id = (community_actions).person_id
-WHERE (community_actions).followed IS NOT NULL
-GROUP BY
-    (community_actions).community_id) AS diff
+    WHERE (community_actions).followed IS NOT NULL GROUP BY (community_actions).community_id) AS diff
 WHERE
     a.id = diff.community_id
-    AND (diff.subscribers,
-        diff.subscribers_local) != (0,
-        0);
+        AND (diff.subscribers, diff.subscribers_local) != (0, 0);
 
 RETURN NULL;
 
@@ -457,32 +334,17 @@ $$);
 
 CALL r.create_triggers ('post_report', $$
 BEGIN
-    /*IF (
+    UPDATE
+        post AS a
+    SET
+        report_count = a.report_count + diff.report_count, unresolved_report_count = a.unresolved_report_count + diff.unresolved_report_count
+    FROM (
         SELECT
-            count(*)
-FROM
-    select_old_and_new_rows) = 0 THEN
-        RETURN NULL;
-
-END IF;*/
-
-UPDATE
-    post AS a
-SET
-    report_count = a.report_count + diff.report_count,
-    unresolved_report_count = a.unresolved_report_count + diff.unresolved_report_count
-FROM (
-    SELECT
-        (post_report).post_id,
-        coalesce(sum(count_diff), 0) AS report_count,
-        coalesce(sum(count_diff) FILTER (WHERE NOT (post_report).resolved
-            AND NOT (post_report).violates_instance_rules), 0) AS unresolved_report_count
-    FROM
-        select_old_and_new_rows AS old_and_new_rows
-    GROUP BY
-        (post_report).post_id) AS diff
+            (post_report).post_id, coalesce(sum(count_diff), 0) AS report_count, coalesce(sum(count_diff) FILTER (WHERE NOT (post_report).resolved
+                AND NOT (post_report).violates_instance_rules), 0) AS unresolved_report_count
+FROM select_old_and_new_rows AS old_and_new_rows GROUP BY (post_report).post_id) AS diff
 WHERE (diff.report_count, diff.unresolved_report_count) != (0, 0)
-    AND a.id = diff.post_id;
+AND a.id = diff.post_id;
 
 RETURN NULL;
 
@@ -492,32 +354,17 @@ $$);
 
 CALL r.create_triggers ('comment_report', $$
 BEGIN
-    /*IF (
+    UPDATE
+        comment AS a
+    SET
+        report_count = a.report_count + diff.report_count, unresolved_report_count = a.unresolved_report_count + diff.unresolved_report_count
+    FROM (
         SELECT
-            count(*)
-FROM
-    select_old_and_new_rows) = 0 THEN
-        RETURN NULL;
-
-END IF;*/
-
-UPDATE
-    comment AS a
-SET
-    report_count = a.report_count + diff.report_count,
-    unresolved_report_count = a.unresolved_report_count + diff.unresolved_report_count
-FROM (
-    SELECT
-        (comment_report).comment_id,
-        coalesce(sum(count_diff), 0) AS report_count,
-        coalesce(sum(count_diff) FILTER (WHERE NOT (comment_report).resolved
-            AND NOT (comment_report).violates_instance_rules), 0) AS unresolved_report_count
-    FROM
-        select_old_and_new_rows AS old_and_new_rows
-    GROUP BY
-        (comment_report).comment_id) AS diff
+            (comment_report).comment_id, coalesce(sum(count_diff), 0) AS report_count, coalesce(sum(count_diff) FILTER (WHERE NOT (comment_report).resolved
+                AND NOT (comment_report).violates_instance_rules), 0) AS unresolved_report_count
+FROM select_old_and_new_rows AS old_and_new_rows GROUP BY (comment_report).comment_id) AS diff
 WHERE (diff.report_count, diff.unresolved_report_count) != (0, 0)
-    AND a.id = diff.comment_id;
+AND a.id = diff.comment_id;
 
 RETURN NULL;
 
@@ -527,29 +374,14 @@ $$);
 
 CALL r.create_triggers ('community_report', $$
 BEGIN
-    /*IF (
+    UPDATE
+        community AS a
+    SET
+        report_count = a.report_count + diff.report_count, unresolved_report_count = a.unresolved_report_count + diff.unresolved_report_count
+    FROM (
         SELECT
-            count(*)
-FROM
-    select_old_and_new_rows) = 0 THEN
-        RETURN NULL;
-
-END IF;*/
-
-UPDATE
-    community AS a
-SET
-    report_count = a.report_count + diff.report_count,
-    unresolved_report_count = a.unresolved_report_count + diff.unresolved_report_count
-FROM (
-    SELECT
-        (community_report).community_id,
-        coalesce(sum(count_diff), 0) AS report_count,
-        coalesce(sum(count_diff) FILTER (WHERE NOT (community_report).resolved), 0) AS unresolved_report_count
-    FROM
-        select_old_and_new_rows AS old_and_new_rows
-    GROUP BY
-        (community_report).community_id) AS diff
+            (community_report).community_id, coalesce(sum(count_diff), 0) AS report_count, coalesce(sum(count_diff) FILTER (WHERE NOT (community_report).resolved), 0) AS unresolved_report_count
+    FROM select_old_and_new_rows AS old_and_new_rows GROUP BY (community_report).community_id) AS diff
 WHERE (diff.report_count, diff.unresolved_report_count) != (0, 0)
     AND a.id = diff.community_id;
 
@@ -560,24 +392,6 @@ END;
 $$);
 
 -- Change the order of some cascading deletions to make deletion triggers run before the deletion of rows that the triggers need to read
-/*CREATE FUNCTION r.delete_comments_before_post ()
-    RETURNS TRIGGER
-    LANGUAGE plpgsql
-    AS $$
-BEGIN
-    DELETE FROM comment AS c
-    WHERE c.post_id = OLD.id;
-    if FOUND then
-    delete from post where id = OLD.id;
-    RETURN NULL; end if; return (SELECT row(post.*) FROM post WHERE id = OLD.id);
-END;
-$$;
-
-CREATE TRIGGER delete_comments
-    BEFORE DELETE ON post
-    FOR EACH ROW
-    EXECUTE FUNCTION r.delete_comments_before_post ();*/
-
 CREATE FUNCTION r.delete_follow_before_person ()
     RETURNS TRIGGER
     LANGUAGE plpgsql
@@ -585,9 +399,7 @@ CREATE FUNCTION r.delete_follow_before_person ()
 BEGIN
     DELETE FROM community_actions AS c
     WHERE c.person_id = OLD.id;
-    /*if FOUND then
-    DELETE from person where id = OLD.id;
-    RETURN NULL; end if;*/ return OLD;
+    RETURN OLD;
 END;
 $$;
 
@@ -595,22 +407,6 @@ CREATE TRIGGER delete_follow
     BEFORE DELETE ON person
     FOR EACH ROW
     EXECUTE FUNCTION r.delete_follow_before_person ();
-
-/*CREATE FUNCTION r.delete_community_before_instance ()
-    RETURNS TRIGGER
-    LANGUAGE plpgsql
-    AS $$
-BEGIN
-    DELETE FROM community AS c
-    WHERE c.instance_id = OLD.id;
-    RETURN NULL;
-END;
-$$;
-
-CREATE TRIGGER delete_community
-    BEFORE DELETE ON instance
-    FOR EACH ROW
-    EXECUTE FUNCTION r.delete_community_before_instance ();*/
 
 -- Triggers that change values before insert or update
 CREATE FUNCTION r.comment_change_values ()
@@ -629,7 +425,13 @@ BEGIN
         NEW.ap_id = coalesce(NEW.ap_id, r.local_url ('/comment/' || id));
     END IF;
     -- Set community_id
-    NEW.community_id = (SELECT post.community_id FROM post WHERE post.id = NEW.post_id);
+    NEW.community_id = (
+        SELECT
+            post.community_id
+        FROM
+            post
+        WHERE
+            post.id = NEW.post_id);
     RETURN NEW;
 END
 $$;
@@ -651,7 +453,13 @@ BEGIN
     -- Set aggregates
     NEW.newest_comment_time = NEW.published;
     NEW.newest_comment_time_necro = NEW.published;
-    NEW.instance_id = (SELECT community.instance_id FROM community WHERE community.id = NEW.community_id);
+    NEW.instance_id = (
+        SELECT
+            community.instance_id
+        FROM
+            community
+        WHERE
+            community.id = NEW.community_id);
     RETURN NEW;
 END
 $$;

--- a/crates/db_schema/replaceable_schema/triggers.sql
+++ b/crates/db_schema/replaceable_schema/triggers.sql
@@ -27,12 +27,12 @@ BEGIN
         -- When a thing gets a vote, update its aggregates and its creator's aggregates
         CALL r.create_triggers ('thing_actions', $$
             BEGIN
-                IF (
+                /*IF (
                     SELECT
                         count(*)
                 FROM select_old_and_new_rows) = 0 THEN
                     RETURN NULL;
-                END IF;
+                END IF;*/
                 WITH thing_diff AS (
                     UPDATE
                         thing AS a
@@ -105,6 +105,7 @@ END;
 
 CALL r.create_triggers ('comment', $$
 BEGIN
+    -- Prevent infinite recursion
     IF (
         SELECT
             count(*)
@@ -243,14 +244,14 @@ $$);
 
 CALL r.create_triggers ('post', $$
 BEGIN
-    IF (
+    /*IF (
         SELECT
             count(*)
 FROM
     select_old_and_new_rows) = 0 THEN
         RETURN NULL;
 
-END IF;
+END IF;*/
 
 UPDATE
     person AS a
@@ -313,14 +314,14 @@ $$);
 
 CALL r.create_triggers ('community', $$
 BEGIN
-    IF (
+    /*IF (
         SELECT
             count(*)
 FROM
     select_old_and_new_rows) = 0 THEN
         RETURN NULL;
 
-END IF;
+END IF;*/
 
 UPDATE
     local_site AS a
@@ -345,14 +346,14 @@ $$);
 
 CALL r.create_triggers ('person', $$
 BEGIN
-    IF (
+    /*IF (
         SELECT
             count(*)
 FROM
     select_old_and_new_rows) = 0 THEN
         RETURN NULL;
 
-END IF;
+END IF;*/
 
 UPDATE
     local_site AS a
@@ -416,14 +417,14 @@ CREATE TRIGGER comment_count
 -- subscribers_local should be updated only when a local person follows a local or remote community.
 CALL r.create_triggers ('community_actions', $$
 BEGIN
-    IF (
+    /*IF (
         SELECT
             count(*)
 FROM
     select_old_and_new_rows) = 0 THEN
         RETURN NULL;
 
-END IF;
+END IF;*/
 
 UPDATE
     community AS a
@@ -456,14 +457,14 @@ $$);
 
 CALL r.create_triggers ('post_report', $$
 BEGIN
-    IF (
+    /*IF (
         SELECT
             count(*)
 FROM
     select_old_and_new_rows) = 0 THEN
         RETURN NULL;
 
-END IF;
+END IF;*/
 
 UPDATE
     post AS a
@@ -491,14 +492,14 @@ $$);
 
 CALL r.create_triggers ('comment_report', $$
 BEGIN
-    IF (
+    /*IF (
         SELECT
             count(*)
 FROM
     select_old_and_new_rows) = 0 THEN
         RETURN NULL;
 
-END IF;
+END IF;*/
 
 UPDATE
     comment AS a
@@ -526,14 +527,14 @@ $$);
 
 CALL r.create_triggers ('community_report', $$
 BEGIN
-    IF (
+    /*IF (
         SELECT
             count(*)
 FROM
     select_old_and_new_rows) = 0 THEN
         RETURN NULL;
 
-END IF;
+END IF;*/
 
 UPDATE
     community AS a

--- a/crates/db_schema/replaceable_schema/triggers.sql
+++ b/crates/db_schema/replaceable_schema/triggers.sql
@@ -849,7 +849,7 @@ BEGIN
     SET
         score = NEW.users_active_month
     WHERE
-        community_id = NEW.community_id;
+        community_id = NEW.id;
     RETURN NULL;
 END
 $$;

--- a/crates/db_schema/replaceable_schema/triggers.sql
+++ b/crates/db_schema/replaceable_schema/triggers.sql
@@ -305,7 +305,6 @@ CREATE TRIGGER comment_count
     FOR EACH STATEMENT
     EXECUTE FUNCTION r.update_comment_count_from_post ();
 
-/
 -- Count subscribers for communities.
 -- subscribers should be updated only when a local community is followed by a local or remote person.
 -- subscribers_local should be updated only when a local person follows a local or remote community.

--- a/crates/db_schema/replaceable_schema/triggers.sql
+++ b/crates/db_schema/replaceable_schema/triggers.sql
@@ -84,7 +84,7 @@ BEGIN
     IF (
         SELECT
             count(*)
-    FROM select_old_and_new_rows) = 0 THEN
+    FROM select_old_and_new_rows AS old_and_new_rows) = 0 THEN
         RETURN NULL;
 
 END IF;

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -26,6 +26,9 @@ pub const CACHE_DURATION_FEDERATION: Duration = Duration::from_millis(500);
 #[cfg(not(debug_assertions))]
 pub const CACHE_DURATION_FEDERATION: Duration = Duration::from_secs(60);
 
+#[cfg(debug_assertions)]
+pub const CACHE_DURATION_API: Duration = Duration::from_secs(0);
+#[cfg(not(debug_assertions))]
 pub const CACHE_DURATION_API: Duration = Duration::from_secs(1);
 
 pub const MAX_COMMENT_DEPTH_LIMIT: usize = 50;

--- a/migrations/2025-02-07-105516_remove-aggregate-tables/down.sql
+++ b/migrations/2025-02-07-105516_remove-aggregate-tables/down.sql
@@ -227,7 +227,8 @@ ALTER TABLE community
     DROP COLUMN subscribers_local,
     DROP COLUMN report_count,
     DROP COLUMN unresolved_report_count,
-    DROP COLUMN interactions_month;
+    DROP COLUMN interactions_month,
+    ALTER CONSTRAINT community_instance_id_fkey NOT DEFERRABLE INITIALLY IMMEDIATE;
 
 CREATE INDEX idx_community_aggregates_hot ON public.community_aggregates USING btree (hot_rank DESC);
 

--- a/migrations/2025-02-07-105516_remove-aggregate-tables/down.sql
+++ b/migrations/2025-02-07-105516_remove-aggregate-tables/down.sql
@@ -35,8 +35,7 @@ ALTER TABLE comment
     DROP COLUMN hot_rank,
     DROP COLUMN controversy_rank,
     DROP COLUMN report_count,
-    DROP COLUMN unresolved_report_count,
-    DROP COLUMN community_id;
+    DROP COLUMN unresolved_report_count;
 
 CREATE INDEX idx_comment_aggregates_controversy ON comment_aggregates USING btree (controversy_rank DESC);
 

--- a/migrations/2025-02-07-105516_remove-aggregate-tables/down.sql
+++ b/migrations/2025-02-07-105516_remove-aggregate-tables/down.sql
@@ -35,7 +35,8 @@ ALTER TABLE comment
     DROP COLUMN hot_rank,
     DROP COLUMN controversy_rank,
     DROP COLUMN report_count,
-    DROP COLUMN unresolved_report_count;
+    DROP COLUMN unresolved_report_count,
+    DROP COLUMN community_id;
 
 CREATE INDEX idx_comment_aggregates_controversy ON comment_aggregates USING btree (controversy_rank DESC);
 

--- a/migrations/2025-02-07-105516_remove-aggregate-tables/up.sql
+++ b/migrations/2025-02-07-105516_remove-aggregate-tables/up.sql
@@ -7,8 +7,7 @@ ALTER TABLE comment
     ADD COLUMN hot_rank double precision NOT NULL DEFAULT 0.0001,
     ADD COLUMN controversy_rank double precision NOT NULL DEFAULT 0,
     ADD COLUMN report_count smallint NOT NULL DEFAULT 0,
-    ADD COLUMN unresolved_report_count smallint NOT NULL DEFAULT 0,
-    ADD COLUMN community_id int NOT NULL DEFAULT 0 REFERENCES community (id) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;
+    ADD COLUMN unresolved_report_count smallint NOT NULL DEFAULT 0;
 
 UPDATE
     comment
@@ -20,12 +19,11 @@ SET
     hot_rank = ca.hot_rank,
     controversy_rank = ca.controversy_rank,
     report_count = ca.report_count,
-    unresolved_report_count = ca.unresolved_report_count,
-    community_id = p.community_id
+    unresolved_report_count = ca.unresolved_report_count
 FROM
-    comment_aggregates AS ca, post AS p
+    comment_aggregates AS ca
 WHERE
-    comment.id = ca.comment_id AND comment.post_id = p.id;
+    comment.id = ca.comment_id;
 
 DROP TABLE comment_aggregates;
 

--- a/migrations/2025-02-07-105516_remove-aggregate-tables/up.sql
+++ b/migrations/2025-02-07-105516_remove-aggregate-tables/up.sql
@@ -159,7 +159,8 @@ ALTER TABLE community
     ADD COLUMN subscribers_local bigint NOT NULL DEFAULT 0,
     ADD COLUMN report_count smallint NOT NULL DEFAULT 0,
     ADD COLUMN unresolved_report_count smallint NOT NULL DEFAULT 0,
-    ADD COLUMN interactions_month bigint NOT NULL DEFAULT 0;
+    ADD COLUMN interactions_month bigint NOT NULL DEFAULT 0,
+    ALTER CONSTRAINT community_instance_id_fkey DEFERRABLE INITIALLY DEFERRED;
 
 UPDATE
     community

--- a/migrations/2025-02-07-105516_remove-aggregate-tables/up.sql
+++ b/migrations/2025-02-07-105516_remove-aggregate-tables/up.sql
@@ -7,7 +7,8 @@ ALTER TABLE comment
     ADD COLUMN hot_rank double precision NOT NULL DEFAULT 0.0001,
     ADD COLUMN controversy_rank double precision NOT NULL DEFAULT 0,
     ADD COLUMN report_count smallint NOT NULL DEFAULT 0,
-    ADD COLUMN unresolved_report_count smallint NOT NULL DEFAULT 0;
+    ADD COLUMN unresolved_report_count smallint NOT NULL DEFAULT 0,
+    ADD COLUMN community_id int NOT NULL DEFAULT 0 REFERENCES community (id) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;
 
 UPDATE
     comment
@@ -19,11 +20,12 @@ SET
     hot_rank = ca.hot_rank,
     controversy_rank = ca.controversy_rank,
     report_count = ca.report_count,
-    unresolved_report_count = ca.unresolved_report_count
+    unresolved_report_count = ca.unresolved_report_count,
+    community_id = p.community_id
 FROM
-    comment_aggregates AS ca
+    comment_aggregates AS ca, post AS p
 WHERE
-    comment.id = ca.comment_id;
+    comment.id = ca.comment_id AND comment.post_id = p.id;
 
 DROP TABLE comment_aggregates;
 


### PR DESCRIPTION
#5407

Looks like `BEFORE DELETE` triggers can't update the row that the deletion is for, which happened in the delete_comments_before_post trigger because the comment trigger updates post.comments