### PR TITLE
Fixing cargo test failures due to backported `pg_dump` security issue.

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -41,87 +41,87 @@ steps:
     when:
       - event: [pull_request, tag]
 
-  # prettier_check:
-  #   image: tmknom/prettier:3.6.2
-  #   commands:
-  #     - prettier -c . '!**/volumes' '!**/dist' '!target' '!**/translations' '!api_tests/pnpm-lock.yaml'
-  #   when:
-  #     - event: pull_request
+  prettier_check:
+    image: tmknom/prettier:3.6.2
+    commands:
+      - prettier -c . '!**/volumes' '!**/dist' '!target' '!**/translations' '!api_tests/pnpm-lock.yaml'
+    when:
+      - event: pull_request
 
-  # bash_fmt:
-  #   image: alpine:3
-  #   commands:
-  #     - apk add shfmt
-  #     - shfmt -i 2 -d */**.bash
-  #     - shfmt -i 2 -d */**.sh
-  #   when:
-  #     - event: pull_request
+  bash_fmt:
+    image: alpine:3
+    commands:
+      - apk add shfmt
+      - shfmt -i 2 -d */**.bash
+      - shfmt -i 2 -d */**.sh
+    when:
+      - event: pull_request
 
-  # toml_fmt:
-  #   image: tamasfe/taplo:0.9.3
-  #   commands:
-  #     - taplo format --check
-  #   when:
-  #     - event: pull_request
+  toml_fmt:
+    image: tamasfe/taplo:0.9.3
+    commands:
+      - taplo format --check
+    when:
+      - event: pull_request
 
-  # sql_fmt:
-  #   image: *rust_image
-  #   commands:
-  #     - apt-get install perl make bash
-  #     - ./scripts/alpine_install_pg_formatter.sh
-  #     - ./scripts/sql_format_check.sh
-  #   when:
-  #     - event: pull_request
+  sql_fmt:
+    image: *rust_image
+    commands:
+      - apt-get install perl make bash
+      - ./scripts/alpine_install_pg_formatter.sh
+      - ./scripts/sql_format_check.sh
+    when:
+      - event: pull_request
 
-  # cargo_fmt:
-  #   image: *rust_nightly_image
-  #   environment:
-  #     # store cargo data in repo folder so that it gets cached between steps
-  #     CARGO_HOME: .cargo_home
-  #     RUSTUP_HOME: .rustup_home
-  #   commands:
-  #     - rustup component add rustfmt --toolchain nightly
-  #     - cargo +nightly fmt -- --check
-  #   when:
-  #     - event: pull_request
+  cargo_fmt:
+    image: *rust_nightly_image
+    environment:
+      # store cargo data in repo folder so that it gets cached between steps
+      CARGO_HOME: .cargo_home
+      RUSTUP_HOME: .rustup_home
+    commands:
+      - rustup component add rustfmt --toolchain nightly
+      - cargo +nightly fmt -- --check
+    when:
+      - event: pull_request
 
-  # cargo_shear:
-  #   image: *rust_nightly_image
-  #   commands:
-  #     - *install_binstall
-  #     - cargo binstall -y cargo-shear
-  #     - cargo shear
-  #   when:
-  #     - event: pull_request
+  cargo_shear:
+    image: *rust_nightly_image
+    commands:
+      - *install_binstall
+      - cargo binstall -y cargo-shear
+      - cargo shear
+    when:
+      - event: pull_request
 
-  # ignored_files:
-  #   image: alpine:3
-  #   commands:
-  #     - apk add git
-  #     - IGNORED=$(git ls-files --cached -i --exclude-standard)
-  #     - if [[ "$IGNORED" ]]; then echo "Ignored files present:\n$IGNORED\n"; exit 1; fi
-  #   when:
-  #     - event: pull_request
+  ignored_files:
+    image: alpine:3
+    commands:
+      - apk add git
+      - IGNORED=$(git ls-files --cached -i --exclude-standard)
+      - if [[ "$IGNORED" ]]; then echo "Ignored files present:\n$IGNORED\n"; exit 1; fi
+    when:
+      - event: pull_request
 
-  # no_empty_files:
-  #   image: alpine:3
-  #   commands:
-  #     # Makes sure there are no files smaller than 2 bytes
-  #     # Don't use completely empty, as some editors use newlines
-  #     - EMPTY_FILES=$(find crates migrations api_tests/src config -type f -size -2c)
-  #     - if [[ "$EMPTY_FILES" ]]; then echo "Empty files present:\n$EMPTY_FILES\n"; exit 1; fi
-  #   when:
-  #     - event: pull_request
+  no_empty_files:
+    image: alpine:3
+    commands:
+      # Makes sure there are no files smaller than 2 bytes
+      # Don't use completely empty, as some editors use newlines
+      - EMPTY_FILES=$(find crates migrations api_tests/src config -type f -size -2c)
+      - if [[ "$EMPTY_FILES" ]]; then echo "Empty files present:\n$EMPTY_FILES\n"; exit 1; fi
+    when:
+      - event: pull_request
 
-  # cargo_clippy:
-  #   image: *rust_image
-  #   environment:
-  #     CARGO_HOME: .cargo_home
-  #     RUSTUP_HOME: .rustup_home
-  #   commands:
-  #     - rustup component add clippy
-  #     - cargo clippy --workspace --tests --all-targets -- -D warnings
-  #   when: *slow_check_paths
+  cargo_clippy:
+    image: *rust_image
+    environment:
+      CARGO_HOME: .cargo_home
+      RUSTUP_HOME: .rustup_home
+    commands:
+      - rustup component add clippy
+      - cargo clippy --workspace --tests --all-targets -- -D warnings
+    when: *slow_check_paths
 
   # `DROP OWNED` doesn't work for default user
   create_database_user:
@@ -151,7 +151,7 @@ steps:
       - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
       - apt update && apt install -y postgresql-client-16
       # Run tests
-      - cargo test -p lemmy_db_schema_setup --no-fail-fast
+      - cargo test --workspace --no-fail-fast
     when: *slow_check_paths
 
   # make sure api builds with default features (used by other crates relying on lemmy api)

--- a/crates/db_schema_setup/src/diff_check.rs
+++ b/crates/db_schema_setup/src/diff_check.rs
@@ -36,6 +36,8 @@ pub(crate) fn get_dump() -> String {
       "--no-table-access-method",
       "--no-tablespaces",
       "--no-large-objects",
+      // Use a fake restrict key, rather than an auto-generated one.
+      // See https://github.com/sqlc-dev/sqlc/issues/4065
       "--restrict-key",
       "empty",
     ])
@@ -45,9 +47,8 @@ pub(crate) fn get_dump() -> String {
 
   // TODO: use exit_ok method when it's stable
   assert!(output.status.success());
-  let out = String::from_utf8(output.stdout).expect("pg_dump output is not valid UTF-8 text");
-  println!("output: {out}");
-  out
+
+  String::from_utf8(output.stdout).expect("pg_dump output is not valid UTF-8 text")
 }
 
 /// Checks dumps returned by [`get_dump`] and panics if they differ in a way that indicates a


### PR DESCRIPTION
Finally found the issue: https://github.com/sqlc-dev/sqlc/issues/4065

Essentially postgres backported a security issue to `pg_dump`, which generated these `\restrict` and `\unrestrict` keys whenever creating a pg_dump, which caused CI errors when doing the diff check. 

This PR specifies the restrict key, so the diffs now match.

Going to merge this once it passes, as its breaking all CI checks.

