### PR TITLE
Print diff-check errors to stdout (fixes #5937)

### DIFF
--- a/crates/db_schema_setup/src/diff_check.rs
+++ b/crates/db_schema_setup/src/diff_check.rs
@@ -43,7 +43,6 @@ pub(crate) fn get_dump() -> String {
       "empty",
     ])
     .stderr(Stdio::inherit())
-    .stderr(Stdio::inherit())
     .output()
     .expect("failed to start pg_dump process");
 


### PR DESCRIPTION
Output:
```
$ ./scripts/test.sh lemmy_db_schema_setup
2025-09-09 15:28:06.415 CEST [139305] LOG:  redirecting log output to logging collector process
2025-09-09 15:28:06.415 CEST [139305] HINT:  Future log output will appear in directory "log".
warning: unused config key `resolver.incompatible-rust-versions` in `/home/felix/workspace/lemmy/lemmy/.cargo/config.toml`
Compiling lemmy_db_schema_setup v1.0.0-alpha.7 (/home/felix/workspace/lemmy/lemmy/crates/db_schema_setup)
Finished `test` profile [unoptimized] target(s) in 1.21s
Running unittests src/lib.rs (target/debug/deps/lemmy_db_schema_setup-26ec14a14b6c64fb)

running 2 tests
test diff_check::tests::test_select_pairs ... ok
pg_dump: unrecognized option '--restrict-key'
pg_dump: hint: Try "pg_dump --help" for more information.
error: test failed, to rerun pass `-p lemmy_db_schema_setup --lib`

Caused by:
process didn't exit successfully: `/home/felix/workspace/lemmy/lemmy/target/debug/deps/lemmy_db_schema_setup-26ec14a14b6c64fb` (exit status: 1)
note: test exited abnormally; to see the full output pass --nocapture to the harness.
Running unittests src/main.rs (target/debug/deps/lemmy_db_schema_setup-444a70e42f02e535)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

error: 1 target failed:
`-p lemmy_db_schema_setup --lib`
```