### PR TITLE
Add config option to enable json logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ console = [
   "tracing-opentelemetry",
   "reqwest-tracing/opentelemetry_0_16",
 ]
-json-log = ["tracing-subscriber/json"]
 default = []
 
 [workspace]
@@ -121,7 +120,7 @@ tracing = "0.1.40"
 tracing-actix-web = { version = "0.7.11", default-features = false }
 tracing-error = "0.2.0"
 tracing-log = "0.2.0"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 url = { version = "2.5.2", features = ["serde"] }
 reqwest = { version = "0.11.27", default-features = false, features = [
   "json",

--- a/config/defaults.hjson
+++ b/config/defaults.hjson
@@ -132,4 +132,6 @@
   # Sets a response Access-Control-Allow-Origin CORS header
   # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
   cors_origin: "lemmy.tld"
+  # Print logs in JSON format. You can also disable ANSI colors in logs with env var `NO_COLOR`.
+  json_logging: false
 }

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -54,6 +54,8 @@ pub struct Settings {
   #[default(None)]
   #[doku(example = "lemmy.tld")]
   cors_origin: Option<String>,
+  /// Print logs in JSON format. You can also disable ANSI colors in logs with env var `NO_COLOR`.
+  pub json_logging: bool,
 }
 
 impl Settings {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,6 @@ use tracing_actix_web::TracingLogger;
 use tracing_error::ErrorLayer;
 use tracing_log::LogTracer;
 use tracing_subscriber::{filter::Targets, layer::SubscriberExt, Layer, Registry};
-use url::Url;
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
@@ -386,7 +385,7 @@ fn cors_config(settings: &Settings) -> Cors {
   }
 }
 
-pub fn init_logging(opentelemetry_url: &Option<Url>) -> LemmyResult<()> {
+pub fn init_logging(settings: &Settings) -> LemmyResult<()> {
   LogTracer::init()?;
 
   let log_description = env::var("RUST_LOG").unwrap_or_else(|_| "info".into());
@@ -396,27 +395,43 @@ pub fn init_logging(opentelemetry_url: &Option<Url>) -> LemmyResult<()> {
     .trim_matches('"')
     .parse::<Targets>()?;
 
-  let format_layer = {
-    #[cfg(feature = "json-log")]
-    let layer = tracing_subscriber::fmt::layer().with_ansi(false).json();
-    #[cfg(not(feature = "json-log"))]
-    let layer = tracing_subscriber::fmt::layer().with_ansi(false);
+  if settings.json_logging {
+    let format_layer = {
+      let layer = tracing_subscriber::fmt::layer().with_ansi(false).json();
+      layer.with_filter(targets.clone())
+    };
 
-    layer.with_filter(targets.clone())
-  };
+    let subscriber = Registry::default()
+      .with(format_layer)
+      .with(ErrorLayer::default());
 
-  let subscriber = Registry::default()
-    .with(format_layer)
-    .with(ErrorLayer::default());
-
-  if let Some(_url) = opentelemetry_url {
-    #[cfg(feature = "console")]
-    telemetry::init_tracing(_url.as_ref(), subscriber, targets)?;
-    #[cfg(not(feature = "console"))]
-    tracing::error!("Feature `console` must be enabled for opentelemetry tracing");
+    if let Some(_url) = &settings.opentelemetry_url {
+      #[cfg(feature = "console")]
+      telemetry::init_tracing(_url.as_ref(), subscriber, targets)?;
+      #[cfg(not(feature = "console"))]
+      tracing::error!("Feature `console` must be enabled for opentelemetry tracing");
+    } else {
+      set_global_default(subscriber)?;
+    }
   } else {
-    set_global_default(subscriber)?;
-  }
+    let format_layer = {
+      let layer = tracing_subscriber::fmt::layer().with_ansi(false);
+      layer.with_filter(targets.clone())
+    };
+
+    let subscriber = Registry::default()
+      .with(format_layer)
+      .with(ErrorLayer::default());
+
+    if let Some(_url) = &settings.opentelemetry_url {
+      #[cfg(feature = "console")]
+      telemetry::init_tracing(_url.as_ref(), subscriber, targets)?;
+      #[cfg(not(feature = "console"))]
+      tracing::error!("Feature `console` must be enabled for opentelemetry tracing");
+    } else {
+      set_global_default(subscriber)?;
+    }
+  };
 
   Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ pub extern crate rustls;
 
 #[tokio::main]
 pub async fn main() -> LemmyResult<()> {
-  init_logging(&SETTINGS.opentelemetry_url)?;
+  init_logging(&SETTINGS)?;
   let args = CmdArgs::parse();
 
   rustls::crypto::ring::default_provider()


### PR DESCRIPTION
This is backported from 97772b95530b112fa10322ce1e9bde5ab7fcf7c2

https://github.com/LemmyNet/lemmy/pull/5471
https://github.com/LemmyNet/lemmy/commit/97772b95530b112fa10322ce1e9bde5ab7fcf7c2

This introduces a bit of code duplication due to type differences when json vs non-json logging are used in combination with opentelemetry.
As opentelemetry has been removed in `main` it's simpler there.