### PR TITLE
Add missing TS derives that were causing errors when generating Typescript bindings

### DIFF
--- a/crates/db_schema/src/newtypes.rs
+++ b/crates/db_schema/src/newtypes.rs
@@ -244,6 +244,8 @@ pub struct ModlogCombinedId(i32);
 
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[cfg_attr(feature = "full", derive(DieselNewType))]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(export))]
 /// The inbox combined id
 pub struct InboxCombinedId(i32);
 

--- a/crates/db_schema/src/source/combined/inbox.rs
+++ b/crates/db_schema/src/source/combined/inbox.rs
@@ -22,6 +22,8 @@ use serde_with::skip_serializing_none;
 #[cfg_attr(feature = "full", diesel(table_name = inbox_combined))]
 #[cfg_attr(feature = "full", diesel(check_for_backend(diesel::pg::Pg)))]
 #[cfg_attr(feature = "full", cursor_keys_module(name = inbox_combined_keys))]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
 /// A combined inbox table.
 pub struct InboxCombined {
   pub id: InboxCombinedId,

--- a/crates/db_views/site/src/api.rs
+++ b/crates/db_views/site/src/api.rs
@@ -696,6 +696,8 @@ pub struct ResolveObject {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(export))]
 pub enum PostOrCommentOrPrivateMessage {
   Post(Post),
   Comment(Comment),
@@ -711,6 +713,8 @@ pub enum PostOrCommentOrPrivateMessage {
 /// Be careful with any changes to this struct, to avoid breaking changes which could prevent
 /// importing older backups.
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
 pub struct UserSettingsBackup {
   pub display_name: Option<String>,
   pub bio: Option<String>,


### PR DESCRIPTION
Ran into this issue when trying to generate the new bindings.

```
error[E0277]: the trait bound `PostOrCommentOrPrivateMessage: TS` is not satisfied
   --> crates/db_views/site/src/api.rs:744:14
    |
744 |   pub inbox: Vec<PostOrCommentOrPrivateMessage>,
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `TS` is not implemented for `PostOrCommentOrPrivateMessage`, which is required by `Vec<PostOrCommentOrPrivateMessage>: TS`
    |
    = help: the following other types implement trait `TS`:
              &T
              ()
              (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
              (T10,)
              (T2, T3, T4, T5, T6, T7, T8, T9, T10)
              (T3, T4, T5, T6, T7, T8, T9, T10)
              (T4, T5, T6, T7, T8, T9, T10)
              (T5, T6, T7, T8, T9, T10)
            and 324 others
    = note: required for `Vec<PostOrCommentOrPrivateMessage>` to implement `TS`

error[E0277]: the trait bound `PostOrCommentOrPrivateMessage: TS` is not satisfied
   --> crates/db_views/site/src/api.rs:740:38
    |
740 | #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
    |                                      ^^^^^^^^^ the trait `TS` is not implemented for `PostOrCommentOrPrivateMessage`, which is required by `Vec<PostOrCommentOrPrivateMessage>: TS`
    |
    = help: the following other types implement trait `TS`:
              &T
              ()
              (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
              (T10,)
              (T2, T3, T4, T5, T6, T7, T8, T9, T10)
              (T3, T4, T5, T6, T7, T8, T9, T10)
              (T4, T5, T6, T7, T8, T9, T10)
              (T5, T6, T7, T8, T9, T10)
            and 324 others
    = note: required for `Vec<PostOrCommentOrPrivateMessage>` to implement `TS`
    = note: this error originates in the derive macro `ts_rs::TS` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `PostOrCommentOrPrivateMessage: TS` is not satisfied
   --> crates/db_views/site/src/api.rs:745:16
    |
745 |   pub content: Vec<PostOrCommentOrPrivateMessage>,
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `TS` is not implemented for `PostOrCommentOrPrivateMessage`, which is required by `Vec<PostOrCommentOrPrivateMessage>: TS`
    |
    = help: the following other types implement trait `TS`:
              &T
              ()
              (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
              (T10,)
              (T2, T3, T4, T5, T6, T7, T8, T9, T10)
              (T3, T4, T5, T6, T7, T8, T9, T10)
              (T4, T5, T6, T7, T8, T9, T10)
              (T5, T6, T7, T8, T9, T10)
            and 324 others
    = note: required for `Vec<PostOrCommentOrPrivateMessage>` to implement `TS`

error[E0277]: the trait bound `UserSettingsBackup: TS` is not satisfied
   --> crates/db_views/site/src/api.rs:749:17
    |
749 |   pub settings: UserSettingsBackup,
    |                 ^^^^^^^^^^^^^^^^^^ the trait `TS` is not implemented for `UserSettingsBackup`
    |
    = help: the following other types implement trait `TS`:
              &T
              ()
              (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
              (T10,)
              (T2, T3, T4, T5, T6, T7, T8, T9, T10)
              (T3, T4, T5, T6, T7, T8, T9, T10)
              (T4, T5, T6, T7, T8, T9, T10)
              (T5, T6, T7, T8, T9, T10)
            and 324 others

For more information about this error, try `rustc --explain E0277`.
error: could not compile `lemmy_db_views_site` (lib) due to 10 previous errors
warning: build failed, waiting for other jobs to finish...
error: could not compile `lemmy_db_views_site` (lib test) due to 10 previous errors
error[E0277]: the trait bound `InboxCombined: TS` is not satisfied
  --> crates/db_views/inbox_combined/src/lib.rs:50:23
   |
50 |   pub inbox_combined: InboxCombined,
   |                       ^^^^^^^^^^^^^ the trait `TS` is not implemented for `InboxCombined`
   |
   = help: the following other types implement trait `TS`:
             &T
             ()
             (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
             (T10,)
             (T2, T3, T4, T5, T6, T7, T8, T9, T10)
             (T3, T4, T5, T6, T7, T8, T9, T10)
             (T4, T5, T6, T7, T8, T9, T10)
             (T5, T6, T7, T8, T9, T10)
           and 215 others

error: could not compile `lemmy_db_views_inbox_combined` (lib test) due to 3 previous errors
error: could not compile `lemmy_db_views_inbox_combined` (lib) due to 3 previous errors
```

Adding the TS derives fixes this.