### PR TITLE
Fix migration local_image_person

### DIFF
--- a/crates/db_schema/src/source/images.rs
+++ b/crates/db_schema/src/source/images.rs
@@ -25,7 +25,7 @@ use {
 pub struct LocalImage {
   pub pictrs_alias: String,
   pub published_at: DateTime<Utc>,
-  pub person_id: PersonId,
+  pub person_id: Option<PersonId>,
   /// This means the image is an auto-generated thumbnail, for a post.
   pub thumbnail_for_post_id: Option<PostId>,
 }

--- a/crates/db_schema_file/src/schema.rs
+++ b/crates/db_schema_file/src/schema.rs
@@ -395,7 +395,7 @@ diesel::table! {
     local_image (pictrs_alias) {
         pictrs_alias -> Text,
         published_at -> Timestamptz,
-        person_id -> Int4,
+        person_id -> Nullable<Int4>,
         thumbnail_for_post_id -> Nullable<Int4>,
     }
 }

--- a/migrations/2025-05-06-145536_local_image_person/up.sql
+++ b/migrations/2025-05-06-145536_local_image_person/up.sql
@@ -5,7 +5,7 @@
 --
 -- See https://github.com/LemmyNet/lemmy/issues/5564
 ALTER TABLE local_image
-    ADD COLUMN person_id int NOT NULL DEFAULT 0 REFERENCES person (id) ON UPDATE CASCADE ON DELETE CASCADE,
+    ADD COLUMN person_id int REFERENCES person (id) ON UPDATE CASCADE ON DELETE CASCADE,
     ADD COLUMN thumbnail_for_post_id int REFERENCES post (id) ON UPDATE CASCADE ON DELETE CASCADE;
 
 -- Update historical person_id columns
@@ -18,10 +18,6 @@ FROM
     local_user AS lu
 WHERE
     li.local_user_id = lu.id;
-
--- Remove the default
-ALTER TABLE local_image
-    ALTER COLUMN person_id DROP DEFAULT;
 
 -- Remove the local_user_id column
 ALTER TABLE local_image


### PR DESCRIPTION
This fails with lemmy.ml database because there is no local user for thumbnails associated with remote user's posts.

```
Error: LemmyError { message: Unknown("Failed to run 2025-05-06-145536_local_image_person with: insert or update on table \"local_image\" violates foreign key constraint \"local_image_person_id_fkey\""), inner: Failed to run 2025-05-06-145536_local_image_person with: insert or update on table "local_image" violates foreign key constraint "local_image_person_id_fkey", context: <disabled> }
```