### PR TITLE
Add support for publishing to GitHub Container Registry

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -240,12 +240,21 @@ steps:
   publish_release_docker:
     image: woodpeckerci/plugin-docker-buildx
     settings:
-      repo: dessalines/lemmy
+      repo: |
+        dessalines/lemmy
+        ghcr.io/lemmynet/lemmy
       dockerfile: docker/Dockerfile
-      username:
-        from_secret: docker_username
-      password:
-        from_secret: docker_password
+      logins:
+        - registry: https://index.docker.io/v1/
+          username:
+            from_secret: docker_username
+          password:
+            from_secret: docker_password
+        - registry: https://ghcr.io
+          username:
+            from_secret: github_username
+          password:
+            from_secret: github_token
       platforms: linux/amd64, linux/arm64
       build_args:
         RUST_RELEASE_MODE: release


### PR DESCRIPTION
This PR is related to #5450 to publish the docker build to github repo as well. I didn't see much documentation for adding githubs' registry from woodpeckerci/plugin-docker-buildx, but I believe this would be a good first run.

Added secrets that will need configured:
- github_username
- github_token