### PR TITLE
[0.19] Remove unnecessary pictrs purge calls

### DIFF
--- a/crates/api/src/site/purge/community.rs
+++ b/crates/api/src/site/purge/community.rs
@@ -2,10 +2,9 @@ use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
   context::LemmyContext,
-  request::purge_image_from_pictrs,
   send_activity::{ActivityChannel, SendActivityData},
   site::PurgeCommunity,
-  utils::{is_admin, purge_image_posts_for_community},
+  utils::is_admin,
   SuccessResponse,
 };
 use lemmy_db_schema::{
@@ -49,16 +48,6 @@ pub async fn purge_community(
     community_mod_person_ids,
   )
   .await?;
-
-  if let Some(banner) = &community.banner {
-    purge_image_from_pictrs(banner, &context).await.ok();
-  }
-
-  if let Some(icon) = &community.icon {
-    purge_image_from_pictrs(icon, &context).await.ok();
-  }
-
-  purge_image_posts_for_community(data.community_id, &context).await?;
 
   Community::delete(&mut context.pool(), data.community_id).await?;
 

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -1,10 +1,6 @@
 use crate::{
   context::LemmyContext,
-  request::{
-    delete_image_from_pictrs,
-    fetch_pictrs_proxied_image_details,
-    purge_image_from_pictrs,
-  },
+  request::{delete_image_from_pictrs, fetch_pictrs_proxied_image_details},
   site::{FederatedInstances, InstanceWithFederationState},
 };
 use chrono::{DateTime, Days, Local, TimeZone, Utc};
@@ -628,26 +624,6 @@ pub async fn read_site_for_actor(
   Ok(site)
 }
 
-pub async fn purge_image_posts_for_person(
-  banned_person_id: PersonId,
-  context: &LemmyContext,
-) -> LemmyResult<()> {
-  let pool = &mut context.pool();
-  let posts = Post::fetch_pictrs_posts_for_creator(pool, banned_person_id).await?;
-  for post in posts {
-    if let Some(url) = post.url {
-      purge_image_from_pictrs(&url, context).await.ok();
-    }
-    if let Some(thumbnail_url) = post.thumbnail_url {
-      purge_image_from_pictrs(&thumbnail_url, context).await.ok();
-    }
-  }
-
-  Post::remove_pictrs_post_images_and_thumbnails_for_creator(pool, banned_person_id).await?;
-
-  Ok(())
-}
-
 /// Delete a local_user's images
 async fn delete_local_user_images(person_id: PersonId, context: &LemmyContext) -> LemmyResult<()> {
   if let Ok(Some(local_user)) = LocalUserView::read_person(&mut context.pool(), person_id).await {
@@ -669,41 +645,11 @@ async fn delete_local_user_images(person_id: PersonId, context: &LemmyContext) -
   Ok(())
 }
 
-pub async fn purge_image_posts_for_community(
-  banned_community_id: CommunityId,
-  context: &LemmyContext,
-) -> LemmyResult<()> {
-  let pool = &mut context.pool();
-  let posts = Post::fetch_pictrs_posts_for_community(pool, banned_community_id).await?;
-  for post in posts {
-    if let Some(url) = post.url {
-      purge_image_from_pictrs(&url, context).await.ok();
-    }
-    if let Some(thumbnail_url) = post.thumbnail_url {
-      purge_image_from_pictrs(&thumbnail_url, context).await.ok();
-    }
-  }
-
-  Post::remove_pictrs_post_images_and_thumbnails_for_community(pool, banned_community_id).await?;
-
-  Ok(())
-}
-
 pub async fn remove_user_data(
   banned_person_id: PersonId,
   context: &LemmyContext,
 ) -> LemmyResult<()> {
   let pool = &mut context.pool();
-  // Purge user images
-  let person = Person::read(pool, banned_person_id)
-    .await?
-    .ok_or(LemmyErrorType::CouldntFindPerson)?;
-  if let Some(avatar) = person.avatar {
-    purge_image_from_pictrs(&avatar, context).await.ok();
-  }
-  if let Some(banner) = person.banner {
-    purge_image_from_pictrs(&banner, context).await.ok();
-  }
 
   // Update the fields to None
   Person::update(
@@ -721,8 +667,7 @@ pub async fn remove_user_data(
   // Posts
   Post::update_removed_for_creator(pool, banned_person_id, None, true).await?;
 
-  // Purge image posts
-  purge_image_posts_for_person(banned_person_id, context).await?;
+  delete_local_user_images(banned_person_id, context).await?;
 
   // Communities
   // Remove all communities where they're the top mod
@@ -747,13 +692,6 @@ pub async fn remove_user_data(
     )
     .await?;
 
-    // Delete the community images
-    if let Some(icon) = first_mod_community.community.icon {
-      purge_image_from_pictrs(&icon, context).await.ok();
-    }
-    if let Some(banner) = first_mod_community.community.banner {
-      purge_image_from_pictrs(&banner, context).await.ok();
-    }
     // Update the fields to None
     Community::update(
       pool,
@@ -813,23 +751,9 @@ pub async fn remove_user_data_in_community(
 pub async fn purge_user_account(person_id: PersonId, context: &LemmyContext) -> LemmyResult<()> {
   let pool = &mut context.pool();
 
-  let person = Person::read(pool, person_id)
-    .await?
-    .ok_or(LemmyErrorType::CouldntFindPerson)?;
-
   // Delete their local images, if they're a local user
-  delete_local_user_images(person_id, context).await.ok();
-
   // No need to update avatar and banner, those are handled in Person::delete_account
-  if let Some(avatar) = person.avatar {
-    purge_image_from_pictrs(&avatar, context).await.ok();
-  }
-  if let Some(banner) = person.banner {
-    purge_image_from_pictrs(&banner, context).await.ok();
-  }
-
-  // Purge image posts
-  purge_image_posts_for_person(person_id, context).await.ok();
+  delete_local_user_images(person_id, context).await.ok();
 
   // Comments
   Comment::permadelete_for_creator(pool, person_id)

--- a/crates/db_schema/src/impls/post.rs
+++ b/crates/db_schema/src/impls/post.rs
@@ -29,14 +29,7 @@ use crate::{
 };
 use ::url::Url;
 use chrono::{DateTime, Utc};
-use diesel::{
-  dsl::insert_into,
-  result::Error,
-  DecoratableTarget,
-  ExpressionMethods,
-  QueryDsl,
-  TextExpressionMethods,
-};
+use diesel::{dsl::insert_into, result::Error, DecoratableTarget, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 use std::collections::HashSet;
 
@@ -172,75 +165,6 @@ impl Post {
       .first(conn)
       .await
       .optional()
-  }
-
-  pub async fn fetch_pictrs_posts_for_creator(
-    pool: &mut DbPool<'_>,
-    for_creator_id: PersonId,
-  ) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let pictrs_search = "%pictrs/image%";
-
-    post::table
-      .filter(post::creator_id.eq(for_creator_id))
-      .filter(post::url.like(pictrs_search))
-      .load::<Self>(conn)
-      .await
-  }
-
-  /// Sets the url and thumbnails fields to None
-  pub async fn remove_pictrs_post_images_and_thumbnails_for_creator(
-    pool: &mut DbPool<'_>,
-    for_creator_id: PersonId,
-  ) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let pictrs_search = "%pictrs/image%";
-
-    diesel::update(
-      post::table
-        .filter(post::creator_id.eq(for_creator_id))
-        .filter(post::url.like(pictrs_search)),
-    )
-    .set((
-      post::url.eq::<Option<String>>(None),
-      post::thumbnail_url.eq::<Option<String>>(None),
-    ))
-    .get_results::<Self>(conn)
-    .await
-  }
-
-  pub async fn fetch_pictrs_posts_for_community(
-    pool: &mut DbPool<'_>,
-    for_community_id: CommunityId,
-  ) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let pictrs_search = "%pictrs/image%";
-    post::table
-      .filter(post::community_id.eq(for_community_id))
-      .filter(post::url.like(pictrs_search))
-      .load::<Self>(conn)
-      .await
-  }
-
-  /// Sets the url and thumbnails fields to None
-  pub async fn remove_pictrs_post_images_and_thumbnails_for_community(
-    pool: &mut DbPool<'_>,
-    for_community_id: CommunityId,
-  ) -> Result<Vec<Self>, Error> {
-    let conn = &mut get_conn(pool).await?;
-    let pictrs_search = "%pictrs/image%";
-
-    diesel::update(
-      post::table
-        .filter(post::community_id.eq(for_community_id))
-        .filter(post::url.like(pictrs_search)),
-    )
-    .set((
-      post::url.eq::<Option<String>>(None),
-      post::thumbnail_url.eq::<Option<String>>(None),
-    ))
-    .get_results::<Self>(conn)
-    .await
   }
 }
 


### PR DESCRIPTION
backports #5565 to 0.19

This commit removes various cases in which Lemmy would purge images from pictrs, which would in many cases not be what admins intended.

pict-rs provides aliases on upload, which allows deduplicating multiple uploads of the same file in the backend, while still providing unique URLs for uploads.

As Lemmy used pictrs' purge API, this meant that not only the image alias referring to removed content was deleted, all other aliases were invalidated as well.

Additionally, even alias deletion would not appropriate in many of these cases, as they were lacking validation that they were exclusively used by the content they were supposed to get removed with.

This implements the following changes:

1. Purging a community no longer purges the community banner or icon from pict-rs.
2. Purging a community no longer purges all images referenced in post URLs and post thumbnails within the community from pict-rs.
3. Banning a user with content removal no longer purges their profile avatar or banner from pict-rs.
4. Banning a user with content removal no longer purges images referenced in post URLs and post thumbnails for all posts they created from pict-rs.
5. Banning a user with content removal no longer purges the community banners or icons for all communities they're the top mod of from pict-rs.
6. Banning a user with content removal now deletes all media they uploaded.
7. Purging a user no longer purges their profile avatar, banner, or images referenced in post URLs and post thumbnails for all posts they created from pict-rs. All media linked to their user account will still get deleted, which was already explicitly the case in the past.

Some of the mentioned actions will still remove references to image URLs from the database, such as purging a community will still set its icon and banner to `NULL` in the db, but the associated images will no longer be purged from pict-rs.

As this stops erasure of thumbnails, #5564 has been created to ensure tracking the person that triggered the creation of thumbnails, which will allow removing them like other images.

The only remaining option to purge images attached to a post is now purging an individual post, which still erases the post URL and thumbnail from pict-rs entirely, including any other aliases. Purging and banning users with content removal will remove all aliases associated with them, which will end up deleting those images entirely when there are no other alias remaining.