### PR TITLE
Include error message for rate limit error (fixes #6019)

### DIFF
--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -134,6 +134,7 @@ pub enum LemmyErrorType {
   MultiCommunityUpdateWrongUser,
   CannotCombineCommunityIdAndMultiCommunityId,
   MultiCommunityEntryLimitReached,
+  TooManyRequests,
 }
 
 /// Federation related errors, these dont need to be translated.


### PR DESCRIPTION
Rate limit errors resulted in an empty response, so Im adding a body to make it easier to handle in frontends.