### PR TITLE
[0.19] Increase page limit to 100

### DIFF
--- a/crates/db_schema/src/utils.rs
+++ b/crates/db_schema/src/utils.rs
@@ -56,7 +56,7 @@ use url::Url;
 
 const FETCH_LIMIT_DEFAULT: i64 = 10;
 pub const FETCH_LIMIT_MAX: i64 = 50;
-pub const PAGE_LIMIT_MAX: i64 = 10;
+pub const PAGE_LIMIT_MAX: i64 = 100;
 pub const SITEMAP_LIMIT: i64 = 50000;
 pub const SITEMAP_DAYS: Option<TimeDelta> = TimeDelta::try_days(31);
 pub const RANK_DEFAULT: f64 = 0.0001;


### PR DESCRIPTION
This was added in https://github.com/LemmyNet/lemmy/pull/6017 with no reason given for using this specific limit. Some users are [reaching this limit](https://lemmy.ml/post/40358485) during normal browsing and get an error.  The issue (https://github.com/LemmyNet/lemmy/issues/6016) mentions a DDoS attack using `page=16413`, so a limit of 100 is enough to prevent that, while being much less likely to be hit by real users.

Also needs to be changed in main branch [here](https://github.com/LemmyNet/lemmy/blob/main/crates/api/api/src/federation/list_posts.rs#L77).