### PR TITLE
TypeScript type CommunityIdQuery for community icon/banner uploads

### DIFF
--- a/crates/api_common/src/image.rs
+++ b/crates/api_common/src/image.rs
@@ -47,6 +47,8 @@ pub struct UploadImageResponse {
 /// Parameter for setting community icon or banner. Can't use POST data here as it already contains
 /// the image data.
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "full", derive(TS))]
+#[cfg_attr(feature = "full", ts(export))]
 pub struct CommunityIdQuery {
   pub id: CommunityId,
 }


### PR DESCRIPTION
`lemmy_js_client` doesn't specify a community when uploading a community icon or banner.