### PR TITLE
Fixes for merge modlog migration

### DIFF
--- a/crates/diesel_utils/Cargo.toml
+++ b/crates/diesel_utils/Cargo.toml
@@ -34,7 +34,7 @@ full = [
   "tokio-postgres-rustls",
   "rustls",
   "i-love-jesus",
-  "lemmy_utils",
+  "lemmy_utils/full",
   "diesel",
   "activitypub_federation",
 ]


### PR DESCRIPTION
I noticed that the migration was failing on voyager because some of the values inserted during migration failed the check. So I added all possible modlog entries to test it manually, and fixed the resulting errors.