### PR TITLE
Check admin status when deleting image (fixes #5563)

### DIFF
--- a/crates/routes/src/images/delete.rs
+++ b/crates/routes/src/images/delete.rs
@@ -127,6 +127,7 @@ pub async fn delete_image(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<SuccessResponse>> {
+  is_admin(&local_user_view)?;
   LocalImage::delete_by_alias_and_user(
     &mut context.pool(),
     &data.filename,


### PR DESCRIPTION
API v4 already includes a function to delete user images, but it was missing an admin check. Was originally added in https://github.com/LemmyNet/lemmy/pull/5260