### PR TITLE
[0.19] Include published in VoteView order by for more consistent pagination

### DIFF
--- a/crates/db_views/src/vote_view.rs
+++ b/crates/db_views/src/vote_view.rs
@@ -41,7 +41,7 @@ impl VoteView {
         community_person_ban::community_id.nullable().is_not_null(),
         post_like::score,
       ))
-      .order_by(post_like::score)
+      .order_by((post_like::score, post_like::published))
       .limit(limit)
       .offset(offset)
       .load::<Self>(conn)
@@ -74,7 +74,7 @@ impl VoteView {
         community_person_ban::community_id.nullable().is_not_null(),
         comment_like::score,
       ))
-      .order_by(comment_like::score)
+      .order_by((comment_like::score, comment_like::published))
       .limit(limit)
       .offset(offset)
       .load::<Self>(conn)


### PR DESCRIPTION
A tie breaker was already included on the main branch when cursor pagination was implemented, but it uses the person id instead.
Sorting by vote time seems more logical to me when paging though.
Should I create a PR against main to also change that to published or do you want to keep it as person id?