### PR TITLE
Adding automated RSS posts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ members = [
   "crates/db_schema",
   "crates/db_views",
   "crates/routes",
-  "crates/federate",
+  "crates/federate", "crates/rss_automation",
 ]
 
 [workspace.lints.clippy]

--- a/crates/rss_automation/Cargo.toml
+++ b/crates/rss_automation/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "rss_automation"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1.0", features = ["full"] }
+reqwest = { version = "0.11", features = ["json"] }
+feed-rs = "1.3"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+chrono = { version = "0.4", features = ["serde"] }
+thiserror = "1.0"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "postgres", "chrono"] }
+anyhow = "1.0"
+async-trait = "0.1"
+futures = "0.3"
+tokio-schedule = "0.2"
+
+[lints]
+workspace = true

--- a/crates/rss_automation/src/main.rs
+++ b/crates/rss_automation/src/main.rs
@@ -1,0 +1,35 @@
+mod models;
+mod processor;
+mod scheduler;
+
+use anyhow::Result;
+use sqlx::postgres::PgPoolOptions;
+use tracing_subscriber::{fmt, EnvFilter};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Initialize logging
+    fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
+
+    // Initialize database connection
+    let database_url = std::env::var("DATABASE_URL")
+        .expect("DATABASE_URL must be set");
+
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&database_url)
+        .await?;
+
+    // Create and start the scheduler
+    let scheduler = scheduler::FeedScheduler::new(pool);
+    
+    info!("Starting RSS feed automation service");
+    if let Err(e) = scheduler.start().await {
+        error!("Scheduler failed: {}", e);
+        std::process::exit(1);
+    }
+
+    Ok(())
+}

--- a/crates/rss_automation/src/models.rs
+++ b/crates/rss_automation/src/models.rs
@@ -1,0 +1,74 @@
+use serde::{Deserialize, Serialize};
+use chrono::{DateTime, Utc};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RssFeed {
+    pub id: i32,
+    pub feed_url: String,
+    pub community_id: i32,
+    pub check_frequency_minutes: i32,
+    pub last_check: Option<DateTime<Utc>>,
+    pub last_item_guid: Option<String>,
+    pub bot_account_id: Option<i32>,
+    pub content_transform_rules: Option<serde_json::Value>,
+    pub is_active: bool,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "rss_feed_status", rename_all = "lowercase")]
+pub enum RssFeedStatus {
+    Success,
+    Error,
+    Skipped,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RssFeedHistory {
+    pub id: i32,
+    pub feed_id: i32,
+    pub status: RssFeedStatus,
+    pub error_message: Option<String>,
+    pub items_processed: i32,
+    pub processed_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ContentTransformRules {
+    pub title_template: Option<String>,
+    pub content_template: Option<String>,
+    pub link_template: Option<String>,
+    pub tags: Option<Vec<String>>,
+    pub custom_fields: Option<serde_json::Value>,
+}
+
+impl Default for ContentTransformRules {
+    fn default() -> Self {
+        Self {
+            title_template: None,
+            content_template: None,
+            link_template: None,
+            tags: None,
+            custom_fields: None,
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RssError {
+    #[error("Database error: {0}")]
+    Database(#[from] sqlx::Error),
+    
+    #[error("Feed fetch error: {0}")]
+    FetchError(String),
+    
+    #[error("Feed parse error: {0}")]
+    ParseError(String),
+    
+    #[error("Post creation error: {0}")]
+    PostError(String),
+    
+    #[error("Configuration error: {0}")]
+    ConfigError(String),
+} 

--- a/crates/rss_automation/src/processor.rs
+++ b/crates/rss_automation/src/processor.rs
@@ -1,0 +1,184 @@
+use crate::models::{RssFeed, RssError, ContentTransformRules};
+use feed_rs::parser;
+use reqwest::Client;
+use sqlx::PgPool;
+use tracing::{info, error, warn};
+use chrono::Utc;
+use lemmy_db_schema::{
+    source::{
+        post::{Post, PostInsertForm},
+        person::Person,
+    },
+    traits::Crud,
+};
+use lemmy_utils::error::LemmyResult;
+
+pub struct FeedProcessor {
+    db: PgPool,
+    client: Client,
+}
+
+impl FeedProcessor {
+    pub fn new(db: PgPool) -> Self {
+        Self {
+            db,
+            client: Client::new(),
+        }
+    }
+
+    pub async fn process_feed(&self, feed: &RssFeed) -> Result<(), RssError> {
+        info!("Processing feed: {}", feed.feed_url);
+
+        // Fetch feed content
+        let response = self.client
+            .get(&feed.feed_url)
+            .send()
+            .await
+            .map_err(|e| RssError::FetchError(e.to_string()))?;
+
+        let content = response
+            .bytes()
+            .await
+            .map_err(|e| RssError::FetchError(e.to_string()))?;
+
+        // Parse feed
+        let parsed_feed = parser::parse(&content[..])
+            .map_err(|e| RssError::ParseError(e.to_string()))?;
+
+        // Process entries
+        let mut items_processed = 0;
+        let mut newest_guid = None;
+        
+        for entry in parsed_feed.entries {
+            // Skip if we've already processed this item
+            if Some(entry.id.clone()) == feed.last_item_guid {
+                break;
+            }
+
+            // Transform content based on rules
+            let transformed_content = self.transform_content(&entry, &feed.content_transform_rules)?;
+
+            // Create post in community
+            self.create_post(feed, &transformed_content).await?;
+            items_processed += 1;
+            newest_guid = Some(entry.id);
+        }
+
+        // Update feed status
+        self.update_feed_status(feed.id, items_processed, newest_guid).await?;
+
+        Ok(())
+    }
+
+    fn transform_content(
+        &self,
+        entry: &feed_rs::model::Entry,
+        rules: &Option<serde_json::Value>,
+    ) -> Result<TransformedContent, RssError> {
+        let rules = match rules {
+            Some(rules_value) => serde_json::from_value(rules_value.clone())
+                .map_err(|e| RssError::ConfigError(e.to_string()))?,
+            None => ContentTransformRules::default(),
+        };
+
+        let title = rules.title_template
+            .as_deref()
+            .map(|template| template.replace("{title}", &entry.title.value))
+            .unwrap_or_else(|| entry.title.value.clone());
+
+        let content = match &entry.content {
+            Some(content) => rules.content_template
+                .as_deref()
+                .map(|template| template.replace("{content}", &content.value))
+                .unwrap_or_else(|| content.value.clone()),
+            None => entry.summary.as_ref()
+                .map(|summary| summary.value.clone())
+                .unwrap_or_else(String::new),
+        };
+
+        let link = rules.link_template
+            .as_deref()
+            .map(|template| template.replace("{link}", &entry.links[0].href))
+            .unwrap_or_else(|| entry.links[0].href.clone());
+
+        Ok(TransformedContent {
+            title,
+            content,
+            link,
+            tags: rules.tags.unwrap_or_default(),
+            custom_fields: rules.custom_fields,
+        })
+    }
+
+    async fn create_post(&self, feed: &RssFeed, content: &TransformedContent) -> Result<(), RssError> {
+        // Get the bot account
+        let bot_account = match feed.bot_account_id {
+            Some(id) => Person::read(&mut self.db, id)
+                .await
+                .map_err(|e| RssError::Database(e))?,
+            None => return Err(RssError::ConfigError("No bot account configured for feed".into())),
+        };
+
+        // Create the post
+        let post_form = PostInsertForm {
+            name: content.title.clone(),
+            body: Some(content.content.clone()),
+            url: Some(content.link.clone()),
+            creator_id: bot_account.id,
+            community_id: feed.community_id,
+            language_id: None, // Use default language
+            ..Default::default()
+        };
+
+        Post::create(&mut self.db, &post_form)
+            .await
+            .map_err(|e| RssError::PostError(e.to_string()))?;
+
+        info!("Created post in community {}: {}", feed.community_id, content.title);
+        Ok(())
+    }
+
+    async fn update_feed_status(
+        &self,
+        feed_id: i32,
+        items_processed: i32,
+        newest_guid: Option<String>,
+    ) -> Result<(), RssError> {
+        sqlx::query!(
+            r#"
+            UPDATE rss_feeds
+            SET last_check = $1,
+                updated_at = $1,
+                last_item_guid = COALESCE($3, last_item_guid)
+            WHERE id = $2
+            "#,
+            Utc::now(),
+            feed_id,
+            newest_guid,
+        )
+        .execute(&self.db)
+        .await?;
+
+        sqlx::query!(
+            r#"
+            INSERT INTO rss_feed_history (feed_id, status, items_processed)
+            VALUES ($1, 'success', $2)
+            "#,
+            feed_id,
+            items_processed
+        )
+        .execute(&self.db)
+        .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct TransformedContent {
+    title: String,
+    content: String,
+    link: String,
+    tags: Vec<String>,
+    custom_fields: Option<serde_json::Value>,
+} 

--- a/crates/rss_automation/src/scheduler.rs
+++ b/crates/rss_automation/src/scheduler.rs
@@ -1,0 +1,114 @@
+use crate::models::{RssFeed, RssError};
+use crate::processor::FeedProcessor;
+use sqlx::PgPool;
+use tokio::time::{sleep, Duration};
+use tracing::{info, error, warn};
+use chrono::{DateTime, Utc};
+
+pub struct FeedScheduler {
+    db: PgPool,
+    processor: FeedProcessor,
+}
+
+impl FeedScheduler {
+    pub fn new(db: PgPool) -> Self {
+        Self {
+            db,
+            processor: FeedProcessor::new(db.clone()),
+        }
+    }
+
+    pub async fn start(&self) -> Result<(), RssError> {
+        info!("Starting RSS feed scheduler");
+        
+        loop {
+            if let Err(e) = self.process_due_feeds().await {
+                error!("Error processing feeds: {}", e);
+            }
+            
+            // Sleep for 1 minute before next check
+            sleep(Duration::from_secs(60)).await;
+        }
+    }
+
+    async fn process_due_feeds(&self) -> Result<(), RssError> {
+        let now = Utc::now();
+        
+        // Get all active feeds that are due for processing
+        let feeds = sqlx::query_as!(
+            RssFeed,
+            r#"
+            SELECT * FROM rss_feeds
+            WHERE is_active = true
+            AND (
+                last_check IS NULL
+                OR last_check + (check_frequency_minutes * interval '1 minute') <= $1
+            )
+            "#,
+            now
+        )
+        .fetch_all(&self.db)
+        .await?;
+
+        info!("Found {} feeds due for processing", feeds.len());
+
+        // Process feeds concurrently with a limit
+        let mut tasks = Vec::new();
+        for feed in feeds {
+            let feed_clone = feed.clone();
+            let self_clone = self.clone();
+            
+            let task = tokio::spawn(async move {
+                if let Err(e) = self_clone.process_feed(&feed_clone).await {
+                    error!("Error processing feed {}: {}", feed_clone.id, e);
+                    self_clone.record_failure(&feed_clone, &e.to_string()).await
+                } else {
+                    Ok(())
+                }
+            });
+            
+            tasks.push(task);
+            
+            // Limit concurrency
+            if tasks.len() >= 5 {
+                futures::future::join_all(tasks.drain(..)).await;
+            }
+        }
+        
+        // Wait for remaining tasks
+        futures::future::join_all(tasks).await;
+        
+        Ok(())
+
+    }
+
+    async fn process_feed(&self, feed: &RssFeed) -> Result<(), RssError> {
+        info!("Processing feed {}: {}", feed.id, feed.feed_url);
+        
+        match self.processor.process_feed(feed).await {
+            Ok(_) => {
+                info!("Successfully processed feed {}", feed.id);
+                Ok(())
+            }
+            Err(e) => {
+                error!("Failed to process feed {}: {}", feed.id, e);
+                Err(e)
+            }
+        }
+    }
+
+    async fn record_failure(&self, feed: &RssFeed, error_message: &str) -> Result<(), RssError> {
+        sqlx::query!(
+            r#"
+            INSERT INTO rss_feed_history (feed_id, status, error_message, items_processed)
+            VALUES ($1, 'error', $2, 0)
+            "#,
+            feed.id,
+            error_message
+        )
+        .execute(&self.db)
+        .await?;
+    
+        Ok(())
+    }
+} 

--- a/migrations/20240324_create_rss_feeds.sql
+++ b/migrations/20240324_create_rss_feeds.sql
@@ -1,0 +1,37 @@
+-- Create RSS feed configurations table
+CREATE TABLE rss_feeds (
+    id SERIAL PRIMARY KEY,
+    feed_url TEXT NOT NULL,
+    community_id INTEGER NOT NULL REFERENCES communities(id) ON DELETE CASCADE,
+    check_frequency_minutes INTEGER NOT NULL DEFAULT 60,
+    last_check TIMESTAMP WITH TIME ZONE,
+    last_item_guid TEXT,
+    bot_account_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+    content_transform_rules JSONB,
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    UNIQUE(feed_url, community_id)
+);
+
+-- Create index for faster lookups
+CREATE INDEX idx_rss_feeds_community_id ON rss_feeds(community_id);
+CREATE INDEX idx_rss_feeds_last_check ON rss_feeds(last_check);
+CREATE INDEX idx_rss_feeds_active ON rss_feeds(last_check) 
+WHERE is_active = true;
+
+CREATE TYPE rss_feed_status AS ENUM ('success', 'error', 'skipped');
+
+-- Create RSS feed processing history table
+CREATE TABLE rss_feed_history (
+    id SERIAL PRIMARY KEY,
+    feed_id INTEGER NOT NULL REFERENCES rss_feeds(id) ON DELETE CASCADE,
+    status rss_feed_status NOT NULL,
+    error_message TEXT,
+    items_processed INTEGER NOT NULL DEFAULT 0,
+    processed_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+-- Create index for feed history
+CREATE INDEX idx_rss_feed_history_feed_id ON rss_feed_history(feed_id);
+CREATE INDEX idx_rss_feed_history_processed_at ON rss_feed_history(processed_at); 


### PR DESCRIPTION
Creating an RSS Feed Automation for Community Posts 

1) Feed Configuration Management: Ability to define which RSS feeds map to which communities, including frequency of checks and content transformation rules

2) Automated Posting: Newly detected items from RSS feeds should be automatically posted to the appropriate communities without manual intervention

3) Posting Attribution: Posts should appear under a system account or configurable community bot account

Technical Considerations:

Reliability: System must handle feed unavailability, malformed content, and retry logic
Scalability: Solution should work for hundreds of feeds and communities
Performance: Minimize database load and API calls
Maintainability: Clear separation of concerns between feed processing, content transformation, and posting logic

The solution should be primarily backend-focused with a scheduled service that:

-Periodically polls configured RSS feeds
-Detects new items since last check
-Creates posts in the appropriate communities