### PR TITLE
Add `creator_banned` to VoteView

### DIFF
--- a/crates/api/api/src/comment/list_comment_likes.rs
+++ b/crates/api/api/src/comment/list_comment_likes.rs
@@ -43,6 +43,7 @@ pub async fn list_comment_likes(
     cursor_data,
     data.page_back,
     data.limit,
+    local_instance_id,
   )
   .await?;
 

--- a/crates/api/api/src/post/list_post_likes.rs
+++ b/crates/api/api/src/post/list_post_likes.rs
@@ -27,6 +27,7 @@ pub async fn list_post_likes(
     cursor_data,
     data.page_back,
     data.limit,
+    local_user_view.person.instance_id,
   )
   .await?;
 

--- a/crates/db_views/vote/src/lib.rs
+++ b/crates/db_views/vote/src/lib.rs
@@ -16,6 +16,7 @@ pub mod impls;
 /// A vote view for checking a post or comments votes.
 pub struct VoteView {
   pub creator: Person,
+  pub creator_banned: bool,
   pub creator_banned_from_community: bool,
   pub score: i16,
 }


### PR DESCRIPTION
Since whether or not a person is banned is no longer returned as part of the `Person` struct, it needs to be re-added to the vote view if we want to be able to show wheter a person who voted on something was instance banned.