### PR TITLE
Adding a local_site and local_user setting for default fetch limit

### DIFF
--- a/crates/api/api/src/local_user/save_settings.rs
+++ b/crates/api/api/src/local_user/save_settings.rs
@@ -102,6 +102,7 @@ pub async fn save_user_settings(
   let default_post_sort_type = data.default_post_sort_type;
   let default_post_time_range_seconds =
     diesel_opt_number_update(data.default_post_time_range_seconds);
+  let default_fetch_limit = diesel_opt_number_update(data.default_fetch_limit);
   let default_comment_sort_type = data.default_comment_sort_type;
 
   let person_form = PersonUpdateForm {
@@ -148,6 +149,7 @@ pub async fn save_user_settings(
     default_post_time_range_seconds,
     default_comment_sort_type,
     default_listing_type,
+    default_fetch_limit,
     theme: data.theme.clone(),
     interface_language: data.interface_language.clone(),
     open_links_in_new_tab: data.open_links_in_new_tab,

--- a/crates/api/api_crud/src/site/update.rs
+++ b/crates/api/api_crud/src/site/update.rs
@@ -72,6 +72,7 @@ pub async fn update_site(
   );
   let default_post_time_range_seconds =
     diesel_opt_number_update(data.default_post_time_range_seconds);
+  let default_fetch_limit = diesel_opt_number_update(data.default_fetch_limit);
 
   let site_form = SiteUpdateForm {
     name: data.name.clone(),
@@ -98,6 +99,7 @@ pub async fn update_site(
     default_post_listing_type: data.default_post_listing_type,
     default_post_sort_type: data.default_post_sort_type,
     default_post_time_range_seconds,
+    default_fetch_limit,
     default_comment_sort_type: data.default_comment_sort_type,
     legal_information: diesel_string_update(data.legal_information.as_deref()),
     application_email_admins: data.application_email_admins,

--- a/crates/apub/src/api/list_comments.rs
+++ b/crates/apub/src/api/list_comments.rs
@@ -1,5 +1,12 @@
 use super::comment_sort_type_with_default;
-use crate::{api::listing_type_with_default, fetcher::resolve_ap_identifier};
+use crate::{
+  api::{
+    fetch_limit_with_default,
+    listing_type_with_default,
+    post_time_range_seconds_with_default,
+  },
+  fetcher::resolve_ap_identifier,
+};
 use activitypub_federation::config::Data;
 use actix_web::web::{Json, Query};
 use lemmy_api_utils::{context::LemmyContext, utils::check_private_instance};
@@ -31,7 +38,9 @@ async fn list_comments_common(
   local_user_view: Option<LocalUserView>,
 ) -> LemmyResult<CommentsCommonOutput> {
   let site_view = SiteView::read_local(&mut context.pool()).await?;
-  check_private_instance(&local_user_view, &site_view.local_site)?;
+  let local_site = &site_view.local_site;
+
+  check_private_instance(&local_user_view, local_site)?;
 
   let community_id = if let Some(name) = &data.community_name {
     Some(
@@ -42,21 +51,20 @@ async fn list_comments_common(
   } else {
     data.community_id
   };
-  let local_user_ref = local_user_view.as_ref().map(|u| &u.local_user);
+  let local_user = local_user_view.as_ref().map(|u| &u.local_user);
   let sort = Some(comment_sort_type_with_default(
-    data.sort,
-    local_user_ref,
-    &site_view.local_site,
+    data.sort, local_user, local_site,
   ));
-  let time_range_seconds = data.time_range_seconds;
+  let time_range_seconds =
+    post_time_range_seconds_with_default(data.time_range_seconds, local_user, local_site);
+  let limit = fetch_limit_with_default(data.limit, local_user, local_site);
   let max_depth = data.max_depth;
-  let limit = data.limit;
   let parent_id = data.parent_id;
 
   let listing_type = Some(listing_type_with_default(
     data.type_,
     local_user_view.as_ref().map(|u| &u.local_user),
-    &site_view.local_site,
+    local_site,
     community_id,
   ));
 

--- a/crates/apub/src/api/list_posts.rs
+++ b/crates/apub/src/api/list_posts.rs
@@ -1,5 +1,6 @@
 use crate::{
   api::{
+    fetch_limit_with_default,
     listing_type_with_default,
     post_sort_type_with_default,
     post_time_range_seconds_with_default,
@@ -30,10 +31,10 @@ pub async fn list_posts(
   local_user_view: Option<LocalUserView>,
 ) -> LemmyResult<Json<GetPostsResponse>> {
   let site_view = SiteView::read_local(&mut context.pool()).await?;
+  let local_site = &site_view.local_site;
 
   check_private_instance(&local_user_view, &site_view.local_site)?;
 
-  let limit = data.limit;
   let community_id = if let Some(name) = &data.community_name {
     Some(
       resolve_ap_identifier::<ApubCommunity, Community>(name, &context, &local_user_view, true)
@@ -55,20 +56,17 @@ pub async fn list_posts(
   let listing_type = Some(listing_type_with_default(
     data.type_,
     local_user,
-    &site_view.local_site,
+    local_site,
     community_id,
   ));
 
   let sort = Some(post_sort_type_with_default(
-    data.sort,
-    local_user,
-    &site_view.local_site,
+    data.sort, local_user, local_site,
   ));
-  let time_range_seconds = post_time_range_seconds_with_default(
-    data.time_range_seconds,
-    local_user,
-    &site_view.local_site,
-  );
+  let time_range_seconds =
+    post_time_range_seconds_with_default(data.time_range_seconds, local_user, local_site);
+  let limit = fetch_limit_with_default(data.limit, local_user, local_site);
+
   let keyword_blocks = if let Some(local_user) = local_user {
     Some(LocalUserKeywordBlock::read(&mut context.pool(), local_user.id).await?)
   } else {

--- a/crates/apub/src/api/mod.rs
+++ b/crates/apub/src/api/mod.rs
@@ -87,6 +87,18 @@ fn comment_sort_type_with_default(
   )
 }
 
+/// Returns a default page fetch limit.
+/// Order is the given, then local user default, then site default.
+fn fetch_limit_with_default(
+  limit: Option<i64>,
+  local_user: Option<&LocalUser>,
+  local_site: &LocalSite,
+) -> Option<i64> {
+  limit
+    .or(local_user.and_then(|u| u.default_fetch_limit.map(i64::from)))
+    .or(local_site.default_fetch_limit.map(i64::from))
+}
+
 async fn resolve_person_id_from_id_or_username(
   person_id: &Option<PersonId>,
   username: &Option<String>,

--- a/crates/db_schema/src/source/local_site.rs
+++ b/crates/db_schema/src/source/local_site.rs
@@ -96,6 +96,7 @@ pub struct LocalSite {
   pub disable_email_notifications: bool,
   pub suggested_communities: Option<MultiCommunityId>,
   pub multi_comm_follower: PersonId,
+  pub default_fetch_limit: Option<i32>,
 }
 
 #[derive(Clone, derive_new::new)]
@@ -163,6 +164,8 @@ pub struct LocalSiteInsertForm {
   pub suggested_communities: Option<MultiCommunityId>,
   #[new(default)]
   pub multi_comm_follower: Option<PersonId>,
+  #[new(default)]
+  pub default_fetch_limit: Option<i32>,
 }
 
 #[derive(Clone, Default)]
@@ -199,4 +202,5 @@ pub struct LocalSiteUpdateForm {
   pub disallow_nsfw_content: Option<bool>,
   pub disable_email_notifications: Option<bool>,
   pub suggested_communities: Option<MultiCommunityId>,
+  pub default_fetch_limit: Option<Option<i32>>,
 }

--- a/crates/db_schema/src/source/local_user.rs
+++ b/crates/db_schema/src/source/local_user.rs
@@ -84,6 +84,7 @@ pub struct LocalUser {
   pub show_downvotes: VoteShow,
   pub show_upvote_percentage: bool,
   pub show_person_votes: bool,
+  pub default_fetch_limit: Option<i32>,
 }
 
 #[derive(Clone, derive_new::new)]
@@ -158,6 +159,8 @@ pub struct LocalUserInsertForm {
   pub show_upvote_percentage: Option<bool>,
   #[new(default)]
   pub show_person_votes: Option<bool>,
+  #[new(default)]
+  pub default_fetch_limit: Option<i32>,
 }
 
 #[derive(Clone, Default)]
@@ -198,4 +201,5 @@ pub struct LocalUserUpdateForm {
   pub show_downvotes: Option<VoteShow>,
   pub show_upvote_percentage: Option<bool>,
   pub show_person_votes: Option<bool>,
+  pub default_fetch_limit: Option<Option<i32>>,
 }

--- a/crates/db_schema_file/src/schema.rs
+++ b/crates/db_schema_file/src/schema.rs
@@ -454,6 +454,7 @@ diesel::table! {
         disable_email_notifications -> Bool,
         suggested_communities -> Nullable<Int4>,
         multi_comm_follower -> Int4,
+        default_fetch_limit -> Nullable<Int4>,
     }
 }
 
@@ -534,6 +535,7 @@ diesel::table! {
         show_downvotes -> VoteShowEnum,
         show_upvote_percentage -> Bool,
         show_person_votes -> Bool,
+        default_fetch_limit -> Nullable<Int4>,
     }
 }
 

--- a/crates/db_views/registration_applications/src/impls.rs
+++ b/crates/db_views/registration_applications/src/impls.rs
@@ -222,6 +222,7 @@ mod tests {
         default_post_sort_type: sara_local_user.default_post_sort_type,
         default_comment_sort_type: sara_local_user.default_comment_sort_type,
         default_listing_type: sara_local_user.default_listing_type,
+        default_fetch_limit: sara_local_user.default_fetch_limit,
         interface_language: sara_local_user.interface_language,
         show_avatars: sara_local_user.show_avatars,
         send_notifications_to_email: sara_local_user.send_notifications_to_email,

--- a/crates/db_views/site/src/api.rs
+++ b/crates/db_views/site/src/api.rs
@@ -216,6 +216,8 @@ pub struct EditSite {
   pub default_post_sort_type: Option<PostSortType>,
   /// A default time range limit to apply to post sorts, in seconds. 0 means none.
   pub default_post_time_range_seconds: Option<i32>,
+  /// A default fetch limit for number of items returned.
+  pub default_fetch_limit: Option<i32>,
   /// The default comment sort, usually "hot"
   pub default_comment_sort_type: Option<CommentSortType>,
   /// An optional page of legal information
@@ -491,6 +493,8 @@ pub struct SaveUserSettings {
   pub default_post_sort_type: Option<PostSortType>,
   /// A default time range limit to apply to post sorts, in seconds. 0 means none.
   pub default_post_time_range_seconds: Option<i32>,
+  /// A default fetch limit for number of items returned.
+  pub default_fetch_limit: Option<i32>,
   /// The default comment sort, usually "hot"
   pub default_comment_sort_type: Option<CommentSortType>,
   /// The language of the lemmy interface

--- a/migrations/2025-07-26-230802_add_default_fetch_limit/down.sql
+++ b/migrations/2025-07-26-230802_add_default_fetch_limit/down.sql
@@ -1,0 +1,7 @@
+-- Drop the new columns
+ALTER TABLE local_user
+    DROP COLUMN default_fetch_limit;
+
+ALTER TABLE local_site
+    DROP COLUMN default_fetch_limit;
+

--- a/migrations/2025-07-26-230802_add_default_fetch_limit/up.sql
+++ b/migrations/2025-07-26-230802_add_default_fetch_limit/up.sql
@@ -1,0 +1,7 @@
+-- Adds an optional default fetch limit (IE fetch a certain number of posts) to local_user and local_site
+ALTER TABLE local_user
+    ADD COLUMN default_fetch_limit integer;
+
+ALTER TABLE local_site
+    ADD COLUMN default_fetch_limit integer;
+


### PR DESCRIPTION
- Currently only used for list_posts and list_comments, like the other defaults.
- Fixes #5474