### PR TITLE
Use same federation keypair for all new users and communities (#5709)

### DIFF
--- a/crates/api_crud/src/community/create.rs
+++ b/crates/api_crud/src/community/create.rs
@@ -18,6 +18,7 @@ use lemmy_api_common::{
   },
 };
 use lemmy_db_schema::{
+  sensitive::SensitiveString,
   source::{
     actor_language::{CommunityLanguage, LocalUserLanguage, SiteLanguage},
     community::{
@@ -95,7 +96,7 @@ pub async fn create_community(
     .banner(banner)
     .nsfw(data.nsfw)
     .actor_id(Some(community_actor_id.clone()))
-    .private_key(site_view.site.private_key.map(|p| p.into_inner()))
+    .private_key(site_view.site.private_key.map(SensitiveString::into_inner))
     .public_key(site_view.site.public_key)
     .followers_url(Some(generate_followers_url(&community_actor_id)?))
     .inbox_url(Some(generate_inbox_url(&community_actor_id)?))

--- a/crates/api_crud/src/community/create.rs
+++ b/crates/api_crud/src/community/create.rs
@@ -1,4 +1,4 @@
-use activitypub_federation::{config::Data, http_signatures::generate_actor_keypair};
+use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_common::{
   build_response::build_community_response,
@@ -87,9 +87,6 @@ pub async fn create_community(
     Err(LemmyErrorType::CommunityAlreadyExists)?
   }
 
-  // When you create a community, make sure the user becomes a moderator and a follower
-  let keypair = generate_actor_keypair()?;
-
   let community_form = CommunityInsertForm::builder()
     .name(data.name.clone())
     .title(data.title.clone())
@@ -98,8 +95,8 @@ pub async fn create_community(
     .banner(banner)
     .nsfw(data.nsfw)
     .actor_id(Some(community_actor_id.clone()))
-    .private_key(Some(keypair.private_key))
-    .public_key(keypair.public_key)
+    .private_key(site_view.site.private_key.map(|p| p.into_inner()))
+    .public_key(site_view.site.public_key)
     .followers_url(Some(generate_followers_url(&community_actor_id)?))
     .inbox_url(Some(generate_inbox_url(&community_actor_id)?))
     .shared_inbox_url(Some(generate_shared_inbox_url(context.settings())?))

--- a/crates/api_crud/src/user/create.rs
+++ b/crates/api_crud/src/user/create.rs
@@ -1,4 +1,4 @@
-use activitypub_federation::{config::Data, http_signatures::generate_actor_keypair};
+use activitypub_federation::config::Data;
 use actix_web::{web::Json, HttpRequest};
 use diesel_async::{scoped_futures::ScopedFutureExt, AsyncConnection};
 use lemmy_api_common::{
@@ -99,7 +99,6 @@ pub async fn register(
   check_slurs(&data.username, &slur_regex)?;
   check_slurs_opt(&data.answer, &slur_regex)?;
 
-  let actor_keypair = generate_actor_keypair()?;
   is_valid_actor_name(&data.username, local_site.actor_name_max_length as usize)?;
   let actor_id = generate_local_apub_endpoint(
     EndpointType::Person,
@@ -159,10 +158,10 @@ pub async fn register(
     actor_id: Some(actor_id.clone()),
     inbox_url: Some(generate_inbox_url(&actor_id)?),
     shared_inbox_url: Some(generate_shared_inbox_url(context.settings())?),
-    private_key: Some(actor_keypair.private_key),
+    private_key: site_view.site.private_key.map(Into::into),
     ..PersonInsertForm::new(
       data.username.clone(),
-      actor_keypair.public_key,
+      site_view.site.public_key,
       site_view.site.instance_id,
     )
   };

--- a/crates/db_schema/src/source/person.rs
+++ b/crates/db_schema/src/source/person.rs
@@ -83,7 +83,7 @@ pub struct PersonInsertForm {
   #[new(default)]
   pub local: Option<bool>,
   #[new(default)]
-  pub private_key: Option<String>,
+  pub private_key: Option<SensitiveString>,
   #[new(default)]
   pub last_refreshed_at: Option<DateTime<Utc>>,
   #[new(default)]

--- a/crates/federate/src/worker.rs
+++ b/crates/federate/src/worker.rs
@@ -491,7 +491,7 @@ mod test {
       let actor_id: DbUrl = Url::parse("http://local.com/u/alice")?.into();
       let person_form = PersonInsertForm {
         actor_id: Some(actor_id.clone()),
-        private_key: (Some(actor_keypair.private_key)),
+        private_key: (Some(actor_keypair.private_key.into())),
         inbox_url: Some(generate_inbox_url(&actor_id)?),
         shared_inbox_url: Some(generate_shared_inbox_url(context.settings())?),
         ..PersonInsertForm::new("alice".to_string(), actor_keypair.public_key, instance.id)

--- a/src/code_migrations.rs
+++ b/src/code_migrations.rs
@@ -459,7 +459,7 @@ async fn initialize_local_site_2022_10_10(
       actor_id: Some(person_actor_id.clone()),
       inbox_url: Some(generate_inbox_url(&person_actor_id)?),
       shared_inbox_url: Some(generate_shared_inbox_url(settings)?),
-      private_key: Some(person_keypair.private_key),
+      private_key: Some(person_keypair.private_key.into()),
       ..PersonInsertForm::new(
         setup.admin_username.clone(),
         person_keypair.public_key,


### PR DESCRIPTION
Seems like this doesnt give any noticable performance benefit, so we may also revert it on main branch.