### PR TITLE
[0.19] diesel CLI version pin for CI backport

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -8,8 +8,8 @@ variables:
   - &install_binstall "wget -O- https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz | tar -xvz -C /usr/local/cargo/bin"
   - install_diesel_cli: &install_diesel_cli
       - apt-get update && apt-get install -y postgresql-client
-      # --locked ensures compatibility with the currently used rust version
-      - cargo install diesel_cli --no-default-features --features postgres --locked
+      # diesel_cli@2.2.8 is the last version that supports rust 1.81, which we are currently locked on due to perf regressions on rust 1.82+ :(
+      - cargo install --locked diesel_cli@2.2.8 --no-default-features --features postgres
       - export PATH="$CARGO_HOME/bin:$PATH"
   - &slow_check_paths
     - event: pull_request


### PR DESCRIPTION
backport of 303db029cf2e3230af50d3db133320c396e8830d from #5389

extracted from #5608 to test if CI passes without the other changes in #5608