### PR TITLE
Set image_mode: None for development

### DIFF
--- a/config/config.hjson
+++ b/config/config.hjson
@@ -2,4 +2,7 @@
 # https://join-lemmy.org/docs/en/administration/configuration.html
 {
   hostname: lemmy-alpha
+  pictrs: {
+    image_mode: None
+  }
 }


### PR DESCRIPTION
This helps to test image-related changes such as https://github.com/LemmyNet/lemmy-ui/pull/3476. Otherwise Lemmy tries to use the default config and proxy all images even when pictrs is not running locally (which is normally the case during development).

Another option would be to remove [this line](https://github.com/LemmyNet/lemmy/blob/main/crates/utils/src/settings/structs.rs#L17) and only use pictrs if it is enabled explicitly. But that would require a lot more changes.