### PR TITLE
Refactor email

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3825,7 +3825,6 @@ dependencies = [
  "lettre",
  "rosetta-build",
  "rosetta-i18n",
- "tracing",
  "uuid",
 ]
 

--- a/crates/api/api/src/local_user/save_settings.rs
+++ b/crates/api/api/src/local_user/save_settings.rs
@@ -51,15 +51,15 @@ pub async fn save_user_settings(
   let email_deref = data.email.as_deref().map(str::to_lowercase);
   let email = diesel_string_update(email_deref.as_deref());
 
-  if let Some(Some(email)) = &email {
+  if let Some(Some(email)) = email.clone() {
     let previous_email = local_user_view.local_user.email.clone().unwrap_or_default();
     // if email was changed, check that it is not taken and send verification mail
     if previous_email.deref() != email {
-      LocalUser::check_is_email_taken(&mut context.pool(), email).await?;
+      LocalUser::check_is_email_taken(&mut context.pool(), &email).await?;
       send_verification_email(
         &site_view.local_site,
         &local_user_view,
-        email,
+        email.into(),
         &mut context.pool(),
         context.settings(),
       )

--- a/crates/api/api/src/local_user/verify_email.rs
+++ b/crates/api/api/src/local_user/verify_email.rs
@@ -48,7 +48,7 @@ pub async fn verify_email(
     .await?;
   }
 
-  send_email_verified_email(&local_user_view, context.settings()).await?;
+  send_email_verified_email(&local_user_view, context.settings())?;
 
   Ok(Json(SuccessResponse::default()))
 }

--- a/crates/api/api/src/site/registration_applications/approve.rs
+++ b/crates/api/api/src/site/registration_applications/approve.rs
@@ -63,14 +63,13 @@ pub async fn approve_registration_application(
   if approved_local_user_view.local_user.email.is_some() {
     // Email sending may fail, but this won't revert the application approval
     if data.approve {
-      send_application_approved_email(&approved_local_user_view, context.settings()).await?;
+      send_application_approved_email(&approved_local_user_view, context.settings())?;
     } else {
       send_application_denied_email(
         &approved_local_user_view,
         data.deny_reason.clone(),
         context.settings(),
-      )
-      .await?;
+      )?;
     }
   }
 

--- a/crates/api/api/src/site/registration_applications/tests.rs
+++ b/crates/api/api/src/site/registration_applications/tests.rs
@@ -27,10 +27,7 @@ use lemmy_db_views_registration_applications::api::{
   ListRegistrationApplicationsResponse,
 };
 use lemmy_db_views_site::api::EditSite;
-use lemmy_utils::{
-  error::{LemmyErrorType, LemmyResult},
-  CACHE_DURATION_API,
-};
+use lemmy_utils::{error::LemmyResult, CACHE_DURATION_API};
 use serial_test::serial;
 
 async fn create_test_site(context: &Data<LemmyContext>) -> LemmyResult<(TestData, LocalUserView)> {
@@ -196,7 +193,7 @@ async fn test_application_approval() -> LemmyResult<()> {
     expected_total_applications,
   );
 
-  let approval = approve_registration_application(
+  approve_registration_application(
     Json(ApproveRegistrationApplication {
       id: app_with_email.id,
       approve: true,
@@ -205,9 +202,7 @@ async fn test_application_approval() -> LemmyResult<()> {
     context.clone(),
     admin_local_user_view.clone(),
   )
-  .await;
-  // Approval should be processed up until email sending is attempted
-  assert!(approval.is_err_and(|e| e.error_type == LemmyErrorType::NoEmailSetup));
+  .await?;
 
   expected_unread_applications -= 1;
 
@@ -290,7 +285,7 @@ async fn test_application_approval() -> LemmyResult<()> {
     expected_total_applications,
   );
 
-  let deny = approve_registration_application(
+  approve_registration_application(
     Json(ApproveRegistrationApplication {
       id: app_with_email_2.id,
       approve: false,
@@ -299,8 +294,7 @@ async fn test_application_approval() -> LemmyResult<()> {
     context.clone(),
     admin_local_user_view.clone(),
   )
-  .await;
-  assert!(deny.is_err_and(|e| e.error_type == LemmyErrorType::NoEmailSetup));
+  .await?;
 
   expected_unread_applications -= 1;
 

--- a/crates/api/api_crud/src/comment/create.rs
+++ b/crates/api/api_crud/src/comment/create.rs
@@ -113,14 +113,13 @@ pub async fn create_comment(
   plugin_hook_after("after_create_local_comment", &inserted_comment)?;
 
   NotifyData::new(
-    &post,
-    Some(&inserted_comment),
-    &local_user_view.person,
-    &post_view.community,
+    post.clone(),
+    Some(inserted_comment.clone()),
+    local_user_view.person.clone(),
+    post_view.community,
     !local_site.disable_email_notifications,
   )
-  .send(&context)
-  .await?;
+  .send(&context);
 
   // You like your own comment by default
   let like_form = CommentLikeForm::new(local_user_view.person.id, inserted_comment.id, 1);

--- a/crates/api/api_crud/src/comment/update.rs
+++ b/crates/api/api_crud/src/comment/update.rs
@@ -80,14 +80,13 @@ pub async fn update_comment(
 
   // Do the mentions / recipients
   NotifyData::new(
-    &orig_comment.post,
-    Some(&updated_comment),
-    &local_user_view.person,
-    &orig_comment.community,
+    orig_comment.post,
+    Some(updated_comment.clone()),
+    local_user_view.person.clone(),
+    orig_comment.community,
     false,
   )
-  .send(&context)
-  .await?;
+  .send(&context);
 
   ActivityChannel::submit_activity(
     SendActivityData::UpdateComment(updated_comment.clone()),

--- a/crates/api/api_crud/src/post/create.rs
+++ b/crates/api/api_crud/src/post/create.rs
@@ -173,14 +173,13 @@ pub async fn create_post(
   PostActions::like(&mut context.pool(), &like_form).await?;
 
   NotifyData::new(
-    &inserted_post,
+    inserted_post.clone(),
     None,
-    &local_user_view.person,
-    community,
+    local_user_view.person.clone(),
+    community.clone(),
     !local_site.disable_email_notifications,
   )
-  .send(&context)
-  .await?;
+  .send(&context);
 
   let read_form = PostReadForm::new(post_id, person_id);
   PostActions::mark_as_read(&mut context.pool(), &read_form).await?;

--- a/crates/api/api_crud/src/post/update.rs
+++ b/crates/api/api_crud/src/post/update.rs
@@ -163,14 +163,13 @@ pub async fn update_post(
   plugin_hook_after("after_update_local_post", &post_form)?;
 
   NotifyData::new(
-    &updated_post,
+    updated_post.clone(),
     None,
-    &local_user_view.person,
-    &orig_post.community,
+    local_user_view.person.clone(),
+    orig_post.community.clone(),
     false,
   )
-  .send(&context)
-  .await?;
+  .send(&context);
 
   // send out federation/webmention if necessary
   match (

--- a/crates/api/api_utils/src/notify.rs
+++ b/crates/api/api_utils/src/notify.rs
@@ -250,11 +250,8 @@ pub async fn notify_private_message(
     return Ok(());
   };
 
-  let form = NotificationInsertForm::new_private_message(
-    view.private_message.id,
-    local_recipient.person.id,
-    NotificationTypes::PrivateMessage,
-  );
+  let form =
+    NotificationInsertForm::new_private_message(view.private_message.id, local_recipient.person.id);
   Notification::create(&mut context.pool(), &[form]).await?;
 
   if is_create {

--- a/crates/api/api_utils/src/notify.rs
+++ b/crates/api/api_utils/src/notify.rs
@@ -487,6 +487,7 @@ mod tests {
       data.sara.person.id,
       NotificationTypes::Mention,
     );
+    Notification::create(pool, &[timmy_mention_sara_form]).await?;
 
     // Jessica mentions sara in a post
     let jessica_mention_sara_form = NotificationInsertForm::new_post(
@@ -494,8 +495,7 @@ mod tests {
       data.sara.person.id,
       NotificationTypes::Mention,
     );
-    let forms = [jessica_mention_sara_form, timmy_mention_sara_form];
-    Notification::create(pool, &forms).await?;
+    Notification::create(pool, &[jessica_mention_sara_form]).await?;
 
     // Test to make sure counts and blocks work correctly
     let sara_unread_mentions =

--- a/crates/apub/src/activities/create_or_update/comment.rs
+++ b/crates/apub/src/activities/create_or_update/comment.rs
@@ -170,9 +170,7 @@ impl Activity for CreateOrUpdateNote {
     // TODO: for compatibility with other projects, it would be much better to read this from cc or
     // tags
     let community = Community::read(&mut context.pool(), post.community_id).await?;
-    NotifyData::new(&post.0, Some(&comment.0), &actor, &community, do_send_email)
-      .send(context)
-      .await?;
+    NotifyData::new(post.0, Some(comment.0), actor.0, community, do_send_email).send(context);
     Ok(())
   }
 }

--- a/crates/apub/src/activities/create_or_update/post.rs
+++ b/crates/apub/src/activities/create_or_update/post.rs
@@ -122,9 +122,7 @@ impl Activity for CreateOrUpdatePage {
     let actor = self.actor.dereference(context).await?;
 
     let community = Community::read(&mut context.pool(), post.community_id).await?;
-    NotifyData::new(&post.0, None, &actor, &community, do_send_email)
-      .send(context)
-      .await?;
+    NotifyData::new(post.0, None, actor.0, community, do_send_email).send(context);
 
     Ok(())
   }

--- a/crates/db_schema/src/impls/notification.rs
+++ b/crates/db_schema/src/impls/notification.rs
@@ -17,6 +17,7 @@ impl Notification {
     let conn = &mut get_conn(pool).await?;
     insert_into(notification::table)
       .values(form)
+      .on_conflict_do_nothing()
       .get_result::<Self>(conn)
       .await
       .with_lemmy_type(LemmyErrorType::CouldntCreateNotification)

--- a/crates/db_schema/src/impls/notification.rs
+++ b/crates/db_schema/src/impls/notification.rs
@@ -13,7 +13,7 @@ use lemmy_db_schema_file::schema::notification;
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 impl Notification {
-  pub async fn create(pool: &mut DbPool<'_>, form: &NotificationInsertForm) -> LemmyResult<Self> {
+  pub async fn create(pool: &mut DbPool<'_>, form: &[NotificationInsertForm]) -> LemmyResult<Self> {
     let conn = &mut get_conn(pool).await?;
     insert_into(notification::table)
       .values(form)

--- a/crates/db_schema/src/source/notification.rs
+++ b/crates/db_schema/src/source/notification.rs
@@ -61,17 +61,13 @@ impl NotificationInsertForm {
       kind,
     }
   }
-  pub fn new_private_message(
-    private_message_id: PrivateMessageId,
-    recipient_id: PersonId,
-    kind: NotificationTypes,
-  ) -> Self {
+  pub fn new_private_message(private_message_id: PrivateMessageId, recipient_id: PersonId) -> Self {
     Self {
       post_id: None,
       comment_id: None,
       private_message_id: Some(private_message_id),
       recipient_id,
-      kind,
+      kind: NotificationTypes::PrivateMessage,
     }
   }
 }

--- a/crates/email/Cargo.toml
+++ b/crates/email/Cargo.toml
@@ -26,7 +26,6 @@ lemmy_utils = { workspace = true, features = ["full"] }
 lemmy_db_schema = { workspace = true, features = ["full"] }
 lemmy_db_views_local_user = { workspace = true, features = ["full"] }
 lemmy_db_schema_file = { workspace = true }
-tracing = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 rosetta-i18n = { workspace = true }
 html2text = { workspace = true }

--- a/crates/email/src/account.rs
+++ b/crates/email/src/account.rs
@@ -1,5 +1,6 @@
 use crate::{send::send_email, user_email, user_language};
 use lemmy_db_schema::{
+  sensitive::SensitiveString,
   source::{
     email_verification::{EmailVerification, EmailVerificationForm},
     local_site::LocalSite,
@@ -18,18 +19,18 @@ use lemmy_utils::{
 pub async fn send_password_reset_email(
   user: &LocalUserView,
   pool: &mut DbPool<'_>,
-  settings: &Settings,
+  settings: &'static Settings,
 ) -> LemmyResult<()> {
   // Generate a random token
   let token = uuid::Uuid::new_v4().to_string();
 
   let lang = user_language(user);
-  let subject = &lang.password_reset_subject(&user.person.name);
+  let subject = lang.password_reset_subject(&user.person.name);
   let protocol_and_hostname = settings.get_protocol_and_hostname();
   let reset_link = format!("{}/password_change/{}", protocol_and_hostname, &token);
   let email = user_email(user)?;
-  let body = &lang.password_reset_body(reset_link, &user.person.name);
-  send_email(subject, &email, &user.person.name, body, settings).await?;
+  let body = lang.password_reset_body(reset_link, &user.person.name);
+  send_email(subject, email, user.person.name.clone(), body, settings);
 
   // Insert the row after successful send, to avoid using daily reset limit while
   // email sending is broken.
@@ -42,9 +43,9 @@ pub async fn send_password_reset_email(
 pub async fn send_verification_email(
   local_site: &LocalSite,
   user: &LocalUserView,
-  new_email: &str,
+  new_email: SensitiveString,
   pool: &mut DbPool<'_>,
-  settings: &Settings,
+  settings: &'static Settings,
 ) -> LemmyResult<()> {
   let form = EmailVerificationForm {
     local_user_id: user.local_user.id,
@@ -68,7 +69,8 @@ pub async fn send_verification_email(
     lang.verify_email_body(&settings.hostname, &user.person.name, verify_link)
   };
 
-  send_email(&subject, new_email, &user.person.name, &body, settings).await
+  send_email(subject, new_email, user.person.name.clone(), body, settings);
+  Ok(())
 }
 
 /// Returns true if email was sent.
@@ -76,36 +78,36 @@ pub async fn send_verification_email_if_required(
   local_site: &LocalSite,
   user: &LocalUserView,
   pool: &mut DbPool<'_>,
-  settings: &Settings,
+  settings: &'static Settings,
 ) -> LemmyResult<bool> {
   if !user.local_user.admin
     && local_site.require_email_verification
     && !user.local_user.email_verified
   {
     let email = user_email(user)?;
-    send_verification_email(local_site, user, &email, pool, settings).await?;
+    send_verification_email(local_site, user, email, pool, settings).await?;
     Ok(true)
   } else {
     Ok(false)
   }
 }
 
-pub async fn send_application_approved_email(
+pub fn send_application_approved_email(
   user: &LocalUserView,
-  settings: &Settings,
+  settings: &'static Settings,
 ) -> LemmyResult<()> {
   let lang = user_language(user);
   let subject = lang.registration_approved_subject(&user.person.name);
   let email = user_email(user)?;
   let body = lang.registration_approved_body(&settings.hostname);
-  send_email(&subject, &email, &user.person.name, &body, settings).await?;
+  send_email(subject, email, user.person.name.clone(), body, settings);
   Ok(())
 }
 
-pub async fn send_application_denied_email(
+pub fn send_application_denied_email(
   user: &LocalUserView,
   deny_reason: Option<String>,
-  settings: &Settings,
+  settings: &'static Settings,
 ) -> LemmyResult<()> {
   let lang = user_language(user);
   let subject = lang.registration_denied_subject(&user.person.name);
@@ -117,18 +119,24 @@ pub async fn send_application_denied_email(
     }
     None => lang.registration_denied_body(&settings.hostname),
   };
-  send_email(&subject, &email, &user.person.name, &body, settings).await?;
+  send_email(subject, email, user.person.name.clone(), body, settings);
   Ok(())
 }
 
-pub async fn send_email_verified_email(
+pub fn send_email_verified_email(
   user: &LocalUserView,
-  settings: &Settings,
+  settings: &'static Settings,
 ) -> LemmyResult<()> {
   let lang = user_language(user);
   let subject = lang.email_verified_subject(&user.person.name);
   let email = user_email(user)?;
   let body = lang.email_verified_body();
-  send_email(&subject, &email, &user.person.name, body, settings).await?;
+  send_email(
+    subject,
+    email,
+    user.person.name.clone(),
+    body.to_string(),
+    settings,
+  );
   Ok(())
 }

--- a/crates/email/src/account.rs
+++ b/crates/email/src/account.rs
@@ -1,4 +1,4 @@
-use crate::{send_email, user_email, user_language};
+use crate::{send::send_email, user_email, user_language};
 use lemmy_db_schema::{
   source::{
     email_verification::{EmailVerification, EmailVerificationForm},

--- a/crates/email/src/admin.rs
+++ b/crates/email/src/admin.rs
@@ -1,4 +1,4 @@
-use crate::{send_email, user_language};
+use crate::{send::send_email, user_language};
 use lemmy_db_schema::utils::DbPool;
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_utils::{error::LemmyResult, settings::structs::Settings};

--- a/crates/email/src/admin.rs
+++ b/crates/email/src/admin.rs
@@ -7,7 +7,7 @@ use lemmy_utils::{error::LemmyResult, settings::structs::Settings};
 pub async fn send_new_applicant_email_to_admins(
   applicant_username: &str,
   pool: &mut DbPool<'_>,
-  settings: &Settings,
+  settings: &'static Settings,
 ) -> LemmyResult<()> {
   // Collect the admins with emails
   let admins = LocalUserView::list_admins_with_emails(pool).await?;
@@ -17,12 +17,12 @@ pub async fn send_new_applicant_email_to_admins(
     settings.get_protocol_and_hostname(),
   );
 
-  for admin in &admins {
-    if let Some(email) = &admin.local_user.email {
-      let lang = user_language(admin);
+  for admin in admins {
+    let lang = user_language(&admin);
+    if let Some(email) = admin.local_user.email {
       let subject = lang.new_application_subject(&settings.hostname, applicant_username);
       let body = lang.new_application_body(applications_link);
-      send_email(&subject, email, &admin.person.name, &body, settings).await?;
+      send_email(subject, email, admin.person.name, body, settings);
     }
   }
   Ok(())
@@ -33,20 +33,20 @@ pub async fn send_new_report_email_to_admins(
   reporter_username: &str,
   reported_username: &str,
   pool: &mut DbPool<'_>,
-  settings: &Settings,
+  settings: &'static Settings,
 ) -> LemmyResult<()> {
   // Collect the admins with emails
   let admins = LocalUserView::list_admins_with_emails(pool).await?;
 
   let reports_link = &format!("{}/reports", settings.get_protocol_and_hostname(),);
 
-  for admin in &admins {
-    if let Some(email) = &admin.local_user.email {
-      let lang = user_language(admin);
+  for admin in admins {
+    let lang = user_language(&admin);
+    if let Some(email) = admin.local_user.email {
       let subject =
         lang.new_report_subject(&settings.hostname, reported_username, reporter_username);
       let body = lang.new_report_body(reports_link);
-      send_email(&subject, email, &admin.person.name, &body, settings).await?;
+      send_email(subject, email, admin.person.name, body, settings);
     }
   }
   Ok(())

--- a/crates/email/src/lib.rs
+++ b/crates/email/src/lib.rs
@@ -1,87 +1,25 @@
-// Avoid warnings for unused 0.19 translations
-#![allow(dead_code)]
-
 use lemmy_db_schema::sensitive::SensitiveString;
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_utils::{
-  error::{LemmyErrorExt, LemmyErrorType, LemmyResult},
+  error::{LemmyErrorType, LemmyResult},
   settings::structs::Settings,
 };
-use lettre::{
-  message::{Mailbox, MultiPart},
-  transport::smtp::extension::ClientId,
-  Address,
-  AsyncTransport,
-  Message,
-};
 use rosetta_i18n::{Language, LanguageId};
-use std::{str::FromStr, sync::OnceLock};
 use translations::Lang;
-use uuid::Uuid;
 
 pub mod account;
 pub mod admin;
 pub mod notifications;
+mod send;
+
+/// Avoid warnings for unused 0.19 translations
+#[allow(dead_code)]
 mod translations {
   rosetta_i18n::include_translations!();
 }
 
-type AsyncSmtpTransport = lettre::AsyncSmtpTransport<lettre::Tokio1Executor>;
-
 fn inbox_link(settings: &Settings) -> String {
   format!("{}/inbox", settings.get_protocol_and_hostname())
-}
-
-async fn send_email(
-  subject: &str,
-  to_email: &str,
-  to_username: &str,
-  html: &str,
-  settings: &Settings,
-) -> LemmyResult<()> {
-  static MAILER: OnceLock<AsyncSmtpTransport> = OnceLock::new();
-  let email_config = settings.email.clone().ok_or(LemmyErrorType::NoEmailSetup)?;
-
-  #[expect(clippy::expect_used)]
-  let mailer = MAILER.get_or_init(|| {
-    AsyncSmtpTransport::from_url(&email_config.connection)
-      .expect("init email transport")
-      .hello_name(ClientId::Domain(settings.hostname.clone()))
-      .build()
-  });
-
-  // use usize::MAX as the line wrap length, since lettre handles the wrapping for us
-  let plain_text = html2text::from_read(html.as_bytes(), usize::MAX)?;
-
-  let smtp_from_address = &email_config.smtp_from_address;
-
-  let email = Message::builder()
-    .from(
-      smtp_from_address
-        .parse()
-        .with_lemmy_type(LemmyErrorType::InvalidEmailAddress(
-          smtp_from_address.into(),
-        ))?,
-    )
-    .to(Mailbox::new(
-      Some(to_username.to_string()),
-      Address::from_str(to_email)
-        .with_lemmy_type(LemmyErrorType::InvalidEmailAddress(to_email.into()))?,
-    ))
-    .message_id(Some(format!("<{}@{}>", Uuid::new_v4(), settings.hostname)))
-    .subject(subject)
-    .multipart(MultiPart::alternative_plain_html(
-      plain_text,
-      html.to_string(),
-    ))
-    .with_lemmy_type(LemmyErrorType::EmailSendFailed)?;
-
-  mailer
-    .send(email)
-    .await
-    .with_lemmy_type(LemmyErrorType::EmailSendFailed)?;
-
-  Ok(())
 }
 
 #[allow(clippy::expect_used)]

--- a/crates/email/src/notifications.rs
+++ b/crates/email/src/notifications.rs
@@ -6,28 +6,28 @@ use lemmy_db_schema::{
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_utils::{settings::structs::Settings, utils::markdown::markdown_to_html};
 
-pub enum NotificationEmailData {
+pub enum NotificationEmailData<'a> {
   Mention {
     content: String,
-    person: Person,
+    person: &'a Person,
   },
   PostSubscribed {
-    post: Post,
-    comment: Comment,
+    post: &'a Post,
+    comment: &'a Comment,
   },
   CommunitySubscribed {
-    post: Post,
-    community: Community,
+    post: &'a Post,
+    community: &'a Community,
   },
   Reply {
-    comment: Comment,
-    person: Person,
+    comment: &'a Comment,
+    person: &'a Person,
     parent_comment: Option<Comment>,
-    post: Post,
+    post: &'a Post,
   },
   PrivateMessage {
-    sender: Person,
-    content: String,
+    sender: &'a Person,
+    content: &'a String,
   },
 }
 
@@ -102,7 +102,7 @@ pub fn send_notification_email(
     }
     NotificationEmailData::PrivateMessage { sender, content } => {
       let sender_name = &sender.name;
-      let content = markdown_to_html(&content);
+      let content = markdown_to_html(content);
       (
         lang.notification_private_message_subject(sender_name),
         lang.notification_private_message_body(inbox_link, &content, sender_name),

--- a/crates/email/src/notifications.rs
+++ b/crates/email/src/notifications.rs
@@ -1,4 +1,4 @@
-use crate::{inbox_link, send_email, user_language};
+use crate::{inbox_link, send::send_email, user_language};
 use lemmy_db_schema::{
   newtypes::DbUrl,
   source::{comment::Comment, community::Community, person::Person, post::Post},

--- a/crates/email/src/notifications.rs
+++ b/crates/email/src/notifications.rs
@@ -4,148 +4,114 @@ use lemmy_db_schema::{
   source::{comment::Comment, community::Community, person::Person, post::Post},
 };
 use lemmy_db_views_local_user::LocalUserView;
-use lemmy_utils::{
-  error::LemmyResult,
-  settings::structs::Settings,
-  utils::markdown::markdown_to_html,
-};
+use lemmy_utils::{settings::structs::Settings, utils::markdown::markdown_to_html};
 use tracing::warn;
 
-pub async fn send_mention_email(
-  mention_user_view: &LocalUserView,
-  content: &str,
-  person: &Person,
-  link: DbUrl,
-  settings: &Settings,
-) {
-  let inbox_link = inbox_link(settings);
-  let lang = user_language(mention_user_view);
-  let content = markdown_to_html(content);
-  send_email_to_user(
-    mention_user_view,
-    &lang.notification_mentioned_by_subject(&person.name),
-    &lang.notification_mentioned_by_body(&link, &content, &inbox_link, &person.name),
-    settings,
-  )
-  .await
+pub enum NotificationEmailData<'a> {
+  Mention {
+    content: &'a str,
+    person: &'a Person,
+  },
+  PostSubscribed {
+    post: &'a Post,
+    comment: &'a Comment,
+  },
+  CommunitySubscribed {
+    post: &'a Post,
+    community: &'a Community,
+  },
+  Reply {
+    comment: &'a Comment,
+    person: &'a Person,
+    parent_comment: &'a Option<Comment>,
+    post: &'a Post,
+  },
+  PrivateMessage {
+    sender: &'a Person,
+    content: &'a str,
+  },
 }
 
-pub async fn send_post_subscribed_email(
-  user_view: &LocalUserView,
-  post: &Post,
-  comment: &Comment,
-  link: DbUrl,
-  settings: &Settings,
-) {
-  let inbox_link = inbox_link(settings);
-  let lang = user_language(user_view);
-  let content = markdown_to_html(&comment.content);
-  send_email_to_user(
-    user_view,
-    &lang.notification_post_subscribed_subject(&post.name),
-    &lang.notification_post_subscribed_body(&content, &link, inbox_link),
-    settings,
-  )
-  .await
-}
-
-pub async fn send_community_subscribed_email(
-  user_view: &LocalUserView,
-  post: &Post,
-  community: &Community,
-  link: DbUrl,
-  settings: &Settings,
-) {
-  let inbox_link = inbox_link(settings);
-  let lang = user_language(user_view);
-  let content = post
-    .body
-    .as_ref()
-    .map(|b| markdown_to_html(b))
-    .unwrap_or_default();
-  send_email_to_user(
-    user_view,
-    &lang.notification_community_subscribed_subject(&post.name, &community.title),
-    &lang.notification_community_subscribed_body(&content, &link, inbox_link),
-    settings,
-  )
-  .await
-}
-
-pub async fn send_reply_email(
-  parent_user_view: &LocalUserView,
-  comment: &Comment,
-  person: &Person,
-  parent_comment: &Option<Comment>,
-  post: &Post,
-  settings: &Settings,
-) -> LemmyResult<()> {
-  let inbox_link = inbox_link(settings);
-  let lang = user_language(parent_user_view);
-  let content = markdown_to_html(&comment.content);
-  let (subject, body) = if let Some(parent_comment) = parent_comment {
-    (
-      lang.notification_comment_reply_subject(&person.name),
-      lang.notification_comment_reply_body(
-        comment.local_url(settings)?,
-        &content,
-        &inbox_link,
-        &parent_comment.content,
-        &post.name,
-        &person.name,
-      ),
-    )
-  } else {
-    (
-      lang.notification_post_reply_subject(&person.name),
-      lang.notification_post_reply_body(
-        comment.local_url(settings)?,
-        &content,
-        &inbox_link,
-        &post.name,
-        &person.name,
-      ),
-    )
-  };
-  send_email_to_user(parent_user_view, &subject, &body, settings).await;
-  Ok(())
-}
-
-pub async fn send_private_message_email(
-  sender: &Person,
-  local_recipient: &LocalUserView,
-  content: &str,
-  settings: &Settings,
-) {
-  let inbox_link = inbox_link(settings);
-  let lang = user_language(local_recipient);
-  let sender_name = &sender.name;
-  let content = markdown_to_html(content);
-  send_email_to_user(
-    local_recipient,
-    &lang.notification_private_message_subject(sender_name),
-    &lang.notification_private_message_body(inbox_link, &content, sender_name),
-    settings,
-  )
-  .await;
-}
-
-async fn send_email_to_user(
+pub async fn send_notification_email(
   local_user_view: &LocalUserView,
-  subject: &str,
-  body: &str,
+  link: DbUrl,
   settings: &Settings,
+  data: NotificationEmailData<'_>,
 ) {
   if local_user_view.banned || !local_user_view.local_user.send_notifications_to_email {
     return;
   }
 
+  let inbox_link = inbox_link(settings);
+  let lang = user_language(local_user_view);
+  let (subject, body) = match data {
+    NotificationEmailData::Mention { content, person } => {
+      let content = markdown_to_html(content);
+      (
+        lang.notification_mentioned_by_subject(&person.name),
+        lang.notification_mentioned_by_body(&link, &content, &inbox_link, &person.name),
+      )
+    }
+    NotificationEmailData::PostSubscribed { post, comment } => {
+      let content = markdown_to_html(&comment.content);
+      (
+        lang.notification_post_subscribed_subject(&post.name),
+        lang.notification_post_subscribed_body(&content, &link, inbox_link),
+      )
+    }
+    NotificationEmailData::CommunitySubscribed { post, community } => {
+      let content = post
+        .body
+        .as_ref()
+        .map(|b| markdown_to_html(b))
+        .unwrap_or_default();
+      (
+        lang.notification_community_subscribed_subject(&post.name, &community.title),
+        lang.notification_community_subscribed_body(&content, &link, inbox_link),
+      )
+    }
+    NotificationEmailData::Reply {
+      comment,
+      person,
+      parent_comment,
+      post,
+    } => {
+      let content = markdown_to_html(&comment.content);
+      if let Some(parent_comment) = parent_comment {
+        (
+          lang.notification_comment_reply_subject(&person.name),
+          lang.notification_comment_reply_body(
+            link,
+            &content,
+            &inbox_link,
+            &parent_comment.content,
+            &post.name,
+            &person.name,
+          ),
+        )
+      } else {
+        (
+          lang.notification_post_reply_subject(&person.name),
+          lang.notification_post_reply_body(link, &content, &inbox_link, &post.name, &person.name),
+        )
+      }
+    }
+    NotificationEmailData::PrivateMessage { sender, content } => {
+      let sender_name = &sender.name;
+      let content = markdown_to_html(content);
+      (
+        lang.notification_private_message_subject(sender_name),
+        lang.notification_private_message_body(inbox_link, &content, sender_name),
+      )
+    }
+  };
+
   if let Some(user_email) = &local_user_view.local_user.email {
     match send_email(
-      subject,
+      &subject,
       user_email,
       &local_user_view.person.name,
-      body,
+      &body,
       settings,
     )
     .await

--- a/crates/email/src/send.rs
+++ b/crates/email/src/send.rs
@@ -1,0 +1,67 @@
+use lemmy_utils::{
+  error::{LemmyErrorExt, LemmyErrorType, LemmyResult},
+  settings::structs::Settings,
+};
+use lettre::{
+  message::{Mailbox, MultiPart},
+  transport::smtp::extension::ClientId,
+  Address,
+  AsyncTransport,
+  Message,
+};
+use std::{str::FromStr, sync::OnceLock};
+use uuid::Uuid;
+
+type AsyncSmtpTransport = lettre::AsyncSmtpTransport<lettre::Tokio1Executor>;
+
+pub(crate) async fn send_email(
+  subject: &str,
+  to_email: &str,
+  to_username: &str,
+  html: &str,
+  settings: &Settings,
+) -> LemmyResult<()> {
+  static MAILER: OnceLock<AsyncSmtpTransport> = OnceLock::new();
+  let email_config = settings.email.clone().ok_or(LemmyErrorType::NoEmailSetup)?;
+
+  #[expect(clippy::expect_used)]
+  let mailer = MAILER.get_or_init(|| {
+    AsyncSmtpTransport::from_url(&email_config.connection)
+      .expect("init email transport")
+      .hello_name(ClientId::Domain(settings.hostname.clone()))
+      .build()
+  });
+
+  // use usize::MAX as the line wrap length, since lettre handles the wrapping for us
+  let plain_text = html2text::from_read(html.as_bytes(), usize::MAX)?;
+
+  let smtp_from_address = &email_config.smtp_from_address;
+
+  let email = Message::builder()
+    .from(
+      smtp_from_address
+        .parse()
+        .with_lemmy_type(LemmyErrorType::InvalidEmailAddress(
+          smtp_from_address.into(),
+        ))?,
+    )
+    .to(Mailbox::new(
+      Some(to_username.to_string()),
+      Address::from_str(to_email)
+        .with_lemmy_type(LemmyErrorType::InvalidEmailAddress(to_email.into()))?,
+    ))
+    .message_id(Some(format!("<{}@{}>", Uuid::new_v4(), settings.hostname)))
+    .subject(subject)
+    .multipart(MultiPart::alternative_plain_html(
+      plain_text,
+      html.to_string(),
+    ))
+    .with_lemmy_type(LemmyErrorType::EmailSendFailed)?;
+
+  mailer
+    .send(email)
+    .await
+    .with_lemmy_type(LemmyErrorType::EmailSendFailed)?;
+
+  Ok(())
+}

--- a/crates/email/src/send.rs
+++ b/crates/email/src/send.rs
@@ -1,6 +1,8 @@
+use lemmy_db_schema::sensitive::SensitiveString;
 use lemmy_utils::{
-  error::{LemmyErrorExt, LemmyErrorType, LemmyResult},
+  error::{LemmyErrorExt, LemmyErrorType},
   settings::structs::Settings,
+  spawn_try_task,
 };
 use lettre::{
   message::{Mailbox, MultiPart},
@@ -14,54 +16,56 @@ use uuid::Uuid;
 
 type AsyncSmtpTransport = lettre::AsyncSmtpTransport<lettre::Tokio1Executor>;
 
-pub(crate) async fn send_email(
-  subject: &str,
-  to_email: &str,
-  to_username: &str,
-  html: &str,
-  settings: &Settings,
-) -> LemmyResult<()> {
-  static MAILER: OnceLock<AsyncSmtpTransport> = OnceLock::new();
-  let email_config = settings.email.clone().ok_or(LemmyErrorType::NoEmailSetup)?;
+pub(crate) fn send_email(
+  subject: String,
+  to_email: SensitiveString,
+  to_username: String,
+  html: String,
+  settings: &'static Settings,
+) {
+  spawn_try_task(async move {
+    static MAILER: OnceLock<AsyncSmtpTransport> = OnceLock::new();
+    let email_config = settings.email.clone().ok_or(LemmyErrorType::NoEmailSetup)?;
 
-  #[expect(clippy::expect_used)]
-  let mailer = MAILER.get_or_init(|| {
-    AsyncSmtpTransport::from_url(&email_config.connection)
-      .expect("init email transport")
-      .hello_name(ClientId::Domain(settings.hostname.clone()))
-      .build()
-  });
+    #[expect(clippy::expect_used)]
+    let mailer = MAILER.get_or_init(|| {
+      AsyncSmtpTransport::from_url(&email_config.connection)
+        .expect("init email transport")
+        .hello_name(ClientId::Domain(settings.hostname.clone()))
+        .build()
+    });
 
-  // use usize::MAX as the line wrap length, since lettre handles the wrapping for us
-  let plain_text = html2text::from_read(html.as_bytes(), usize::MAX)?;
+    // use usize::MAX as the line wrap length, since lettre handles the wrapping for us
+    let plain_text = html2text::from_read(html.as_bytes(), usize::MAX)?;
 
-  let smtp_from_address = &email_config.smtp_from_address;
+    let smtp_from_address = &email_config.smtp_from_address;
 
-  let email = Message::builder()
-    .from(
-      smtp_from_address
-        .parse()
-        .with_lemmy_type(LemmyErrorType::InvalidEmailAddress(
-          smtp_from_address.into(),
-        ))?,
-    )
-    .to(Mailbox::new(
-      Some(to_username.to_string()),
-      Address::from_str(to_email)
-        .with_lemmy_type(LemmyErrorType::InvalidEmailAddress(to_email.into()))?,
-    ))
-    .message_id(Some(format!("<{}@{}>", Uuid::new_v4(), settings.hostname)))
-    .subject(subject)
-    .multipart(MultiPart::alternative_plain_html(
-      plain_text,
-      html.to_string(),
-    ))
-    .with_lemmy_type(LemmyErrorType::EmailSendFailed)?;
+    let email = Message::builder()
+      .from(
+        smtp_from_address
+          .parse()
+          .with_lemmy_type(LemmyErrorType::InvalidEmailAddress(
+            smtp_from_address.into(),
+          ))?,
+      )
+      .to(Mailbox::new(
+        Some(to_username.to_string()),
+        Address::from_str(&to_email)
+          .with_lemmy_type(LemmyErrorType::InvalidEmailAddress(to_email.into_inner()))?,
+      ))
+      .message_id(Some(format!("<{}@{}>", Uuid::new_v4(), settings.hostname)))
+      .subject(subject)
+      .multipart(MultiPart::alternative_plain_html(
+        plain_text,
+        html.to_string(),
+      ))
+      .with_lemmy_type(LemmyErrorType::EmailSendFailed)?;
 
-  mailer
-    .send(email)
-    .await
-    .with_lemmy_type(LemmyErrorType::EmailSendFailed)?;
+    mailer
+      .send(email)
+      .await
+      .with_lemmy_type(LemmyErrorType::EmailSendFailed)?;
 
-  Ok(())
+    Ok(())
+  })
 }


### PR DESCRIPTION
By using a single send function with enum for data the code in notify.rs can be more generic and handle things in a single place. Also moves email sending to a background task so it doesnt block the api call, and uses only a single db call to insert multiple notifications.