### PR TITLE
Don't export inbox combined view internal.

### DIFF
--- a/crates/db_views/inbox_combined/src/lib.rs
+++ b/crates/db_views/inbox_combined/src/lib.rs
@@ -42,8 +42,6 @@ pub mod impls;
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "full", derive(Queryable, Selectable))]
 #[cfg_attr(feature = "full", diesel(check_for_backend(diesel::pg::Pg)))]
-#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
-#[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
 /// A combined inbox view
 pub struct InboxCombinedViewInternal {
   #[cfg_attr(feature = "full", diesel(embed))]


### PR DESCRIPTION
Noticed this in the js-client. It's only used internally.