### PR TITLE
Fix error type returned by verify_person

### DIFF
--- a/crates/apub/src/activities/mod.rs
+++ b/crates/apub/src/activities/mod.rs
@@ -29,7 +29,6 @@ use activitypub_federation::{
   kinds::{activity::AnnounceType, public},
   traits::{ActivityHandler, Actor},
 };
-use anyhow::anyhow;
 use following::send_accept_or_reject_follow;
 use lemmy_api_common::{
   context::LemmyContext,
@@ -44,7 +43,7 @@ use lemmy_db_schema::{
   CommunityVisibility,
 };
 use lemmy_db_views::structs::{CommunityPersonBanView, CommunityView};
-use lemmy_utils::error::{FederationError, LemmyError, LemmyErrorExt, LemmyErrorType, LemmyResult};
+use lemmy_utils::error::{FederationError, LemmyError, LemmyResult};
 use serde::Serialize;
 use tracing::info;
 use url::{ParseError, Url};
@@ -65,8 +64,7 @@ async fn verify_person(
 ) -> LemmyResult<()> {
   let person = person_id.dereference(context).await?;
   if person.banned {
-    Err(anyhow!("Person {} is banned", person_id))
-      .with_lemmy_type(LemmyErrorType::CouldntUpdateComment)
+    Err(FederationError::PersonIsBannedFromSite(person.ap_id.to_string()).into())
   } else {
     Ok(())
   }


### PR DESCRIPTION
The function is used for things other than comments, so i made it use the more general error used by verify_person_in_community