### PR TITLE
Use rusts Url::parse with post_url_only

### DIFF
--- a/crates/db_views/search_combined/Cargo.toml
+++ b/crates/db_views/search_combined/Cargo.toml
@@ -55,9 +55,9 @@ ts-rs = { workspace = true, optional = true }
 i-love-jesus = { workspace = true, optional = true }
 serde_with = { workspace = true }
 chrono = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
 serial_test = { workspace = true }
 tokio = { workspace = true }
-url = { workspace = true }

--- a/crates/db_views/search_combined/src/impls.rs
+++ b/crates/db_views/search_combined/src/impls.rs
@@ -72,6 +72,7 @@ use lemmy_diesel_utils::{
   utils::{fuzzy_search, now, paginate, seconds_to_pg_interval},
 };
 use lemmy_utils::error::{LemmyErrorType, LemmyResult};
+use url::Url;
 
 impl SearchCombinedViewInternal {
   #[diesel::dsl::auto_type(no_type_alias)]
@@ -249,7 +250,10 @@ impl SearchCombinedQuery {
     // The search term
     if let Some(search_term) = &self.search_term {
       if self.post_url_only.unwrap_or_default() {
-        query = query.filter(post::url.eq(search_term));
+        // Needs to be parsed to a rusts common url format before searching, since those are whats
+        // inserted as the post url
+        let search_url: String = Url::parse(search_term)?.into();
+        query = query.filter(post::url.eq(search_url));
       } else {
         let searcher = fuzzy_search(search_term);
 


### PR DESCRIPTION
I noticed when adding the `post_url_only`, it often didn't find results, because rusts `Url::parse` adds a `/` on the end.

This parses as a url first before filtering.

We could also *clean* the urls, but that might cause more problems than its worth.