### PR TITLE
Change private instance setting to allow federation

### DIFF
--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -641,14 +641,6 @@ pub async fn send_new_report_email_to_admins(
   Ok(())
 }
 
-pub fn check_private_instance_and_federation_enabled(local_site: &LocalSite) -> LemmyResult<()> {
-  if local_site.private_instance && local_site.federation_enabled {
-    Err(LemmyErrorType::CantEnablePrivateInstanceAndFederationTogether)?
-  } else {
-    Ok(())
-  }
-}
-
 pub fn check_nsfw_allowed(nsfw: Option<bool>, local_site: Option<&LocalSite>) -> LemmyResult<()> {
   let is_nsfw = nsfw.unwrap_or_default();
   let nsfw_disallowed = local_site.is_some_and(|s| s.disallow_nsfw_content);

--- a/crates/api_crud/src/site/create.rs
+++ b/crates/api_crud/src/site/create.rs
@@ -32,7 +32,6 @@ use lemmy_utils::{
     slurs::check_slurs,
     validation::{
       build_and_check_regex,
-      check_site_visibility_valid,
       is_valid_body_field,
       site_name_length_check,
       site_or_community_description_length_check,
@@ -166,13 +165,6 @@ fn validate_create_payload(local_site: &LocalSite, create_site: &CreateSite) -> 
 
   site_default_post_listing_type_check(&create_site.default_post_listing_type)?;
 
-  check_site_visibility_valid(
-    local_site.private_instance,
-    local_site.federation_enabled,
-    &create_site.private_instance,
-    &create_site.federation_enabled,
-  )?;
-
   // Ensure that the sidebar has fewer than the max num characters...
   if let Some(body) = &create_site.sidebar {
     is_valid_body_field(body, false)?;
@@ -264,38 +256,6 @@ mod tests {
         &CreateSite {
           name: String::from("site_name"),
           default_post_listing_type: Some(ListingType::Subscribed),
-          ..Default::default()
-        },
-      ),
-      (
-        "CreateSite is both private and federated",
-        LemmyErrorType::CantEnablePrivateInstanceAndFederationTogether,
-        &LocalSite {
-          site_setup: false,
-          private_instance: true,
-          federation_enabled: false,
-          ..Default::default()
-        },
-        &CreateSite {
-          name: String::from("site_name"),
-          private_instance: Some(true),
-          federation_enabled: Some(true),
-          ..Default::default()
-        },
-      ),
-      (
-        "LocalSite is private, but CreateSite also makes it federated",
-        LemmyErrorType::CantEnablePrivateInstanceAndFederationTogether,
-        &LocalSite {
-          site_setup: false,
-          private_instance: true,
-          federation_enabled: false,
-          registration_mode: RegistrationMode::Open,
-          ..Default::default()
-        },
-        &CreateSite {
-          name: String::from("site_name"),
-          federation_enabled: Some(true),
           ..Default::default()
         },
       ),

--- a/crates/api_crud/src/site/update.rs
+++ b/crates/api_crud/src/site/update.rs
@@ -34,7 +34,6 @@ use lemmy_utils::{
     slurs::check_slurs_opt,
     validation::{
       build_and_check_regex,
-      check_site_visibility_valid,
       check_urls_are_valid,
       is_valid_body_field,
       site_name_length_check,
@@ -212,13 +211,6 @@ fn validate_update_payload(local_site: &LocalSite, edit_site: &EditSite) -> Lemm
 
   site_default_post_listing_type_check(&edit_site.default_post_listing_type)?;
 
-  check_site_visibility_valid(
-    local_site.private_instance,
-    local_site.federation_enabled,
-    &edit_site.private_instance,
-    &edit_site.federation_enabled,
-  )?;
-
   // Ensure that the sidebar has fewer than the max num characters...
   if let Some(body) = &edit_site.sidebar {
     is_valid_body_field(body, false)?;
@@ -292,37 +284,6 @@ mod tests {
         &EditSite {
           name: Some(String::from("site_name")),
           default_post_listing_type: Some(ListingType::Subscribed),
-          ..Default::default()
-        },
-      ),
-      (
-        "EditSite is both private and federated",
-        LemmyErrorType::CantEnablePrivateInstanceAndFederationTogether,
-        &LocalSite {
-          private_instance: true,
-          federation_enabled: false,
-          registration_mode: RegistrationMode::Open,
-          ..Default::default()
-        },
-        &EditSite {
-          name: Some(String::from("site_name")),
-          private_instance: Some(true),
-          federation_enabled: Some(true),
-          ..Default::default()
-        },
-      ),
-      (
-        "LocalSite is private, but EditSite also makes it federated",
-        LemmyErrorType::CantEnablePrivateInstanceAndFederationTogether,
-        &LocalSite {
-          private_instance: true,
-          federation_enabled: false,
-          registration_mode: RegistrationMode::Open,
-          ..Default::default()
-        },
-        &EditSite {
-          name: Some(String::from("site_name")),
-          federation_enabled: Some(true),
           ..Default::default()
         },
       ),

--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -48,7 +48,6 @@ pub enum LemmyErrorType {
   SiteDescriptionLengthOverflow,
   HoneypotFailed,
   RegistrationApplicationIsPending,
-  CantEnablePrivateInstanceAndFederationTogether,
   Locked,
   CouldntCreateComment,
   MaxCommentDepthReached,

--- a/crates/utils/src/utils/validation.rs
+++ b/crates/utils/src/utils/validation.rs
@@ -270,22 +270,6 @@ pub fn clean_urls_in_text(text: &str) -> String {
   }
 }
 
-pub fn check_site_visibility_valid(
-  current_private_instance: bool,
-  current_federation_enabled: bool,
-  new_private_instance: &Option<bool>,
-  new_federation_enabled: &Option<bool>,
-) -> LemmyResult<()> {
-  let private_instance = new_private_instance.unwrap_or(current_private_instance);
-  let federation_enabled = new_federation_enabled.unwrap_or(current_federation_enabled);
-
-  if private_instance && federation_enabled {
-    Err(LemmyErrorType::CantEnablePrivateInstanceAndFederationTogether.into())
-  } else {
-    Ok(())
-  }
-}
-
 pub fn is_valid_url(url: &Url) -> LemmyResult<()> {
   if !ALLOWED_POST_URL_SCHEMES.contains(&url.scheme()) {
     Err(LemmyErrorType::InvalidUrlScheme)?
@@ -355,7 +339,6 @@ mod tests {
     error::{LemmyErrorType, LemmyResult},
     utils::validation::{
       build_and_check_regex,
-      check_site_visibility_valid,
       check_urls_are_valid,
       clean_url,
       clean_urls_in_text,
@@ -607,18 +590,6 @@ Line3",
           expected_err
         );
       });
-  }
-
-  #[test]
-  fn test_check_site_visibility_valid() {
-    assert!(check_site_visibility_valid(true, true, &None, &None).is_err());
-    assert!(check_site_visibility_valid(true, false, &None, &Some(true)).is_err());
-    assert!(check_site_visibility_valid(false, true, &Some(true), &None).is_err());
-    assert!(check_site_visibility_valid(false, false, &Some(true), &Some(true)).is_err());
-    assert!(check_site_visibility_valid(true, false, &None, &None).is_ok());
-    assert!(check_site_visibility_valid(false, true, &None, &None).is_ok());
-    assert!(check_site_visibility_valid(false, false, &Some(true), &None).is_ok());
-    assert!(check_site_visibility_valid(false, false, &None, &Some(true)).is_ok());
   }
 
   #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,10 +17,7 @@ use lemmy_api_common::{
   lemmy_db_views::structs::SiteView,
   request::client_builder,
   send_activity::{ActivityChannel, MATCH_OUTGOING_ACTIVITIES},
-  utils::{
-    check_private_instance_and_federation_enabled,
-    local_site_rate_limit_to_rate_limit_config,
-  },
+  utils::local_site_rate_limit_to_rate_limit_config,
 };
 use lemmy_apub::{
   activities::{handle_outgoing_activities, match_outgoing_activities},
@@ -193,7 +190,6 @@ pub async fn start_lemmy_server(args: CmdArgs) -> LemmyResult<()> {
   let rate_limit_config =
     local_site_rate_limit_to_rate_limit_config(&site_view.local_site_rate_limit);
   let rate_limit_cell = RateLimitCell::new(rate_limit_config);
-  check_private_instance_and_federation_enabled(&site_view.local_site)?;
 
   println!(
     "Starting HTTP server at {}:{}",


### PR DESCRIPTION
The `private instance` setting makes it so that only logged-in users can browse posts. It also includes a check which requires that federation is disabled. The idea was that content on such instances should be truly private, and not publicly visible on other instances. 

Now that there is a setting for community visibility: private, making the whole instance private isnt really necessary anymore. By allowing "private instance" with federation enabled, it can be used to fight of AI crawlers or DDoS attacks as they cannot access any content anymore. At the same time there is no change for logged-in users. We could change the setting name at the same time if there is a better suggestion.

cc @db0 This is the "raid mode" you were talking about.