### PR TITLE
Fix migration problems with initially deferred and not null constraints

### DIFF
--- a/migrations/2025-03-04-105516_remove-aggregate-tables/down.sql
+++ b/migrations/2025-03-04-105516_remove-aggregate-tables/down.sql
@@ -37,6 +37,10 @@ ALTER TABLE comment
     DROP COLUMN report_count,
     DROP COLUMN unresolved_report_count;
 
+SET CONSTRAINTS comment_aggregates_comment_id_fkey IMMEDIATE;
+
+SET CONSTRAINTS comment_aggregates_comment_id_fkey DEFERRED;
+
 CREATE INDEX idx_comment_aggregates_controversy ON comment_aggregates USING btree (controversy_rank DESC);
 
 CREATE INDEX idx_comment_aggregates_hot ON comment_aggregates USING btree (hot_rank DESC, score DESC);
@@ -109,6 +113,10 @@ ALTER TABLE post
     DROP COLUMN scaled_rank,
     DROP COLUMN report_count,
     DROP COLUMN unresolved_report_count;
+
+SET CONSTRAINTS post_aggregates_community_id_fkey, post_aggregates_creator_id_fkey, post_aggregates_instance_id_fkey, post_aggregates_post_id_fkey IMMEDIATE;
+
+SET CONSTRAINTS post_aggregates_community_id_fkey, post_aggregates_creator_id_fkey, post_aggregates_instance_id_fkey, post_aggregates_post_id_fkey DEFERRED;
 
 CREATE INDEX idx_post_aggregates_community_active ON post_aggregates USING btree (community_id, featured_local DESC, hot_rank_active DESC, published DESC, post_id DESC);
 
@@ -241,6 +249,10 @@ ALTER TABLE community
     DROP COLUMN interactions_month,
     ALTER CONSTRAINT community_instance_id_fkey NOT DEFERRABLE INITIALLY IMMEDIATE;
 
+SET CONSTRAINTS community_aggregates_community_id_fkey IMMEDIATE;
+
+SET CONSTRAINTS community_aggregates_community_id_fkey DEFERRED;
+
 CREATE INDEX idx_community_aggregates_hot ON public.community_aggregates USING btree (hot_rank DESC);
 
 CREATE INDEX idx_community_aggregates_nonzero_hotrank ON public.community_aggregates USING btree (published)
@@ -278,6 +290,10 @@ ALTER TABLE person
     DROP COLUMN post_score,
     DROP COLUMN comment_count,
     DROP COLUMN comment_score;
+
+SET CONSTRAINTS person_aggregates_person_id_fkey IMMEDIATE;
+
+SET CONSTRAINTS person_aggregates_person_id_fkey DEFERRED;
 
 CREATE INDEX idx_person_aggregates_comment_score ON public.person_aggregates USING btree (comment_score DESC);
 
@@ -346,6 +362,10 @@ ALTER TABLE local_user
     DROP COLUMN show_upvote_percentage;
 
 CREATE INDEX idx_search_combined_score ON public.search_combined USING btree (score DESC, id DESC);
+
+SET CONSTRAINTS site_aggregates_site_id_fkey IMMEDIATE;
+
+SET CONSTRAINTS site_aggregates_site_id_fkey DEFERRED;
 
 CREATE UNIQUE INDEX idx_site_aggregates_1_row_only ON public.site_aggregates USING btree ((TRUE));
 

--- a/migrations/2025-03-04-105516_remove-aggregate-tables/up.sql
+++ b/migrations/2025-03-04-105516_remove-aggregate-tables/up.sql
@@ -48,7 +48,7 @@ ALTER TABLE post
     ADD COLUMN hot_rank double precision NOT NULL DEFAULT 0.0001,
     ADD COLUMN hot_rank_active double precision NOT NULL DEFAULT 0.0001,
     ADD COLUMN controversy_rank double precision NOT NULL DEFAULT 0,
-    ADD COLUMN instance_id int NOT NULL DEFAULT 0 REFERENCES instance (id) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    ADD COLUMN instance_id int REFERENCES instance (id) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
     ADD COLUMN scaled_rank double precision NOT NULL DEFAULT 0.0001,
     ADD COLUMN report_count smallint NOT NULL DEFAULT 0,
     ADD COLUMN unresolved_report_count smallint NOT NULL DEFAULT 0;
@@ -73,6 +73,13 @@ FROM
     post_aggregates AS pa
 WHERE
     post.id = pa.post_id;
+
+SET CONSTRAINTS post_instance_id_fkey IMMEDIATE;
+
+SET CONSTRAINTS post_instance_id_fkey DEFERRED;
+
+ALTER TABLE post
+    ALTER COLUMN instance_id SET NOT NULL;
 
 DROP TABLE post_aggregates;
 

--- a/migrations/2025-03-11-124442_community-hidden-visibility/down.sql
+++ b/migrations/2025-03-11-124442_community-hidden-visibility/down.sql
@@ -2,7 +2,7 @@
 ALTER TABLE community
     ADD COLUMN hidden bool DEFAULT FALSE NOT NULL,
     ADD COLUMN posting_restricted_to_mods_new bool NOT NULL DEFAULT FALSE,
-    ADD COLUMN instance_id_new int NOT NULL,
+    ADD COLUMN instance_id_new int,
     ADD COLUMN moderators_url_new varchar(255),
     ADD COLUMN featured_url_new varchar(255),
     ADD COLUMN visibility_new community_visibility NOT NULL DEFAULT 'Public',
@@ -62,7 +62,12 @@ SET
         unresolved_report_count,
         interactions_month);
 
+SET CONSTRAINTS community_instance_id_fkey IMMEDIATE;
+
+SET CONSTRAINTS community_instance_id_fkey DEFERRED;
+
 ALTER TABLE community
+    ALTER COLUMN instance_id_new SET NOT NULL,
     DROP COLUMN posting_restricted_to_mods,
     DROP COLUMN instance_id,
     DROP COLUMN moderators_url,


### PR DESCRIPTION
Executes `SET CONSTRAINTS xyz IMMEDIATE;` before `CREATE INDEX` and `ALTER COLUMN` that otherwise fail because of "pending trigger events".

These errors only show up when the tables hold data during the migrations.

Fixes #5531 