### PR TITLE
Enable nightly builds (ref #6163)

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -244,12 +244,13 @@ steps:
         from_secret: docker_username
       password:
         from_secret: docker_password
-      platforms: linux/amd64,linux/arm64
+      platforms: linux/amd64
       build_args:
         RUST_RELEASE_MODE: release
-      tag: ${CI_COMMIT_TAG}
+      tag: ${CI_COMMIT_TAG=dev}
     when:
       - event: tag
+      - event: cron
 
   # lemmy container doesnt run as root so we need to change permissions to let it copy the binary
   chmod_for_native_binary:


### PR DESCRIPTION
Had to disable the ARM build for now as its broken. Already enabled the cronjob in woodpecker so this should start producing nightly builds as soon as its merged. Then we just need to have the server pull the images automatically.