### PR TITLE
Dont allow write api actions for banned user

### DIFF
--- a/crates/api/api/src/comment/like.rs
+++ b/crates/api/api/src/comment/like.rs
@@ -5,7 +5,12 @@ use lemmy_api_utils::{
   context::LemmyContext,
   plugins::{plugin_hook_after, plugin_hook_before},
   send_activity::{ActivityChannel, SendActivityData},
-  utils::{check_bot_account, check_community_user_action, check_local_vote_mode},
+  utils::{
+    check_bot_account,
+    check_community_user_action,
+    check_local_user_valid,
+    check_local_vote_mode,
+  },
 };
 use lemmy_db_schema::{
   newtypes::PostOrCommentId,
@@ -29,6 +34,7 @@ pub async fn like_comment(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<CommentResponse>> {
+  check_local_user_valid(&local_user_view)?;
   let local_site = SiteView::read_local(&mut context.pool()).await?.local_site;
   let local_instance_id = local_user_view.person.instance_id;
   let comment_id = data.comment_id;

--- a/crates/api/api/src/comment/save.rs
+++ b/crates/api/api/src/comment/save.rs
@@ -1,5 +1,5 @@
 use actix_web::web::{Data, Json};
-use lemmy_api_utils::context::LemmyContext;
+use lemmy_api_utils::{context::LemmyContext, utils::check_local_user_valid};
 use lemmy_db_schema::{
   source::comment::{CommentActions, CommentSavedForm},
   traits::Saveable,
@@ -16,6 +16,7 @@ pub async fn save_comment(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<CommentResponse>> {
+  check_local_user_valid(&local_user_view)?;
   let comment_saved_form = CommentSavedForm::new(local_user_view.person.id, data.comment_id);
 
   if data.save {

--- a/crates/api/api/src/community/block.rs
+++ b/crates/api/api/src/community/block.rs
@@ -4,6 +4,7 @@ use diesel_async::scoped_futures::ScopedFutureExt;
 use lemmy_api_utils::{
   context::LemmyContext,
   send_activity::{ActivityChannel, SendActivityData},
+  utils::check_local_user_valid,
 };
 use lemmy_db_schema::{
   source::community::{CommunityActions, CommunityBlockForm},
@@ -22,6 +23,7 @@ pub async fn user_block_community(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<BlockCommunityResponse>> {
+  check_local_user_valid(&local_user_view)?;
   let community_id = data.community_id;
   let person_id = local_user_view.person.id;
   let community_block_form = CommunityBlockForm::new(community_id, person_id);

--- a/crates/api/api/src/local_user/block.rs
+++ b/crates/api/api/src/local_user/block.rs
@@ -1,5 +1,5 @@
 use actix_web::web::{Data, Json};
-use lemmy_api_utils::context::LemmyContext;
+use lemmy_api_utils::{context::LemmyContext, utils::check_local_user_valid};
 use lemmy_db_schema::{
   source::person::{PersonActions, PersonBlockForm},
   traits::Blockable,
@@ -16,6 +16,7 @@ pub async fn user_block_person(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<BlockPersonResponse>> {
+  check_local_user_valid(&local_user_view)?;
   let target_id = data.person_id;
   let my_person_id = local_user_view.person.id;
   let local_instance_id = local_user_view.person.instance_id;

--- a/crates/api/api/src/local_user/change_password.rs
+++ b/crates/api/api/src/local_user/change_password.rs
@@ -3,7 +3,11 @@ use actix_web::{
   HttpRequest,
 };
 use bcrypt::verify;
-use lemmy_api_utils::{claims::Claims, context::LemmyContext, utils::password_length_check};
+use lemmy_api_utils::{
+  claims::Claims,
+  context::LemmyContext,
+  utils::{check_local_user_valid, password_length_check},
+};
 use lemmy_db_schema::source::{local_user::LocalUser, login_token::LoginToken};
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_db_views_site::api::{ChangePassword, LoginResponse};
@@ -15,6 +19,7 @@ pub async fn change_password(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<LoginResponse>> {
+  check_local_user_valid(&local_user_view)?;
   password_length_check(&data.new_password)?;
 
   // Make sure passwords match

--- a/crates/api/api/src/local_user/generate_totp_secret.rs
+++ b/crates/api/api/src/local_user/generate_totp_secret.rs
@@ -1,7 +1,7 @@
 use crate::{build_totp_2fa, generate_totp_2fa_secret};
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
-use lemmy_api_utils::context::LemmyContext;
+use lemmy_api_utils::{context::LemmyContext, utils::check_local_user_valid};
 use lemmy_db_schema::source::{
   local_user::{LocalUser, LocalUserUpdateForm},
   site::Site,
@@ -16,6 +16,7 @@ pub async fn generate_totp_secret(
   local_user_view: LocalUserView,
   context: Data<LemmyContext>,
 ) -> LemmyResult<Json<GenerateTotpSecretResponse>> {
+  check_local_user_valid(&local_user_view)?;
   let site = Site::read_local(&mut context.pool()).await?;
 
   if local_user_view.local_user.totp_2fa_enabled {

--- a/crates/api/api/src/local_user/note_person.rs
+++ b/crates/api/api/src/local_user/note_person.rs
@@ -1,7 +1,7 @@
 use actix_web::web::{Data, Json};
 use lemmy_api_utils::{
   context::LemmyContext,
-  utils::{get_url_blocklist, process_markdown, slur_regex},
+  utils::{check_local_user_valid, get_url_blocklist, process_markdown, slur_regex},
 };
 use lemmy_db_schema::source::person::{PersonActions, PersonNoteForm};
 use lemmy_db_views_local_user::LocalUserView;
@@ -17,6 +17,7 @@ pub async fn user_note_person(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<SuccessResponse>> {
+  check_local_user_valid(&local_user_view)?;
   let target_id = data.person_id;
   let person_id = local_user_view.person.id;
 

--- a/crates/api/api/src/local_user/resend_verification_email.rs
+++ b/crates/api/api/src/local_user/resend_verification_email.rs
@@ -1,5 +1,5 @@
 use actix_web::web::{Data, Json};
-use lemmy_api_utils::context::LemmyContext;
+use lemmy_api_utils::{context::LemmyContext, utils::check_local_user_valid};
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_db_views_site::{
   api::{ResendVerificationEmail, SuccessResponse},
@@ -17,6 +17,7 @@ pub async fn resend_verification_email(
 
   // Fetch that email
   let local_user_view = LocalUserView::find_by_email(&mut context.pool(), &email).await?;
+  check_local_user_valid(&local_user_view)?;
 
   send_verification_email_if_required(
     &site_view.local_site,

--- a/crates/api/api/src/local_user/reset_password.rs
+++ b/crates/api/api/src/local_user/reset_password.rs
@@ -1,5 +1,8 @@
 use actix_web::web::{Data, Json};
-use lemmy_api_utils::{context::LemmyContext, utils::check_email_verified};
+use lemmy_api_utils::{
+  context::LemmyContext,
+  utils::{check_email_verified, check_local_user_valid},
+};
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_db_views_site::{
   api::{PasswordReset, SuccessResponse},
@@ -22,6 +25,7 @@ pub async fn reset_password(
 
 async fn try_reset_password(email: &str, context: &LemmyContext) -> LemmyResult<()> {
   let local_user_view = LocalUserView::find_by_email(&mut context.pool(), email).await?;
+  check_local_user_valid(&local_user_view)?;
   let site_view = SiteView::read_local(&mut context.pool()).await?;
 
   check_email_verified(&local_user_view, &site_view)?;

--- a/crates/api/api/src/local_user/save_settings.rs
+++ b/crates/api/api/src/local_user/save_settings.rs
@@ -2,7 +2,7 @@ use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use lemmy_api_utils::{
   context::LemmyContext,
-  utils::{get_url_blocklist, process_markdown_opt, slur_regex},
+  utils::{check_local_user_valid, get_url_blocklist, process_markdown_opt, slur_regex},
 };
 use lemmy_db_schema::{
   source::{
@@ -36,6 +36,7 @@ pub async fn save_user_settings(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<SuccessResponse>> {
+  check_local_user_valid(&local_user_view)?;
   let site_view = SiteView::read_local(&mut context.pool()).await?;
 
   let slur_regex = slur_regex(&context).await?;

--- a/crates/api/api/src/local_user/update_totp.rs
+++ b/crates/api/api/src/local_user/update_totp.rs
@@ -1,6 +1,6 @@
 use crate::check_totp_2fa_valid;
 use actix_web::web::{Data, Json};
-use lemmy_api_utils::context::LemmyContext;
+use lemmy_api_utils::{context::LemmyContext, utils::check_local_user_valid};
 use lemmy_db_schema::source::local_user::{LocalUser, LocalUserUpdateForm};
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_db_views_site::api::{UpdateTotp, UpdateTotpResponse};
@@ -19,6 +19,7 @@ pub async fn update_totp(
   local_user_view: LocalUserView,
   context: Data<LemmyContext>,
 ) -> LemmyResult<Json<UpdateTotpResponse>> {
+  check_local_user_valid(&local_user_view)?;
   check_totp_2fa_valid(
     &local_user_view,
     &Some(data.totp_token.clone()),

--- a/crates/api/api/src/local_user/user_block_instance.rs
+++ b/crates/api/api/src/local_user/user_block_instance.rs
@@ -1,6 +1,6 @@
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
-use lemmy_api_utils::context::LemmyContext;
+use lemmy_api_utils::{context::LemmyContext, utils::check_local_user_valid};
 use lemmy_db_schema::source::instance::{
   InstanceActions,
   InstanceCommunitiesBlockForm,
@@ -19,6 +19,7 @@ pub async fn user_block_instance_communities(
   local_user_view: LocalUserView,
   context: Data<LemmyContext>,
 ) -> LemmyResult<Json<SuccessResponse>> {
+  check_local_user_valid(&local_user_view)?;
   let instance_id = data.instance_id;
   let person_id = local_user_view.person.id;
   if local_user_view.person.instance_id == instance_id {

--- a/crates/api/api/src/local_user/verify_email.rs
+++ b/crates/api/api/src/local_user/verify_email.rs
@@ -1,5 +1,5 @@
 use actix_web::web::{Data, Json};
-use lemmy_api_utils::context::LemmyContext;
+use lemmy_api_utils::{context::LemmyContext, utils::check_local_user_valid};
 use lemmy_db_schema::source::{
   email_verification::EmailVerification,
   local_user::{LocalUser, LocalUserUpdateForm},
@@ -21,6 +21,7 @@ pub async fn verify_email(
   let verification = EmailVerification::read_for_token(&mut context.pool(), &token).await?;
   let local_user_id = verification.local_user_id;
   let local_user_view = LocalUserView::read(&mut context.pool(), local_user_id).await?;
+  check_local_user_valid(&local_user_view)?;
 
   // Check if their email has already been verified once, before this
   let email_already_verified = local_user_view.local_user.email_verified;

--- a/crates/api/api/src/post/hide.rs
+++ b/crates/api/api/src/post/hide.rs
@@ -1,5 +1,5 @@
 use actix_web::web::{Data, Json};
-use lemmy_api_utils::context::LemmyContext;
+use lemmy_api_utils::{context::LemmyContext, utils::check_local_user_valid};
 use lemmy_db_schema::source::post::{PostActions, PostHideForm};
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_db_views_post::{
@@ -13,6 +13,7 @@ pub async fn hide_post(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<PostResponse>> {
+  check_local_user_valid(&local_user_view)?;
   let person_id = local_user_view.person.id;
   let local_instance_id = local_user_view.person.instance_id;
   let post_id = data.post_id;

--- a/crates/api/api/src/post/like.rs
+++ b/crates/api/api/src/post/like.rs
@@ -5,7 +5,12 @@ use lemmy_api_utils::{
   context::LemmyContext,
   plugins::{plugin_hook_after, plugin_hook_before},
   send_activity::{ActivityChannel, SendActivityData},
-  utils::{check_bot_account, check_community_user_action, check_local_vote_mode},
+  utils::{
+    check_bot_account,
+    check_community_user_action,
+    check_local_user_valid,
+    check_local_vote_mode,
+  },
 };
 use lemmy_db_schema::{
   newtypes::PostOrCommentId,
@@ -29,6 +34,7 @@ pub async fn like_post(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<PostResponse>> {
+  check_local_user_valid(&local_user_view)?;
   let local_site = SiteView::read_local(&mut context.pool()).await?.local_site;
   let local_instance_id = local_user_view.person.instance_id;
   let post_id = data.post_id;

--- a/crates/api/api/src/post/save.rs
+++ b/crates/api/api/src/post/save.rs
@@ -1,5 +1,5 @@
 use actix_web::web::{Data, Json};
-use lemmy_api_utils::context::LemmyContext;
+use lemmy_api_utils::{context::LemmyContext, utils::check_local_user_valid};
 use lemmy_db_schema::{
   source::post::{PostActions, PostReadForm, PostSavedForm},
   traits::Saveable,
@@ -16,6 +16,7 @@ pub async fn save_post(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<PostResponse>> {
+  check_local_user_valid(&local_user_view)?;
   let post_saved_form = PostSavedForm::new(data.post_id, local_user_view.person.id);
 
   if data.save {

--- a/crates/api/api/src/reports/comment_report/create.rs
+++ b/crates/api/api/src/reports/comment_report/create.rs
@@ -5,7 +5,12 @@ use either::Either;
 use lemmy_api_utils::{
   context::LemmyContext,
   send_activity::{ActivityChannel, SendActivityData},
-  utils::{check_comment_deleted_or_removed, check_community_user_action, slur_regex},
+  utils::{
+    check_comment_deleted_or_removed,
+    check_community_user_action,
+    check_local_user_valid,
+    slur_regex,
+  },
 };
 use lemmy_db_schema::{
   source::comment_report::{CommentReport, CommentReportForm},
@@ -27,6 +32,7 @@ pub async fn create_comment_report(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<CommentReportResponse>> {
+  check_local_user_valid(&local_user_view)?;
   let reason = data.reason.trim().to_string();
   let slur_regex = slur_regex(&context).await?;
   check_report_reason(&reason, &slur_regex)?;

--- a/crates/api/api/src/reports/community_report/create.rs
+++ b/crates/api/api/src/reports/community_report/create.rs
@@ -5,7 +5,7 @@ use either::Either;
 use lemmy_api_utils::{
   context::LemmyContext,
   send_activity::{ActivityChannel, SendActivityData},
-  utils::slur_regex,
+  utils::{check_local_user_valid, slur_regex},
 };
 use lemmy_db_schema::{
   source::{
@@ -29,6 +29,7 @@ pub async fn create_community_report(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<CommunityReportResponse>> {
+  check_local_user_valid(&local_user_view)?;
   let reason = data.reason.trim().to_string();
   let slur_regex = slur_regex(&context).await?;
   check_report_reason(&reason, &slur_regex)?;

--- a/crates/api/api/src/reports/post_report/create.rs
+++ b/crates/api/api/src/reports/post_report/create.rs
@@ -5,7 +5,12 @@ use either::Either;
 use lemmy_api_utils::{
   context::LemmyContext,
   send_activity::{ActivityChannel, SendActivityData},
-  utils::{check_community_user_action, check_post_deleted_or_removed, slur_regex},
+  utils::{
+    check_community_user_action,
+    check_local_user_valid,
+    check_post_deleted_or_removed,
+    slur_regex,
+  },
 };
 use lemmy_db_schema::{
   source::post_report::{PostReport, PostReportForm},
@@ -27,6 +32,7 @@ pub async fn create_post_report(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<PostReportResponse>> {
+  check_local_user_valid(&local_user_view)?;
   let reason = data.reason.trim().to_string();
   let slur_regex = slur_regex(&context).await?;
   check_report_reason(&reason, &slur_regex)?;

--- a/crates/api/api/src/reports/private_message_report/create.rs
+++ b/crates/api/api/src/reports/private_message_report/create.rs
@@ -1,6 +1,9 @@
 use crate::check_report_reason;
 use actix_web::web::{Data, Json};
-use lemmy_api_utils::{context::LemmyContext, utils::slur_regex};
+use lemmy_api_utils::{
+  context::LemmyContext,
+  utils::{check_local_user_valid, slur_regex},
+};
 use lemmy_db_schema::{
   source::{
     private_message::PrivateMessage,
@@ -22,6 +25,7 @@ pub async fn create_pm_report(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<PrivateMessageReportResponse>> {
+  check_local_user_valid(&local_user_view)?;
   let reason = data.reason.trim().to_string();
   let slur_regex = slur_regex(&context).await?;
   check_report_reason(&reason, &slur_regex)?;

--- a/crates/api/api_crud/src/community/create.rs
+++ b/crates/api/api_crud/src/community/create.rs
@@ -5,6 +5,7 @@ use lemmy_api_utils::{
   build_response::build_community_response,
   context::LemmyContext,
   utils::{
+    check_local_user_valid,
     check_nsfw_allowed,
     generate_featured_url,
     generate_followers_url,
@@ -51,6 +52,7 @@ pub async fn create_community(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<CommunityResponse>> {
+  check_local_user_valid(&local_user_view)?;
   let site_view = SiteView::read_local(&mut context.pool()).await?;
   let local_site = site_view.local_site;
 

--- a/crates/api/api_crud/src/community/delete.rs
+++ b/crates/api/api_crud/src/community/delete.rs
@@ -4,7 +4,7 @@ use lemmy_api_utils::{
   build_response::build_community_response,
   context::LemmyContext,
   send_activity::{ActivityChannel, SendActivityData},
-  utils::{check_community_mod_action, is_top_mod},
+  utils::{check_community_mod_action, check_local_user_valid, is_top_mod},
 };
 use lemmy_db_schema::{
   source::community::{Community, CommunityUpdateForm},
@@ -20,6 +20,7 @@ pub async fn delete_community(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<CommunityResponse>> {
+  check_local_user_valid(&local_user_view)?;
   // Fetch the community mods
   let community_mods =
     CommunityModeratorView::for_community(&mut context.pool(), data.community_id).await?;

--- a/crates/api/api_crud/src/community/update.rs
+++ b/crates/api/api_crud/src/community/update.rs
@@ -8,6 +8,7 @@ use lemmy_api_utils::{
   send_activity::{ActivityChannel, SendActivityData},
   utils::{
     check_community_mod_action,
+    check_local_user_valid,
     check_nsfw_allowed,
     get_url_blocklist,
     process_markdown_opt,
@@ -39,6 +40,7 @@ pub async fn update_community(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<CommunityResponse>> {
+  check_local_user_valid(&local_user_view)?;
   let local_site = SiteView::read_local(&mut context.pool()).await?.local_site;
 
   let slur_regex = slur_regex(&context).await?;

--- a/crates/api/api_crud/src/multi_community/create.rs
+++ b/crates/api/api_crud/src/multi_community/create.rs
@@ -1,7 +1,10 @@
 use crate::multi_community::get_multi;
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
-use lemmy_api_utils::{context::LemmyContext, utils::slur_regex};
+use lemmy_api_utils::{
+  context::LemmyContext,
+  utils::{check_local_user_valid, slur_regex},
+};
 use lemmy_db_schema::{
   source::multi_community::{MultiCommunity, MultiCommunityInsertForm},
   traits::Crud,
@@ -20,6 +23,7 @@ pub async fn create_multi_community(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<GetMultiCommunityResponse>> {
+  check_local_user_valid(&local_user_view)?;
   let site_view = SiteView::read_local(&mut context.pool()).await?;
   is_valid_display_name(&data.name)?;
 

--- a/crates/api/api_crud/src/multi_community/create_entry.rs
+++ b/crates/api/api_crud/src/multi_community/create_entry.rs
@@ -4,7 +4,7 @@ use actix_web::web::Json;
 use lemmy_api_utils::{
   context::LemmyContext,
   send_activity::{ActivityChannel, SendActivityData},
-  utils::check_community_deleted_removed,
+  utils::{check_community_deleted_removed, check_local_user_valid},
 };
 use lemmy_db_schema::{
   source::{
@@ -24,6 +24,7 @@ pub async fn create_multi_community_entry(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<SuccessResponse>> {
+  check_local_user_valid(&local_user_view)?;
   let multi = check_multi_community_creator(data.id, &local_user_view, &context).await?;
 
   let community = Community::read(&mut context.pool(), data.community_id).await?;

--- a/crates/api/api_crud/src/multi_community/update.rs
+++ b/crates/api/api_crud/src/multi_community/update.rs
@@ -2,7 +2,7 @@ use super::{check_multi_community_creator, send_federation_update};
 use activitypub_federation::config::Data;
 use actix_web::web::Json;
 use chrono::Utc;
-use lemmy_api_utils::context::LemmyContext;
+use lemmy_api_utils::{context::LemmyContext, utils::check_local_user_valid};
 use lemmy_db_schema::{
   source::multi_community::{MultiCommunity, MultiCommunityUpdateForm},
   traits::Crud,
@@ -18,6 +18,7 @@ pub async fn update_multi_community(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<SuccessResponse>> {
+  check_local_user_valid(&local_user_view)?;
   check_multi_community_creator(data.id, &local_user_view, &context).await?;
 
   let form = MultiCommunityUpdateForm {

--- a/crates/api/api_crud/src/private_message/create.rs
+++ b/crates/api/api_crud/src/private_message/create.rs
@@ -5,7 +5,13 @@ use lemmy_api_utils::{
   notify::notify_private_message,
   plugins::{plugin_hook_after, plugin_hook_before},
   send_activity::{ActivityChannel, SendActivityData},
-  utils::{check_private_messages_enabled, get_url_blocklist, process_markdown, slur_regex},
+  utils::{
+    check_local_user_valid,
+    check_private_messages_enabled,
+    get_url_blocklist,
+    process_markdown,
+    slur_regex,
+  },
 };
 use lemmy_db_schema::{
   source::{
@@ -26,6 +32,7 @@ pub async fn create_private_message(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<PrivateMessageResponse>> {
+  check_local_user_valid(&local_user_view)?;
   let slur_regex = slur_regex(&context).await?;
   let url_blocklist = get_url_blocklist(&context).await?;
   let content = process_markdown(&data.content, &slur_regex, &url_blocklist, &context).await?;

--- a/crates/api/api_crud/src/private_message/delete.rs
+++ b/crates/api/api_crud/src/private_message/delete.rs
@@ -3,6 +3,7 @@ use actix_web::web::Json;
 use lemmy_api_utils::{
   context::LemmyContext,
   send_activity::{ActivityChannel, SendActivityData},
+  utils::check_local_user_valid,
 };
 use lemmy_db_schema::{
   source::private_message::{PrivateMessage, PrivateMessageUpdateForm},
@@ -20,6 +21,7 @@ pub async fn delete_private_message(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<PrivateMessageResponse>> {
+  check_local_user_valid(&local_user_view)?;
   // Checking permissions
   let private_message_id = data.private_message_id;
   let orig_private_message = PrivateMessage::read(&mut context.pool(), private_message_id).await?;

--- a/crates/api/api_crud/src/private_message/update.rs
+++ b/crates/api/api_crud/src/private_message/update.rs
@@ -6,7 +6,7 @@ use lemmy_api_utils::{
   notify::notify_private_message,
   plugins::{plugin_hook_after, plugin_hook_before},
   send_activity::{ActivityChannel, SendActivityData},
-  utils::{get_url_blocklist, process_markdown, slur_regex},
+  utils::{check_local_user_valid, get_url_blocklist, process_markdown, slur_regex},
 };
 use lemmy_db_schema::{
   source::private_message::{PrivateMessage, PrivateMessageUpdateForm},
@@ -27,6 +27,7 @@ pub async fn update_private_message(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<PrivateMessageResponse>> {
+  check_local_user_valid(&local_user_view)?;
   // Checking permissions
   let private_message_id = data.private_message_id;
   let orig_private_message = PrivateMessage::read(&mut context.pool(), private_message_id).await?;


### PR DESCRIPTION
As banned users can login now (https://github.com/LemmyNet/lemmy/pull/5643), we need to check in all write api actions that the user is not banned.