### PR TITLE
 Mark some *Action struct fields as serde(skip) (ref #5532) 

### DIFF
--- a/crates/db_schema/src/source/comment.rs
+++ b/crates/db_schema/src/source/comment.rs
@@ -139,7 +139,9 @@ pub struct CommentUpdateForm {
 #[cfg_attr(feature = "full", ts(export))]
 #[cfg_attr(feature = "full", cursor_keys_module(name = comment_actions_keys))]
 pub struct CommentActions {
+  #[serde(skip)]
   pub person_id: PersonId,
+  #[serde(skip)]
   pub comment_id: CommentId,
   #[cfg_attr(feature = "full", ts(optional))]
   /// The like / score for the comment.

--- a/crates/db_schema/src/source/community.rs
+++ b/crates/db_schema/src/source/community.rs
@@ -202,7 +202,9 @@ pub struct CommunityUpdateForm {
 #[cfg_attr(feature = "full", ts(export))]
 #[cfg_attr(feature = "full", cursor_keys_module(name = community_actions_keys))]
 pub struct CommunityActions {
+  #[serde(skip)]
   pub community_id: CommunityId,
+  #[serde(skip)]
   pub person_id: PersonId,
   #[cfg_attr(feature = "full", ts(optional))]
   /// When the community was followed.
@@ -210,8 +212,8 @@ pub struct CommunityActions {
   #[cfg_attr(feature = "full", ts(optional))]
   /// The state of the community follow.
   pub follow_state: Option<CommunityFollowerState>,
-  #[cfg_attr(feature = "full", ts(optional))]
   /// The approver of the community follow.
+  #[serde(skip)]
   pub follow_approver_id: Option<PersonId>,
   #[cfg_attr(feature = "full", ts(optional))]
   /// When the community was blocked.

--- a/crates/db_schema/src/source/instance.rs
+++ b/crates/db_schema/src/source/instance.rs
@@ -58,7 +58,9 @@ pub struct InstanceForm {
 #[cfg_attr(feature = "full", diesel(check_for_backend(diesel::pg::Pg)))]
 #[cfg_attr(feature = "full", ts(export))]
 pub struct InstanceActions {
+  #[serde(skip)]
   pub person_id: PersonId,
+  #[serde(skip)]
   pub instance_id: InstanceId,
   #[cfg_attr(feature = "full", ts(optional))]
   /// When the instance was blocked.

--- a/crates/db_schema/src/source/person.rs
+++ b/crates/db_schema/src/source/person.rs
@@ -140,7 +140,9 @@ pub struct PersonUpdateForm {
 #[cfg_attr(feature = "full", diesel(check_for_backend(diesel::pg::Pg)))]
 #[cfg_attr(feature = "full", ts(export))]
 pub struct PersonActions {
+  #[serde(skip)]
   pub target_id: PersonId,
+  #[serde(skip)]
   pub person_id: PersonId,
   #[serde(skip)]
   pub followed: Option<DateTime<Utc>>,

--- a/crates/db_schema/src/source/post.rs
+++ b/crates/db_schema/src/source/post.rs
@@ -198,7 +198,9 @@ pub struct PostUpdateForm {
 #[cfg_attr(feature = "full", ts(export))]
 #[cfg_attr(feature = "full", cursor_keys_module(name = post_actions_keys))]
 pub struct PostActions {
+  #[serde(skip)]
   pub post_id: PostId,
+  #[serde(skip)]
   pub person_id: PersonId,
   #[cfg_attr(feature = "full", ts(optional))]
   /// When the post was read.


### PR DESCRIPTION
These are already part of the api response and dont need to be duplicated. Its not possible to remove them entirely because of `diesel(primary_key)` and `diesel(table_name)` annotations.