### PR TITLE
[0.19] Allow admins to view deleted user profiles

### DIFF
--- a/crates/api/src/community/ban.rs
+++ b/crates/api/src/community/ban.rs
@@ -101,7 +101,7 @@ pub async fn ban_from_community(
 
   ModBanFromCommunity::create(&mut context.pool(), &form).await?;
 
-  let person_view = PersonView::read(&mut context.pool(), data.person_id)
+  let person_view = PersonView::read(&mut context.pool(), data.person_id, false)
     .await?
     .ok_or(LemmyErrorType::CouldntFindPerson)?;
 

--- a/crates/api/src/local_user/ban_person.rs
+++ b/crates/api/src/local_user/ban_person.rs
@@ -81,7 +81,7 @@ pub async fn ban_from_site(
 
   ModBan::create(&mut context.pool(), &form).await?;
 
-  let person_view = PersonView::read(&mut context.pool(), person.id)
+  let person_view = PersonView::read(&mut context.pool(), person.id, false)
     .await?
     .ok_or(LemmyErrorType::CouldntFindPerson)?;
 

--- a/crates/api/src/local_user/block.rs
+++ b/crates/api/src/local_user/block.rs
@@ -49,7 +49,7 @@ pub async fn block_person(
       .with_lemmy_type(LemmyErrorType::PersonBlockAlreadyExists)?;
   }
 
-  let person_view = PersonView::read(&mut context.pool(), target_id)
+  let person_view = PersonView::read(&mut context.pool(), target_id, false)
     .await?
     .ok_or(LemmyErrorType::CouldntFindPerson)?;
   Ok(Json(BlockPersonResponse {

--- a/crates/apub/src/api/read_person.rs
+++ b/crates/apub/src/api/read_person.rs
@@ -48,7 +48,11 @@ pub async fn read_person(
 
   // You don't need to return settings for the user, since this comes back with GetSite
   // `my_user`
-  let person_view = PersonView::read(&mut context.pool(), person_details_id)
+  let is_admin = local_user_view
+    .as_ref()
+    .map(|l| l.local_user.admin)
+    .unwrap_or_default();
+  let person_view = PersonView::read(&mut context.pool(), person_details_id, is_admin)
     .await?
     .ok_or(LemmyErrorType::CouldntFindPerson)?;
 

--- a/crates/apub/src/api/resolve_object.rs
+++ b/crates/apub/src/api/resolve_object.rs
@@ -72,7 +72,7 @@ async fn convert_response(
       UserOrCommunity::User(u) => {
         removed_or_deleted = u.deleted;
         res.person = Some(
-          PersonView::read(pool, u.id)
+          PersonView::read(pool, u.id, false)
             .await?
             .ok_or(LemmyErrorType::CouldntFindPerson)?,
         )

--- a/crates/db_views_actor/src/community_view.rs
+++ b/crates/db_views_actor/src/community_view.rs
@@ -194,7 +194,7 @@ impl CommunityView {
       CommunityModeratorView::is_community_moderator(pool, community_id, person_id).await?;
     if is_mod {
       Ok(true)
-    } else if let Ok(Some(person_view)) = PersonView::read(pool, person_id).await {
+    } else if let Ok(Some(person_view)) = PersonView::read(pool, person_id, false).await {
       Ok(person_view.is_admin)
     } else {
       Ok(false)
@@ -210,7 +210,7 @@ impl CommunityView {
       CommunityModeratorView::is_community_moderator_of_any(pool, person_id).await?;
     if is_mod_of_any {
       Ok(true)
-    } else if let Ok(Some(person_view)) = PersonView::read(pool, person_id).await {
+    } else if let Ok(Some(person_view)) = PersonView::read(pool, person_id, false).await {
       Ok(person_view.is_admin)
     } else {
       Ok(false)


### PR DESCRIPTION
Checking the modlog on lemmy.ml, this behaviour of posting content that violates the rules and then deleting the account seems very common now. So its worth making another 0.19 release to fix it. Tested manually that it works.

Edit: Verified that admins can also ban + remove content for deleted accounts. Removing individual posts from deleted user also works.