### PR TITLE
Remove private instance check for get image (fixes #5763)

### DIFF
--- a/crates/routes/src/images/download.rs
+++ b/crates/routes/src/images/download.rs
@@ -10,8 +10,6 @@ use actix_web::{
 use lemmy_api_utils::context::LemmyContext;
 use lemmy_db_schema::source::images::RemoteImage;
 use lemmy_db_views_local_image::api::{ImageGetParams, ImageProxyParams};
-use lemmy_db_views_local_user::LocalUserView;
-use lemmy_db_views_site::SiteView;
 use lemmy_utils::error::LemmyResult;
 use url::Url;
 
@@ -19,16 +17,8 @@ pub async fn get_image(
   filename: Path<String>,
   Query(params): Query<ImageGetParams>,
   req: HttpRequest,
-  local_user_view: Option<LocalUserView>,
   context: Data<LemmyContext>,
 ) -> LemmyResult<HttpResponse> {
-  // block access to images if instance is private
-  if local_user_view.is_none() {
-    let local_site = SiteView::read_local(&mut context.pool()).await?.local_site;
-    if local_site.private_instance {
-      return Ok(HttpResponse::Unauthorized().finish());
-    }
-  }
   let name = &filename.into_inner();
 
   // If there are no query params, the URL is original


### PR DESCRIPTION
Note that rss feeds still require login if instance is private, but that seems desirable to prevent ddos.