### PR TITLE
Add community name to RSS post titles

### DIFF
--- a/crates/routes/src/feeds.rs
+++ b/crates/routes/src/feeds.rs
@@ -505,7 +505,7 @@ fn create_post_items(posts: Vec<PostView>, settings: &Settings) -> LemmyResult<V
     };
 
     let i = Item {
-      title: Some(p.post.name),
+      title: Some(format!("[{}] {}", p.community.name, p.post.name)),
       pub_date: Some(p.post.published.to_rfc2822()),
       comments: Some(post_url.to_string()),
       guid,


### PR DESCRIPTION
Some people were confused because posts would show up multiple times in their RSS feed aggregator. It wasn't clear at first glance that the same article had been posted in multiple different communities.

With this commit every RSS post is prefixed with the community name in brackets.

This fixes #5729.