### PR TITLE
Downscale proxied thumbnails (fixes #5673)

### DIFF
--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -213,7 +213,7 @@ pub async fn generate_post_link_metadata(
 
   // Proxy the post url itself if it is an image
   let url = if let (true, Some(url)) = (is_image_post, post.url.clone()) {
-    Some(Some(proxy_image_link(url.into(), &context).await?))
+    Some(Some(proxy_image_link(url.into(), false, &context).await?))
   } else {
     None
   };
@@ -227,7 +227,7 @@ pub async fn generate_post_link_metadata(
   // Attempt to generate a thumbnail depending on the instance settings. Either by proxying,
   // storing image persistently in pict-rs or returning the remote url directly as thumbnail.
   let thumbnail_url = if let (false, Some(url)) = (is_image_post, custom_thumbnail) {
-    proxy_image_link(url.clone(), &context)
+    proxy_image_link(url.clone(), true, &context)
       .await
       .map_err(|e| warn!("Failed to proxy thumbnail: {e}"))
       .ok()
@@ -449,7 +449,11 @@ async fn generate_pictrs_thumbnail(image_url: &Url, context: &LemmyContext) -> L
   match pictrs_config.image_mode {
     PictrsImageMode::None => return Ok(image_url.clone()),
     PictrsImageMode::ProxyAllImages => {
-      return Ok(proxy_image_link(image_url.clone(), context).await?.into())
+      return Ok(
+        proxy_image_link(image_url.clone(), true, context)
+          .await?
+          .into(),
+      )
     }
     _ => {}
   };

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -857,8 +857,7 @@ pub async fn process_markdown(
       // Insert image details for the remote image
       let details_res = fetch_pictrs_proxied_image_details(&link, context).await;
       if let Ok(details) = details_res {
-        let proxied =
-          build_proxied_image_url(&link, &context.settings().get_protocol_and_hostname())?;
+        let proxied = build_proxied_image_url(&link, false, context)?;
         let details_form = details.build_image_details_form(&proxied);
         ImageDetails::create(&mut context.pool(), &details_form).await?;
       }
@@ -890,6 +889,7 @@ pub async fn process_markdown_opt(
 async fn proxy_image_link_internal(
   link: Url,
   image_mode: PictrsImageMode,
+  is_thumbnail: bool,
   context: &LemmyContext,
 ) -> LemmyResult<DbUrl> {
   // Dont rewrite links pointing to local domain.
@@ -898,7 +898,7 @@ async fn proxy_image_link_internal(
   } else if image_mode == PictrsImageMode::ProxyAllImages {
     RemoteImage::create(&mut context.pool(), vec![link.clone()]).await?;
 
-    let proxied = build_proxied_image_url(&link, &context.settings().get_protocol_and_hostname())?;
+    let proxied = build_proxied_image_url(&link, is_thumbnail, context)?;
     // This should fail softly, since pictrs might not even be running
     let details_res = fetch_pictrs_proxied_image_details(&link, context).await;
 
@@ -915,8 +915,18 @@ async fn proxy_image_link_internal(
 
 /// Rewrite a link to go through `/api/v4/image_proxy` endpoint. This is only for remote urls and
 /// if image_proxy setting is enabled.
-pub async fn proxy_image_link(link: Url, context: &LemmyContext) -> LemmyResult<DbUrl> {
-  proxy_image_link_internal(link, context.settings().pictrs()?.image_mode, context).await
+pub async fn proxy_image_link(
+  link: Url,
+  is_thumbnail: bool,
+  context: &LemmyContext,
+) -> LemmyResult<DbUrl> {
+  proxy_image_link_internal(
+    link,
+    context.settings().pictrs()?.image_mode,
+    is_thumbnail,
+    context,
+  )
+  .await
 }
 
 pub async fn proxy_image_link_opt_apub(
@@ -924,7 +934,7 @@ pub async fn proxy_image_link_opt_apub(
   context: &LemmyContext,
 ) -> LemmyResult<Option<DbUrl>> {
   if let Some(l) = link {
-    proxy_image_link(l, context).await.map(Some)
+    proxy_image_link(l, false, context).await.map(Some)
   } else {
     Ok(None)
   }
@@ -932,13 +942,21 @@ pub async fn proxy_image_link_opt_apub(
 
 fn build_proxied_image_url(
   link: &Url,
-  protocol_and_hostname: &str,
-) -> Result<Url, url::ParseError> {
-  Url::parse(&format!(
+  is_thumbnail: bool,
+  context: &LemmyContext,
+) -> LemmyResult<Url> {
+  let mut url = format!(
     "{}/api/v4/image/proxy?url={}",
-    protocol_and_hostname,
-    encode(link.as_str())
-  ))
+    context.settings().get_protocol_and_hostname(),
+    encode(link.as_str()),
+  );
+  if is_thumbnail {
+    url = format!(
+      "{url}&max_size={}",
+      context.settings().pictrs()?.max_thumbnail_size
+    );
+  }
+  Ok(Url::parse(&url)?)
 }
 
 pub async fn local_user_view_from_jwt(
@@ -1036,9 +1054,13 @@ mod tests {
 
     // image from local domain is unchanged
     let local_url = Url::parse("http://lemmy-alpha/image.png")?;
-    let proxied =
-      proxy_image_link_internal(local_url.clone(), PictrsImageMode::ProxyAllImages, &context)
-        .await?;
+    let proxied = proxy_image_link_internal(
+      local_url.clone(),
+      PictrsImageMode::ProxyAllImages,
+      false,
+      &context,
+    )
+    .await?;
     assert_eq!(&local_url, proxied.inner());
 
     // image from remote domain is proxied
@@ -1046,6 +1068,7 @@ mod tests {
     let proxied = proxy_image_link_internal(
       remote_image.clone(),
       PictrsImageMode::ProxyAllImages,
+      false,
       &context,
     )
     .await?;


### PR DESCRIPTION
When using ProxyAllImages add `&max_size={config.pictrs.max_thumbnail_size}` to thumbnail url. In case of StoreLinkPreviews these are already being downscaled inside `generate_pictrs_thumbnail()`. 