### PR TITLE
Adding search term filters for item type.

### DIFF
--- a/crates/db_views/search_combined/src/impls.rs
+++ b/crates/db_views/search_combined/src/impls.rs
@@ -286,7 +286,7 @@ impl SearchCombinedQuery {
           let body_or_description_filter = is_post
             .and(post::body.ilike(searcher.clone()))
             .or(is_community.and(community::description.ilike(searcher.clone())))
-            .or(is_multi_community.and(multi_community::description.ilike(searcher.clone())));
+            .or(is_multi_community.and(multi_community::description.ilike(searcher.clone())))
             .or(is_person.and(person::bio.ilike(searcher.clone())));
           query.filter(name_or_title_filter.or(body_or_description_filter))
         }


### PR DESCRIPTION
- Fixes #6158

This was all that was missing: adding the content type `is_not_null()` check to each search term filter.