### PR TITLE
Ensure new posts in NSFW communities are marked NSFW

### DIFF
--- a/crates/api_crud/src/post/create.rs
+++ b/crates/api_crud/src/post/create.rs
@@ -92,8 +92,12 @@ pub async fn create_post(
   let community = &community_view.community;
   check_community_user_action(&local_user_view, community, &mut context.pool()).await?;
 
-  // If its an NSFW community, then use that as a default
-  let nsfw = data.nsfw.or(Some(community.nsfw));
+  // Ensure that all posts in NSFW communities are marked as NSFW
+  let nsfw = if community.nsfw {
+    Some(true)
+  } else {
+    data.nsfw
+  };
 
   if community.posting_restricted_to_mods {
     let community_id = data.community_id;

--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -232,9 +232,16 @@ impl Object for ApubPost {
       None
     };
 
+    // Ensure that all posts in NSFW communities are marked as NSFW
+    let nsfw = if community.nsfw {
+      Some(true)
+    } else {
+      page.sensitive
+    };
+
     // If NSFW is not allowed, reject NSFW posts and delete existing
     // posts that get updated to be NSFW
-    let block_for_nsfw = check_nsfw_allowed(page.sensitive, local_site.as_ref());
+    let block_for_nsfw = check_nsfw_allowed(nsfw, local_site.as_ref());
     if let Err(e) = block_for_nsfw {
       // TODO: Remove locally generated thumbnail if one exists, depends on
       //       https://github.com/LemmyNet/lemmy/issues/5564 to be implemented to be able to
@@ -276,7 +283,7 @@ impl Object for ApubPost {
       published: page.published,
       updated: page.updated,
       deleted: Some(false),
-      nsfw: page.sensitive,
+      nsfw,
       ap_id: Some(page.id.clone().into()),
       local: Some(false),
       language_id,


### PR DESCRIPTION
Clients exposing the NSFW setting to users will typically do so by providing a checkbox, which is either checked or unchecked, but there is no third option to let the server decide. As a result, virtually all posts created through user interfaces will have a bool value for NSFW, so this logic likely is used only for posts created by scripts/bots.

In #5310 the behavior for new posts was changed to default the NSFW flag to the community's NSFW setting, but it only did so as a default if no value was provided when creating a post via API.

This changes the logic to force all new posts created via API or received from federation to be NSFW if the community they're posted in is marked NSFW, otherwise use the value provided by the creator, with a default of false if nothing is provided.

It also ensures that this logic is used for filtering out NSFW posts on instances blocking NSFW content.

Related to https://github.com/LemmyNet/lemmy/issues/5651

Fixes #5651 