### PR TITLE
Decrement fail_count instead of reset to 0 (ref #5716)

### DIFF
--- a/crates/federate/src/worker.rs
+++ b/crates/federate/src/worker.rs
@@ -25,7 +25,7 @@ use lemmy_db_schema::{
   utils::{ActualDbPool, DbPool},
 };
 use lemmy_utils::error::LemmyResult;
-use std::{collections::BinaryHeap, ops::Add, time::Duration};
+use std::{cmp::max, collections::BinaryHeap, ops::Add, time::Duration};
 use tokio::{
   sync::mpsc::{self, UnboundedSender},
   time::sleep,
@@ -265,7 +265,7 @@ impl InstanceWorker {
         SendActivityResult::Success(s) => {
           self.in_flight -= 1;
           if !s.was_skipped {
-            self.state.fail_count = 0;
+            self.state.fail_count = max(0, self.state.fail_count - 1);
             self.mark_instance_alive().await?;
           }
           self.successfuls.push(s);


### PR DESCRIPTION
This way activity sending can gradually ramp up once an instance becomes available, instead of instantly overloading it again.