### PR TITLE
Adding a post undelete delay to fix federation tests.

### DIFF
--- a/api_tests/src/post.spec.ts
+++ b/api_tests/src/post.spec.ts
@@ -375,6 +375,7 @@ test("Delete a post", async () => {
     postRes.post_view.post,
     p => p?.post?.deleted || p == undefined,
   );
+  await delay();
 
   // Undelete
   let undeletedPost = await deletePost(alpha, false, postRes.post_view.post);


### PR DESCRIPTION
Necessary because we can't `waitUntil(post.deleted == true)` for post deleting, since it will just return undefined due to the tombstone.