### PR TITLE
Use more standard AP fields for community tags

### DIFF
--- a/crates/apub/assets/lemmy/objects/group.json
+++ b/crates/apub/assets/lemmy/objects/group.json
@@ -47,7 +47,7 @@
     {
       "type": "CommunityPostTag",
       "id": "https://enterprise.lemmy.ml/c/tenforward/tag/news",
-      "name": "news"
+      "preferredUsername": "news"
     }
   ],
   "published": "2019-06-02T16:43:50.799554Z",

--- a/crates/apub/assets/lemmy/objects/page.json
+++ b/crates/apub/assets/lemmy/objects/page.json
@@ -32,7 +32,7 @@
     {
       "type": "CommunityPostTag",
       "id": "https://enterprise.lemmy.ml/c/tenforward/tag/news",
-      "name": "news"
+      "preferredUsername": "news"
     }
   ],
   "context": "https://enterprise.lemmy.ml/post/55143/context",

--- a/crates/apub/src/http/community.rs
+++ b/crates/apub/src/http/community.rs
@@ -219,7 +219,7 @@ pub(crate) async fn get_apub_community_tag_http(
     .await?
     .into_iter()
     .map(CommunityTag::to_json)
-    .find(|t| t.name == info.tag_name)
+    .find(|t| t.preferred_username == info.tag_name)
     .ok_or(LemmyErrorType::NotFound)?;
 
   Ok(create_http_response(tag, &FEDERATION_CONTEXT)?)

--- a/crates/apub_objects/src/protocol/tags.rs
+++ b/crates/apub_objects/src/protocol/tags.rs
@@ -16,13 +16,13 @@ enum CommunityTagType {
 
 /// A tag that a community owns, that is added to a post.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct CommunityTag {
   #[serde(rename = "type")]
   kind: CommunityTagType,
   pub id: Url,
-  pub name: String,
-  /// custom field
-  pub display_name: Option<String>,
+  pub name: Option<String>,
+  pub preferred_username: String,
   pub content: Option<String>,
 }
 
@@ -31,8 +31,8 @@ impl CommunityTag {
     CommunityTag {
       kind: Default::default(),
       id: tag.ap_id.into(),
-      name: tag.name,
-      display_name: tag.display_name,
+      name: tag.display_name,
+      preferred_username: tag.name,
       content: tag.description,
     }
   }
@@ -40,8 +40,8 @@ impl CommunityTag {
   pub fn to_insert_form(&self, community_id: CommunityId) -> TagInsertForm {
     TagInsertForm {
       ap_id: self.id.clone().into(),
-      name: self.name.clone(),
-      display_name: self.display_name.clone(),
+      name: self.preferred_username.clone(),
+      display_name: self.name.clone(),
       description: self.content.clone(),
       community_id,
       deleted: Some(false),


### PR DESCRIPTION
I noticed that #5869 introduced a non-standard `display_name` attribute for community tags. This seems weird to me, especially with how it's out-of-step with how we handle `display_name`/`name` for communities and users. This PR just changes it so that `name` maps to `preferredUsername` and `display_name` maps to `name`, same as we do for communities and users.