### PR TITLE
Keep rustup home dir between ci steps

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -74,6 +74,7 @@ steps:
     environment:
       # store cargo data in repo folder so that it gets cached between steps
       CARGO_HOME: .cargo_home
+      RUSTUP_HOME: .rustup_home
     commands:
       - rustup component add rustfmt --toolchain nightly
       - cargo +nightly fmt -- --check
@@ -112,6 +113,7 @@ steps:
     image: *rust_image
     environment:
       CARGO_HOME: .cargo_home
+      RUSTUP_HOME: .rustup_home
     commands:
       - rustup component add clippy
       - cargo clippy --workspace --tests --all-targets -- -D warnings
@@ -135,6 +137,7 @@ steps:
       LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
       RUST_BACKTRACE: "1"
       CARGO_HOME: .cargo_home
+      RUSTUP_HOME: .rustup_home
       LEMMY_TEST_FAST_FEDERATION: "1"
       LEMMY_CONFIG_LOCATION: /woodpecker/src/github.com/LemmyNet/lemmy/config/config.hjson
     commands:
@@ -151,6 +154,7 @@ steps:
     image: *rust_image
     environment:
       CARGO_HOME: .cargo_home
+      RUSTUP_HOME: .rustup_home
     commands:
       - ./scripts/ts_bindings_check.sh
     when:
@@ -161,6 +165,7 @@ steps:
     image: *rust_image
     environment:
       CARGO_HOME: .cargo_home
+      RUSTUP_HOME: .rustup_home
     commands:
       - cargo check --package lemmy_api_common
     when: *slow_check_paths
@@ -169,6 +174,7 @@ steps:
     image: *rust_image
     environment:
       CARGO_HOME: .cargo_home
+      RUSTUP_HOME: .rustup_home
     commands:
       - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
     when: *slow_check_paths
@@ -177,6 +183,7 @@ steps:
     image: *rust_image
     environment:
       CARGO_HOME: .cargo_home
+      RUSTUP_HOME: .rustup_home
     commands:
       - "rustup target add wasm32-unknown-unknown"
       - "cargo check --target wasm32-unknown-unknown -p lemmy_api_common"
@@ -186,6 +193,7 @@ steps:
     image: *rust_image
     environment:
       CARGO_HOME: .cargo_home
+      RUSTUP_HOME: .rustup_home
     commands:
       - ./scripts/update_config_defaults.sh config/defaults_current.hjson
       - diff config/defaults.hjson config/defaults_current.hjson
@@ -195,6 +203,7 @@ steps:
     image: *rust_image
     environment:
       CARGO_HOME: .cargo_home
+      RUSTUP_HOME: .rustup_home
     commands:
       - cargo build
       - mv target/debug/lemmy_server target/lemmy_server
@@ -207,6 +216,7 @@ steps:
       DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
       RUST_BACKTRACE: "1"
       CARGO_HOME: .cargo_home
+      RUSTUP_HOME: .rustup_home
     commands:
       - cp crates/db_schema_file/src/schema.rs tmp.schema
       - target/lemmy_server migration --all run
@@ -221,6 +231,7 @@ steps:
       LEMMY_DATABASE_URL: postgres://lemmy:password@database:5432/lemmy
       RUST_BACKTRACE: "1"
       CARGO_HOME: .cargo_home
+      RUSTUP_HOME: .rustup_home
     commands:
       # same as scripts/db_perf.sh but without creating a new database server
       - cargo run --package lemmy_db_perf -- --posts 10 --read-post-pages 1


### PR DESCRIPTION
This avoids [syncing channel updates](https://woodpecker.join-lemmy.org/repos/129/pipeline/14449/12#L2) for each ci step that uses cargo.