### PR TITLE
Avoid constant rebuilding due to git version

### DIFF
--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -12,15 +12,17 @@ cfg_if! {
 }
 
 pub mod error;
-use git_version::git_version;
 use std::time::Duration;
 
 pub type ConnectionId = usize;
 
-pub const VERSION: &str = git_version!(
+#[cfg(not(debug_assertions))]
+pub const VERSION: &str = git_version::git_version!(
   args = ["--tags", "--dirty=-modified"],
   fallback = env!("CARGO_PKG_VERSION")
 );
+#[cfg(debug_assertions)]
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub const REQWEST_TIMEOUT: Duration = Duration::from_secs(10);
 


### PR DESCRIPTION
I noticed that all of the crates were constantly being rebuilt even without any relevant changes. You can see it like this:
- Run `cargo build`
- Make a change in main.rs
- Run `cargo build`

Note that all crates starting from lemmy_utils are being rebuilt, which wastes a lot of time. `cargo build -v` showed that this is because `.git/index` gets changed, which the `git_version!` macro depends on. In development builds the exact version doesnt matter much anyway, so I changed it to use the macro only in release builds.