### PR TITLE
[0.19] Only use HTTP/1

### DIFF
--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -48,6 +48,7 @@ pub fn client_builder(settings: &Settings) -> ClientBuilder {
     .user_agent(user_agent.clone())
     .timeout(REQWEST_TIMEOUT)
     .connect_timeout(REQWEST_TIMEOUT)
+    // Workaround for https://github.com/LemmyNet/lemmy/issues/5742
     .http1_only()
     .redirect(Policy::none())
 }


### PR DESCRIPTION
Fix for the issue in #5742.

As Nothing4You said, somehow we started using HTTP/2 and we don't send valid HTTP/2 requests. So as as workaround, we just manually set up reqwest to only use HTTP/1.1.