### PR TITLE
Simplifying transaction call (#5703)

### DIFF
--- a/crates/api/src/community/ban.rs
+++ b/crates/api/src/community/ban.rs
@@ -1,14 +1,12 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
-use diesel_async::{scoped_futures::ScopedFutureExt, AsyncConnection};
+use diesel_async::scoped_futures::ScopedFutureExt;
 use lemmy_api_common::{
   community::{BanFromCommunity, BanFromCommunityResponse},
   context::LemmyContext,
   send_activity::{ActivityChannel, SendActivityData},
   utils::{
-    check_community_mod_action,
-    check_expire_time,
-    remove_or_restore_user_data_in_community,
+    check_community_mod_action, check_expire_time, remove_or_restore_user_data_in_community,
   },
 };
 use lemmy_db_schema::{
@@ -23,7 +21,7 @@ use lemmy_db_schema::{
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_db_views_person::PersonView;
 use lemmy_utils::{
-  error::{LemmyError, LemmyResult},
+  error::LemmyResult,
   utils::validation::is_valid_body_field,
 };
 
@@ -60,51 +58,50 @@ pub async fn ban_from_community(
   let pool = &mut context.pool();
   let conn = &mut get_conn(pool).await?;
   let tx_data = data.clone();
-  conn
-    .transaction::<_, LemmyError, _>(|conn| {
-      async move {
-        if tx_data.ban {
-          CommunityActions::ban(&mut conn.into(), &community_user_ban_form).await?;
+  conn.run_transaction(|conn| {
+    async move {
+      if tx_data.ban {
+        CommunityActions::ban(&mut conn.into(), &community_user_ban_form).await?;
 
-          // Also unsubscribe them from the community, if they are subscribed
-          CommunityActions::unfollow(&mut conn.into(), banned_person_id, tx_data.community_id)
-            .await
-            .ok();
-        } else {
-          CommunityActions::unban(&mut conn.into(), &community_user_ban_form).await?;
-        }
-
-        // Remove/Restore their data if that's desired
-        if tx_data.remove_or_restore_data.unwrap_or(false) {
-          let remove_data = tx_data.ban;
-          remove_or_restore_user_data_in_community(
-            tx_data.community_id,
-            local_user_view.person.id,
-            banned_person_id,
-            remove_data,
-            &tx_data.reason,
-            &mut conn.into(),
-          )
-          .await?;
-        };
-
-        // Mod tables
-        let form = ModBanFromCommunityForm {
-          mod_person_id: local_user_view.person.id,
-          other_person_id: tx_data.person_id,
-          community_id: tx_data.community_id,
-          reason: tx_data.reason.clone(),
-          banned: Some(tx_data.ban),
-          expires,
-        };
-
-        ModBanFromCommunity::create(&mut conn.into(), &form).await?;
-
-        Ok(())
+        // Also unsubscribe them from the community, if they are subscribed
+        CommunityActions::unfollow(&mut conn.into(), banned_person_id, tx_data.community_id)
+          .await
+          .ok();
+      } else {
+        CommunityActions::unban(&mut conn.into(), &community_user_ban_form).await?;
       }
-      .scope_boxed()
-    })
-    .await?;
+
+      // Remove/Restore their data if that's desired
+      if tx_data.remove_or_restore_data.unwrap_or(false) {
+        let remove_data = tx_data.ban;
+        remove_or_restore_user_data_in_community(
+          tx_data.community_id,
+          local_user_view.person.id,
+          banned_person_id,
+          remove_data,
+          &tx_data.reason,
+          &mut conn.into(),
+        )
+        .await?;
+      };
+
+      // Mod tables
+      let form = ModBanFromCommunityForm {
+        mod_person_id: local_user_view.person.id,
+        other_person_id: tx_data.person_id,
+        community_id: tx_data.community_id,
+        reason: tx_data.reason.clone(),
+        banned: Some(tx_data.ban),
+        expires,
+      };
+
+      ModBanFromCommunity::create(&mut conn.into(), &form).await?;
+
+      Ok(())
+    }
+    .scope_boxed()
+  })
+  .await?;
 
   let person_view = PersonView::read(
     &mut context.pool(),

--- a/crates/api/src/community/transfer.rs
+++ b/crates/api/src/community/transfer.rs
@@ -1,6 +1,6 @@
 use actix_web::web::{Data, Json};
 use anyhow::Context;
-use diesel_async::{scoped_futures::ScopedFutureExt, AsyncConnection};
+use diesel_async::scoped_futures::ScopedFutureExt;
 use lemmy_api_common::{
   community::{GetCommunityResponse, TransferCommunity},
   context::LemmyContext,
@@ -18,7 +18,7 @@ use lemmy_db_views_community::CommunityView;
 use lemmy_db_views_community_moderator::CommunityModeratorView;
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_utils::{
-  error::{LemmyError, LemmyErrorType, LemmyResult},
+  error::{LemmyErrorType, LemmyResult},
   location_info,
 };
 
@@ -57,34 +57,33 @@ pub async fn transfer_community(
   let pool = &mut context.pool();
   let conn = &mut get_conn(pool).await?;
   let tx_data = data.clone();
-  conn
-    .transaction::<_, LemmyError, _>(|conn| {
-      async move {
-        CommunityActions::delete_mods_for_community(&mut conn.into(), community_id).await?;
+  conn.run_transaction(|conn| {
+    async move {
+      CommunityActions::delete_mods_for_community(&mut conn.into(), community_id).await?;
 
-        // TODO: this should probably be a bulk operation
-        // Re-add the mods, in the new order
-        for cmod in &community_mods {
-          let community_moderator_form =
-            CommunityModeratorForm::new(cmod.community.id, cmod.moderator.id);
+      // TODO: this should probably be a bulk operation
+      // Re-add the mods, in the new order
+      for cmod in &community_mods {
+        let community_moderator_form =
+          CommunityModeratorForm::new(cmod.community.id, cmod.moderator.id);
 
-          CommunityActions::join(&mut conn.into(), &community_moderator_form).await?;
-        }
-
-        // Mod tables
-        let form = ModTransferCommunityForm {
-          mod_person_id: local_user_view.person.id,
-          other_person_id: tx_data.person_id,
-          community_id: tx_data.community_id,
-        };
-
-        ModTransferCommunity::create(&mut conn.into(), &form).await?;
-
-        Ok(())
+        CommunityActions::join(&mut conn.into(), &community_moderator_form).await?;
       }
-      .scope_boxed()
-    })
-    .await?;
+
+      // Mod tables
+      let form = ModTransferCommunityForm {
+        mod_person_id: local_user_view.person.id,
+        other_person_id: tx_data.person_id,
+        community_id: tx_data.community_id,
+      };
+
+      ModTransferCommunity::create(&mut conn.into(), &form).await?;
+
+      Ok(())
+    }
+    .scope_boxed()
+  })
+  .await?;
 
   let community_id = data.community_id;
   let community_view = CommunityView::read(

--- a/crates/api/src/site/registration_applications/approve.rs
+++ b/crates/api/src/site/registration_applications/approve.rs
@@ -32,32 +32,33 @@ pub async fn approve_registration_application(
   let pool = &mut context.pool();
   let conn = &mut get_conn(pool).await?;
   let tx_data = data.clone();
-  let approved_user_id = conn.run_transaction(|conn| {
-    async move {
-      // Update the registration with reason, admin_id
-      let deny_reason = diesel_string_update(tx_data.deny_reason.as_deref());
-      let app_form = RegistrationApplicationUpdateForm {
-        admin_id: Some(Some(local_user_view.person.id)),
-        deny_reason,
-      };
+  let approved_user_id = conn
+    .run_transaction(|conn| {
+      async move {
+        // Update the registration with reason, admin_id
+        let deny_reason = diesel_string_update(tx_data.deny_reason.as_deref());
+        let app_form = RegistrationApplicationUpdateForm {
+          admin_id: Some(Some(local_user_view.person.id)),
+          deny_reason,
+        };
 
-      let registration_application =
-        RegistrationApplication::update(&mut conn.into(), app_id, &app_form).await?;
+        let registration_application =
+          RegistrationApplication::update(&mut conn.into(), app_id, &app_form).await?;
 
-      // Update the local_user row
-      let local_user_form = LocalUserUpdateForm {
-        accepted_application: Some(tx_data.approve),
-        ..Default::default()
-      };
+        // Update the local_user row
+        let local_user_form = LocalUserUpdateForm {
+          accepted_application: Some(tx_data.approve),
+          ..Default::default()
+        };
 
-      let approved_user_id = registration_application.local_user_id;
-      LocalUser::update(&mut conn.into(), approved_user_id, &local_user_form).await?;
+        let approved_user_id = registration_application.local_user_id;
+        LocalUser::update(&mut conn.into(), approved_user_id, &local_user_form).await?;
 
-      Ok(approved_user_id)
-    }
-    .scope_boxed()
-  })
-  .await?;
+        Ok(approved_user_id)
+      }
+      .scope_boxed()
+    })
+    .await?;
 
   let approved_local_user_view = LocalUserView::read(&mut context.pool(), approved_user_id).await?;
   if approved_local_user_view.local_user.email.is_some() {

--- a/crates/api/src/site/registration_applications/approve.rs
+++ b/crates/api/src/site/registration_applications/approve.rs
@@ -1,6 +1,6 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
-use diesel_async::{scoped_futures::ScopedFutureExt, AsyncConnection};
+use diesel_async::scoped_futures::ScopedFutureExt;
 use lemmy_api_common::{
   context::LemmyContext,
   site::{ApproveRegistrationApplication, RegistrationApplicationResponse},
@@ -17,7 +17,7 @@ use lemmy_db_schema::{
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_db_views_registration_applications::RegistrationApplicationView;
 use lemmy_email::account::{send_application_approved_email, send_application_denied_email};
-use lemmy_utils::error::{LemmyError, LemmyResult};
+use lemmy_utils::error::LemmyResult;
 
 pub async fn approve_registration_application(
   data: Json<ApproveRegistrationApplication>,
@@ -32,33 +32,32 @@ pub async fn approve_registration_application(
   let pool = &mut context.pool();
   let conn = &mut get_conn(pool).await?;
   let tx_data = data.clone();
-  let approved_user_id = conn
-    .transaction::<_, LemmyError, _>(|conn| {
-      async move {
-        // Update the registration with reason, admin_id
-        let deny_reason = diesel_string_update(tx_data.deny_reason.as_deref());
-        let app_form = RegistrationApplicationUpdateForm {
-          admin_id: Some(Some(local_user_view.person.id)),
-          deny_reason,
-        };
+  let approved_user_id = conn.run_transaction(|conn| {
+    async move {
+      // Update the registration with reason, admin_id
+      let deny_reason = diesel_string_update(tx_data.deny_reason.as_deref());
+      let app_form = RegistrationApplicationUpdateForm {
+        admin_id: Some(Some(local_user_view.person.id)),
+        deny_reason,
+      };
 
-        let registration_application =
-          RegistrationApplication::update(&mut conn.into(), app_id, &app_form).await?;
+      let registration_application =
+        RegistrationApplication::update(&mut conn.into(), app_id, &app_form).await?;
 
-        // Update the local_user row
-        let local_user_form = LocalUserUpdateForm {
-          accepted_application: Some(tx_data.approve),
-          ..Default::default()
-        };
+      // Update the local_user row
+      let local_user_form = LocalUserUpdateForm {
+        accepted_application: Some(tx_data.approve),
+        ..Default::default()
+      };
 
-        let approved_user_id = registration_application.local_user_id;
-        LocalUser::update(&mut conn.into(), approved_user_id, &local_user_form).await?;
+      let approved_user_id = registration_application.local_user_id;
+      LocalUser::update(&mut conn.into(), approved_user_id, &local_user_form).await?;
 
-        Ok(approved_user_id)
-      }
-      .scope_boxed()
-    })
-    .await?;
+      Ok(approved_user_id)
+    }
+    .scope_boxed()
+  })
+  .await?;
 
   let approved_local_user_view = LocalUserView::read(&mut context.pool(), approved_user_id).await?;
   if approved_local_user_view.local_user.email.is_some() {

--- a/crates/api_crud/src/user/create.rs
+++ b/crates/api_crud/src/user/create.rs
@@ -1,6 +1,6 @@
 use activitypub_federation::config::Data;
 use actix_web::{web::Json, HttpRequest};
-use diesel_async::{scoped_futures::ScopedFutureExt, AsyncConnection, AsyncPgConnection};
+use diesel_async::{scoped_futures::ScopedFutureExt, AsyncPgConnection};
 use lemmy_api_common::{
   claims::Claims,
   context::LemmyContext,
@@ -350,7 +350,7 @@ pub async fn authenticate_with_oauth(
       let tx_data = data.clone();
       let tx_context = context.clone();
       let user = conn
-        .transaction::<_, LemmyError, _>(|conn| {
+        .run_transaction(|conn| {
           async move {
             let site_view = SiteView::read_local(&mut tx_context.pool()).await?;
             // make sure the username is provided

--- a/crates/api_crud/src/user/create.rs
+++ b/crates/api_crud/src/user/create.rs
@@ -7,13 +7,8 @@ use lemmy_api_common::{
   oauth_provider::AuthenticateWithOauth,
   person::{LoginResponse, Register},
   utils::{
-    check_email_verified,
-    check_local_user_valid,
-    check_registration_application,
-    generate_inbox_url,
-    honeypot_check,
-    password_length_check,
-    slur_regex,
+    check_email_verified, check_local_user_valid, check_registration_application,
+    generate_inbox_url, honeypot_check, password_length_check, slur_regex,
   },
 };
 use lemmy_db_schema::{
@@ -36,8 +31,7 @@ use lemmy_db_schema_file::enums::RegistrationMode;
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_db_views_site::SiteView;
 use lemmy_email::{
-  account::send_verification_email_if_required,
-  admin::send_new_applicant_email_to_admins,
+  account::send_verification_email_if_required, admin::send_new_applicant_email_to_admins,
 };
 use lemmy_utils::{
   error::{LemmyError, LemmyErrorExt, LemmyErrorType, LemmyResult},
@@ -132,45 +126,44 @@ pub async fn register(
   let conn = &mut get_conn(pool).await?;
   let tx_data = data.clone();
   let tx_context = context.clone();
-  let user = conn
-    .transaction::<_, LemmyError, _>(|conn| {
-      async move {
-        let site_view = SiteView::read_local(&mut tx_context.pool()).await?;
-        // We have to create both a person, and local_user
-        let person = create_person(tx_data.username.clone(), &site_view, &tx_context, conn).await?;
+  let user = conn.run_transaction(|conn| {
+    async move {
+      let site_view = SiteView::read_local(&mut tx_context.pool()).await?;
+      // We have to create both a person, and local_user
+      let person = create_person(tx_data.username.clone(), &site_view, &tx_context, conn).await?;
 
-        // Create the local user
-        let local_user_form = LocalUserInsertForm {
-          email: tx_data.email.as_deref().map(str::to_lowercase),
-          show_nsfw: Some(show_nsfw),
-          accepted_application,
-          ..LocalUserInsertForm::new(person.id, Some(tx_data.password.to_string()))
-        };
+      // Create the local user
+      let local_user_form = LocalUserInsertForm {
+        email: tx_data.email.as_deref().map(str::to_lowercase),
+        show_nsfw: Some(show_nsfw),
+        accepted_application,
+        ..LocalUserInsertForm::new(person.id, Some(tx_data.password.to_string()))
+      };
 
-        let local_user =
-          create_local_user(conn, language_tags, local_user_form, &site_view.local_site).await?;
+      let local_user =
+        create_local_user(conn, language_tags, local_user_form, &site_view.local_site).await?;
 
-        if local_site.site_setup && require_registration_application {
-          if let Some(answer) = tx_data.answer.clone() {
-            // Create the registration application
-            let form = RegistrationApplicationInsertForm {
-              local_user_id: local_user.id,
-              answer,
-            };
+      if local_site.site_setup && require_registration_application {
+        if let Some(answer) = tx_data.answer.clone() {
+          // Create the registration application
+          let form = RegistrationApplicationInsertForm {
+            local_user_id: local_user.id,
+            answer,
+          };
 
-            RegistrationApplication::create(&mut conn.into(), &form).await?;
-          }
+          RegistrationApplication::create(&mut conn.into(), &form).await?;
         }
-
-        Ok(LocalUserView {
-          person,
-          local_user,
-          instance_actions: None,
-        })
       }
-      .scope_boxed()
-    })
-    .await?;
+
+      Ok(LocalUserView {
+        person,
+        local_user,
+        instance_actions: None,
+      })
+    }
+    .scope_boxed()
+  })
+  .await?;
 
   // Email the admins, only if email verification is not required
   if local_site.application_email_admins && !local_site.require_email_verification {

--- a/crates/db_schema/src/impls/actor_language.rs
+++ b/crates/db_schema/src/impls/actor_language.rs
@@ -19,14 +19,12 @@ use diesel::{
   delete,
   dsl::{count, exists},
   insert_into,
-  result::Error,
   select,
   ExpressionMethods,
   QueryDsl,
 };
 use diesel_async::{
   scoped_futures::ScopedFutureExt,
-  AsyncConnection,
   AsyncPgConnection,
   RunQueryDsl,
 };
@@ -76,14 +74,15 @@ impl LocalUserLanguage {
     }
 
     conn
-      .transaction::<_, Error, _>(|conn| {
+      .run_transaction(|conn| {
         async move {
           // Delete old languages, not including new languages
           delete(local_user_language::table)
             .filter(local_user_language::local_user_id.eq(for_local_user_id))
             .filter(local_user_language::language_id.ne_all(&lang_ids))
             .execute(conn)
-            .await?;
+            .await
+            .with_lemmy_type(LemmyErrorType::CouldntUpdateLanguages)?;
 
           let forms = lang_ids
             .iter()
@@ -103,11 +102,11 @@ impl LocalUserLanguage {
             .do_nothing()
             .execute(conn)
             .await
+            .with_lemmy_type(LemmyErrorType::CouldntUpdateLanguages)
         }
         .scope_boxed()
       })
       .await
-      .with_lemmy_type(LemmyErrorType::CouldntUpdateLanguages)
   }
 }
 
@@ -153,14 +152,15 @@ impl SiteLanguage {
     }
 
     conn
-      .transaction::<_, Error, _>(|conn| {
+      .run_transaction(|conn| {
         async move {
           // Delete old languages, not including new languages
           delete(site_language::table)
             .filter(site_language::site_id.eq(for_site_id))
             .filter(site_language::language_id.ne_all(&lang_ids))
             .execute(conn)
-            .await?;
+            .await
+            .with_lemmy_type(LemmyErrorType::CouldntUpdateLanguages)?;
 
           let forms = lang_ids
             .iter()
@@ -176,18 +176,16 @@ impl SiteLanguage {
             .on_conflict((site_language::site_id, site_language::language_id))
             .do_nothing()
             .execute(conn)
-            .await?;
-
-          CommunityLanguage::limit_languages(conn, instance_id)
             .await
-            .map_err(|_e| diesel::result::Error::NotFound)?;
+            .with_lemmy_type(LemmyErrorType::CouldntUpdateLanguages)?;
+
+          CommunityLanguage::limit_languages(conn, instance_id).await?;
 
           Ok(())
         }
         .scope_boxed()
       })
       .await
-      .with_lemmy_type(LemmyErrorType::CouldntUpdateLanguages)
   }
 }
 
@@ -289,14 +287,15 @@ impl CommunityLanguage {
       .collect::<Vec<_>>();
 
     conn
-      .transaction::<_, Error, _>(|conn| {
+      .run_transaction(|conn| {
         async move {
           // Delete old languages, not including new languages
           delete(community_language::table)
             .filter(community_language::community_id.eq(for_community_id))
             .filter(community_language::language_id.ne_all(&lang_ids))
             .execute(conn)
-            .await?;
+            .await
+            .with_lemmy_type(LemmyErrorType::CouldntUpdateLanguages)?;
 
           // Insert new languages
           insert_into(community_language::table)
@@ -308,11 +307,11 @@ impl CommunityLanguage {
             .do_nothing()
             .execute(conn)
             .await
+            .with_lemmy_type(LemmyErrorType::CouldntUpdateLanguages)
         }
         .scope_boxed()
       })
       .await
-      .with_lemmy_type(LemmyErrorType::CouldntUpdateLanguages)
   }
 }
 

--- a/crates/db_schema/src/impls/actor_language.rs
+++ b/crates/db_schema/src/impls/actor_language.rs
@@ -23,11 +23,7 @@ use diesel::{
   ExpressionMethods,
   QueryDsl,
 };
-use diesel_async::{
-  scoped_futures::ScopedFutureExt,
-  AsyncPgConnection,
-  RunQueryDsl,
-};
+use diesel_async::{scoped_futures::ScopedFutureExt, AsyncPgConnection, RunQueryDsl};
 use lemmy_db_schema_file::schema::{
   community_language,
   local_site,

--- a/crates/db_schema/src/utils.rs
+++ b/crates/db_schema/src/utils.rs
@@ -12,38 +12,45 @@ use diesel::{
   query_builder::{Query, QueryFragment},
   query_dsl::methods::LimitDsl,
   result::{
-    ConnectionError, ConnectionResult,
+    ConnectionError,
+    ConnectionResult,
     Error::{self as DieselError, QueryBuilderError},
   },
   sql_types::{self, Timestamptz},
-  Expression, IntoSql,
+  Expression,
+  IntoSql,
 };
-use diesel_async::scoped_futures::ScopedBoxFuture;
 use diesel_async::{
   pg::AsyncPgConnection,
   pooled_connection::{
     deadpool::{Hook, HookError, Object as PooledConnection, Pool},
-    AsyncDieselConnectionManager, ManagerConfig,
+    AsyncDieselConnectionManager,
+    ManagerConfig,
   },
+  scoped_futures::ScopedBoxFuture,
   AsyncConnection,
 };
 use futures_util::{future::BoxFuture, FutureExt};
 use i_love_jesus::{CursorKey, PaginatedQueryBuilder, SortDirection};
 use lemmy_db_schema_file::schema_setup;
-use lemmy_utils::error::LemmyError;
 use lemmy_utils::{
-  error::{LemmyErrorExt, LemmyErrorType, LemmyResult},
+  error::{LemmyError, LemmyErrorExt, LemmyErrorType, LemmyResult},
   settings::SETTINGS,
   utils::validation::clean_url,
 };
 use regex::Regex;
 use rustls::{
   client::danger::{
-    DangerousClientConfigBuilder, HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier,
+    DangerousClientConfigBuilder,
+    HandshakeSignatureValid,
+    ServerCertVerified,
+    ServerCertVerifier,
   },
   crypto::{self, verify_tls12_signature, verify_tls13_signature},
   pki_types::{CertificateDer, ServerName, UnixTime},
-  ClientConfig, DigitallySignedStruct, SignatureScheme,
+  ClientConfig,
+  DigitallySignedStruct,
+  SignatureScheme,
 };
 use std::{
   ops::{Deref, DerefMut},
@@ -87,11 +94,15 @@ pub async fn get_conn<'a, 'b: 'a>(pool: &'a mut DbPool<'b>) -> Result<DbConn<'a>
 impl DbConn<'_> {
   pub async fn run_transaction<'a, R, F>(&mut self, callback: F) -> LemmyResult<R>
   where
-    F: for<'r> FnOnce(&'r mut AsyncPgConnection) -> ScopedBoxFuture<'a, 'r, LemmyResult<R>> + Send + 'a,
+    F: for<'r> FnOnce(&'r mut AsyncPgConnection) -> ScopedBoxFuture<'a, 'r, LemmyResult<R>>
+      + Send
+      + 'a,
     R: Send + 'a,
   {
-    self.deref_mut()
-      .transaction::<_, LemmyError, _>(callback).await
+    self
+      .deref_mut()
+      .transaction::<_, LemmyError, _>(callback)
+      .await
   }
 }
 


### PR DESCRIPTION
Addresses #5703 

Now instead of calling:
```
conn.transaction::<_, LemmyError, _>(|conn| {
    async move {
    ...
    }.scope_boxed()
}).await?;
```
you do:
```
conn.run_transaction(|conn| {
    async move {
    ...
    }.scope_boxed()
}).await?;
```