### PR TITLE
Fix comment depth test

### DIFF
--- a/api_tests/src/comment.spec.ts
+++ b/api_tests/src/comment.spec.ts
@@ -854,6 +854,14 @@ test("Dont send a comment reply to a blocked community", async () => {
 /// Fetching a deeply nested comment can lead to stack overflow as all parent comments are also
 /// fetched recursively. Ensure that it works properly.
 test("Fetch a deeply nested comment", async () => {
+  const alphaCommunity = await resolveCommunity(
+    alpha,
+    "!main@lemmy-alpha:8541",
+  );
+  if (!alphaCommunity) {
+    throw "Missing alpha community";
+  }
+  const postOnAlphaRes = await createPost(alpha, alphaCommunity.community.id);
   let lastComment;
   for (let i = 1; i < 50; i++) {
     let commentRes = await createComment(


### PR DESCRIPTION
I made this change while working on #5787 but forgot to keep it.

While debugging, I discovered that this change is needed in order to make the recursion level reach 50. Without this change, parents might be fetched before children.