### PR TITLE
Remove local_user.enable_keyboard_navigation (fixes #5988)

### DIFF
--- a/crates/api/api/src/local_user/save_settings.rs
+++ b/crates/api/api/src/local_user/save_settings.rs
@@ -152,7 +152,6 @@ pub async fn save_user_settings(
     open_links_in_new_tab: data.open_links_in_new_tab,
     infinite_scroll_enabled: data.infinite_scroll_enabled,
     post_listing_mode: data.post_listing_mode,
-    enable_keyboard_navigation: data.enable_keyboard_navigation,
     enable_animated_images: data.enable_animated_images,
     enable_private_messages: data.enable_private_messages,
     collapse_bot_comments: data.collapse_bot_comments,

--- a/crates/db_schema/src/source/local_user.rs
+++ b/crates/db_schema/src/source/local_user.rs
@@ -60,8 +60,6 @@ pub struct LocalUser {
   /// A post-view mode that changes how multiple post listings look.
   pub post_listing_mode: PostListingMode,
   pub totp_2fa_enabled: bool,
-  /// Whether to allow keyboard navigation (for browsing and interacting with posts and comments).
-  pub enable_keyboard_navigation: bool,
   /// Whether user avatars and inline images in the UI that are gifs should be allowed to play or
   /// should be paused
   pub enable_animated_images: bool,
@@ -132,8 +130,6 @@ pub struct LocalUserInsertForm {
   #[new(default)]
   pub totp_2fa_enabled: Option<bool>,
   #[new(default)]
-  pub enable_keyboard_navigation: Option<bool>,
-  #[new(default)]
   pub enable_animated_images: Option<bool>,
   #[new(default)]
   pub collapse_bot_comments: Option<bool>,
@@ -185,7 +181,6 @@ pub struct LocalUserUpdateForm {
   pub admin: Option<bool>,
   pub post_listing_mode: Option<PostListingMode>,
   pub totp_2fa_enabled: Option<bool>,
-  pub enable_keyboard_navigation: Option<bool>,
   pub enable_animated_images: Option<bool>,
   pub collapse_bot_comments: Option<bool>,
   pub last_donation_notification_at: Option<DateTime<Utc>>,

--- a/crates/db_schema_file/src/schema.rs
+++ b/crates/db_schema_file/src/schema.rs
@@ -556,7 +556,6 @@ diesel::table! {
         admin -> Bool,
         post_listing_mode -> PostListingModeEnum,
         totp_2fa_enabled -> Bool,
-        enable_keyboard_navigation -> Bool,
         enable_animated_images -> Bool,
         collapse_bot_comments -> Bool,
         last_donation_notification_at -> Timestamptz,

--- a/crates/db_views/registration_applications/src/impls.rs
+++ b/crates/db_views/registration_applications/src/impls.rs
@@ -236,7 +236,6 @@ mod tests {
         infinite_scroll_enabled: sara_local_user.infinite_scroll_enabled,
         post_listing_mode: sara_local_user.post_listing_mode,
         totp_2fa_enabled: sara_local_user.totp_2fa_enabled,
-        enable_keyboard_navigation: sara_local_user.enable_keyboard_navigation,
         enable_animated_images: sara_local_user.enable_animated_images,
         enable_private_messages: sara_local_user.enable_private_messages,
         collapse_bot_comments: sara_local_user.collapse_bot_comments,

--- a/crates/db_views/site/src/api.rs
+++ b/crates/db_views/site/src/api.rs
@@ -523,8 +523,6 @@ pub struct SaveUserSettings {
   pub open_links_in_new_tab: Option<bool>,
   /// Enable infinite scroll
   pub infinite_scroll_enabled: Option<bool>,
-  /// Whether to allow keyboard navigation (for browsing and interacting with posts and comments).
-  pub enable_keyboard_navigation: Option<bool>,
   /// Whether user avatars or inline images in the UI that are gifs should be allowed to play or
   /// should be paused
   pub enable_animated_images: Option<bool>,

--- a/migrations/2025-09-15-090401_remove-keyboard-nav/down.sql
+++ b/migrations/2025-09-15-090401_remove-keyboard-nav/down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE local_user
+    ADD COLUMN enable_keyboard_navigation boolean NOT NULL DEFAULT FALSE;
+

--- a/migrations/2025-09-15-090401_remove-keyboard-nav/up.sql
+++ b/migrations/2025-09-15-090401_remove-keyboard-nav/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE local_user
+    DROP COLUMN enable_keyboard_navigation;
+


### PR DESCRIPTION
The frontend feature was not added yet and when it is, it makes sense to always enable keyboard navigation instead of using yet another setting.