### PR TITLE
fix removal of post.instance_id

### DIFF
--- a/crates/db_schema/src/impls/post.rs
+++ b/crates/db_schema/src/impls/post.rs
@@ -162,7 +162,15 @@ impl Post {
     }
 
     if let Some(for_instance_id) = for_instance_id {
-      update = update.filter(post::instance_id.eq(for_instance_id));
+      // Diesel can't update from join unfortunately, so you'll need to loop over these
+      let post_ids = post::table
+        .inner_join(community::table)
+        .filter(post::creator_id.eq(for_creator_id))
+        .filter(community::instance_id.eq(for_instance_id))
+        .select(post::id)
+        .load::<PostId>(conn)
+        .await?;
+      update = update.filter(post::id.eq_any(post_ids));
     }
 
     update


### PR DESCRIPTION
this was originally removed in #5546, but #5515 introduced a new usage of it. due to the order of PR merges this slipped through and broke the build on main.

fixes #5561