### PR TITLE
Adding follow_state to MultiCommunityView

### DIFF
--- a/api_tests/src/user.spec.ts
+++ b/api_tests/src/user.spec.ts
@@ -24,6 +24,7 @@ import {
   getMyUser,
   getPersonDetails,
   banPersonFromSite,
+  delay,
 } from "./shared";
 import {
   EditSite,
@@ -103,6 +104,9 @@ test("Delete user", async () => {
   expect(remoteComment).toBeDefined();
 
   await deleteUser(user);
+
+  // Wait, in order to make sure it federates
+  await delay(1_000);
   await expect(getMyUser(user)).rejects.toStrictEqual(
     new LemmyError("incorrect_login"),
   );

--- a/crates/api/api/src/federation/resolve_object.rs
+++ b/crates/api/api/src/federation/resolve_object.rs
@@ -76,7 +76,9 @@ pub(super) async fn resolve_object_internal(
     Left(Right(Right(c))) => {
       Community(CommunityView::read(pool, c.id, local_user.as_ref(), is_admin).await?)
     }
-    Right(multi) => MultiCommunity(MultiCommunityView::read(pool, multi.id).await?),
+    Right(multi) => {
+      MultiCommunity(MultiCommunityView::read(pool, multi.id, my_person_id_opt).await?)
+    }
   })
 }
 

--- a/crates/api/api_crud/src/multi_community/create.rs
+++ b/crates/api/api_crud/src/multi_community/create.rs
@@ -6,9 +6,10 @@ use lemmy_api_utils::{
   utils::{check_local_user_valid, slur_regex},
 };
 use lemmy_db_schema::{
-  source::multi_community::{MultiCommunity, MultiCommunityInsertForm},
+  source::multi_community::{MultiCommunity, MultiCommunityFollowForm, MultiCommunityInsertForm},
   traits::Crud,
 };
+use lemmy_db_schema_file::enums::CommunityFollowerState;
 use lemmy_db_views_community::api::{CreateMultiCommunity, GetMultiCommunityResponse};
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_db_views_site::SiteView;
@@ -52,7 +53,13 @@ pub async fn create_multi_community(
   };
   let multi = MultiCommunity::create(&mut context.pool(), &form).await?;
 
-  // TODO what about following your own community?
-  //
+  // You follow your own community
+  let follow_form = MultiCommunityFollowForm {
+    multi_community_id: multi.id,
+    person_id: local_user_view.person.id,
+    follow_state: CommunityFollowerState::Accepted,
+  };
+  MultiCommunity::follow(&mut context.pool(), &follow_form).await?;
+
   get_multi(multi.id, context, Some(local_user_view)).await
 }

--- a/crates/api/api_crud/src/multi_community/create.rs
+++ b/crates/api/api_crud/src/multi_community/create.rs
@@ -51,5 +51,8 @@ pub async fn create_multi_community(
     )
   };
   let multi = MultiCommunity::create(&mut context.pool(), &form).await?;
-  get_multi(multi.id, context).await
+
+  // TODO what about following your own community?
+  //
+  get_multi(multi.id, context, Some(local_user_view)).await
 }

--- a/crates/api/api_crud/src/multi_community/get.rs
+++ b/crates/api/api_crud/src/multi_community/get.rs
@@ -3,11 +3,13 @@ use activitypub_federation::config::Data;
 use actix_web::web::{Json, Query};
 use lemmy_api_utils::context::LemmyContext;
 use lemmy_db_views_community::api::{GetMultiCommunity, GetMultiCommunityResponse};
+use lemmy_db_views_local_user::LocalUserView;
 use lemmy_utils::error::LemmyResult;
 
 pub async fn get_multi_community(
   data: Query<GetMultiCommunity>,
   context: Data<LemmyContext>,
+  local_user_view: Option<LocalUserView>,
 ) -> LemmyResult<Json<GetMultiCommunityResponse>> {
-  get_multi(data.id, context).await
+  get_multi(data.id, context, local_user_view).await
 }

--- a/crates/api/api_crud/src/multi_community/list.rs
+++ b/crates/api/api_crud/src/multi_community/list.rs
@@ -13,12 +13,13 @@ pub async fn list_multi_communities(
   context: Data<LemmyContext>,
   local_user_view: Option<LocalUserView>,
 ) -> LemmyResult<Json<ListMultiCommunitiesResponse>> {
-  let followed_by = if let Some(true) = data.followed_only {
-    local_user_view.map(|l| l.person.id)
-  } else {
-    None
-  };
-  let multi_communities =
-    MultiCommunityView::list(&mut context.pool(), data.creator_id, followed_by).await?;
+  let my_person_id = local_user_view.map(|l| l.person.id);
+  let multi_communities = MultiCommunityView::list(
+    &mut context.pool(),
+    data.creator_id,
+    my_person_id,
+    data.followed_only.unwrap_or_default(),
+  )
+  .await?;
   Ok(Json(ListMultiCommunitiesResponse { multi_communities }))
 }

--- a/crates/api/api_crud/src/multi_community/mod.rs
+++ b/crates/api/api_crud/src/multi_community/mod.rs
@@ -56,9 +56,12 @@ async fn send_federation_update(
 async fn get_multi(
   id: MultiCommunityId,
   context: Data<LemmyContext>,
+  local_user_view: Option<LocalUserView>,
 ) -> LemmyResult<Json<GetMultiCommunityResponse>> {
   let local_site = SiteView::read_local(&mut context.pool()).await?;
-  let multi_community_view = MultiCommunityView::read(&mut context.pool(), id).await?;
+  let my_person_id = local_user_view.map(|l| l.person.id);
+  let multi_community_view =
+    MultiCommunityView::read(&mut context.pool(), id, my_person_id).await?;
   let communities = CommunityQuery {
     multi_community_id: Some(multi_community_view.multi.id),
     ..Default::default()

--- a/crates/db_schema/src/utils/queries/joins.rs
+++ b/crates/db_schema/src/utils/queries/joins.rs
@@ -18,6 +18,8 @@ use lemmy_db_schema_file::schema::{
   image_details,
   instance_actions,
   local_user,
+  multi_community,
+  multi_community_follow,
   person,
   person_actions,
   post,
@@ -166,6 +168,19 @@ pub fn my_local_user_admin_join(my_person_id: Option<PersonId>) -> _ {
       .nullable()
       .eq(my_person_id)
       .and(local_user::admin.eq(true)),
+  )
+}
+
+#[diesel::dsl::auto_type]
+pub fn my_multi_community_follower_join(my_person_id: Option<PersonId>) -> _ {
+  multi_community_follow::table.on(
+    multi_community_follow::multi_community_id
+      .eq(multi_community::id)
+      .and(
+        multi_community_follow::person_id
+          .nullable()
+          .eq(my_person_id),
+      ),
   )
 }
 

--- a/crates/db_schema/src/utils/queries/selects.rs
+++ b/crates/db_schema/src/utils/queries/selects.rs
@@ -35,6 +35,7 @@ use lemmy_db_schema_file::schema::{
   community_actions,
   instance_actions,
   local_user,
+  multi_community_follow,
   person,
   post,
   post_tag,
@@ -318,4 +319,10 @@ pub fn my_instance_persons_actions_select() -> Nullable<MyInstancePersonsActions
   my_instance_persons_actions
     .fields(instance_actions::all_columns)
     .nullable()
+}
+
+// The select for the multi_community_follow_state
+#[diesel::dsl::auto_type]
+pub fn multi_community_follow_state_select() -> _ {
+  multi_community_follow::follow_state.nullable()
 }

--- a/crates/db_schema/src/utils/queries/selects.rs
+++ b/crates/db_schema/src/utils/queries/selects.rs
@@ -320,9 +320,3 @@ pub fn my_instance_persons_actions_select() -> Nullable<MyInstancePersonsActions
     .fields(instance_actions::all_columns)
     .nullable()
 }
-
-// The select for the multi_community_follow_state
-#[diesel::dsl::auto_type]
-pub fn multi_community_follow_state_select() -> _ {
-  multi_community_follow::follow_state.nullable()
-}

--- a/crates/db_schema/src/utils/queries/selects.rs
+++ b/crates/db_schema/src/utils/queries/selects.rs
@@ -35,7 +35,6 @@ use lemmy_db_schema_file::schema::{
   community_actions,
   instance_actions,
   local_user,
-  multi_community_follow,
   person,
   post,
   post_tag,

--- a/crates/db_views/community/src/lib.rs
+++ b/crates/db_views/community/src/lib.rs
@@ -4,7 +4,7 @@ use lemmy_db_schema::source::{
   person::Person,
   tag::TagsView,
 };
-use lemmy_db_schema_file::{enums::CommunityFollowerState, schema::multi_community_follow};
+use lemmy_db_schema_file::enums::CommunityFollowerState;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 #[cfg(feature = "full")]
@@ -14,6 +14,7 @@ use {
     community_post_tags_fragment,
     local_user_community_can_mod,
   },
+  lemmy_db_schema_file::schema::multi_community_follow,
 };
 
 pub mod api;

--- a/crates/db_views/community/src/lib.rs
+++ b/crates/db_views/community/src/lib.rs
@@ -4,6 +4,7 @@ use lemmy_db_schema::source::{
   person::Person,
   tag::TagsView,
 };
+use lemmy_db_schema_file::enums::CommunityFollowerState;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 #[cfg(feature = "full")]
@@ -12,6 +13,7 @@ use {
   lemmy_db_schema::utils::queries::selects::{
     community_post_tags_fragment,
     local_user_community_can_mod,
+    multi_community_follow_state_select,
   },
 };
 
@@ -54,6 +56,12 @@ pub struct CommunityView {
 pub struct MultiCommunityView {
   #[cfg_attr(feature = "full", diesel(embed))]
   pub multi: MultiCommunity,
+  #[cfg_attr(feature = "full",
+    diesel(
+      select_expression = multi_community_follow_state_select()
+    )
+  )]
+  pub follow_state: Option<CommunityFollowerState>,
   #[cfg_attr(feature = "full", diesel(embed))]
   pub owner: Person,
 }

--- a/crates/db_views/community/src/lib.rs
+++ b/crates/db_views/community/src/lib.rs
@@ -4,16 +4,15 @@ use lemmy_db_schema::source::{
   person::Person,
   tag::TagsView,
 };
-use lemmy_db_schema_file::enums::CommunityFollowerState;
+use lemmy_db_schema_file::{enums::CommunityFollowerState, schema::multi_community_follow};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 #[cfg(feature = "full")]
 use {
-  diesel::{Queryable, Selectable},
+  diesel::{NullableExpressionMethods, Queryable, Selectable},
   lemmy_db_schema::utils::queries::selects::{
     community_post_tags_fragment,
     local_user_community_can_mod,
-    multi_community_follow_state_select,
   },
 };
 
@@ -58,7 +57,7 @@ pub struct MultiCommunityView {
   pub multi: MultiCommunity,
   #[cfg_attr(feature = "full",
     diesel(
-      select_expression = multi_community_follow_state_select()
+      select_expression = multi_community_follow::follow_state.nullable()
     )
   )]
   pub follow_state: Option<CommunityFollowerState>,

--- a/crates/db_views/search_combined/src/impls.rs
+++ b/crates/db_views/search_combined/src/impls.rs
@@ -470,6 +470,7 @@ impl InternalToCombinedView for SearchCombinedViewInternal {
       Some(SearchCombinedView::MultiCommunity(MultiCommunityView {
         multi,
         owner: creator.clone(),
+        follow_state: None,
       }))
     } else if let Some(person) = v.item_creator {
       Some(SearchCombinedView::Person(PersonView {


### PR DESCRIPTION
This is necessary for the front end, because otherwise you have no idea if the multi you're currently viewing is one you've subscribed to.

Also added some tests to make sure its working properly.