### PR TITLE
Replace newlines with spaces in Note attachments

### DIFF
--- a/crates/apub/src/protocol/objects/page.rs
+++ b/crates/apub/src/protocol/objects/page.rs
@@ -133,6 +133,7 @@ impl Attachment {
 
     let is_image =
       media_type.is_some_and(|media| media.starts_with("video") || media.starts_with("image"));
+    let name = name.map(|n| n.replace("\n", " "));
 
     if is_image {
       let url = proxy_image_link(url, context).await?;


### PR DESCRIPTION
Markdown links can't have newlines, but the alt-text of microblog images can, so #5143 creates broken image embeds ([example](https://feddit.uk/post/25594037/15821567)).