### PR TITLE
Fixing username-instance duplicate migration.

### DIFF
--- a/migrations/2025-07-10-105316_username-instance-unique/up.sql
+++ b/migrations/2025-07-10-105316_username-instance-unique/up.sql
@@ -1,11 +1,21 @@
 -- lemmy requires (username + instance_id) to be unique
 -- delete any existing duplicates
-DELETE FROM person p1 USING person p2
-WHERE p1.id > p2.id
-    AND p1.name = p2.name
+DELETE FROM person p1 USING (
+    SELECT
+        min(id) AS id,
+        name,
+        instance_id
+    FROM
+        person
+    GROUP BY
+        name,
+        instance_id
+    HAVING
+        count(*) > 1) p2
+WHERE
+    p1.name = p2.name
     AND p1.instance_id = p2.instance_id
-    AND NOT (p1.local
-        OR p2.local);
+    AND p1.id <> p2.id;
 
 ALTER TABLE person
     ADD CONSTRAINT person_name_instance_unique UNIQUE (name, instance_id);


### PR DESCRIPTION
The dupes query was incorrect, and failed with lemmy.ml prod data. 

Also needed to remove the local check as it found another dupe there.

This migration deleted 77 rows total btw.

Context: #5045 , #5858