### PR TITLE
Provide native binary for releases

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -289,13 +289,15 @@ steps:
     when:
       - event: tag
 
+  # https://woodpecker-ci.org/plugins/Release
   publish_native_binary:
     image: woodpeckerci/plugin-release
     settings:
       files:
         - lemmy_server.gz
         - sha256sum.txt
-      title: ${CI_COMMIT_TAG##v}
+      title: ${CI_COMMIT_TAG}
+      prerelease: true
       api-key:
         from_secret: github_token
     when:


### PR DESCRIPTION
During release builds, extract the Lemmy binary from newly built Docker image and upload it to Github releases. This can be used for lemmy-plugins repo and for simpler native installation.

Unfortunately this approach only works for x86, for ARM it would require a more complicated approach:
- https://woodpecker-ci.org/docs/next/usage/advanced-usage#docker-in-docker-dind-setup
- https://stackoverflow.com/a/51186557

[Here](https://github.com/LemmyNet/lemmy/releases/tag/1.0.0-publish-native-binary.8) you can see a test release created by this.