### PR TITLE
Update user count from local_user table instead of person table, and only count users with accepted application

### DIFF
--- a/crates/db_schema/replaceable_schema/triggers.sql
+++ b/crates/db_schema/replaceable_schema/triggers.sql
@@ -280,7 +280,7 @@ END;
 
 $$);
 
-CALL r.create_triggers ('person', $$
+CALL r.create_triggers ('local_user', $$
 BEGIN
     UPDATE
         local_site AS a
@@ -290,7 +290,7 @@ BEGIN
         SELECT
             coalesce(sum(count_diff), 0) AS users
         FROM select_old_and_new_rows AS old_and_new_rows
-        WHERE (person).local) AS diff
+        WHERE (person).accepted_application) AS diff
 WHERE
     diff.users != 0;
 

--- a/crates/db_schema/replaceable_schema/triggers.sql
+++ b/crates/db_schema/replaceable_schema/triggers.sql
@@ -290,7 +290,7 @@ BEGIN
         SELECT
             coalesce(sum(count_diff), 0) AS users
         FROM select_old_and_new_rows AS old_and_new_rows
-        WHERE (person).accepted_application) AS diff
+        WHERE (local_user).accepted_application) AS diff
 WHERE
     diff.users != 0;
 

--- a/migrations/2025-03-11-015056_local_user_trigger/down.sql
+++ b/migrations/2025-03-11-015056_local_user_trigger/down.sql
@@ -1,0 +1,11 @@
+UPDATE
+    local_site
+SET
+    users = users + (
+        SELECT
+            count(*)
+        FROM
+            local_user
+        WHERE
+            NOT accepted_application);
+

--- a/migrations/2025-03-11-015056_local_user_trigger/down.sql
+++ b/migrations/2025-03-11-015056_local_user_trigger/down.sql
@@ -1,11 +1,9 @@
 UPDATE
     local_site
 SET
-    users = users + (
+    users = (
         SELECT
             count(*)
         FROM
-            local_user
-        WHERE
-            NOT accepted_application);
+            local_user);
 

--- a/migrations/2025-03-11-015056_local_user_trigger/up.sql
+++ b/migrations/2025-03-11-015056_local_user_trigger/up.sql
@@ -1,0 +1,11 @@
+UPDATE
+    local_site
+SET
+    users = users - (
+        SELECT
+            count(*)
+        FROM
+            local_user
+        WHERE
+            NOT accepted_application);
+

--- a/migrations/2025-03-11-015056_local_user_trigger/up.sql
+++ b/migrations/2025-03-11-015056_local_user_trigger/up.sql
@@ -1,11 +1,11 @@
 UPDATE
     local_site
 SET
-    users = users - (
+    users = (
         SELECT
             count(*)
         FROM
             local_user
         WHERE
-            NOT accepted_application);
+            accepted_application);
 


### PR DESCRIPTION
#5480 would result in longer locks on the local_site table. With this trigger change, the lock won't begin until after the local_user insert, and the registration_application insert afterward will not prolong the lock because the insert implies that accepted_application is false.