### PR TITLE
Fix nightly version by passing CI_PIPELINE_EVENT to Docker

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -249,6 +249,8 @@ steps:
       platforms: linux/amd64
       build_args:
         RUST_RELEASE_MODE: release
+      build_args_from_env:
+        - CI_PIPELINE_EVENT
       tag: ${CI_COMMIT_TAG=nightly}
     when:
       - event: tag


### PR DESCRIPTION
Nightly builds are not showing the version correctly. I suspect its because the env var isnt being passed into the Docker build. Hopefully this will fix it.

