### PR TITLE
[0.19] Use version from git to indicate unreleased changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2155,6 +2155,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "git-version"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
+dependencies = [
+ "git-version-macro",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3194,6 +3214,7 @@ dependencies = [
  "doku",
  "enum-map",
  "futures",
+ "git-version",
  "html2text",
  "http 0.2.12",
  "itertools 0.13.0",

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -84,6 +84,7 @@ ts-rs = { workspace = true, optional = true }
 enum-map = { workspace = true, optional = true }
 cfg-if = "1"
 clearurls = { version = "0.0.4", features = ["linkify"] }
+git-version = "0.3.9"
 
 [dev-dependencies]
 reqwest = { workspace = true }

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -14,11 +14,15 @@ cfg_if! {
 
 pub mod error;
 pub use error::LemmyErrorType;
+use git_version::git_version;
 use std::time::Duration;
 
 pub type ConnectionId = usize;
 
-pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const VERSION: &str = git_version!(
+  args = ["--tags", "--dirty=-modified"],
+  fallback = env!("CARGO_PKG_VERSION")
+);
 
 pub const REQWEST_TIMEOUT: Duration = Duration::from_secs(10);
 


### PR DESCRIPTION
backported from #5470, 62fb03599a5268e02286689225a994bc75bbe907