### PR TITLE
Properly parse icons federated from Peertube (fixes #5894)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "8f27d075294830fcab6f66e320dab524bc6d048f4a151698e153205559113772"
 
 [[package]]
 name = "activitypub_federation"
-version = "0.7.0-beta.5"
+version = "0.7.0-beta.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e58f584c183501d7865b18d8b94c9477f750051ce99d54a399a2f4180667574c"
+checksum = "db2b37b4bda9656b5bcb0ee5fb45a616e98500207519d684305996c329bfd520"
 dependencies = [
  "activitystreams-kinds",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ lemmy_db_views_report_combined = { version = "=1.0.0-alpha.5", path = "./crates/
 lemmy_db_views_search_combined = { version = "=1.0.0-alpha.5", path = "./crates/db_views/search_combined" }
 lemmy_db_views_site = { version = "=1.0.0-alpha.5", path = "./crates/db_views/site" }
 lemmy_db_views_vote = { version = "=1.0.0-alpha.5", path = "./crates/db_views/vote" }
-activitypub_federation = { version = "0.7.0-beta.5", default-features = false, features = [
+activitypub_federation = { version = "0.7.0-beta.6", default-features = false, features = [
   "actix-web",
 ] }
 diesel = { version = "2.2.10", features = [

--- a/crates/apub_objects/src/protocol/group.rs
+++ b/crates/apub_objects/src/protocol/group.rs
@@ -6,7 +6,11 @@ use crate::{
 use activitypub_federation::{
   fetch::object_id::ObjectId,
   kinds::actor::GroupType,
-  protocol::{helpers::deserialize_skip_error, public_key::PublicKey, values::MediaTypeHtml},
+  protocol::{
+    helpers::{deserialize_last, deserialize_skip_error},
+    public_key::PublicKey,
+    values::MediaTypeHtml,
+  },
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -36,10 +40,10 @@ pub struct Group {
   pub(crate) media_type: Option<MediaTypeHtml>,
   // short instance description
   pub summary: Option<String>,
-  #[serde(deserialize_with = "deserialize_skip_error", default)]
+  #[serde(deserialize_with = "deserialize_last", default)]
   pub icon: Option<ImageObject>,
   /// banner
-  #[serde(deserialize_with = "deserialize_skip_error", default)]
+  #[serde(deserialize_with = "deserialize_last", default)]
   pub image: Option<ImageObject>,
   // lemmy extension
   pub sensitive: Option<bool>,

--- a/crates/apub_objects/src/protocol/person.rs
+++ b/crates/apub_objects/src/protocol/person.rs
@@ -4,7 +4,10 @@ use crate::{
 };
 use activitypub_federation::{
   fetch::object_id::ObjectId,
-  protocol::{helpers::deserialize_skip_error, public_key::PublicKey},
+  protocol::{
+    helpers::{deserialize_last, deserialize_skip_error},
+    public_key::PublicKey,
+  },
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -38,9 +41,10 @@ pub struct Person {
   #[serde(deserialize_with = "deserialize_skip_error", default)]
   pub(crate) source: Option<Source>,
   /// user avatar
-  #[serde(deserialize_with = "deserialize_skip_error", default)]
+  #[serde(deserialize_with = "deserialize_last", default)]
   pub(crate) icon: Option<ImageObject>,
   /// user banner
+  #[serde(deserialize_with = "deserialize_last", default)]
   pub(crate) image: Option<ImageObject>,
   pub(crate) matrix_user_id: Option<String>,
   pub(crate) endpoints: Option<Endpoints>,


### PR DESCRIPTION
Peertube federates icons and banners as [array](https://github.com/LemmyNet/lemmy/blob/main/crates/apub/assets/peertube/objects/person.json#L32) instead of a single value. With these PR these are parsed properly, instead of ignoring them. It takes the last icon from the array as that is generally the largest.

[Library change](https://github.com/LemmyNet/activitypub-federation-rust/pull/148)