### PR TITLE
Only use MiMalloc on x86_64 target arch (fixes #5695)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -248,6 +248,8 @@ serde_json = { workspace = true }
 rustls = { workspace = true }
 tokio.workspace = true
 clap = { workspace = true }
+
+[target.'cfg(target_arch = "x86_64")'.dependencies]
 mimalloc = "0.1.46"
 
 # Speedup RSA key generation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,6 @@ use lemmy_utils::{
   settings::{structs::Settings, SETTINGS},
   VERSION,
 };
-use mimalloc::MiMalloc;
 use reqwest_middleware::ClientBuilder;
 use reqwest_tracing::TracingMiddleware;
 use serde_json::json;
@@ -57,8 +56,9 @@ use std::{ops::Deref, time::Duration};
 use tokio::signal::unix::SignalKind;
 use tracing_actix_web::{DefaultRootSpanBuilder, TracingLogger};
 
-#[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
+#[cfg_attr(target_arch = "x86_64", global_allocator)]
+#[cfg(target_arch = "x86_64")]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 /// Timeout for HTTP requests while sending activities. A longer timeout provides better
 /// compatibility with other ActivityPub software that might allocate more time for synchronous


### PR DESCRIPTION
Should be backported to 0.19