### PR TITLE
Re-export PersonResponse from lemmy-api-common

### DIFF
--- a/crates/api/api_common/src/person.rs
+++ b/crates/api/api_common/src/person.rs
@@ -8,7 +8,7 @@ pub use lemmy_db_schema::{
 };
 pub use lemmy_db_views_local_user::LocalUserView;
 pub use lemmy_db_views_person::{
-  api::{GetPersonDetails, GetPersonDetailsResponse},
+  api::{GetPersonDetails, GetPersonDetailsResponse, PersonResponse},
   PersonView,
 };
 


### PR DESCRIPTION
I noticed this wasn't re-exported after the response types for some endpoints were changed.