### PR TITLE
[0.19] Improve media deletion logic

### DIFF
--- a/crates/api/src/local_user/save_settings.rs
+++ b/crates/api/src/local_user/save_settings.rs
@@ -49,11 +49,23 @@ pub async fn save_user_settings(
   );
 
   let avatar = diesel_url_update(data.avatar.as_deref())?;
-  replace_image(&avatar, &local_user_view.person.avatar, &context).await?;
+  replace_image(
+    &avatar,
+    &local_user_view.person.avatar,
+    &context,
+    &local_user_view.local_user,
+  )
+  .await?;
   let avatar = proxy_image_link_opt_api(avatar, &context).await?;
 
   let banner = diesel_url_update(data.banner.as_deref())?;
-  replace_image(&banner, &local_user_view.person.banner, &context).await?;
+  replace_image(
+    &banner,
+    &local_user_view.person.banner,
+    &context,
+    &local_user_view.local_user,
+  )
+  .await?;
   let banner = proxy_image_link_opt_api(banner, &context).await?;
 
   let display_name = diesel_string_update(data.display_name.as_deref());

--- a/crates/api_crud/src/site/update.rs
+++ b/crates/api_crud/src/site/update.rs
@@ -76,11 +76,11 @@ pub async fn update_site(
   );
 
   let icon = diesel_url_update(data.icon.as_deref())?;
-  replace_image(&icon, &site.icon, &context).await?;
+  replace_image(&icon, &site.icon, &context, &local_user_view.local_user).await?;
   let icon = proxy_image_link_opt_api(icon, &context).await?;
 
   let banner = diesel_url_update(data.banner.as_deref())?;
-  replace_image(&banner, &site.banner, &context).await?;
+  replace_image(&banner, &site.banner, &context, &local_user_view.local_user).await?;
   let banner = proxy_image_link_opt_api(banner, &context).await?;
 
   let site_form = SiteUpdateForm {

--- a/crates/db_schema/src/impls/images.rs
+++ b/crates/db_schema/src/impls/images.rs
@@ -1,7 +1,10 @@
 use crate::{
   newtypes::DbUrl,
   schema::{image_details, local_image, remote_image},
-  source::images::{ImageDetails, ImageDetailsForm, LocalImage, LocalImageForm, RemoteImage},
+  source::{
+    images::{ImageDetails, ImageDetailsForm, LocalImage, LocalImageForm, RemoteImage},
+    local_user::LocalUser,
+  },
   utils::{get_conn, DbPool},
 };
 use diesel::{
@@ -40,16 +43,29 @@ impl LocalImage {
       .await
   }
 
-  pub async fn delete_by_alias(pool: &mut DbPool<'_>, alias: &str) -> Result<Self, Error> {
+  /// Deletes the matching row if either the upload is associated with the correct person or the
+  /// user is an admin.
+  pub async fn delete_by_alias_and_user(
+    pool: &mut DbPool<'_>,
+    local_user: &LocalUser,
+    alias: &str,
+  ) -> Result<Self, Error> {
     let conn = &mut get_conn(pool).await?;
-    diesel::delete(local_image::table.filter(local_image::pictrs_alias.eq(alias)))
-      .get_result(conn)
-      .await
+    let mut query =
+      diesel::delete(local_image::table.filter(local_image::pictrs_alias.eq(alias))).into_boxed();
+    if !local_user.admin {
+      query = query.filter(local_image::local_user_id.eq(local_user.id))
+    };
+    query.get_result(conn).await
   }
 
-  pub async fn delete_by_url(pool: &mut DbPool<'_>, url: &DbUrl) -> Result<Self, Error> {
+  pub async fn delete_by_url_and_user(
+    pool: &mut DbPool<'_>,
+    local_user: &LocalUser,
+    url: &DbUrl,
+  ) -> Result<Self, Error> {
     let alias = url.as_str().split('/').last().ok_or(NotFound)?;
-    Self::delete_by_alias(pool, alias).await
+    Self::delete_by_alias_and_user(pool, local_user, alias).await
   }
 }
 


### PR DESCRIPTION
Media replacements for avatars, banners, and icons now only delete previously used media if it was uploaded by the person performing the change or if that person is an admin.

Removing avatars, banners, and icons has previously incorrectly retained them, this has also been addressed by using the same deletion logic for both replacements with new media and also removal of media in those places.

Updating community metadata now validates that the user has appropriate permissions before executing media replacement code to delete old media.

Media deletions via API now validate that the user performing the deletion either owns the upload or is an admin. This is a partial backport of #5317 and #5588 without the associated DB migrations and the requirement of having a correct pict-rs API key set up in Lemmy's configuration. The media deletion token provided via API is now completely ignored and Lemmy only evaluates media ownership or admin status to decide whether deletion is allowed.

For community banner and icon updates this no longer deletes old media unless it's been uploaded by the current user or the person changing it is an admin. Cleanup of old media in these cases will return in 1.0, which has a different approach to dealing with this type of media.