### PR TITLE
Fixing a few issues with federation-view exports.

### DIFF
--- a/crates/db_schema/src/source/federation_allowlist.rs
+++ b/crates/db_schema/src/source/federation_allowlist.rs
@@ -17,6 +17,8 @@ use std::fmt::Debug;
 #[cfg_attr(feature = "full", diesel(table_name = federation_allowlist))]
 #[cfg_attr(feature = "full", diesel(primary_key(instance_id)))]
 #[cfg_attr(feature = "full", diesel(check_for_backend(diesel::pg::Pg)))]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
 pub struct FederationAllowList {
   #[serde(skip)]
   pub instance_id: InstanceId,

--- a/crates/db_schema/src/source/federation_queue_state.rs
+++ b/crates/db_schema/src/source/federation_queue_state.rs
@@ -14,7 +14,7 @@ use serde_with::skip_serializing_none;
 #[cfg_attr(feature = "full", diesel(table_name = lemmy_db_schema_file::schema::federation_queue_state))]
 #[cfg_attr(feature = "full", diesel(check_for_backend(diesel::pg::Pg)))]
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
-#[cfg_attr(feature = "ts-rs", ts(optional_fields))]
+#[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
 pub struct FederationQueueState {
   pub instance_id: InstanceId,
   /// the last successfully sent activity id

--- a/crates/db_views/site/src/api.rs
+++ b/crates/db_views/site/src/api.rs
@@ -286,7 +286,7 @@ pub struct EditSite {
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
-#[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
+#[cfg_attr(feature = "ts-rs", ts(export))]
 pub enum GetFederatedInstancesKind {
   #[default]
   All,


### PR DESCRIPTION
This was discovered when trying to update the `lemmy-js-client` types