### PR TITLE
Allow users to view their own removed content

### DIFF
--- a/crates/db_schema/src/utils/queries/selects.rs
+++ b/crates/db_schema/src/utils/queries/selects.rs
@@ -246,10 +246,13 @@ pub fn local_user_community_can_mod() -> _ {
 pub fn comment_select_remove_deletes() -> _ {
   let deleted_or_removed = comment::deleted.or(comment::removed);
 
-  // You can only view the content if it hasn't been removed, or you can mod.
+  // You can only view the content if it hasn't been removed, you're a mod or it's your own comment.
+  let is_creator = local_user::person_id
+    .nullable()
+    .eq(comment::creator_id.nullable());
   let can_view_content = not(deleted_or_removed)
     .or(local_user_can_mod_comment())
-    .or(local_user::person_id.eq(comment::creator_id));
+    .or(is_creator);
   let content = case_when(can_view_content, comment::content).otherwise("");
 
   (
@@ -285,10 +288,13 @@ pub fn comment_select_remove_deletes() -> _ {
 pub fn post_select_remove_deletes() -> _ {
   let deleted_or_removed = post::deleted.or(post::removed);
 
-  // You can only view the content if it hasn't been removed, or you can mod.
+  // You can only view the content if it hasn't been removed, you're a mod or it's your own post.
+  let is_creator = local_user::person_id
+    .nullable()
+    .eq(post::creator_id.nullable());
   let can_view_content = not(deleted_or_removed)
     .or(local_user_can_mod_post())
-    .or(local_user::person_id.eq(comment::creator_id));
+    .or(is_creator);
   let body = case_when(can_view_content, post::body).otherwise("");
 
   (


### PR DESCRIPTION
Imagine this scenario:

1. Create  post in a community
2. Mod removes it for being off topic
3. Attempt to repost it in the correct community

Result: Not possible because Lemmy doesnt show you the content of your own removed posts/comments.