### PR TITLE
Wrap attributedTo for group to fix Peertube federation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2900,6 +2900,7 @@ dependencies = [
  "tokio",
  "tracing",
  "ts-rs",
+ "unicode-segmentation",
  "url",
  "urlencoding",
  "uuid",
@@ -5514,6 +5515,12 @@ name = "unicode-properties"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ea75f83c0137a9b98608359a5f1af8144876eb67bcb1ce837368e906a9f524"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"

--- a/crates/apub/assets/peertube/objects/group.json
+++ b/crates/apub/assets/peertube/objects/group.json
@@ -64,7 +64,13 @@
       "url": "https://tilvids.com/lazy-static/banners/1a8d6881-30c8-47cb-8576-7af62d869c45.jpg"
     }
   ],
-  "summary": "I'm Nick, and I like to tinker with Linux stuff. I'll bumble through distro reviews, tutorials, and general helpful tidbits and impressions onLinux desktop environments, applications, and news. \n\nYou might see a bit of Linux gaming here and there, and some more personal opinion pieces, but in the end, it's more or less all about Linux and FOSS !\n\nIf you want to stay up to snuff, follow me on Mastodon: https://mastodon.social/@thelinuxEXP \n\nIf you can, consider supporting the channel here: \nhttps://www.patreon.com/thelinuxexperiment",
+  "summary": "I'm Nick, and I like to tinker with Linux stuff. I'll bumble through distro reviews, tutorials, and general helpful tidbits and impressions on Linux desktop environments, applications, and news. \n\nYou might see a bit of Linux gaming here and there, and some more personal opinion pieces, but in the end, it's more or less all about Linux and FOSS !\n\nIf you want to stay up to snuff, follow me on Mastodon: https://mastodon.social/@thelinuxEXP \n\nIf you can, consider supporting the channel here: \nhttps://www.patreon.com/thelinuxexperiment",
   "support": "Support the channel on Patreon: \nhttps://www.patreon.com/thelinuxexperiment\n\nSupport on Liberapay:\nhttps://liberapay.com/TheLinuxExperiment/",
-  "postingRestrictedToMods": true
+  "postingRestrictedToMods": true,
+  "attributedTo": [
+    {
+      "type": "Person",
+      "id": "https://tilvids.com/accounts/thelinuxexperiment"
+    }
+  ]
 }

--- a/crates/apub/src/activities/community/update.rs
+++ b/crates/apub/src/activities/community/update.rs
@@ -10,11 +10,7 @@ use crate::{
   activity_lists::AnnouncableActivities,
   insert_received_activity,
   objects::{community::ApubCommunity, person::ApubPerson, read_from_string_or_source_opt},
-  protocol::{
-    activities::community::update::UpdateCommunity,
-    objects::group::AttributedTo,
-    InCommunity,
-  },
+  protocol::{activities::community::update::UpdateCommunity, objects::AttributedTo, InCommunity},
 };
 use activitypub_federation::{
   config::Data,

--- a/crates/apub/src/activities/community/update.rs
+++ b/crates/apub/src/activities/community/update.rs
@@ -10,7 +10,11 @@ use crate::{
   activity_lists::AnnouncableActivities,
   insert_received_activity,
   objects::{community::ApubCommunity, person::ApubPerson, read_from_string_or_source_opt},
-  protocol::{activities::community::update::UpdateCommunity, InCommunity},
+  protocol::{
+    activities::community::update::UpdateCommunity,
+    objects::group::AttributedTo,
+    InCommunity,
+  },
 };
 use activitypub_federation::{
   config::Data,
@@ -112,7 +116,7 @@ impl ActivityHandler for UpdateCommunity {
           .unwrap_or(self.object.inbox)
           .into(),
       ),
-      moderators_url: self.object.attributed_to.map(Into::into),
+      moderators_url: self.object.attributed_to.and_then(AttributedTo::url),
       posting_restricted_to_mods: self.object.posting_restricted_to_mods,
       featured_url: self.object.featured.map(Into::into),
       ..Default::default()

--- a/crates/apub/src/objects/community.rs
+++ b/crates/apub/src/objects/community.rs
@@ -125,7 +125,7 @@ impl Object for ApubCommunity {
       published: Some(self.published),
       updated: self.updated,
       posting_restricted_to_mods: Some(self.posting_restricted_to_mods),
-      attributed_to: Some(AttributedTo::Moderators(
+      attributed_to: Some(AttributedTo::Lemmy(
         generate_moderators_url(&self.ap_id)?.into(),
       )),
       manually_approves_followers: Some(self.visibility == CommunityVisibility::Private),
@@ -220,8 +220,11 @@ impl Object for ApubCommunity {
         featured.dereference(&community_, &context_).await.ok();
       }
       if let Some(moderators) = group.attributed_to {
-        if let AttributedTo::Moderators(l) = moderators {
-          l.dereference(&community_, &context_).await.ok();
+        if let AttributedTo::Lemmy(l) = moderators {
+          l.moderators()
+            .dereference(&community_, &context_)
+            .await
+            .ok();
         } else if let AttributedTo::Peertube(p) = moderators {
           let new_mods = p
             .iter()

--- a/crates/apub/src/objects/community.rs
+++ b/crates/apub/src/objects/community.rs
@@ -179,7 +179,7 @@ impl Object for ApubCommunity {
       banner,
       sidebar,
       removed,
-      description: group.summary.map(truncate_description),
+      description: group.summary.as_deref().map(truncate_description),
       followers_url: group.followers.clone().map(Into::into),
       inbox_url: Some(
         group

--- a/crates/apub/src/objects/community.rs
+++ b/crates/apub/src/objects/community.rs
@@ -47,7 +47,7 @@ use lemmy_db_schema::{
 use lemmy_utils::{
   error::{LemmyError, LemmyResult},
   spawn_try_task,
-  utils::markdown::markdown_to_html,
+  utils::{markdown::markdown_to_html, validation::truncate_description},
 };
 use std::ops::Deref;
 use url::Url;
@@ -179,7 +179,7 @@ impl Object for ApubCommunity {
       banner,
       sidebar,
       removed,
-      description: group.summary,
+      description: group.summary.map(truncate_description),
       followers_url: group.followers.clone().map(Into::into),
       inbox_url: Some(
         group

--- a/crates/apub/src/objects/mod.rs
+++ b/crates/apub/src/objects/mod.rs
@@ -1,8 +1,19 @@
 use crate::protocol::{objects::page::Attachment, Source};
-use activitypub_federation::{config::Data, protocol::values::MediaTypeMarkdownOrHtml};
+use activitypub_federation::{
+  config::Data,
+  fetch::object_id::ObjectId,
+  protocol::values::MediaTypeMarkdownOrHtml,
+};
+use community::ApubCommunity;
 use html2md::parse_html;
 use lemmy_api_common::context::LemmyContext;
+use lemmy_db_schema::{
+  source::community::{CommunityActions, CommunityModeratorForm},
+  traits::Joinable,
+};
+use lemmy_db_views::structs::CommunityModeratorView;
 use lemmy_utils::error::LemmyResult;
+use person::ApubPerson;
 
 pub mod comment;
 pub mod community;
@@ -53,4 +64,40 @@ pub(crate) async fn append_attachments_to_comment(
   }
 
   Ok(content)
+}
+
+pub(crate) async fn handle_community_moderators(
+  new_mods: &Vec<ObjectId<ApubPerson>>,
+  community: &ApubCommunity,
+  context: &Data<LemmyContext>,
+) -> LemmyResult<()> {
+  let community_id = community.id;
+  let current_moderators =
+    CommunityModeratorView::for_community(&mut context.pool(), community_id).await?;
+  // Remove old mods from database which arent in the moderators collection anymore
+  for mod_user in &current_moderators {
+    let mod_id = ObjectId::from(mod_user.moderator.ap_id.clone());
+    if !new_mods.contains(&mod_id) {
+      let community_moderator_form =
+        CommunityModeratorForm::new(mod_user.community.id, mod_user.moderator.id);
+      CommunityActions::leave(&mut context.pool(), &community_moderator_form).await?;
+    }
+  }
+
+  // Add new mods to database which have been added to moderators collection
+  for mod_id in new_mods {
+    // Ignore errors as mod accounts might be deleted or instances unavailable.
+    let mod_user: Option<ApubPerson> = mod_id.dereference(context).await.ok();
+    if let Some(mod_user) = mod_user {
+      if !current_moderators
+        .iter()
+        .map(|c| c.moderator.ap_id.clone())
+        .any(|x| x == mod_user.ap_id)
+      {
+        let community_moderator_form = CommunityModeratorForm::new(community.id, mod_user.id);
+        CommunityActions::join(&mut context.pool(), &community_moderator_form).await?;
+      }
+    }
+  }
+  Ok(())
 }

--- a/crates/apub/src/objects/mod.rs
+++ b/crates/apub/src/objects/mod.rs
@@ -91,8 +91,7 @@ pub(crate) async fn handle_community_moderators(
     if let Some(mod_user) = mod_user {
       if !current_moderators
         .iter()
-        .map(|c| c.moderator.ap_id.clone())
-        .any(|x| x == mod_user.ap_id)
+        .any(|x| x.moderator.ap_id == mod_user.ap_id)
       {
         let community_moderator_form = CommunityModeratorForm::new(community.id, mod_user.id);
         CommunityActions::join(&mut context.pool(), &community_moderator_form).await?;

--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -245,7 +245,11 @@ impl Object for ApubPost {
     let url = if let Some(url) = url {
       is_url_blocked(&url, &url_blocklist)?;
       is_valid_url(&url)?;
-      to_local_url(url.as_str(), context).await.or(Some(url))
+      if !(page.kind == PageType::Video) {
+        to_local_url(url.as_str(), context).await.or(Some(url))
+      } else {
+        Some(url)
+      }
     } else {
       None
     };

--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -5,7 +5,8 @@ use crate::{
   objects::read_from_string_or_source_opt,
   protocol::{
     objects::{
-      page::{Attachment, AttributedTo, Hashtag, HashtagType, Page, PageType},
+      page::{Attachment, Hashtag, HashtagType, Page, PageType},
+      AttributedTo,
       LanguageTag,
     },
     ImageObject,
@@ -138,7 +139,7 @@ impl Object for ApubPost {
     let page = Page {
       kind: PageType::Page,
       id: self.ap_id.clone().into(),
-      attributed_to: AttributedTo::Lemmy(creator.ap_id.into()),
+      attributed_to: AttributedTo::Creator(creator.ap_id.into()),
       to: generate_to(&community)?,
       cc: vec![],
       name: Some(self.name.clone()),

--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -250,7 +250,7 @@ impl Object for ApubPost {
     let url = if let Some(url) = url {
       is_url_blocked(&url, &url_blocklist)?;
       is_valid_url(&url)?;
-      if !(page.kind == PageType::Video) {
+      if page.kind != PageType::Video {
         to_local_url(url.as_str(), context).await.or(Some(url))
       } else {
         Some(url)

--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -139,7 +139,7 @@ impl Object for ApubPost {
     let page = Page {
       kind: PageType::Page,
       id: self.ap_id.clone().into(),
-      attributed_to: AttributedTo::Creator(creator.ap_id.into()),
+      attributed_to: AttributedTo::Lemmy(creator.ap_id.into()),
       to: generate_to(&community)?,
       cc: vec![],
       name: Some(self.name.clone()),

--- a/crates/apub/src/protocol/objects/group.rs
+++ b/crates/apub/src/protocol/objects/group.rs
@@ -46,7 +46,7 @@ where
     Ok(
       Vec::<AttributedToPeertube>::deserialize(&value)
         .ok()
-        .map(|p| AttributedTo::Peertube(p)),
+        .map(AttributedTo::Peertube),
     )
   }
 }

--- a/crates/apub/src/protocol/objects/group.rs
+++ b/crates/apub/src/protocol/objects/group.rs
@@ -7,7 +7,7 @@ use crate::{
   },
   objects::community::ApubCommunity,
   protocol::{
-    objects::{AttributedTo, AttributedToPeertube, Endpoints, LanguageTag},
+    objects::{AttributedTo, Endpoints, LanguageTag},
     ImageObject,
     Source,
   },
@@ -29,27 +29,10 @@ use lemmy_utils::{
   error::LemmyResult,
   utils::slurs::{check_slurs, check_slurs_opt},
 };
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use std::fmt::Debug;
 use url::Url;
-
-pub fn deserialize_make_moderator<'de, D>(deserializer: D) -> Result<Option<AttributedTo>, D::Error>
-where
-  D: Deserializer<'de>,
-{
-  let value = serde_json::Value::deserialize(deserializer)?;
-  let url = Url::deserialize(&value);
-  if let Ok(u) = url {
-    Ok(Some(AttributedTo::Moderators(u.into())))
-  } else {
-    Ok(
-      Vec::<AttributedToPeertube>::deserialize(&value)
-        .ok()
-        .map(AttributedTo::Peertube),
-    )
-  }
-}
 
 #[skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
@@ -80,7 +63,7 @@ pub struct Group {
   pub(crate) image: Option<ImageObject>,
   // lemmy extension
   pub(crate) sensitive: Option<bool>,
-  #[serde(deserialize_with = "deserialize_make_moderator", default)]
+  #[serde(deserialize_with = "deserialize_skip_error", default)]
   pub(crate) attributed_to: Option<AttributedTo>,
   // lemmy extension
   pub(crate) posting_restricted_to_mods: Option<bool>,

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -93,6 +93,7 @@ markdown-it-ruby = "1.0.1"
 markdown-it-footnote = "0.2.0"
 moka = { workspace = true, optional = true }
 git-version = "0.3.9"
+unicode-segmentation = "1.9.0"
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/utils/src/utils/validation.rs
+++ b/crates/utils/src/utils/validation.rs
@@ -351,6 +351,7 @@ pub fn build_url_str_without_scheme(url_str: &str) -> LemmyResult<String> {
 
 // Shorten a string to n chars, being mindful of unicode grapheme
 // boundaries
+#[allow(clippy::indexing_slicing)]
 pub fn truncate_for_db(string: String, len: usize) -> String {
   if string.chars().count() <= len {
     return string;

--- a/crates/utils/src/utils/validation.rs
+++ b/crates/utils/src/utils/validation.rs
@@ -407,6 +407,7 @@ mod tests {
       is_valid_url,
       site_name_length_check,
       site_or_community_description_length_check,
+      truncate_for_db,
       BIO_MAX_LENGTH,
       SITE_DESCRIPTION_MAX_LENGTH,
       SITE_NAME_MAX_LENGTH,
@@ -720,6 +721,16 @@ Line3",
     );
 
     assert!(check_urls_are_valid(&vec!["https://example .com".to_string()]).is_err());
+    Ok(())
+  }
+
+  #[test]
+  fn test_truncate() -> LemmyResult<()> {
+    assert_eq!("Hell", truncate_for_db("Hello".to_string(), 4));
+    assert_eq!("word", truncate_for_db("word".to_string(), 10));
+    assert_eq!("Wales: ", truncate_for_db("Wales: 🏴󠁧󠁢󠁷󠁬󠁳󠁿".to_string(), 10));
+    assert_eq!("Wales: 🏴󠁧󠁢󠁷󠁬󠁳󠁿", truncate_for_db("Wales: 🏴󠁧󠁢󠁷󠁬󠁳󠁿".to_string(), 14));
+
     Ok(())
   }
 }


### PR DESCRIPTION
Peertube uses `attributedTo` on `Group`s differently to Lemmy, which has the knock-on effect of making Lemmy reject videos from Peertube ([more details](https://feddit.uk/post/25402557/15843079)). To get around this, we need to wrap `attributedTo` for `Group` like we do for `Page`.