### PR TITLE
Changing NotePerson response from SuccessResponse to PersonView

### DIFF
--- a/api_tests/src/post.spec.ts
+++ b/api_tests/src/post.spec.ts
@@ -531,7 +531,7 @@ test("Enforce site ban federation for local user", async () => {
     true,
     true,
   );
-  expect(banAlpha.banned).toBe(true);
+  expect(banAlpha.person_view.banned).toBe(true);
 
   // alpha ban should be federated to beta
   let alphaUserOnBeta1 = await waitUntil(
@@ -554,7 +554,7 @@ test("Enforce site ban federation for local user", async () => {
     false,
     true,
   );
-  expect(unBanAlpha.banned).toBe(false);
+  expect(unBanAlpha.person_view.banned).toBe(false);
 
   // existing alpha post should be restored on beta
   betaBanRes = await waitUntil(
@@ -612,7 +612,7 @@ test("Enforce site ban federation for federated user", async () => {
     true,
     true,
   );
-  expect(banAlphaOnBeta.banned).toBe(true);
+  expect(banAlphaOnBeta.person_view.banned).toBe(true);
 
   // existing alpha post should be removed on beta
   let betaRemovedPost = await getPost(beta, searchBeta1.post.id);

--- a/api_tests/src/user.spec.ts
+++ b/api_tests/src/user.spec.ts
@@ -24,6 +24,7 @@ import {
   getMyUser,
   getPersonDetails,
   banPersonFromSite,
+  delay,
 } from "./shared";
 import {
   EditSite,
@@ -103,6 +104,9 @@ test("Delete user", async () => {
   expect(remoteComment).toBeDefined();
 
   await deleteUser(user);
+
+  // Wait, in order to make sure it federates
+  await delay(1_000);
   await expect(getMyUser(user)).rejects.toStrictEqual(
     new LemmyError("incorrect_login"),
   );

--- a/api_tests/src/user.spec.ts
+++ b/api_tests/src/user.spec.ts
@@ -251,7 +251,7 @@ test("Make sure banned user can delete their account", async () => {
     true,
     false,
   );
-  expect(banUser.banned).toBe(true);
+  expect(banUser.person_view.banned).toBe(true);
 
   // Make sure post is there
   let postAfterBan = await getPost(alpha, postId);

--- a/crates/api/api/src/local_user/ban_person.rs
+++ b/crates/api/api/src/local_user/ban_person.rs
@@ -16,7 +16,7 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_db_views_person::{
-  api::{BanPerson, BanPersonResponse},
+  api::{BanPerson, PersonResponse},
   PersonView,
 };
 use lemmy_utils::{error::LemmyResult, utils::validation::is_valid_body_field};
@@ -25,7 +25,7 @@ pub async fn ban_from_site(
   data: Json<BanPerson>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> LemmyResult<Json<BanPersonResponse>> {
+) -> LemmyResult<Json<PersonResponse>> {
   let local_instance_id = local_user_view.person.instance_id;
   let my_person_id = local_user_view.person.id;
 
@@ -97,8 +97,5 @@ pub async fn ban_from_site(
     &context,
   )?;
 
-  Ok(Json(BanPersonResponse {
-    person_view,
-    banned: data.ban,
-  }))
+  Ok(Json(PersonResponse { person_view }))
 }

--- a/crates/api/api/src/local_user/block.rs
+++ b/crates/api/api/src/local_user/block.rs
@@ -6,7 +6,7 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_db_views_person::{
-  api::{BlockPerson, BlockPersonResponse},
+  api::{BlockPerson, PersonResponse},
   PersonView,
 };
 use lemmy_utils::error::{LemmyErrorType, LemmyResult};
@@ -15,7 +15,7 @@ pub async fn user_block_person(
   data: Json<BlockPerson>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> LemmyResult<Json<BlockPersonResponse>> {
+) -> LemmyResult<Json<PersonResponse>> {
   check_local_user_valid(&local_user_view)?;
   let target_id = data.person_id;
   let my_person_id = local_user_view.person.id;
@@ -50,8 +50,5 @@ pub async fn user_block_person(
     false,
   )
   .await?;
-  Ok(Json(BlockPersonResponse {
-    person_view,
-    blocked: data.block,
-  }))
+  Ok(Json(PersonResponse { person_view }))
 }

--- a/crates/api/api/src/local_user/note_person.rs
+++ b/crates/api/api/src/local_user/note_person.rs
@@ -5,8 +5,10 @@ use lemmy_api_utils::{
 };
 use lemmy_db_schema::source::person::{PersonActions, PersonNoteForm};
 use lemmy_db_views_local_user::LocalUserView;
-use lemmy_db_views_person::api::NotePerson;
-use lemmy_db_views_site::api::SuccessResponse;
+use lemmy_db_views_person::{
+  api::{NotePerson, PersonResponse},
+  PersonView,
+};
 use lemmy_utils::{
   error::{LemmyErrorType, LemmyResult},
   utils::{slurs::check_slurs, validation::is_valid_body_field},
@@ -16,31 +18,41 @@ pub async fn user_note_person(
   data: Json<NotePerson>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> LemmyResult<Json<SuccessResponse>> {
+) -> LemmyResult<Json<PersonResponse>> {
   check_local_user_valid(&local_user_view)?;
   let target_id = data.person_id;
-  let person_id = local_user_view.person.id;
+  let my_person_id = local_user_view.person.id;
+  let local_instance_id = local_user_view.person.instance_id;
 
   let slur_regex = slur_regex(&context).await?;
   let url_blocklist = get_url_blocklist(&context).await?;
 
   // Don't let a person note themselves
-  if target_id == person_id {
+  if target_id == my_person_id {
     Err(LemmyErrorType::CantNoteYourself)?
   }
 
   // If the note is empty, delete it
   if data.note.is_empty() {
-    PersonActions::delete_note(&mut context.pool(), person_id, target_id).await?;
+    PersonActions::delete_note(&mut context.pool(), my_person_id, target_id).await?;
   } else {
     check_slurs(&data.note, &slur_regex)?;
     is_valid_body_field(&data.note, false)?;
 
     let note = process_markdown(&data.note, &slur_regex, &url_blocklist, &context).await?;
-    let note_form = PersonNoteForm::new(person_id, target_id, note);
+    let note_form = PersonNoteForm::new(my_person_id, target_id, note);
 
     PersonActions::note(&mut context.pool(), &note_form).await?;
   }
 
-  Ok(Json(SuccessResponse::default()))
+  let person_view = PersonView::read(
+    &mut context.pool(),
+    target_id,
+    Some(my_person_id),
+    local_instance_id,
+    false,
+  )
+  .await?;
+
+  Ok(Json(PersonResponse { person_view }))
 }

--- a/crates/api/api_common/src/person.rs
+++ b/crates/api/api_common/src/person.rs
@@ -14,7 +14,7 @@ pub use lemmy_db_views_person::{
 
 pub mod actions {
   pub use lemmy_db_schema::newtypes::PersonContentCombinedId;
-  pub use lemmy_db_views_person::api::{BlockPerson, BlockPersonResponse, NotePerson};
+  pub use lemmy_db_views_person::api::{BlockPerson, NotePerson};
   pub use lemmy_db_views_person_content_combined::{
     ListPersonContent,
     ListPersonContentResponse,

--- a/crates/api/api_common/src/person.rs
+++ b/crates/api/api_common/src/person.rs
@@ -26,7 +26,7 @@ pub mod actions {
       newtypes::RegistrationApplicationId,
       source::registration_application::RegistrationApplication,
     };
-    pub use lemmy_db_views_person::api::{BanPerson, BanPersonResponse, PurgePerson};
+    pub use lemmy_db_views_person::api::{BanPerson, PurgePerson};
     pub use lemmy_db_views_registration_applications::{
       api::{GetRegistrationApplication, RegistrationApplicationResponse},
       RegistrationApplicationView,

--- a/crates/db_views/person/src/api.rs
+++ b/crates/db_views/person/src/api.rs
@@ -39,15 +39,6 @@ pub struct BanPerson {
   pub expires_at: Option<i64>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
-#[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
-/// A response for a banned person.
-pub struct BanPersonResponse {
-  pub person_view: PersonView,
-  pub banned: bool,
-}
-
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]

--- a/crates/db_views/person/src/api.rs
+++ b/crates/db_views/person/src/api.rs
@@ -60,10 +60,9 @@ pub struct BlockPerson {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
-/// The response for a person block.
-pub struct BlockPersonResponse {
+/// A person response for actions done to a person.
+pub struct PersonResponse {
   pub person_view: PersonView,
-  pub blocked: bool,
 }
 
 #[skip_serializing_none]


### PR DESCRIPTION
- Also updates `BlockPersonResponse` to a simple PersonView, since blocked_at already comes back with person_actions.
- Fixes #6049