### PR TITLE
Fixing Cargo.toml deps.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2098,7 +2098,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4943,7 +4943,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6155,7 +6155,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6931,7 +6931,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7685,13 +7685,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
- "serde",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -8344,7 +8344,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,18 +136,18 @@ lemmy_db_views_vote = { version = "=1.0.0-alpha.12", path = "./crates/db_views/v
 activitypub_federation = { git = "https://github.com/LemmyNet/activitypub-federation-rust.git", default-features = false, features = [
   "actix-web",
 ] }
-diesel = { version = "2.3.3", features = [
+diesel = { version = "2.3.4", features = [
   "chrono",
   "postgres",
   "serde_json",
   "uuid",
   "64-column-tables",
 ] }
-diesel_migrations = "2.3.0"
-diesel-async = "0.7.3"
+diesel_migrations = "2.3.1"
+diesel-async = "0.7.4"
 serde = { version = "1.0.228", features = ["derive"] }
-serde_with = "3.15.1"
-actix-web = { version = "4.11.0", default-features = false, features = [
+serde_with = "3.16.1"
+actix-web = { version = "4.12.1", default-features = false, features = [
   "compress-brotli",
   "compress-gzip",
   "compress-zstd",
@@ -155,9 +155,9 @@ actix-web = { version = "4.11.0", default-features = false, features = [
   "macros",
   "rustls-0_23",
 ] }
-tracing = { version = "0.1.41", default-features = false }
+tracing = { version = "0.1.43", default-features = false }
 tracing-actix-web = { version = "0.7.19", default-features = false }
-tracing-subscriber = { version = "0.3.20", features = ["env-filter", "json"] }
+tracing-subscriber = { version = "0.3.22", features = ["env-filter", "json"] }
 url = { version = "2.5.7", features = ["serde"] }
 reqwest = { version = "0.12.24", default-features = false, features = [
   "blocking",
@@ -176,7 +176,7 @@ chrono = { version = "0.4.42", features = [
 ], default-features = false }
 serde_json = { version = "1.0.145", features = ["preserve_order"] }
 base64 = "0.22.1"
-uuid = { version = "1.18.1", features = ["serde"] }
+uuid = { version = "1.19.0", features = ["serde"] }
 captcha = "1.0.0"
 anyhow = { version = "1.0.100", features = ["backtrace"] }
 diesel_ltree = "0.4.0"
@@ -197,24 +197,24 @@ ts-rs = { version = "11.1.0", features = [
   "no-serde-warnings",
   "url-impl",
 ] }
-rustls = { version = "0.23.34", features = ["ring"] }
+rustls = { version = "0.23.35", features = ["ring"] }
 tokio-postgres = "0.7.15"
 tokio-postgres-rustls = "0.13.0"
 urlencoding = "2.1.3"
 moka = { version = "0.12.11", features = ["future"] }
 i-love-jesus = { version = "0.3.0" }
-clap = { version = "4.5.51", features = ["derive", "env"] }
+clap = { version = "4.5.53", features = ["derive", "env"] }
 pretty_assertions = "1.4.1"
 derive-new = "0.7.0"
-html2text = "0.16.0"
+html2text = "0.16.4"
 async-trait = "0.1.89"
 either = { version = "1.15.0", features = ["serde"] }
-extism = { version = "1.12.0", default-features = false, features = [
+extism = { version = "1.13.0", default-features = false, features = [
   "http",
   "register-http",
   "register-filesystem",
 ] }
-extism-convert = "1.12.0"
+extism-convert = "1.13.0"
 unified-diff = "0.2.1"
 diesel-uplete = { version = "0.2.0" }
 cfg-if = "1"

--- a/crates/api/api_utils/Cargo.toml
+++ b/crates/api/api_utils/Cargo.toml
@@ -53,7 +53,7 @@ tracing = { workspace = true }
 lemmy_utils = { workspace = true }
 extism = { workspace = true }
 extism-convert = { workspace = true }
-extism-manifest = "1.12.0"
+extism-manifest = "1.13.0"
 reqwest-middleware = { workspace = true }
 activitypub_federation = { workspace = true }
 mime = { version = "0.3.17" }
@@ -72,7 +72,7 @@ webmention = { version = "0.6.0" }
 urlencoding = { workspace = true }
 webpage = { version = "2.0", default-features = false, features = ["serde"] }
 regex = { workspace = true }
-jsonwebtoken = { version = "10.1.0", features = ["rust_crypto"] }
+jsonwebtoken = { version = "10.2.0", features = ["rust_crypto"] }
 either.workspace = true
 derive-new.workspace = true
 lemmy_diesel_utils = { workspace = true }

--- a/crates/apub/send/Cargo.toml
+++ b/crates/apub/send/Cargo.toml
@@ -53,5 +53,5 @@ url.workspace = true
 actix-web.workspace = true
 tracing-test = "0.2.5"
 uuid.workspace = true
-test-context = "0.5.0"
+test-context = "0.5.4"
 mockall = "0.14.0"

--- a/crates/db_views/post/Cargo.toml
+++ b/crates/db_views/post/Cargo.toml
@@ -47,5 +47,5 @@ serial_test = { workspace = true }
 tokio = { workspace = true }
 pretty_assertions = { workspace = true }
 url = { workspace = true }
-test-context = "0.5.0"
+test-context = "0.5.4"
 diesel-uplete.workspace = true

--- a/crates/diesel_utils/Cargo.toml
+++ b/crates/diesel_utils/Cargo.toml
@@ -24,7 +24,6 @@ full = [
   "chrono",
   "diesel_migrations",
   "anyhow",
-  "diesel-async",
   "diesel_ltree",
   "tracing",
   "deadpool",


### PR DESCRIPTION
Due to our previously misconfigured renovate.json (which ignored cargo.toml), our cargo.lock deps are all far ahead our cargo.toml deps. Ran `cargo interactive-update` to correct this.