### PR TITLE
Use same federation keypair for all new users and communities

### DIFF
--- a/crates/api_crud/src/community/create.rs
+++ b/crates/api_crud/src/community/create.rs
@@ -1,5 +1,5 @@
 use super::check_community_visibility_allowed;
-use activitypub_federation::{config::Data, http_signatures::generate_actor_keypair};
+use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
   build_response::build_community_response,
@@ -88,15 +88,12 @@ pub async fn create_community(
     Err(LemmyErrorType::CommunityAlreadyExists)?
   }
 
-  // When you create a community, make sure the user becomes a moderator and a follower
-  let keypair = generate_actor_keypair()?;
-
   let community_form = CommunityInsertForm {
     sidebar,
     description,
     nsfw: data.nsfw,
     ap_id: Some(community_ap_id.clone()),
-    private_key: Some(keypair.private_key),
+    private_key: site_view.site.private_key,
     followers_url: Some(generate_followers_url(&community_ap_id)?),
     inbox_url: Some(generate_inbox_url()?),
     posting_restricted_to_mods: data.posting_restricted_to_mods,
@@ -105,7 +102,7 @@ pub async fn create_community(
       site_view.site.instance_id,
       data.name.clone(),
       data.title.clone(),
-      keypair.public_key,
+      site_view.site.public_key,
     )
   };
 

--- a/crates/db_schema/src/source/community.rs
+++ b/crates/db_schema/src/source/community.rs
@@ -126,7 +126,7 @@ pub struct CommunityInsertForm {
   #[new(default)]
   pub local: Option<bool>,
   #[new(default)]
-  pub private_key: Option<String>,
+  pub private_key: Option<SensitiveString>,
   #[new(default)]
   pub last_refreshed_at: Option<DateTime<Utc>>,
   #[new(default)]

--- a/crates/db_schema/src/source/person.rs
+++ b/crates/db_schema/src/source/person.rs
@@ -93,7 +93,7 @@ pub struct PersonInsertForm {
   #[new(default)]
   pub local: Option<bool>,
   #[new(default)]
-  pub private_key: Option<String>,
+  pub private_key: Option<SensitiveString>,
   #[new(default)]
   pub last_refreshed_at: Option<DateTime<Utc>>,
   #[new(default)]

--- a/crates/federate/src/worker.rs
+++ b/crates/federate/src/worker.rs
@@ -496,7 +496,7 @@ mod test {
       let ap_id: DbUrl = Url::parse("http://local.com/u/alice")?.into();
       let person_form = PersonInsertForm {
         ap_id: Some(ap_id.clone()),
-        private_key: (Some(actor_keypair.private_key)),
+        private_key: (Some(actor_keypair.private_key.into())),
         inbox_url: Some(generate_inbox_url()?),
         ..PersonInsertForm::new("alice".to_string(), actor_keypair.public_key, instance.id)
       };

--- a/crates/routes/src/utils/code_migrations.rs
+++ b/crates/routes/src/utils/code_migrations.rs
@@ -406,7 +406,7 @@ async fn initialize_local_site_2022_10_10(
     let person_form = PersonInsertForm {
       ap_id: Some(person_ap_id.clone()),
       inbox_url: Some(generate_inbox_url()?),
-      private_key: Some(person_keypair.private_key),
+      private_key: Some(person_keypair.private_key.into()),
       ..PersonInsertForm::new(
         setup.admin_username.clone(),
         person_keypair.public_key,


### PR DESCRIPTION
There is no reason why every user and community needs a different private/public keypair for federation. It would be enough to have a single keypair per instance, which could reduce db size and memory usage. But in practice this would be complicated to change, see https://github.com/LemmyNet/lemmy/issues/4530.

Another problem is that key generation is relatively slow. So for a partial solution we can simply copy the local site keypair when creating a new user/community instead of generating new keys. This way the change is minimal and can easily be backported to 0.19.