### PR TITLE
Dont run scheduled tasks at startup (ref #5716)

### DIFF
--- a/crates/routes/src/utils/scheduled_tasks.rs
+++ b/crates/routes/src/utils/scheduled_tasks.rs
@@ -52,10 +52,6 @@ use tracing::{info, warn};
 pub async fn setup(context: Data<LemmyContext>) -> LemmyResult<()> {
   // Setup the connections
   let mut scheduler = AsyncScheduler::new();
-  startup_jobs(&mut context.pool())
-    .await
-    .inspect_err(|e| warn!("Failed to run startup tasks: {e}"))
-    .ok();
 
   let context_1 = context.clone();
   // Update active counts expired bans and unpublished posts every hour
@@ -141,18 +137,6 @@ pub async fn setup(context: Data<LemmyContext>) -> LemmyResult<()> {
     scheduler.run_pending().await;
     tokio::time::sleep(Duration::from_millis(1000)).await;
   }
-}
-
-/// Run these on server startup
-async fn startup_jobs(pool: &mut DbPool<'_>) -> LemmyResult<()> {
-  active_counts(pool).await?;
-  update_hot_ranks(pool).await?;
-  update_banned_when_expired(pool).await?;
-  delete_instance_block_when_expired(pool).await?;
-  clear_old_activities(pool).await?;
-  overwrite_deleted_posts_and_comments(pool).await?;
-  delete_old_denied_users(pool).await?;
-  Ok(())
 }
 
 /// Update the hot_rank columns for the aggregates tables

--- a/crates/routes/src/utils/scheduled_tasks.rs
+++ b/crates/routes/src/utils/scheduled_tasks.rs
@@ -50,8 +50,8 @@ use tracing::{info, warn};
 
 /// Schedules various cleanup tasks for lemmy in a background thread
 pub async fn setup(context: Data<LemmyContext>) -> LemmyResult<()> {
-  // Setup the connections
-  let mut scheduler = AsyncScheduler::new();
+  // https://github.com/mdsherry/clokwerk/issues/38
+  let mut scheduler = AsyncScheduler::with_tz(Utc);
 
   let context_1 = context.reset_request_count();
   // Every 10 minutes update hot ranks, delete expired captchas and publish scheduled posts

--- a/crates/routes/src/utils/scheduled_tasks.rs
+++ b/crates/routes/src/utils/scheduled_tasks.rs
@@ -581,7 +581,13 @@ mod tests {
     let context = LemmyContext::init_test_context().await;
     let instance = create_test_instance(&mut context.pool()).await?;
 
-    startup_jobs(&mut context.pool()).await?;
+    active_counts(&mut context.pool()).await?;
+    update_hot_ranks(&mut context.pool()).await?;
+    update_banned_when_expired(&mut context.pool()).await?;
+    delete_instance_block_when_expired(&mut context.pool()).await?;
+    clear_old_activities(&mut context.pool()).await?;
+    overwrite_deleted_posts_and_comments(&mut context.pool()).await?;
+    delete_old_denied_users(&mut context.pool()).await?;
     update_instance_software(&mut context.pool(), context.client()).await?;
     delete_expired_captcha_answers(&mut context.pool()).await?;
     publish_scheduled_posts(&context).await?;


### PR DESCRIPTION
None of these are really necessary, its fine to run the tasks a bit later at the normal schedule. This way we can reduce server load after startup when Lemmy is busy handling incoming activities from other instances.