### PR TITLE
[0.19] Launch new task to avoid stack overflow during nested comment fetch

### DIFF
--- a/crates/apub/src/objects/comment.rs
+++ b/crates/apub/src/objects/comment.rs
@@ -42,6 +42,7 @@ use lemmy_utils::{
   utils::markdown::markdown_to_html,
 };
 use std::ops::Deref;
+use tokio::spawn;
 use url::Url;
 
 #[derive(Clone, Debug)]
@@ -170,7 +171,17 @@ impl Object for ApubComment {
     ))
     .await?;
 
-    let (post, _) = Box::pin(note.get_parents(context)).await?;
+    // When fetching a deeply nested comment we may have also have to fetch dozens of parent
+    // comments which can easily result in stack overflow. So we launch a new task instead
+    // which gives a new stack and avoids overflow. This was successfully tested with a comment
+    // nested 200 deep (max in production is 50).
+    let note2 = note.clone();
+    let context2 = context.reset_request_count();
+    let (post, parent_comment) = spawn(async move { note2.get_parents(&context2).await }).await??;
+    if let Some(c) = &parent_comment {
+      check_comment_depth(c)?;
+    }
+
     let creator = Box::pin(note.attributed_to.dereference(context)).await?;
     let is_mod_or_admin = is_mod_or_admin(&mut context.pool(), &creator, community.id)
       .await
@@ -188,10 +199,8 @@ impl Object for ApubComment {
   #[tracing::instrument(skip_all)]
   async fn from_json(note: Note, context: &Data<LemmyContext>) -> LemmyResult<ApubComment> {
     let creator = note.attributed_to.dereference(context).await?;
+    // Parent comment is already fetched in verify method, no risk of stack overflow here.
     let (post, parent_comment) = note.get_parents(context).await?;
-    if let Some(c) = &parent_comment {
-      check_comment_depth(c)?;
-    }
 
     let content = read_from_string_or_source(&note.content, &note.media_type, &note.source);
 


### PR DESCRIPTION
Also tested this with depth 200 and worked fine. We can make a new beta version as soon as this is merged and put it on lemmy.ml