### PR TITLE
Adding multi_community_name to list_posts.

### DIFF
--- a/crates/api/api/src/federation/list_comments.rs
+++ b/crates/api/api/src/federation/list_comments.rs
@@ -43,9 +43,9 @@ async fn list_comments_common(
   let community_id = if let Some(name) = &data.community_name {
     Some(
       resolve_ap_identifier::<ApubCommunity, Community>(name, &context, &local_user_view, true)
-        .await?,
+        .await?
+        .id,
     )
-    .map(|c| c.id)
   } else {
     data.community_id
   };

--- a/crates/db_views/post/src/api.rs
+++ b/crates/db_views/post/src/api.rs
@@ -117,6 +117,7 @@ pub struct GetPosts {
   pub community_id: Option<CommunityId>,
   pub community_name: Option<String>,
   pub multi_community_id: Option<MultiCommunityId>,
+  pub multi_community_name: Option<String>,
   pub show_hidden: Option<bool>,
   /// If true, then show the read posts (even if your user setting is to hide them)
   pub show_read: Option<bool>,


### PR DESCRIPTION
- This is necessary for front ends to not have to pre-fetch the multi-community.id
- Works the same way as community_name.