### PR TITLE
Fix SSRF in resolve_object by validating IP before dereference

### DIFF
--- a/crates/api/api/Cargo.toml
+++ b/crates/api/api/Cargo.toml
@@ -71,10 +71,10 @@ itertools = { workspace = true }
 serde_json = { workspace = true }
 diesel = { workspace = true }
 lemmy_diesel_utils = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
 serial_test = { workspace = true }
-tokio = { workspace = true }
 elementtree = "1.2.3"
 pretty_assertions = { workspace = true }
 lemmy_api_crud = { workspace = true }

--- a/crates/api/api/src/federation/resolve_object.rs
+++ b/crates/api/api/src/federation/resolve_object.rs
@@ -16,8 +16,11 @@ use lemmy_db_views_local_user::LocalUserView;
 use lemmy_db_views_person::PersonView;
 use lemmy_db_views_post::PostView;
 use lemmy_db_views_site::{ResolveObjectView, SiteView, api::ResolveObject};
-use lemmy_utils::error::{LemmyErrorType, LemmyResult};
+use lemmy_utils::error::{LemmyErrorType, LemmyResult, UntranslatedError};
 use url::Url;
+use lemmy_api_utils::request::{v4_is_invalid, v6_is_invalid};
+use std::net::IpAddr;
+use tokio::net::lookup_host;
 
 pub async fn resolve_object(
   Query(data): Query<ResolveObject>,
@@ -86,11 +89,22 @@ async fn search_query_to_object_id(
 ) -> LemmyResult<SearchableObjects> {
   Ok(match Url::parse(&query) {
     Ok(url) => {
-      // its already an url, just go with it
+      // resolve the domain and throw an error if it points to any internal IP
+      if !cfg!(debug_assertions) {
+        let domain = url.domain().ok_or(UntranslatedError::UrlWithoutDomain)?;
+        let invalid_ip = lookup_host((domain.to_owned(), 80))
+          .await?
+          .any(|addr: std::net::SocketAddr| match addr.ip() {
+            IpAddr::V4(addr) => v4_is_invalid(addr),
+            IpAddr::V6(addr) => v6_is_invalid(addr),
+          });
+        if invalid_ip {
+          return Err(LemmyErrorType::InvalidUrl.into());
+        }
+      }
       ObjectId::from(url).dereference(context).await?
     }
     Err(_) => {
-      // not an url, try to resolve via webfinger
       if query.starts_with('!') || query.starts_with('@') {
         query.remove(0);
       }

--- a/crates/api/api_utils/src/request.rs
+++ b/crates/api/api_utils/src/request.rs
@@ -163,7 +163,7 @@ pub async fn fetch_link_metadata(
   })
 }
 
-fn v4_is_invalid(v4: Ipv4Addr) -> bool {
+pub fn v4_is_invalid(v4: Ipv4Addr) -> bool {
   v4.is_private()
     || v4.is_loopback()
     || v4.is_link_local()
@@ -173,7 +173,7 @@ fn v4_is_invalid(v4: Ipv4Addr) -> bool {
     || v4.is_broadcast()
 }
 
-fn v6_is_invalid(v6: Ipv6Addr) -> bool {
+pub fn v6_is_invalid(v6: Ipv6Addr) -> bool {
   let is_documentation = matches!(
     v6.segments(),
     [0x2001, 0xdb8, ..] | [0x3fff, 0..=0x0fff, ..]


### PR DESCRIPTION
Based on [advisory  GHSA-c482-7gjx-pp36](https://github.com/LemmyNet/lemmy/security/advisories/GHSA-c482-7gjx-pp36)
Fixed SSRF vulnerability in `resolve_object` endpoint by adding IP validation before `ObjectId::dereference` is called.
The `search_query_to_object_id` function was fetching arbitrary URLs via the ActivityPub client without validating whether the destination IP is internal. This allowed any authenticated user to make the server requests to internal services.
Fix follows the same pattern as `fetch_link_metadata`, it resolves the domain, validates against `v4_is_invalid` / `v6_is_invalid`, and skips the check in debug mode to allow local development.