### PR TITLE
API should return pending follows count for all private comms

### DIFF
--- a/crates/api/api/src/community/pending_follows/count.rs
+++ b/crates/api/api/src/community/pending_follows/count.rs
@@ -1,19 +1,19 @@
-use actix_web::web::{Data, Json, Query};
-use lemmy_api_utils::{context::LemmyContext, utils::is_mod_or_admin};
+use actix_web::web::{Data, Json};
+use lemmy_api_utils::{context::LemmyContext, utils::check_community_mod_of_any_or_admin_action};
 use lemmy_db_views_community_follower::{
-  api::{GetCommunityPendingFollowsCount, GetCommunityPendingFollowsCountResponse},
+  api::GetCommunityPendingFollowsCountResponse,
   CommunityFollowerView,
 };
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_utils::error::LemmyResult;
 
 pub async fn get_pending_follows_count(
-  data: Query<GetCommunityPendingFollowsCount>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<GetCommunityPendingFollowsCountResponse>> {
-  is_mod_or_admin(&mut context.pool(), &local_user_view, data.community_id).await?;
+  check_community_mod_of_any_or_admin_action(&local_user_view, &mut context.pool()).await?;
   let count =
-    CommunityFollowerView::count_approval_required(&mut context.pool(), data.community_id).await?;
+    CommunityFollowerView::count_approval_required(&mut context.pool(), local_user_view.person.id)
+      .await?;
   Ok(Json(GetCommunityPendingFollowsCountResponse { count }))
 }

--- a/crates/db_views/community_follower/src/api.rs
+++ b/crates/db_views/community_follower/src/api.rs
@@ -1,14 +1,7 @@
 use crate::PendingFollow;
-use lemmy_db_schema::newtypes::{CommunityId, PaginationCursor};
+use lemmy_db_schema::newtypes::PaginationCursor;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
-#[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
-pub struct GetCommunityPendingFollowsCount {
-  pub community_id: CommunityId,
-}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]

--- a/crates/db_views/community_follower/src/impls.rs
+++ b/crates/db_views/community_follower/src/impls.rs
@@ -144,7 +144,7 @@ impl CommunityFollowerView {
       ))
       .limit(limit)
       .into_boxed();
-    if all_communities {
+    if !all_communities {
       // if param is false, only return items for communities where user is a mod
       query = query
         .filter(community_actions::became_moderator_at.is_not_null())
@@ -179,11 +179,12 @@ impl CommunityFollowerView {
 
   pub async fn count_approval_required(
     pool: &mut DbPool<'_>,
-    community_id: CommunityId,
+    person_id: PersonId,
   ) -> LemmyResult<i64> {
     let conn = &mut get_conn(pool).await?;
     Self::joins()
-      .filter(community_actions::community_id.eq(community_id))
+      .filter(community_actions::became_moderator_at.is_not_null())
+      .filter(community_actions::person_id.eq(person_id))
       .filter(community_actions::follow_state.eq(CommunityFollowerState::ApprovalRequired))
       .select(count(community_actions::community_id))
       .first::<i64>(conn)


### PR DESCRIPTION
Doesnt make sense to make a separate request for each community. Also matches the behaviour of the related list endpoint.