### PR TITLE
Wait for email sending on shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3825,6 +3825,7 @@ dependencies = [
  "lettre",
  "rosetta-build",
  "rosetta-i18n",
+ "tokio",
  "uuid",
 ]
 
@@ -3920,6 +3921,7 @@ dependencies = [
  "lemmy_db_schema",
  "lemmy_db_schema_setup",
  "lemmy_db_views_site",
+ "lemmy_email",
  "lemmy_federate",
  "lemmy_routes",
  "lemmy_utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -237,6 +237,7 @@ lemmy_api_utils = { workspace = true }
 lemmy_routes = { workspace = true }
 lemmy_federate = { workspace = true }
 lemmy_db_views_site = { workspace = true }
+lemmy_email = { workspace = true }
 activitypub_federation = { workspace = true }
 actix-web = { workspace = true }
 tracing = { workspace = true }

--- a/crates/api/api_utils/src/notify.rs
+++ b/crates/api/api_utils/src/notify.rs
@@ -48,7 +48,9 @@ impl NotifyData {
   /// to mentioned users and parent creator. Spawns a task for background processing.
   pub fn send(self, context: &LemmyContext) {
     let context = context.clone();
-    spawn_try_task(self.send_internal(context))
+    // TODO: Do we also need to cancel this on shutdown? Will get very verbose without a generic
+    // solution.
+    spawn_try_task(self.send_internal(context));
   }
 
   /// Logic for send(), in separate function so it can run serially in tests.
@@ -86,7 +88,7 @@ impl NotifyData {
       };
 
       if self.do_send_email {
-        send_notification_email(user_view, c.local_url, c.data, context.settings());
+        send_notification_email(user_view, c.local_url, c.data, context.settings())?;
       }
     }
     Notification::create(&mut context.pool(), &forms).await?;
@@ -266,7 +268,7 @@ pub async fn notify_private_message(
         view.private_message.local_url(context.settings())?,
         d,
         context.settings(),
-      );
+      )?;
     }
   }
   Ok(())

--- a/crates/email/Cargo.toml
+++ b/crates/email/Cargo.toml
@@ -27,6 +27,7 @@ lemmy_db_schema = { workspace = true, features = ["full"] }
 lemmy_db_views_local_user = { workspace = true, features = ["full"] }
 lemmy_db_schema_file = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
+tokio = { workspace = true }
 rosetta-i18n = { workspace = true }
 html2text = { workspace = true }
 lettre = { version = "0.11.17", default-features = false, features = [

--- a/crates/email/src/account.rs
+++ b/crates/email/src/account.rs
@@ -30,7 +30,7 @@ pub async fn send_password_reset_email(
   let reset_link = format!("{}/password_change/{}", protocol_and_hostname, &token);
   let email = user_email(user)?;
   let body = lang.password_reset_body(reset_link, &user.person.name);
-  send_email(subject, email, user.person.name.clone(), body, settings);
+  send_email(subject, email, user.person.name.clone(), body, settings)?;
 
   // Insert the row after successful send, to avoid using daily reset limit while
   // email sending is broken.
@@ -69,7 +69,7 @@ pub async fn send_verification_email(
     lang.verify_email_body(&settings.hostname, &user.person.name, verify_link)
   };
 
-  send_email(subject, new_email, user.person.name.clone(), body, settings);
+  send_email(subject, new_email, user.person.name.clone(), body, settings)?;
   Ok(())
 }
 
@@ -100,7 +100,7 @@ pub fn send_application_approved_email(
   let subject = lang.registration_approved_subject(&user.person.name);
   let email = user_email(user)?;
   let body = lang.registration_approved_body(&settings.hostname);
-  send_email(subject, email, user.person.name.clone(), body, settings);
+  send_email(subject, email, user.person.name.clone(), body, settings)?;
   Ok(())
 }
 
@@ -119,7 +119,7 @@ pub fn send_application_denied_email(
     }
     None => lang.registration_denied_body(&settings.hostname),
   };
-  send_email(subject, email, user.person.name.clone(), body, settings);
+  send_email(subject, email, user.person.name.clone(), body, settings)?;
   Ok(())
 }
 
@@ -137,6 +137,6 @@ pub fn send_email_verified_email(
     user.person.name.clone(),
     body.to_string(),
     settings,
-  );
+  )?;
   Ok(())
 }

--- a/crates/email/src/admin.rs
+++ b/crates/email/src/admin.rs
@@ -22,7 +22,7 @@ pub async fn send_new_applicant_email_to_admins(
     if let Some(email) = admin.local_user.email {
       let subject = lang.new_application_subject(&settings.hostname, applicant_username);
       let body = lang.new_application_body(applications_link);
-      send_email(subject, email, admin.person.name, body, settings);
+      send_email(subject, email, admin.person.name, body, settings)?;
     }
   }
   Ok(())
@@ -46,7 +46,7 @@ pub async fn send_new_report_email_to_admins(
       let subject =
         lang.new_report_subject(&settings.hostname, reported_username, reporter_username);
       let body = lang.new_report_body(reports_link);
-      send_email(subject, email, admin.person.name, body, settings);
+      send_email(subject, email, admin.person.name, body, settings)?;
     }
   }
   Ok(())

--- a/crates/email/src/lib.rs
+++ b/crates/email/src/lib.rs
@@ -1,3 +1,4 @@
+pub use crate::send::send_email_task;
 use lemmy_db_schema::sensitive::SensitiveString;
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_utils::{
@@ -5,12 +6,51 @@ use lemmy_utils::{
   settings::structs::Settings,
 };
 use rosetta_i18n::{Language, LanguageId};
+use std::sync::LazyLock;
+use tokio::{
+  sync::{
+    mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender, WeakUnboundedSender},
+    Mutex,
+  },
+  task::JoinHandle,
+};
 use translations::Lang;
 
 pub mod account;
 pub mod admin;
 pub mod notifications;
 mod send;
+
+// TODO: this could be merged with `ActivityChannel` using generics
+struct EmailChannel {
+  weak_sender: WeakUnboundedSender<EmailParams>,
+  receiver: Mutex<UnboundedReceiver<EmailParams>>,
+  keepalive_sender: Mutex<Option<UnboundedSender<EmailParams>>>,
+}
+
+static EMAIL_CHANNEL: LazyLock<EmailChannel> = LazyLock::new(|| {
+  let (sender, receiver) = unbounded_channel();
+  let weak_sender = sender.downgrade();
+  EmailChannel {
+    weak_sender,
+    receiver: Mutex::new(receiver),
+    keepalive_sender: Mutex::new(Some(sender)),
+  }
+});
+
+struct EmailParams {
+  subject: String,
+  to_email: SensitiveString,
+  to_username: String,
+  html: String,
+  settings: &'static Settings,
+}
+
+pub async fn cancel_email_task(receive_task: JoinHandle<()>) -> LemmyResult<()> {
+  EMAIL_CHANNEL.keepalive_sender.lock().await.take();
+  receive_task.await?;
+  Ok(())
+}
 
 /// Avoid warnings for unused 0.19 translations
 #[allow(dead_code)]

--- a/crates/email/src/notifications.rs
+++ b/crates/email/src/notifications.rs
@@ -4,7 +4,11 @@ use lemmy_db_schema::{
   source::{comment::Comment, community::Community, person::Person, post::Post},
 };
 use lemmy_db_views_local_user::LocalUserView;
-use lemmy_utils::{settings::structs::Settings, utils::markdown::markdown_to_html};
+use lemmy_utils::{
+  error::LemmyResult,
+  settings::structs::Settings,
+  utils::markdown::markdown_to_html,
+};
 
 pub enum NotificationEmailData<'a> {
   Mention {
@@ -36,9 +40,9 @@ pub fn send_notification_email(
   link: DbUrl,
   data: NotificationEmailData,
   settings: &'static Settings,
-) {
+) -> LemmyResult<()> {
   if local_user_view.banned || !local_user_view.local_user.send_notifications_to_email {
-    return;
+    return Ok(());
   }
 
   let inbox_link = inbox_link(settings);
@@ -117,6 +121,7 @@ pub fn send_notification_email(
       local_user_view.person.name,
       body,
       settings,
-    );
+    )?;
   }
+  Ok(())
 }

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -1,5 +1,6 @@
 use cfg_if::cfg_if;
 use std::cmp::min;
+use tokio::task::JoinHandle;
 
 cfg_if! {
   if #[cfg(feature = "full")] {
@@ -81,7 +82,7 @@ pub static FEDERATION_CONTEXT: LazyLock<Value> = LazyLock::new(|| {
 /// * attaches the spawned task to the tracing span of the caller for better logging
 pub fn spawn_try_task(
   task: impl futures::Future<Output = Result<(), error::LemmyError>> + Send + 'static,
-) {
+) -> JoinHandle<()>{
   use tracing::Instrument;
   tokio::spawn(
     async {
@@ -91,7 +92,7 @@ pub fn spawn_try_task(
     }
     .in_current_span(), /* this makes sure the inner tracing gets the same context as where
                          * spawn was called */
-  );
+  )
 }
 
 pub fn build_cache<K, V>() -> Cache<K, V>


### PR DESCRIPTION
Followup for https://github.com/LemmyNet/lemmy/pull/5877

These are all the background tasks that we may have to wait for on shutdown:
- collect notified users for post/comment
- send out emails
- send webmention for post
- import user settings (probably too slow and not worth it)
- generate metadata for incoming federated posts
- purge images for user (https://github.com/LemmyNet/lemmy/pull/5883)
- maybe [make_send()](https://github.com/LemmyNet/lemmy/blob/main/crates/routes/src/images/utils.rs#L43) for image requests (probably fine as we wait for http shutdown)