### PR TITLE
Remove unnecessary pictrs purge calls

### DIFF
--- a/crates/api/src/site/purge/community.rs
+++ b/crates/api/src/site/purge/community.rs
@@ -2,10 +2,9 @@ use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
   context::LemmyContext,
-  request::purge_image_from_pictrs,
   send_activity::{ActivityChannel, SendActivityData},
   site::PurgeCommunity,
-  utils::{is_admin, purge_image_posts_for_community},
+  utils::is_admin,
   SuccessResponse,
 };
 use lemmy_db_schema::{
@@ -45,16 +44,6 @@ pub async fn purge_community(
     community_mod_person_ids,
   )
   .await?;
-
-  if let Some(banner) = &community.banner {
-    purge_image_from_pictrs(banner, &context).await.ok();
-  }
-
-  if let Some(icon) = &community.icon {
-    purge_image_from_pictrs(icon, &context).await.ok();
-  }
-
-  purge_image_posts_for_community(data.community_id, &context).await?;
 
   Community::delete(&mut context.pool(), data.community_id).await?;
 

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -695,21 +695,6 @@ pub async fn purge_post_images(
   }
 }
 
-pub async fn purge_image_posts_for_person(
-  banned_person_id: PersonId,
-  context: &LemmyContext,
-) -> LemmyResult<()> {
-  let pool = &mut context.pool();
-  let posts = Post::fetch_pictrs_posts_for_creator(pool, banned_person_id).await?;
-  for post in posts {
-    purge_post_images(post.url, post.thumbnail_url, context).await;
-  }
-
-  Post::remove_pictrs_post_images_and_thumbnails_for_creator(pool, banned_person_id).await?;
-
-  Ok(())
-}
-
 /// Delete a local_user's images
 async fn delete_local_user_images(person_id: PersonId, context: &LemmyContext) -> LemmyResult<()> {
   if let Ok(local_user) = LocalUserView::read_person(&mut context.pool(), person_id).await {
@@ -727,21 +712,6 @@ async fn delete_local_user_images(person_id: PersonId, context: &LemmyContext) -
   Ok(())
 }
 
-pub async fn purge_image_posts_for_community(
-  banned_community_id: CommunityId,
-  context: &LemmyContext,
-) -> LemmyResult<()> {
-  let pool = &mut context.pool();
-  let posts = Post::fetch_pictrs_posts_for_community(pool, banned_community_id).await?;
-  for post in posts {
-    purge_post_images(post.url, post.thumbnail_url, context).await;
-  }
-
-  Post::remove_pictrs_post_images_and_thumbnails_for_community(pool, banned_community_id).await?;
-
-  Ok(())
-}
-
 /// Removes or restores user data.
 pub async fn remove_or_restore_user_data(
   mod_person_id: PersonId,
@@ -752,16 +722,9 @@ pub async fn remove_or_restore_user_data(
 ) -> LemmyResult<()> {
   let pool = &mut context.pool();
 
-  // Only these actions are possible when removing, not restoring
+  // These actions are only possible when removing, not restoring
   if removed {
-    // Purge user images
-    let person = Person::read(pool, banned_person_id).await?;
-    if let Some(avatar) = person.avatar {
-      purge_image_from_pictrs(&avatar, context).await.ok();
-    }
-    if let Some(banner) = person.banner {
-      purge_image_from_pictrs(&banner, context).await.ok();
-    }
+    delete_local_user_images(banned_person_id, context).await?;
 
     // Update the fields to None
     Person::update(
@@ -775,9 +738,6 @@ pub async fn remove_or_restore_user_data(
       },
     )
     .await?;
-
-    // Purge image posts
-    purge_image_posts_for_person(banned_person_id, context).await?;
 
     // Communities
     // Remove all communities where they're the top mod
@@ -802,13 +762,6 @@ pub async fn remove_or_restore_user_data(
       )
       .await?;
 
-      // Delete the community images
-      if let Some(icon) = first_mod_community.community.icon {
-        purge_image_from_pictrs(&icon, context).await.ok();
-      }
-      if let Some(banner) = first_mod_community.community.banner {
-        purge_image_from_pictrs(&banner, context).await.ok();
-      }
       // Update the fields to None
       Community::update(
         pool,
@@ -959,21 +912,9 @@ pub async fn remove_or_restore_user_data_in_community(
 pub async fn purge_user_account(person_id: PersonId, context: &LemmyContext) -> LemmyResult<()> {
   let pool = &mut context.pool();
 
-  let person = Person::read(pool, person_id).await?;
-
   // Delete their local images, if they're a local user
-  delete_local_user_images(person_id, context).await.ok();
-
   // No need to update avatar and banner, those are handled in Person::delete_account
-  if let Some(avatar) = person.avatar {
-    purge_image_from_pictrs(&avatar, context).await.ok();
-  }
-  if let Some(banner) = person.banner {
-    purge_image_from_pictrs(&banner, context).await.ok();
-  }
-
-  // Purge image posts
-  purge_image_posts_for_person(person_id, context).await.ok();
+  delete_local_user_images(person_id, context).await.ok();
 
   // Comments
   Comment::permadelete_for_creator(pool, person_id)

--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -29,13 +29,7 @@ use lemmy_api_common::{
   context::LemmyContext,
   plugins::{plugin_hook_after, plugin_hook_before},
   request::generate_post_link_metadata,
-  utils::{
-    check_nsfw_allowed,
-    get_url_blocklist,
-    process_markdown_opt,
-    purge_post_images,
-    slur_regex,
-  },
+  utils::{check_nsfw_allowed, get_url_blocklist, process_markdown_opt, slur_regex},
 };
 use lemmy_db_schema::{
   source::{
@@ -241,9 +235,9 @@ impl Object for ApubPost {
     // posts that get updated to be NSFW
     let block_for_nsfw = check_nsfw_allowed(page.sensitive, local_site.as_ref());
     if let Err(e) = block_for_nsfw {
-      let url = url.clone().map(std::convert::Into::into);
-      let thumbnail_url = page.image.map(|i| i.url.into());
-      purge_post_images(url, thumbnail_url, context).await;
+      // TODO: Remove locally generated thumbnail if one exists, depends on
+      //       https://github.com/LemmyNet/lemmy/issues/5564 to be implemented to be able to
+      //       safely do this.
       Post::delete_from_apub_id(&mut context.pool(), page.id.inner().clone()).await?;
       Err(e)?
     }

--- a/crates/db_schema/src/impls/post.rs
+++ b/crates/db_schema/src/impls/post.rs
@@ -40,7 +40,6 @@ use diesel::{
   NullableExpressionMethods,
   OptionalExtension,
   QueryDsl,
-  TextExpressionMethods,
 };
 use diesel_async::RunQueryDsl;
 use lemmy_utils::{
@@ -208,75 +207,6 @@ impl Post {
       .set(post::deleted.eq(true))
       .get_results::<Self>(conn)
       .await
-  }
-
-  pub async fn fetch_pictrs_posts_for_creator(
-    pool: &mut DbPool<'_>,
-    for_creator_id: PersonId,
-  ) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let pictrs_search = "%pictrs/image%";
-
-    post::table
-      .filter(post::creator_id.eq(for_creator_id))
-      .filter(post::url.like(pictrs_search))
-      .load::<Self>(conn)
-      .await
-  }
-
-  /// Sets the url and thumbnails fields to None
-  pub async fn remove_pictrs_post_images_and_thumbnails_for_creator(
-    pool: &mut DbPool<'_>,
-    for_creator_id: PersonId,
-  ) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let pictrs_search = "%pictrs/image%";
-
-    diesel::update(
-      post::table
-        .filter(post::creator_id.eq(for_creator_id))
-        .filter(post::url.like(pictrs_search)),
-    )
-    .set((
-      post::url.eq::<Option<String>>(None),
-      post::thumbnail_url.eq::<Option<String>>(None),
-    ))
-    .get_results::<Self>(conn)
-    .await
-  }
-
-  pub async fn fetch_pictrs_posts_for_community(
-    pool: &mut DbPool<'_>,
-    for_community_id: CommunityId,
-  ) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let pictrs_search = "%pictrs/image%";
-    post::table
-      .filter(post::community_id.eq(for_community_id))
-      .filter(post::url.like(pictrs_search))
-      .load::<Self>(conn)
-      .await
-  }
-
-  /// Sets the url and thumbnails fields to None
-  pub async fn remove_pictrs_post_images_and_thumbnails_for_community(
-    pool: &mut DbPool<'_>,
-    for_community_id: CommunityId,
-  ) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let pictrs_search = "%pictrs/image%";
-
-    diesel::update(
-      post::table
-        .filter(post::community_id.eq(for_community_id))
-        .filter(post::url.like(pictrs_search)),
-    )
-    .set((
-      post::url.eq::<Option<String>>(None),
-      post::thumbnail_url.eq::<Option<String>>(None),
-    ))
-    .get_results::<Self>(conn)
-    .await
   }
 
   pub async fn user_scheduled_post_count(


### PR DESCRIPTION
This commit removes various cases in which Lemmy would purge images from pictrs, which would in many cases not be what admins intended.

pict-rs provides aliases on upload, which allows deduplicating multiple uploads of the same file in the backend, while still providing unique URLs for uploads.

As Lemmy used pictrs' purge API, this meant that not only the image alias referring to removed content was deleted, all other aliases were invalidated as well.

Additionally, even alias deletion would not appropriate in many of these cases, as they were lacking validation that they were exclusively used by the content they were supposed to get removed with.

This implements the following changes:

1. Purging a community no longer purges the community banner or icon from pict-rs.
2. Purging a community no longer purges all images referenced in post URLs and post thumbnails within the community from pict-rs.
3. Banning a user with content removal no longer purges their profile avatar or banner from pict-rs.
4. Banning a user with content removal no longer purges images referenced in post URLs and post thumbnails for all posts they created from pict-rs.
5. Banning a user with content removal no longer purges the community banners or icons for all communities they're the top mod of from pict-rs.
6. Banning a user with content removal now deletes all media they uploaded.
7. Purging a user no longer purges their profile avatar, banner, or images referenced in post URLs and post thumbnails for all posts they created from pict-rs. All media linked to their user account will still get deleted, which was already explicitly the case in the past.
8. On an NSFW-disabled instance, receiving a post update via federation, which changes the post from not NSFW to NSFW no longer purges post URL and thumbnail from pict-rs.

Some of the mentioned actions will still remove references to image URLs from the database, such as purging a community will still set its icon and banner to `NULL` in the db, but the associated images will no longer be purged from pict-rs.

As this stops erasure of thumbnails, #5564 has been created to ensure tracking the person that triggered the creation of thumbnails, which will allow removing them like other images.

The only remaining option to purge images attached to a post is now purging an individual post, which still erases the post URL and thumbnail from pict-rs entirely, including any other aliases. Purging and banning users with content removal will remove all aliases associated with them, which will end up deleting those images entirely when there are no other alias remaining.

fixes #5560