### PR TITLE
[0.19] Ignore apub person banners which cannot be parsed

### DIFF
--- a/crates/apub/src/protocol/objects/person.rs
+++ b/crates/apub/src/protocol/objects/person.rs
@@ -41,6 +41,7 @@ pub struct Person {
   #[serde(deserialize_with = "deserialize_skip_error", default)]
   pub(crate) icon: Option<ImageObject>,
   /// user banner
+  #[serde(deserialize_with = "deserialize_skip_error", default)]
   pub(crate) image: Option<ImageObject>,
   pub(crate) matrix_user_id: Option<String>,
   pub(crate) endpoints: Option<Endpoints>,


### PR DESCRIPTION
This fixes a federation [problem with bridgy-fed](https://github.com/snarfed/bridgy-fed/issues/372#issuecomment-3332897637). It is already fixed on the [main branch](https://github.com/LemmyNet/lemmy/blob/main/crates/apub_objects/src/protocol/person.rs#L48).