### PR TITLE
Let banned users login

### DIFF
--- a/crates/api/api_crud/src/user/my_user.rs
+++ b/crates/api/api_crud/src/user/my_user.rs
@@ -1,5 +1,5 @@
 use actix_web::web::{Data, Json};
-use lemmy_api_utils::{context::LemmyContext, utils::check_local_user_valid};
+use lemmy_api_utils::{context::LemmyContext, utils::check_local_user_deleted};
 use lemmy_db_schema::{
   source::{
     actor_language::LocalUserLanguage,
@@ -20,7 +20,7 @@ pub async fn get_my_user(
   local_user_view: LocalUserView,
   context: Data<LemmyContext>,
 ) -> LemmyResult<Json<MyUserInfo>> {
-  check_local_user_valid(&local_user_view)?;
+  check_local_user_deleted(&local_user_view)?;
 
   // Build the local user with parallel queries and add it to site response
   let person_id = local_user_view.person.id;


### PR DESCRIPTION
With this change banned users can login, browse the site passivel, export settings and delete the account.