### PR TITLE
Remove git-tracked paths from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,17 +1,1 @@
-# build folders and similar which are not needed for the docker build
-# don't include git-tracked paths here, as they will result in a dirty git version being embedded
-target
-ansible
-tests
-*.sh
-pictrs
-
-# docker build files
-docker/lemmy_mine.hjson
-docker/dev/env_deploy.sh
-
-# API tests
-api_tests/node_modules
-api_tests/.yalc
-api_tests/yalc.lock
-api_tests/pict-rs
+.gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,17 @@
 # build folders and similar which are not needed for the docker build
+# don't include git-tracked paths here, as they will result in a dirty git version being embedded
 target
-docker
-api_tests
 ansible
 tests
 *.sh
 pictrs
+
+# docker build files
+docker/lemmy_mine.hjson
+docker/dev/env_deploy.sh
+
+# API tests
+api_tests/node_modules
+api_tests/.yalc
+api_tests/yalc.lock
+api_tests/pict-rs


### PR DESCRIPTION
Since #5470 added automatic git version tags builds will include a `-modified` version suffix if they have uncommitted changes in the Git repository.

The final container images are not copying any files from the local directory, so none of the files copied into the builder stage will end up in the final image.

Fixes #5589