### PR TITLE
Refined slur_regex pattern

### DIFF
--- a/crates/utils/src/utils/slurs.rs
+++ b/crates/utils/src/utils/slurs.rs
@@ -52,7 +52,7 @@ mod test {
 
   #[test]
   fn test_slur_filter() -> LemmyResult<()> {
-    let slur_regex = RegexBuilder::new(r"(fag(g|got|tard)?\b|cock\s?sucker(s|ing)?|ni((g{2,}|q)+|[gq]{2,})[e3r]+(s|z)?|mudslime?s?|kikes?|\bspi(c|k)s?\b|\bchinks?|gooks?|bitch(es|ing|y)?|whor(es?|ing)|\btr(a|@)nn?(y|ies?)|\b(b|re|r)tard(ed)?s?)").case_insensitive(true).build()?;
+    let slur_regex = RegexBuilder::new(r"(fag(g|got|tard)?\b|cock\s?sucker(s|ing)?|ni[gq]{2}[e3]?r[sz]?|mudslime?s?|kikes?|\bspi(c|k)s?\b|\bchinks?|gooks?|bitch(es|ing|y)?|whor(es?|ing)|\btr(a|@)nn?(y|ies?)|\b(b|re|r)tard(ed)?s?)").case_insensitive(true).build()?;
     let test =
       "faggot test kike tranny cocksucker retardeds. Capitalized Niggerz. This is a bunch of other safe text.";
     let slur_free = "No slurs here";


### PR DESCRIPTION
The current pattern `ni((g{2,}|q)+|[gq]{2,})[e3r]+(s|z)?` will match all of the following:
niqe
nigge
niqq3
nigqe
niggge
niqgq3
niqqqe

Maybe I'm naive or unaware, but I feel like none of these have any reason to be censored.

Additionally, the groupings `(g{2,}|q)+` and `[gq]{2,}` are pretty much redundant.
___
Switching to `ni[gq]{2}[e3]?r[sz]?` will then only match with:
- "ni"
- two of any combination of "g" or "q"
- one optional "e" or substitute "3"
- one "r"
- one optional "s" or substitute "z"
___
I suppose a discussion could be had about what structure of the word warrants the censorship, and how much should be added to the pattern to mitigate attempted bypasses (like adding or switching letters?)
Is it the "er", or the "gg" with the "r"?
Should multiple "g"s or "e"s be considered?