### PR TITLE
Enable connection timeout (ref #5112)

### DIFF
--- a/crates/apub/send/src/worker.rs
+++ b/crates/apub/send/src/worker.rs
@@ -624,9 +624,10 @@ mod test {
     assert_eq!(data.instance.id, rcv.state.instance_id);
     // assert_eq!(Some(ActivityId(0)), rcv.state.last_successful_id);
     // let last_id_before = rcv.state.last_successful_id.unwrap();
-    let sent =
-      try_join_all((0..40).map(|_| send_activity(data.person.ap_id.clone(), &data.context, false)))
-        .await?;
+    let mut sent = vec![];
+    for _ in 0..40 {
+      sent.push(send_activity(data.person.ap_id.clone(), &data.context, false).await?);
+    }
     sleep(2 * *WORK_FINISHED_RECHECK_DELAY).await;
     tracing::debug!("sent activity");
     compare_sent_with_receive(data, sent).await?;

--- a/crates/diesel_utils/src/connection.rs
+++ b/crates/diesel_utils/src/connection.rs
@@ -166,9 +166,9 @@ pub fn build_db_pool() -> LemmyResult<ActualDbPool> {
     .max_size(SETTINGS.database.pool_size)
     .runtime(Runtime::Tokio1)
     .timeouts(Timeouts {
-      wait: Some(Duration::from_secs(2)),
-      create: Some(Duration::from_secs(10)),
-      recycle: Some(Duration::from_secs(10)),
+      wait: Some(Duration::from_secs(1)),
+      create: Some(Duration::from_secs(5)),
+      recycle: Some(Duration::from_secs(5)),
     })
     // Limit connection age to prevent use of prepared statements that have query plans based on
     // very old statistics


### PR DESCRIPTION
While testing the linked issue, I noticed that Lemmy waits forever for a db connection to become available, and never throws a timeout error. Turns out that there is no timeout at all unless we specify it manually.