### PR TITLE
[v0.19] Adding tests for image file_type

### DIFF
--- a/crates/routes/src/images.rs
+++ b/crates/routes/src/images.rs
@@ -73,7 +73,7 @@ impl ProcessUrl for PictrsGetParams {
   }
 }
 
-#[derive(EnumString, Display, PartialEq, Default)]
+#[derive(EnumString, Display, PartialEq, Debug, Default)]
 #[strum(ascii_case_insensitive, serialize_all = "snake_case")]
 enum PictrsFileType {
   Apng,


### PR DESCRIPTION
Attempting to fix image file types, which I broke in https://github.com/LemmyNet/lemmy/pull/6357

This still needs to be tested, but I think the issue was that I was using a `serde` rename to snake case, which was being ignored. I needed to use strum's to snake case.

Going to test this locally first, and then if it works, it can be merged, and then ported to `main`.

EDIT: I've verified that pictrs's `Process endpoint was called with invalid extension` error comes from incorrectly cased formats. So this does fix the issue.
