### PR TITLE
Re-export some types from lemmy-api-common

### DIFF
--- a/crates/api/api_common/src/account.rs
+++ b/crates/api/api_common/src/account.rs
@@ -24,6 +24,7 @@ pub mod auth {
   pub use lemmy_db_views_site::api::{
     CaptchaResponse,
     ChangePassword,
+    ExportDataResponse,
     GenerateTotpSecretResponse,
     GetCaptchaResponse,
     ListLoginsResponse,
@@ -34,6 +35,7 @@ pub mod auth {
     ResendVerificationEmail,
     UpdateTotp,
     UpdateTotpResponse,
+    UserSettingsBackup,
     VerifyEmail,
   };
 }

--- a/crates/api/api_common/src/community.rs
+++ b/crates/api/api_common/src/community.rs
@@ -1,7 +1,8 @@
 pub use lemmy_db_schema::{
-  newtypes::{CommunityId, TagId},
+  newtypes::{CommunityId, MultiCommunityId, TagId},
   source::{
     community::{Community, CommunityActions},
+    multi_community::{MultiCommunity, MultiCommunityFollow},
     tag::{Tag, TagsView},
   },
 };
@@ -9,13 +10,22 @@ pub use lemmy_db_schema_file::enums::CommunityVisibility;
 pub use lemmy_db_views_community::{
   api::{
     CommunityResponse,
+    CreateMultiCommunity,
+    CreateOrDeleteMultiCommunityEntry,
+    FollowMultiCommunity,
     GetCommunity,
     GetCommunityResponse,
+    GetMultiCommunity,
+    GetMultiCommunityResponse,
     GetRandomCommunity,
     ListCommunities,
     ListCommunitiesResponse,
+    ListMultiCommunities,
+    ListMultiCommunitiesResponse,
+    UpdateMultiCommunity,
   },
   CommunityView,
+  MultiCommunityView,
 };
 pub use lemmy_db_views_community_follower::PendingFollow;
 pub use lemmy_db_views_community_moderator::CommunityModeratorView;

--- a/crates/api/api_common/src/notification.rs
+++ b/crates/api/api_common/src/notification.rs
@@ -4,7 +4,7 @@ pub use lemmy_db_schema::{
   NotificationDataType,
 };
 pub use lemmy_db_views_notification::{
-  api::{GetUnreadCountResponse, MarkNotificationAsRead, MarkPrivateMessageAsRead},
+  api::{GetUnreadCountResponse, MarkNotificationAsRead},
   ListNotifications,
   ListNotificationsResponse,
   NotificationView,

--- a/crates/api/api_common/src/post.rs
+++ b/crates/api/api_common/src/post.rs
@@ -3,7 +3,7 @@ pub use lemmy_db_schema::{
   source::post::{Post, PostActions},
   PostFeatureType,
 };
-pub use lemmy_db_schema_file::enums::PostListingMode;
+pub use lemmy_db_schema_file::enums::{PostListingMode, PostNotificationsMode};
 pub use lemmy_db_views_post::{
   api::{
     GetPost,
@@ -29,6 +29,7 @@ pub mod actions {
     MarkManyPostsAsRead,
     MarkPostAsRead,
     SavePost,
+    UpdatePostNotifications,
   };
 
   pub mod moderation {
@@ -37,6 +38,7 @@ pub mod actions {
       ListPostLikes,
       ListPostLikesResponse,
       LockPost,
+      ModEditPost,
       PurgePost,
       RemovePost,
     };

--- a/crates/api/api_common/src/site.rs
+++ b/crates/api/api_common/src/site.rs
@@ -9,7 +9,7 @@ pub use lemmy_db_schema::{
 };
 pub use lemmy_db_schema_file::enums::RegistrationMode;
 pub use lemmy_db_views_site::{
-  api::{GetSiteResponse, SiteResponse},
+  api::{GetSiteResponse, PostOrCommentOrPrivateMessage, SiteResponse},
   SiteView,
 };
 

--- a/crates/db_views/notification/src/api.rs
+++ b/crates/db_views/notification/src/api.rs
@@ -25,12 +25,3 @@ pub struct MarkNotificationAsRead {
   pub notification_id: NotificationId,
   pub read: bool,
 }
-
-#[derive(Debug, Serialize, Deserialize, Clone, Copy, Default, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
-#[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
-/// Mark a private message as read.
-pub struct MarkPrivateMessageAsRead {
-  pub private_message_id: PrivateMessageId,
-  pub read: bool,
-}

--- a/crates/db_views/notification/src/api.rs
+++ b/crates/db_views/notification/src/api.rs
@@ -1,4 +1,4 @@
-use lemmy_db_schema::newtypes::{NotificationId, PrivateMessageId};
+use lemmy_db_schema::newtypes::NotificationId;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
There were some newly added types with no re-exports from `lemmy-api-common`. This takes care of it.