### PR TITLE
Revert "[0.19] Downscale proxied thumbnails (#5686)"

### DIFF
--- a/api_tests/src/image.spec.ts
+++ b/api_tests/src/image.spec.ts
@@ -206,8 +206,8 @@ test("Images in remote image post are proxied if setting enabled", async () => {
     post.body?.startsWith("![](http://lemmy-gamma:8561/api/v3/image_proxy?url"),
   ).toBeTruthy();
 
-  // Make sure that it contains `jpg`, to be sure its an image
-  expect(post.thumbnail_url?.includes(".jpg")).toBeTruthy();
+  // Make sure that it ends with jpg, to be sure its an image
+  expect(post.thumbnail_url?.endsWith(".jpg")).toBeTruthy();
 
   let epsilonPostRes = await resolvePost(epsilon, postRes.post_view.post);
   expect(epsilonPostRes.post).toBeDefined();
@@ -231,8 +231,8 @@ test("Images in remote image post are proxied if setting enabled", async () => {
     ),
   ).toBeTruthy();
 
-  // Make sure that it contains `jpg`, to be sure its an image
-  expect(epsilonPost.thumbnail_url?.includes(".jpg")).toBeTruthy();
+  // Make sure that it ends with jpg, to be sure its an image
+  expect(epsilonPost.thumbnail_url?.endsWith(".jpg")).toBeTruthy();
 });
 
 test("Thumbnail of remote image link is proxied if setting enabled", async () => {
@@ -253,8 +253,8 @@ test("Thumbnail of remote image link is proxied if setting enabled", async () =>
     ),
   ).toBeTruthy();
 
-  // Make sure that it contains `png`, to be sure its an image
-  expect(post.thumbnail_url?.includes(".png")).toBeTruthy();
+  // Make sure that it ends with png, to be sure its an image
+  expect(post.thumbnail_url?.endsWith(".png")).toBeTruthy();
 
   let epsilonPostRes = await resolvePost(epsilon, postRes.post_view.post);
   expect(epsilonPostRes.post).toBeDefined();
@@ -271,8 +271,8 @@ test("Thumbnail of remote image link is proxied if setting enabled", async () =>
     ),
   ).toBeTruthy();
 
-  // Make sure that it contains `png`, to be sure its an image
-  expect(epsilonPost.thumbnail_url?.includes(".png")).toBeTruthy();
+  // Make sure that it ends with png, to be sure its an image
+  expect(epsilonPost.thumbnail_url?.endsWith(".png")).toBeTruthy();
 });
 
 test("No image proxying if setting is disabled", async () => {

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -218,7 +218,7 @@ pub async fn generate_post_link_metadata(
 
   // Proxy the post url itself if it is an image
   let url = if let (true, Some(url)) = (is_image_post, post.url.clone()) {
-    Some(Some(proxy_image_link(url.into(), false, &context).await?))
+    Some(Some(proxy_image_link(url.into(), &context).await?))
   } else {
     None
   };
@@ -232,7 +232,7 @@ pub async fn generate_post_link_metadata(
   // Attempt to generate a thumbnail depending on the instance settings. Either by proxying,
   // storing image persistently in pict-rs or returning the remote url directly as thumbnail.
   let thumbnail_url = if let (false, Some(url)) = (is_image_post, custom_thumbnail) {
-    proxy_image_link(url.clone(), true, &context)
+    proxy_image_link(url.clone(), &context)
       .await
       .map_err(|e| warn!("Failed to proxy thumbnail: {e}"))
       .ok()
@@ -430,11 +430,7 @@ async fn generate_pictrs_thumbnail(image_url: &Url, context: &LemmyContext) -> L
   match pictrs_config.image_mode() {
     PictrsImageMode::None => return Ok(image_url.clone()),
     PictrsImageMode::ProxyAllImages => {
-      return Ok(
-        proxy_image_link(image_url.clone(), true, context)
-          .await?
-          .into(),
-      )
+      return Ok(proxy_image_link(image_url.clone(), context).await?.into())
     }
     _ => {}
   };

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -870,7 +870,8 @@ pub async fn process_markdown(
       // Insert image details for the remote image
       let details_res = fetch_pictrs_proxied_image_details(&link, context).await;
       if let Ok(details) = details_res {
-        let proxied = build_proxied_image_url(&link, false, context)?;
+        let proxied =
+          build_proxied_image_url(&link, &context.settings().get_protocol_and_hostname())?;
         let details_form = details.build_image_details_form(&proxied);
         ImageDetails::create(&mut context.pool(), &details_form).await?;
       }
@@ -902,7 +903,6 @@ pub async fn process_markdown_opt(
 async fn proxy_image_link_internal(
   link: Url,
   image_mode: PictrsImageMode,
-  is_thumbnail: bool,
   context: &LemmyContext,
 ) -> LemmyResult<DbUrl> {
   // Dont rewrite links pointing to local domain.
@@ -911,7 +911,7 @@ async fn proxy_image_link_internal(
   } else if image_mode == PictrsImageMode::ProxyAllImages {
     RemoteImage::create(&mut context.pool(), vec![link.clone()]).await?;
 
-    let proxied = build_proxied_image_url(&link, is_thumbnail, context)?;
+    let proxied = build_proxied_image_url(&link, &context.settings().get_protocol_and_hostname())?;
     // This should fail softly, since pictrs might not even be running
     let details_res = fetch_pictrs_proxied_image_details(&link, context).await;
 
@@ -928,15 +928,10 @@ async fn proxy_image_link_internal(
 
 /// Rewrite a link to go through `/api/v3/image_proxy` endpoint. This is only for remote urls and
 /// if image_proxy setting is enabled.
-pub async fn proxy_image_link(
-  link: Url,
-  is_thumbnail: bool,
-  context: &LemmyContext,
-) -> LemmyResult<DbUrl> {
+pub async fn proxy_image_link(link: Url, context: &LemmyContext) -> LemmyResult<DbUrl> {
   proxy_image_link_internal(
     link,
     context.settings().pictrs_config()?.image_mode(),
-    is_thumbnail,
     context,
   )
   .await
@@ -947,7 +942,7 @@ pub async fn proxy_image_link_opt_api(
   context: &LemmyContext,
 ) -> LemmyResult<Option<Option<DbUrl>>> {
   if let Some(Some(link)) = link {
-    proxy_image_link(link.into(), false, context)
+    proxy_image_link(link.into(), context)
       .await
       .map(Some)
       .map(Some)
@@ -961,9 +956,7 @@ pub async fn proxy_image_link_api(
   context: &LemmyContext,
 ) -> LemmyResult<Option<DbUrl>> {
   if let Some(link) = link {
-    proxy_image_link(link.into(), false, context)
-      .await
-      .map(Some)
+    proxy_image_link(link.into(), context).await.map(Some)
   } else {
     Ok(link)
   }
@@ -974,7 +967,7 @@ pub async fn proxy_image_link_opt_apub(
   context: &LemmyContext,
 ) -> LemmyResult<Option<DbUrl>> {
   if let Some(l) = link {
-    proxy_image_link(l, false, context).await.map(Some)
+    proxy_image_link(l, context).await.map(Some)
   } else {
     Ok(None)
   }
@@ -982,21 +975,13 @@ pub async fn proxy_image_link_opt_apub(
 
 fn build_proxied_image_url(
   link: &Url,
-  is_thumbnail: bool,
-  context: &LemmyContext,
-) -> LemmyResult<Url> {
-  let mut url = format!(
+  protocol_and_hostname: &str,
+) -> Result<Url, url::ParseError> {
+  Url::parse(&format!(
     "{}/api/v3/image_proxy?url={}",
-    context.settings().get_protocol_and_hostname(),
-    encode(link.as_str()),
-  );
-  if is_thumbnail {
-    url = format!(
-      "{url}&thumbnail={}",
-      context.settings().pictrs_config()?.max_thumbnail_size
-    );
-  }
-  Ok(Url::parse(&url)?)
+    protocol_and_hostname,
+    encode(link.as_str())
+  ))
 }
 
 #[cfg(test)]
@@ -1053,14 +1038,10 @@ mod tests {
 
     // image from local domain is unchanged
     let local_url = Url::parse("http://lemmy-alpha/image.png").unwrap();
-    let proxied = proxy_image_link_internal(
-      local_url.clone(),
-      PictrsImageMode::ProxyAllImages,
-      false,
-      &context,
-    )
-    .await
-    .unwrap();
+    let proxied =
+      proxy_image_link_internal(local_url.clone(), PictrsImageMode::ProxyAllImages, &context)
+        .await
+        .unwrap();
     assert_eq!(&local_url, proxied.inner());
 
     // image from remote domain is proxied
@@ -1068,7 +1049,6 @@ mod tests {
     let proxied = proxy_image_link_internal(
       remote_image.clone(),
       PictrsImageMode::ProxyAllImages,
-      false,
       &context,
     )
     .await

--- a/crates/apub/src/protocol/objects/page.rs
+++ b/crates/apub/src/protocol/objects/page.rs
@@ -148,7 +148,7 @@ impl Attachment {
     let name = name.map(|n| n.split_whitespace().collect::<Vec<_>>().join(" "));
 
     if is_image {
-      let url = proxy_image_link(url, false, context).await?;
+      let url = proxy_image_link(url, context).await?;
       Ok(format!("![{}]({url})", name.unwrap_or_default()))
     } else {
       Ok(format!("[{url}]({url})"))


### PR DESCRIPTION
[This reverts commit 9b045a9786cbda8988571f55e328f3fefa27cbf7.](https://github.com/LemmyNet/lemmy/issues/5749)