### PR TITLE
Add wait after delete user to fix federation CI tests.

### DIFF
--- a/api_tests/src/user.spec.ts
+++ b/api_tests/src/user.spec.ts
@@ -24,6 +24,7 @@ import {
   getMyUser,
   getPersonDetails,
   banPersonFromSite,
+  delay,
 } from "./shared";
 import {
   EditSite,
@@ -103,6 +104,9 @@ test("Delete user", async () => {
   expect(remoteComment).toBeDefined();
 
   await deleteUser(user);
+
+  // Wait, in order to make sure it federates
+  await delay(1_000);
   await expect(getMyUser(user)).rejects.toStrictEqual(
     new LemmyError("incorrect_login"),
   );


### PR DESCRIPTION
All our CI jobs are currently failing: https://woodpecker.join-lemmy.org/repos/129/pipeline/16667/21#L846

Going to add a wait to see if this fixes it.