### PR TITLE
Fix random failures in can_mod test

### DIFF
--- a/crates/db_views/src/community/community_view.rs
+++ b/crates/db_views/src/community/community_view.rs
@@ -208,6 +208,7 @@ mod tests {
   };
   use lemmy_utils::error::{LemmyErrorType, LemmyResult};
   use serial_test::serial;
+  use std::collections::HashSet;
   use url::Url;
 
   struct Data {
@@ -469,20 +470,19 @@ mod tests {
 
     let mod_query = CommunityQuery {
       local_user: Some(&data.local_user),
-      sort: Some(CommunitySortType::New),
       ..Default::default()
     }
     .list(&data.site, pool)
     .await?
     .into_iter()
     .map(|c| (c.community.name, c.can_mod))
-    .collect::<Vec<_>>();
+    .collect::<HashSet<_>>();
 
-    let expected_communities = vec![
+    let expected_communities = HashSet::from([
       ("test_community_3".to_owned(), false),
       ("test_community_2".to_owned(), true),
       ("test_community_1".to_owned(), true),
-    ];
+    ]);
     assert_eq!(expected_communities, mod_query);
 
     cleanup(data, pool).await


### PR DESCRIPTION
Despite sorting by new the results are sometimes in the wrong order, so use a hashset instead of vec.

https://woodpecker.join-lemmy.org/repos/129/pipeline/13042/14#L1133

```
  left: [("test_community_1", true), ("test_community_2", true), ("test_community_3", false)]
 right: [("test_community_2", true), ("test_community_3", false), ("test_community_1", true)]
```