### PR TITLE
Fixing renovate, changing to weekends.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "schedule": ["schedule:weekends"],
+  "schedule": ["every weekend"],
   "automerge": true,
   "packageRules": [
     {


### PR DESCRIPTION
Our current renovate was broken, as it ignored all cargo.toml files, meaning only the cargo.lock was being updated.

I also changed it to do weekends, so we don't get too far behind, and it doesn't disrupt daily work. I have this on all my repos, including lemmy-ui and it works fine.