### PR TITLE
Fix post like not decrementing vote totals.

### DIFF
--- a/crates/api/api/src/post/like.rs
+++ b/crates/api/api/src/post/like.rs
@@ -45,8 +45,14 @@ pub async fn like_post(
   check_bot_account(&local_user_view.person)?;
 
   // Check for a community ban
-  let orig_post =
-    PostView::read(&mut context.pool(), post_id, None, local_instance_id, false).await?;
+  let orig_post = PostView::read(
+    &mut context.pool(),
+    post_id,
+    Some(&local_user_view.local_user),
+    local_instance_id,
+    false,
+  )
+  .await?;
   let previous_score = orig_post.post_actions.and_then(|p| p.like_score);
 
   check_community_user_action(&local_user_view, &orig_post.community, &mut context.pool()).await?;

--- a/crates/api/api/src/post/lock.rs
+++ b/crates/api/api/src/post/lock.rs
@@ -28,8 +28,14 @@ pub async fn lock_post(
   let post_id = data.post_id;
   let local_instance_id = local_user_view.person.instance_id;
 
-  let orig_post =
-    PostView::read(&mut context.pool(), post_id, None, local_instance_id, false).await?;
+  let orig_post = PostView::read(
+    &mut context.pool(),
+    post_id,
+    Some(&local_user_view.local_user),
+    local_instance_id,
+    false,
+  )
+  .await?;
 
   check_community_mod_action(
     &local_user_view,

--- a/crates/api/api/src/post/mod_update.rs
+++ b/crates/api/api/src/post/mod_update.rs
@@ -37,8 +37,14 @@ pub async fn mod_update_post(
   check_nsfw_allowed(data.nsfw, Some(&local_site))?;
 
   let post_id = data.post_id;
-  let orig_post =
-    PostView::read(&mut context.pool(), post_id, None, local_instance_id, false).await?;
+  let orig_post = PostView::read(
+    &mut context.pool(),
+    post_id,
+    Some(&local_user_view.local_user),
+    local_instance_id,
+    false,
+  )
+  .await?;
   let community = orig_post.community;
 
   check_community_user_action(&local_user_view, &community, &mut context.pool()).await?;

--- a/crates/api/api/src/reports/post_report/create.rs
+++ b/crates/api/api/src/reports/post_report/create.rs
@@ -34,19 +34,25 @@ pub async fn create_post_report(
   let person = &local_user_view.person;
   let post_id = data.post_id;
   let local_instance_id = local_user_view.person.instance_id;
-  let post_view =
-    PostView::read(&mut context.pool(), post_id, None, local_instance_id, false).await?;
+  let orig_post = PostView::read(
+    &mut context.pool(),
+    post_id,
+    Some(&local_user_view.local_user),
+    local_instance_id,
+    false,
+  )
+  .await?;
 
-  check_community_user_action(&local_user_view, &post_view.community, &mut context.pool()).await?;
+  check_community_user_action(&local_user_view, &orig_post.community, &mut context.pool()).await?;
 
-  check_post_deleted_or_removed(&post_view.post)?;
+  check_post_deleted_or_removed(&orig_post.post)?;
 
   let report_form = PostReportForm {
     creator_id: person.id,
     post_id,
-    original_post_name: post_view.post.name,
-    original_post_url: post_view.post.url,
-    original_post_body: post_view.post.body,
+    original_post_name: orig_post.post.name,
+    original_post_url: orig_post.post.url,
+    original_post_body: orig_post.post.body,
     reason,
     violates_instance_rules: data.violates_instance_rules.unwrap_or_default(),
   };
@@ -70,9 +76,9 @@ pub async fn create_post_report(
 
   ActivityChannel::submit_activity(
     SendActivityData::CreateReport {
-      object_id: post_view.post.ap_id.inner().clone(),
+      object_id: orig_post.post.ap_id.inner().clone(),
       actor: local_user_view.person,
-      receiver: Either::Right(post_view.community),
+      receiver: Either::Right(orig_post.community),
       reason: data.reason.clone(),
     },
     &context,

--- a/crates/api/api_crud/src/post/update.rs
+++ b/crates/api/api_crud/src/post/update.rs
@@ -97,8 +97,14 @@ pub async fn update_post(
   }
 
   let post_id = data.post_id;
-  let orig_post =
-    PostView::read(&mut context.pool(), post_id, None, local_instance_id, false).await?;
+  let orig_post = PostView::read(
+    &mut context.pool(),
+    post_id,
+    Some(&local_user_view.local_user),
+    local_instance_id,
+    false,
+  )
+  .await?;
 
   check_community_user_action(&local_user_view, &orig_post.community, &mut context.pool()).await?;
 


### PR DESCRIPTION
- Issue was: reading the original post like didn't pass my user, so it couldn't grab post_actions.like_score.
- Fixes #5940

Also went through a few more `PostView::read` and made sure they passed the local user.