### PR TITLE
Fixes for "Move config updated check to unit test, use diffy" PR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,6 +1379,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "deprecate-until"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3767f826efbbe5a5ae093920b58b43b01734202be697e1354914e862e8e704"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "semver",
+ "syn 2.0.102",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1610,15 +1622,6 @@ name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
-name = "diffy"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b545b8c50194bdd008283985ab0b31dba153cfd5b3066a92770634fbc0d7d291"
-dependencies = [
- "nu-ansi-term 0.50.1",
-]
 
 [[package]]
 name = "digest"
@@ -2901,6 +2904,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-sqrt"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "invisible-characters"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3376,9 +3388,10 @@ dependencies = [
  "diesel-derive-enum",
  "diesel_ltree",
  "diesel_migrations",
- "diffy",
+ "diff",
  "itertools 0.14.0",
  "lemmy_utils",
+ "pathfinding",
  "serde",
  "serial_test",
  "strum",
@@ -4546,15 +4559,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.50.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4691,6 +4695,20 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pathfinding"
+version = "4.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ac35caa284c08f3721fb33c2741b5f763decaf42d080c8a6a722154347017e"
+dependencies = [
+ "deprecate-until",
+ "indexmap 2.9.0",
+ "integer-sqrt",
+ "num-traits",
+ "rustc-hash 2.1.1",
+ "thiserror 2.0.12",
+]
 
 [[package]]
 name = "pem"
@@ -6818,7 +6836,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
- "nu-ansi-term 0.46.0",
+ "nu-ansi-term",
  "once_cell",
  "regex",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3940,7 +3940,6 @@ dependencies = [
  "clearurls",
  "deser-hjson",
  "diesel",
- "diffy",
  "doku",
  "enum-map",
  "futures",
@@ -3966,6 +3965,7 @@ dependencies = [
  "tracing",
  "ts-rs",
  "unicode-segmentation",
+ "unified-diff",
  "url",
  "urlencoding",
 ]
@@ -6962,6 +6962,15 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unified-diff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "496a3d395ed0c30f411ceace4a91f7d93b148fb5a9b383d5d4cff7850f048d5f"
+dependencies = [
+ "diff",
+]
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3397,6 +3397,7 @@ dependencies = [
  "strum",
  "tracing",
  "ts-rs",
+ "unified-diff",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,6 +220,7 @@ either = { version = "1.15.0", features = ["serde"] }
 extism = { git = "https://github.com/extism/extism.git", branch = "main" }
 extism-convert = { git = "https://github.com/extism/extism.git", branch = "main" }
 diffy = "0.4.2"
+unified-diff = "0.2.1"
 
 [dependencies]
 lemmy_api = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,7 +219,6 @@ async-trait = "0.1.88"
 either = { version = "1.15.0", features = ["serde"] }
 extism = { git = "https://github.com/extism/extism.git", branch = "main" }
 extism-convert = { git = "https://github.com/extism/extism.git", branch = "main" }
-diffy = "0.4.2"
 unified-diff = "0.2.1"
 
 [dependencies]

--- a/crates/db_schema_file/Cargo.toml
+++ b/crates/db_schema_file/Cargo.toml
@@ -48,3 +48,4 @@ serial_test = { workspace = true }
 diff = "0.1.13"
 itertools = { workspace = true }
 pathfinding = "4.14.0"
+unified-diff = { workspace = true }

--- a/crates/db_schema_file/Cargo.toml
+++ b/crates/db_schema_file/Cargo.toml
@@ -45,5 +45,6 @@ tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
 serial_test = { workspace = true }
-diffy = { workspace = true }
+diff = "0.1.13"
 itertools = { workspace = true }
+pathfinding = "4.14.0"

--- a/crates/db_schema_file/src/diff_check.rs
+++ b/crates/db_schema_file/src/diff_check.rs
@@ -2,6 +2,7 @@
 #![expect(clippy::expect_used)]
 use itertools::Itertools;
 use lemmy_utils::settings::SETTINGS;
+use pathfinding::matrix::Matrix;
 use std::{
   borrow::Cow,
   process::{Command, Stdio},
@@ -65,11 +66,27 @@ pub fn check_dump_diff(dumps: [&str; 2], label_of_change_from_0_to_1: &str) {
       .filter(|&chunk| !(is_ignored_trigger(chunk) || is_view(chunk) || is_comment(chunk)))
       .map(remove_ignored_uniqueness_from_statement)
       .sorted_unstable()
-      .collect::<String>()
+      .collect::<Vec<_>>()
   });
-  let patch = diffy::create_patch(&sorted_statements_in_0, &sorted_statements_in_1);
-  if !patch.hunks().is_empty() {
-    panic!("{label_of_change_from_0_to_1}\n\n{}", patch);
+  let mut statements_only_in_0 = Vec::new();
+  let mut statements_only_in_1 = Vec::new();
+  for diff in diff::slice(&sorted_statements_in_0, &sorted_statements_in_1) {
+    match diff {
+      diff::Result::Left(statement) => statements_only_in_0.push(&**statement),
+      diff::Result::Right(statement) => statements_only_in_1.push(&**statement),
+      diff::Result::Both(_, _) => {}
+    }
+  }
+
+  if !(statements_only_in_0.is_empty() && statements_only_in_1.is_empty()) {
+    panic!(
+      "{label_of_change_from_0_to_1}\n\n{}",
+      select_pairs([&statements_only_in_0, &statements_only_in_1])
+        .flat_map(|pair| {
+          display_change(pair).chain(["\n"]) // Blank line after each chunk diff
+        })
+        .collect::<String>()
+    );
   }
 }
 
@@ -140,4 +157,56 @@ fn remove_ignored_uniqueness_from_statement(statement: &str) -> Cow<'_, str> {
 
 fn sort_within_sections<T: Ord + ?Sized>(vec: &mut [&T], mut section: impl FnMut(&T) -> u8) {
   vec.sort_unstable_by_key(|&i| (section(i), i));
+}
+
+/// For each string in list 0, makes a guess of which string in list 1 is a variant of it (or vice
+/// versa).
+fn select_pairs<'a>([a, b]: [&'a [&'a str]; 2]) -> impl Iterator<Item = [&'a str; 2]> {
+  let len = std::cmp::max(a.len(), b.len());
+  let get_candidate_pair_at =
+    |(row, column)| [a.get(row), b.get(column)].map(|item| *item.unwrap_or(&""));
+  let difference_amounts = Matrix::from_fn(len, len, |position| {
+    amount_of_difference_between(get_candidate_pair_at(position))
+  });
+  pathfinding::kuhn_munkres::kuhn_munkres_min(&difference_amounts)
+    .1
+    .into_iter()
+    .enumerate()
+    .map(get_candidate_pair_at)
+}
+
+/// Computes string distance, using the already required [`diff`] crate to avoid adding another
+/// dependency.
+fn amount_of_difference_between([a, b]: [&str; 2]) -> isize {
+  diff::chars(a, b)
+    .into_iter()
+    .filter(|i| !matches!(i, diff::Result::Both(_, _)))
+    .fold(0, |count, _| count.saturating_add(1))
+}
+
+/// Returns a string representation of the change from string 0 to string 1.
+fn display_change([before, after]: [&str; 2]) -> impl Iterator<Item = &str> {
+  diff::lines(before, after)
+    .into_iter()
+    .flat_map(|line| match line {
+      diff::Result::Left(s) => ["- ", s, "\n"],
+      diff::Result::Right(s) => ["+ ", s, "\n"],
+      diff::Result::Both(s, _) => ["  ", s, "\n"],
+    })
+}
+
+// `#[cfg(test)]` would be redundant here
+mod tests {
+  #[test]
+  fn test_select_pairs() {
+    let x = "Cupcake";
+    let x_variant = "Cupcaaaaake";
+    let y = "eee";
+    let y_variant = "ee";
+    let z = "bruh";
+    assert_eq!(
+      super::select_pairs([&[x, y, z], &[y_variant, x_variant]]).collect::<Vec<_>>(),
+      vec![[x, x_variant], [y, y_variant], [z, ""]]
+    );
+  }
 }

--- a/crates/db_schema_file/src/diff_check.rs
+++ b/crates/db_schema_file/src/diff_check.rs
@@ -80,17 +80,12 @@ pub fn check_dump_diff(dumps: [&str; 2], label_of_change_from_0_to_1: &str) {
 
   if !(statements_only_in_0.is_empty() && statements_only_in_1.is_empty()) {
     let (a, b): (String, String) = select_pairs([&statements_only_in_0, &statements_only_in_1])
-      .flat_map(|[a, b]| std::iter::once((a, b)).chain([("\n\n", "\n\n")]))
+      .flat_map(|[a, b]| [(a, b), ("\n\n", "\n\n")])
       .unzip();
+    let diff = unified_diff::diff(a.as_bytes(), "", b.as_bytes(), "", 10000);
     panic!(
       "{label_of_change_from_0_to_1}\n\n{}",
-      String::from_utf8_lossy(&unified_diff::diff(
-        a.as_bytes(),
-        "without change",
-        b.as_bytes(),
-        "with change",
-        10000
-      ))
+      String::from_utf8_lossy(&diff)
     );
   }
 }

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -86,4 +86,4 @@ invisible-characters = "0.1.3"
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
-diffy = { workspace = true }
+unified-diff = { workspace = true }

--- a/crates/utils/src/main.rs
+++ b/crates/utils/src/main.rs
@@ -33,16 +33,14 @@ fn test_config_defaults_updated() -> lemmy_utils::error::LemmyResult<()> {
   let mut updated_config = config_to_string();
   updated_config.push('\n');
   if current_config != updated_config {
-    panic!(
-      "{}",
-      String::from_utf8_lossy(&unified_diff::diff(
-        current_config.as_bytes(),
-        "current",
-        updated_config.as_bytes(),
-        "expected",
-        3
-      ))
+    let diff = unified_diff::diff(
+      current_config.as_bytes(),
+      "current",
+      updated_config.as_bytes(),
+      "expected",
+      3,
     );
+    panic!("{}", String::from_utf8_lossy(&diff));
   }
   Ok(())
 }

--- a/crates/utils/src/main.rs
+++ b/crates/utils/src/main.rs
@@ -32,9 +32,17 @@ fn test_config_defaults_updated() -> lemmy_utils::error::LemmyResult<()> {
   let current_config = std::fs::read_to_string("../../config/defaults.hjson")?;
   let mut updated_config = config_to_string();
   updated_config.push('\n');
-  let res = diffy::create_patch(&current_config, &updated_config);
-  if !res.hunks().is_empty() {
-    panic!("{}", res);
+  if current_config != updated_config {
+    panic!(
+      "{}",
+      String::from_utf8_lossy(&unified_diff::diff(
+        current_config.as_bytes(),
+        "current",
+        updated_config.as_bytes(),
+        "expected",
+        3
+      ))
+    );
   }
   Ok(())
 }


### PR DESCRIPTION
For #5803

* Replaced diffy with unified-diff because it uses the same diff crate used by lemmy_db_schema_file and pretty_assertions, instead of having a similar algorithm built-in like diffy does. This avoids the added bloat of a second diff algorithm.
* Added back most things that were removed from the diff checker. In some cases, the absence of those things would cause missing newlines between statements, missing context (e.g. table names), or diffs becoming extremely messy from rearrangement of statements (prevented by the `select_pairs` function). The unified-diff and diffy libraries are only useful for building the panic string.