### PR TITLE
Remove hardcoded ratelimit

### DIFF
--- a/api_tests/src/shared.ts
+++ b/api_tests/src/shared.ts
@@ -156,12 +156,6 @@ export async function setupLogins() {
   // Registration applications are now enabled by default, need to disable them
   let editSiteForm: EditSite = {
     registration_mode: "Open",
-    rate_limit_message: 999,
-    rate_limit_post: 999,
-    rate_limit_register: 999,
-    rate_limit_image: 999,
-    rate_limit_comment: 999,
-    rate_limit_search: 999,
   };
   await alpha.editSite(editSiteForm);
   await beta.editSite(editSiteForm);

--- a/crates/routes/src/utils/code_migrations.rs
+++ b/crates/routes/src/utils/code_migrations.rs
@@ -454,12 +454,6 @@ async fn initialize_local_site_2022_10_10(
 
   // Create the rate limit table
   let local_site_rate_limit_form = LocalSiteRateLimitInsertForm {
-    message: Some(999),
-    post: Some(999),
-    register: Some(999),
-    image: Some(999),
-    comment: Some(999),
-    search: Some(999),
     ..LocalSiteRateLimitInsertForm::new(local_site.id)
   };
   // TODO these have to be set, because the database defaults are too low for the federation

--- a/crates/routes/src/utils/code_migrations.rs
+++ b/crates/routes/src/utils/code_migrations.rs
@@ -453,8 +453,18 @@ async fn initialize_local_site_2022_10_10(
   let local_site = LocalSite::create(pool, &local_site_form).await?;
 
   // Create the rate limit table
-  let local_site_rate_limit_form = LocalSiteRateLimitInsertForm {
-    ..LocalSiteRateLimitInsertForm::new(local_site.id)
+  let local_site_rate_limit_form = if cfg!(debug_assertions) {
+    LocalSiteRateLimitInsertForm {
+      message: Some(999),
+      post: Some(999),
+      register: Some(999),
+      image: Some(999),
+      comment: Some(999),
+      search: Some(999),
+      ..LocalSiteRateLimitInsertForm::new(local_site.id)
+    }
+  } else {
+    LocalSiteRateLimitInsertForm::new(local_site.id)
   };
   // TODO these have to be set, because the database defaults are too low for the federation
   // tests to pass, and there's no way to live update the rate limits without restarting the


### PR DESCRIPTION
Not sure how this ended up in the production code. Its also included in 0.19 releases...