### PR TITLE
Add build.rs to update db migrations macro (fixes #6005)

### DIFF
--- a/crates/db_schema_setup/build.rs
+++ b/crates/db_schema_setup/build.rs
@@ -1,0 +1,10 @@
+use std::path::Path;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+  let migrations_dir = Path::new("../../migrations/");
+  if !migrations_dir.exists() {
+    return Err("Migrations dir not found".into());
+  }
+  println!("cargo:rerun-if-changed={}", migrations_dir.display());
+  Ok(())
+}


### PR DESCRIPTION
As indicated in diesel docs: https://docs.diesel.rs/2.3.x/diesel_migrations/macro.embed_migrations.html#automatic-rebuilds

Confirmed that it gets triggered from any change to migrations, and that it throws an error if the migrations path is wrong.