### PR TITLE
Avoid sending BanFromSite activities twice on user purges

### DIFF
--- a/crates/api/src/site/purge/person.rs
+++ b/crates/api/src/site/purge/person.rs
@@ -40,7 +40,7 @@ pub async fn purge_person(
   ActivityChannel::submit_activity(
     SendActivityData::BanFromSite {
       moderator: local_user_view.person.clone(),
-      banned_user: person.clone(),
+      banned_user: person,
       reason: data.reason.clone(),
       remove_or_restore_data: Some(true),
       ban: true,
@@ -65,18 +65,6 @@ pub async fn purge_person(
     reason: data.reason.clone(),
   };
   AdminPurgePerson::create(&mut context.pool(), &form).await?;
-
-  ActivityChannel::submit_activity(
-    SendActivityData::BanFromSite {
-      moderator: local_user_view.person,
-      banned_user: person,
-      reason: data.reason.clone(),
-      remove_or_restore_data: Some(true),
-      ban: true,
-      expires: None,
-    },
-    &context,
-  )?;
 
   Ok(Json(SuccessResponse::default()))
 }


### PR DESCRIPTION
Prior to #5515, when a user was purged, a function was called to ensure that in addtition to the site ban, purges of remote users would result in individual community bans for each local local community being federated out, as this was an intermediate solution to address the lack of federated content removal otherwise.

As proper handling of banned users was implemented in that PR, the logic for federating out community bans was changed to federate directly as a site ban. This logic already existed in the user purge function, resulting in duplication.

The first instance of the ban is kept rather than the second one to ensure that federation happens even if any of the later local DB writes run into issues, as those will be more likely to be caught by the admin performing the purge, so they can just repeat the request to resolve that.