### PR TITLE
Remove ts-bindings null check from CI.

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -145,16 +145,6 @@ steps:
       - cargo test --workspace --no-fail-fast
     when: *slow_check_paths
 
-  check_ts_bindings:
-    image: *rust_image
-    environment:
-      CARGO_HOME: .cargo_home
-      RUSTUP_HOME: .rustup_home
-    commands:
-      - ./scripts/ts_bindings_check.sh
-    when:
-      - event: pull_request
-
   # make sure api builds with default features (used by other crates relying on lemmy api)
   check_api_common_default_features:
     image: *rust_image


### PR DESCRIPTION
- This takes 12 minutes, and its a waste of time.
- I'm adding it to the lemmy-js-client copy script which needs to do this build there anyway, so errors will be found while devving.