### PR TITLE
Avoid regenerating metadata for unchanged post url (fixes #5956)

### DIFF
--- a/crates/apub_objects/src/objects/post.rs
+++ b/crates/apub_objects/src/objects/post.rs
@@ -287,6 +287,7 @@ impl Object for ApubPost {
       .await?,
     );
 
+    let orig_post = Post::read_from_apub_id(&mut context.pool(), page.id.clone().into()).await;
     let mut form = PostInsertForm {
       url: url.map(Into::into),
       body,
@@ -312,11 +313,15 @@ impl Object for ApubPost {
     let post_ = post.clone();
     let context_ = context.clone();
 
-    // Generates a post thumbnail in background task, because some sites can be very slow to
-    // respond.
-    spawn_try_task(
-      async move { generate_post_link_metadata(post_, None, |_| None, context_).await },
-    );
+    // Avoid regenerating metadata if the post already existed with the same url
+    let no_generate_metadata = orig_post.ok().flatten().is_some_and(|p| p.url == post.url);
+    if !no_generate_metadata {
+      // Generates a post thumbnail in background task, because some sites can be very slow to
+      // respond.
+      spawn_try_task(
+        async move { generate_post_link_metadata(post_, None, |_| None, context_).await },
+      );
+    }
 
     Ok(post.into())
   }


### PR DESCRIPTION
Maybe not the most elegant solution but it should help.

Alternatively we would have to figure out which code is causing posts to be refederated unnecessarily. Maybe community outbox/featured collections.