### PR TITLE
Fixing active counts slow queries.

### DIFF
--- a/migrations/2025-07-29-152742_add_indexes_for_aggregates_activity/down.sql
+++ b/migrations/2025-07-29-152742_add_indexes_for_aggregates_activity/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX idx_post_published, idx_post_like_published, idx_comment_like_published;
+

--- a/migrations/2025-07-29-152742_add_indexes_for_aggregates_activity/up.sql
+++ b/migrations/2025-07-29-152742_add_indexes_for_aggregates_activity/up.sql
@@ -1,0 +1,7 @@
+-- These actually increased query time, but they prevent more postgres workers from being launched, and so should free up locks.
+CREATE INDEX idx_post_published ON post (published);
+
+CREATE INDEX idx_post_like_published ON post_like (published);
+
+CREATE INDEX idx_comment_like_published ON comment_like (published);
+


### PR DESCRIPTION
The slowness for #5902 is coming from the [community aggregates activity postgres function](https://github.com/LemmyNet/lemmy/blob/release/v0.19/crates/db_schema/replaceable_schema/utils.sql#L155). This function collects up and unions the comments, posts, comment likes, and post likes for a community, at different intervals. The longer intervals like month and six months unavoidably take a long time.

I added a few indexes (which didn't speed it up on my machine, but at least they did launch less postgres worker processes). They'll likely be faster on slower machines.

The main speed increase comes from only updating the daily stats hourly, and every stat daily.

It'd be nice to run the longer stats (like 6 months, 1 month), _even less frequently_ than daily, but that might be dangerous, because we can't guarantee that lemmy instances will run for more than a week, and so couldn't guarantee that these stats would ever get updated.

After this gets approved, I'll cherry-pick to main.

- Fixes #5902
