### PR TITLE
Handle plain identifiers in markdown

### DIFF
--- a/crates/utils/src/utils/markdown/identifier_rule.rs
+++ b/crates/utils/src/utils/markdown/identifier_rule.rs
@@ -1,0 +1,110 @@
+use crate::utils::markdown::link_rule::Link;
+use markdown_it::{
+  parser::inline::{InlineRule, InlineState},
+  MarkdownIt,
+  Node,
+  NodeValue,
+  Renderer,
+};
+
+#[derive(Debug)]
+pub struct Identifier {
+  pub is_community: bool,
+  pub name: String,
+  pub domain: String,
+}
+
+impl NodeValue for Identifier {
+  fn render(&self, node: &Node, fmt: &mut dyn Renderer) {
+    let mut attrs = node.attrs.clone();
+    let path = if self.is_community { 'c' } else { 'u' };
+    attrs.push(("href", format!("/{path}/{}@{}", &self.name, &self.domain)));
+    attrs.push(("rel", "nofollow".to_string()));
+    attrs.push(("class", "u-url".to_string()));
+    attrs.push(("class", "mention".to_string()));
+
+    fmt.open("a", &attrs);
+    let marker = if self.is_community { '!' } else { '@' };
+    fmt.text(&format!("{marker}{}@{}", self.name, self.domain));
+    fmt.close("a");
+  }
+}
+
+struct CommunityIdentifierScanner;
+struct PersonIdentifierScanner;
+
+impl InlineRule for CommunityIdentifierScanner {
+  const MARKER: char = '!';
+
+  fn run(state: &mut InlineState) -> Option<(Node, usize)> {
+    scan_for_identifier(true, Self::MARKER, state)
+  }
+}
+
+impl InlineRule for PersonIdentifierScanner {
+  const MARKER: char = '@';
+
+  fn run(state: &mut InlineState) -> Option<(Node, usize)> {
+    scan_for_identifier(false, Self::MARKER, state)
+  }
+}
+
+fn scan_for_identifier(
+  is_community: bool,
+  marker: char,
+  state: &mut InlineState,
+) -> Option<(Node, usize)> {
+  // Dont allow identifier inside link, otherwise it outputs nested `<a>` tags.
+  if state.node.is::<Link>() {
+    return None;
+  }
+
+  let input = &state.src[state.pos..state.pos_max];
+  // wrong start character
+  if !input.starts_with(marker) {
+    return None;
+  }
+
+  let mut found_at = false;
+  let mut name = String::new();
+  let mut domain = String::new();
+  for c in input.chars().skip(1) {
+    // whitespace means we reached the end
+    if c.is_whitespace() {
+      break;
+    }
+
+    // we are inside a markdown link, ignore
+    if c == ']' {
+      return None;
+    }
+
+    // found the @ character between name and domain
+    if c == '@' {
+      found_at = true;
+      continue;
+    }
+    if !found_at {
+      name.push(c);
+    } else {
+      domain.push(c);
+    }
+  }
+
+  // check if we found a valid, nonempty identifier
+  if !name.is_empty() && !domain.is_empty() {
+    let len = name.len() + domain.len() + 2;
+    let identifier = Identifier {
+      is_community,
+      name,
+      domain,
+    };
+    Some((Node::new(identifier), len))
+  } else {
+    None
+  }
+}
+pub fn add(md: &mut MarkdownIt) {
+  md.inline.add_rule::<CommunityIdentifierScanner>();
+  md.inline.add_rule::<PersonIdentifierScanner>();
+}

--- a/crates/utils/src/utils/markdown/mod.rs
+++ b/crates/utils/src/utils/markdown/mod.rs
@@ -3,6 +3,7 @@ use markdown_it::MarkdownIt;
 use regex::RegexSet;
 use std::sync::LazyLock;
 
+mod identifier_rule;
 pub mod image_links;
 mod link_rule;
 
@@ -16,6 +17,7 @@ static MARKDOWN_PARSER: LazyLock<MarkdownIt> = LazyLock::new(|| {
   markdown_it_ruby::add(&mut parser);
   markdown_it_footnote::add(&mut parser);
   link_rule::add(&mut parser);
+  identifier_rule::add(&mut parser);
 
   parser
 });
@@ -42,6 +44,16 @@ mod tests {
   #[test]
   fn test_basic_markdown() {
     let tests: Vec<_> = vec![
+      (
+        "rewrite community identifier",
+        "!test@lemmy-alpha",
+        "<p><a href=\"/c/test@lemmy-alpha\" rel=\"nofollow\" class=\"u-url mention\">!test@lemmy-alpha</a></p>\n",
+      ),
+      (
+        "rewrite user identifier",
+        "@garda@lemmy-alpha",
+        "<p><a href=\"/u/garda@lemmy-alpha\" rel=\"nofollow\" class=\"u-url mention\">@garda@lemmy-alpha</a></p>\n",
+      ),
       (
         "headings",
         "# h1\n## h2\n### h3\n#### h4\n##### h5\n###### h6",


### PR DESCRIPTION
So that eg `!test@lemmy-alpha` gets turned into a valid HTML link for email, federation and RSS. 