### PR TITLE
[0.19] Use Rust 1.89

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -2,13 +2,12 @@
 # See https://github.com/woodpecker-ci/woodpecker/issues/1677
 
 variables:
-  - &rust_image "rust:1.81"
+  - &rust_image "rust:1.89"
   - &rust_nightly_image "rustlang/rust:nightly"
   - &install_pnpm "npm install -g corepack@latest && corepack enable pnpm"
   - &install_binstall "wget -O- https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz | tar -xvz -C /usr/local/cargo/bin"
   - install_diesel_cli: &install_diesel_cli
       - apt-get update && apt-get install -y postgresql-client
-      # diesel_cli@2.2.8 is the last version that supports rust 1.81, which we are currently locked on due to perf regressions on rust 1.82+ :(
       - cargo install --locked diesel_cli@2.2.8 --no-default-features --features postgres
       - export PATH="$CARGO_HOME/bin:$PATH"
   - &slow_check_paths
@@ -281,7 +280,7 @@ steps:
         from_secret: cargo_api_token
     commands:
       - *install_binstall
-      # Install cargo-workspaces, need pinned version for Rust 1.81 compat
+      # Install cargo-workspaces
       - cargo binstall -y cargo-workspaces@0.3.6
       - cp -r migrations crates/db_schema/
       - cargo workspaces publish --token "$CARGO_API_TOKEN" --from-git --allow-dirty --no-verify --allow-branch "${CI_COMMIT_TAG}" --yes custom "${CI_COMMIT_TAG}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "AGPL-3.0"
 homepage = "https://join-lemmy.org/"
 documentation = "https://join-lemmy.org/docs/en/index.html"
 repository = "https://github.com/LemmyNet/lemmy"
-rust-version = "1.81"
+rust-version = "1.89"
 
 [package]
 name = "lemmy_server"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.9
 # check=skip=FromPlatformFlagConstDisallowed
-ARG RUST_VERSION=1.81
+ARG RUST_VERSION=1.89
 ARG CARGO_BUILD_FEATURES=default
 ARG RUST_RELEASE_MODE=debug
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.81"
+channel = "1.89"


### PR DESCRIPTION
This branch is not affected by the compilation slowdown with Rust 1.89 and can directly use the newer version. The build time is roughly identical with both 1.81 and 1.89.