### PR TITLE
Avoid specifying crate features multiple times

### DIFF
--- a/crates/apub/send/Cargo.toml
+++ b/crates/apub/send/Cargo.toml
@@ -36,8 +36,8 @@ anyhow.workspace = true
 async-trait.workspace = true
 futures.workspace = true
 chrono.workspace = true
-diesel = { workspace = true, features = ["chrono", "postgres", "serde_json"] }
-diesel-async = { workspace = true, features = ["deadpool", "postgres"] }
+diesel = { workspace = true }
+diesel-async = { workspace = true }
 reqwest.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["full"] }

--- a/crates/db_schema/Cargo.toml
+++ b/crates/db_schema/Cargo.toml
@@ -49,10 +49,7 @@ lemmy_diesel_utils = { workspace = true }
 bcrypt = { workspace = true, optional = true }
 diesel = { workspace = true, optional = true }
 diesel-derive-newtype = { workspace = true, optional = true }
-diesel-async = { workspace = true, features = [
-  "deadpool",
-  "postgres",
-], optional = true }
+diesel-async = { workspace = true, optional = true }
 diesel-uplete = { workspace = true, optional = true }
 diesel_ltree = { workspace = true, optional = true }
 ts-rs = { workspace = true, optional = true }

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -62,7 +62,7 @@ actix-web = { workspace = true, optional = true }
 anyhow = { workspace = true, optional = true }
 strum = { workspace = true }
 futures = { workspace = true, optional = true }
-diesel = { workspace = true, optional = true, features = ["chrono"] }
+diesel = { workspace = true, optional = true }
 http = { workspace = true, optional = true }
 doku = { workspace = true, features = ["url-2"], optional = true }
 tokio = { workspace = true, optional = true }


### PR DESCRIPTION
These seem unnecessary, and might be the reason why running `./scripts/test.sh` and then `./scripts/test.sh lemmy_db_views_post` rebuilds all of diesel (which is very slow).