### PR TITLE
feat: add RequireInvitation registration mode for invite-link-style signups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3347,6 +3347,7 @@ dependencies = [
  "activitypub_federation",
  "actix-web",
  "anyhow",
+ "base64 0.22.1",
  "bcrypt",
  "chrono",
  "diesel-async",
@@ -3362,6 +3363,7 @@ dependencies = [
  "lemmy_db_views_community_moderator",
  "lemmy_db_views_custom_emoji",
  "lemmy_db_views_local_user",
+ "lemmy_db_views_local_user_invite",
  "lemmy_db_views_person",
  "lemmy_db_views_post",
  "lemmy_db_views_private_message",
@@ -3376,6 +3378,7 @@ dependencies = [
  "serde_with",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -3833,6 +3836,23 @@ dependencies = [
  "serde_with",
  "serial_test",
  "tokio",
+ "ts-rs",
+]
+
+[[package]]
+name = "lemmy_db_views_local_user_invite"
+version = "1.0.0-test-arm-qemu.0"
+dependencies = [
+ "chrono",
+ "diesel",
+ "diesel-async",
+ "i-love-jesus",
+ "lemmy_db_schema 1.0.0-test-arm-qemu.0",
+ "lemmy_db_schema_file",
+ "lemmy_diesel_utils",
+ "lemmy_utils 1.0.0-test-arm-qemu.0",
+ "serde",
+ "serde_with",
  "ts-rs",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3347,7 +3347,6 @@ dependencies = [
  "activitypub_federation",
  "actix-web",
  "anyhow",
- "base64 0.22.1",
  "bcrypt",
  "chrono",
  "diesel-async",
@@ -3379,7 +3378,6 @@ dependencies = [
  "serde_with",
  "tracing",
  "url",
- "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3372,6 +3372,7 @@ dependencies = [
  "lemmy_diesel_utils",
  "lemmy_email",
  "lemmy_utils 1.0.0-test-arm-qemu.0",
+ "rand 0.10.0",
  "regex",
  "serde",
  "serde_json",
@@ -3851,8 +3852,11 @@ dependencies = [
  "lemmy_db_schema_file",
  "lemmy_diesel_utils",
  "lemmy_utils 1.0.0-test-arm-qemu.0",
+ "pretty_assertions",
  "serde",
  "serde_with",
+ "serial_test",
+ "tokio",
  "ts-rs",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
   "crates/db_views/private_message",
   "crates/db_views/local_user",
   "crates/db_views/local_image",
+  "crates/db_views/local_user_invite",
   "crates/db_views/person",
   "crates/db_views/post",
   "crates/db_views/vote",
@@ -128,6 +129,7 @@ lemmy_db_views_community_follower = { version = "=1.0.0-test-arm-qemu.0", path =
 lemmy_db_views_community_follower_approval = { version = "=1.0.0-test-arm-qemu.0", path = "./crates/db_views/community_follower_approval" }
 lemmy_db_views_community_moderator = { version = "=1.0.0-test-arm-qemu.0", path = "./crates/db_views/community_moderator" }
 lemmy_db_views_custom_emoji = { version = "=1.0.0-test-arm-qemu.0", path = "./crates/db_views/custom_emoji" }
+lemmy_db_views_local_user_invite = { version = "=1.0.0-test-arm-qemu.0", path = "./crates/db_views/local_user_invite" }
 lemmy_db_views_notification = { version = "=1.0.0-test-arm-qemu.0", path = "./crates/db_views/notification" }
 lemmy_db_views_notification_sql = { version = "=1.0.0-test-arm-qemu.0", path = "./crates/db_views/notification_sql" }
 lemmy_db_views_local_image = { version = "=1.0.0-test-arm-qemu.0", path = "./crates/db_views/local_image" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,6 +189,7 @@ chrono = { version = "0.4.44", features = [
 ], default-features = false }
 serde_json = { version = "1.0.149", features = ["preserve_order"] }
 base64 = "0.22.1"
+rand = "0.10.0"
 uuid = { version = "1.22.0", features = ["serde"] }
 anyhow = { version = "1.0.102", features = ["backtrace"] }
 diesel_ltree = "0.4.0"

--- a/crates/api/api_crud/Cargo.toml
+++ b/crates/api/api_crud/Cargo.toml
@@ -46,8 +46,6 @@ futures = { workspace = true }
 futures-util = { workspace = true }
 anyhow.workspace = true
 chrono.workspace = true
-uuid = { workspace = true }
-base64 = { workspace = true }
 rand = { workspace = true }
 accept-language = "3.1.0"
 regex = { workspace = true }

--- a/crates/api/api_crud/Cargo.toml
+++ b/crates/api/api_crud/Cargo.toml
@@ -25,6 +25,7 @@ lemmy_db_views_post = { workspace = true, features = ["full"] }
 lemmy_db_views_local_user = { workspace = true, features = ["full"] }
 lemmy_db_views_person = { workspace = true, features = ["full"] }
 lemmy_db_views_custom_emoji = { workspace = true, features = ["full"] }
+lemmy_db_views_local_user_invite = { workspace = true, features = ["full"] }
 lemmy_db_views_private_message = { workspace = true, features = ["full"] }
 lemmy_db_views_registration_applications = { workspace = true, features = [
   "full",
@@ -45,6 +46,8 @@ futures = { workspace = true }
 futures-util = { workspace = true }
 anyhow.workspace = true
 chrono.workspace = true
+uuid = { workspace = true }
+base64 = { workspace = true }
 accept-language = "3.1.0"
 regex = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/api/api_crud/Cargo.toml
+++ b/crates/api/api_crud/Cargo.toml
@@ -48,6 +48,7 @@ anyhow.workspace = true
 chrono.workspace = true
 uuid = { workspace = true }
 base64 = { workspace = true }
+rand = { workspace = true }
 accept-language = "3.1.0"
 regex = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/api/api_crud/src/invite/create.rs
+++ b/crates/api/api_crud/src/invite/create.rs
@@ -32,10 +32,11 @@ pub async fn create_invitation(
   .count(pool)
   .await?;
 
-  if let Some(max) = context.settings().max_invites_per_user_allowed {
-    if !is_admin(&local_user_view).is_ok() && active_invite_count >= max as i64 {
-      return Err(LemmyErrorType::TooManyInvites.into());
-    }
+  if let Some(max) = context.settings().max_invites_per_user_allowed
+    && is_admin(&local_user_view).is_err()
+    && active_invite_count >= i64::from(max)
+  {
+    return Err(LemmyErrorType::TooManyInvites.into());
   }
 
   let token = generate_invite_token();
@@ -51,7 +52,7 @@ pub async fn create_invitation(
   let invite = LocalUserInvite::create(pool, &insert).await?;
 
   Ok(Json(CreateInvitationResponse {
-    invite_link: invite.get_invite_url(&context.settings()),
+    invite_link: invite.get_invite_url(context.settings())?,
   }))
 }
 

--- a/crates/api/api_crud/src/invite/create.rs
+++ b/crates/api/api_crud/src/invite/create.rs
@@ -44,9 +44,7 @@ pub async fn create_invitation(
 
   let invite = LocalUserInvite::create(pool, &insert).await?;
 
-  Ok(Json(CreateInvitationResponse {
-    invite_link: invite.get_invite_url(context.settings())?,
-  }))
+  Ok(Json(CreateInvitationResponse { invite }))
 }
 
 fn generate_invite_token() -> String {

--- a/crates/api/api_crud/src/invite/create.rs
+++ b/crates/api/api_crud/src/invite/create.rs
@@ -1,11 +1,7 @@
 use actix_web::web::{Data, Json};
 use base64::{Engine, engine::general_purpose};
 use lemmy_api_utils::{context::LemmyContext, utils::is_admin};
-use lemmy_db_schema::{
-  InvitationListingType,
-  source::local_user_invite::{LocalUserInvite, LocalUserInviteInsertForm},
-};
-use lemmy_db_schema_file::enums::LocalUserInviteStatus;
+use lemmy_db_schema::source::local_user_invite::{LocalUserInvite, LocalUserInviteInsertForm};
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_db_views_local_user_invite::{
   api::{CreateInvitation, CreateInvitationResponse},
@@ -24,9 +20,7 @@ pub async fn create_invitation(
   let local_user_id = local_user_view.local_user.id;
 
   let active_invite_count = LocalUserInviteQuery {
-    local_user_id: Some(local_user_id),
-    listing_type: Some(InvitationListingType::Own),
-    status: Some(LocalUserInviteStatus::Active),
+    local_user_id,
     ..Default::default()
   }
   .count(pool)
@@ -46,7 +40,6 @@ pub async fn create_invitation(
     local_user_id,
     max_uses: data.max_uses,
     expires_at: data.expires_at,
-    status: LocalUserInviteStatus::default(),
   };
 
   let invite = LocalUserInvite::create(pool, &insert).await?;

--- a/crates/api/api_crud/src/invite/create.rs
+++ b/crates/api/api_crud/src/invite/create.rs
@@ -1,0 +1,62 @@
+use actix_web::web::{Data, Json};
+use base64::{Engine, engine::general_purpose};
+use lemmy_api_utils::{context::LemmyContext, utils::is_admin};
+use lemmy_db_schema::{
+  InvitationListingType,
+  source::local_user_invite::{LocalUserInvite, LocalUserInviteInsertForm},
+};
+use lemmy_db_schema_file::enums::LocalUserInviteStatus;
+use lemmy_db_views_local_user::LocalUserView;
+use lemmy_db_views_local_user_invite::{
+  api::{CreateInvitation, CreateInvitationResponse},
+  impls::LocalUserInviteQuery,
+};
+use lemmy_utils::error::{LemmyErrorType, LemmyResult};
+use uuid::Uuid;
+
+pub async fn create_invitation(
+  Json(data): Json<CreateInvitation>,
+  context: Data<LemmyContext>,
+  local_user_view: LocalUserView,
+) -> LemmyResult<Json<CreateInvitationResponse>> {
+  let pool = &mut context.pool();
+
+  let local_user_id = local_user_view.local_user.id;
+
+  let active_invite_count = LocalUserInviteQuery {
+    local_user_id: Some(local_user_id),
+    listing_type: Some(InvitationListingType::Own),
+    status: Some(LocalUserInviteStatus::Active),
+    ..Default::default()
+  }
+  .count(pool)
+  .await?;
+
+  if let Some(max) = context.settings().max_invites_per_user_allowed {
+    if !is_admin(&local_user_view).is_ok() && active_invite_count >= max as i64 {
+      return Err(LemmyErrorType::TooManyInvites.into());
+    }
+  }
+
+  let token = generate_invite_token();
+
+  let insert = LocalUserInviteInsertForm {
+    token,
+    local_user_id,
+    max_uses: data.max_uses,
+    expires_at: data.expires_at,
+    status: LocalUserInviteStatus::default(),
+  };
+
+  let invite = LocalUserInvite::create(pool, &insert).await?;
+
+  Ok(Json(CreateInvitationResponse {
+    invite_link: invite.get_invite_url(&context.settings()),
+  }))
+}
+
+fn generate_invite_token() -> String {
+  let id = Uuid::new_v4();
+  // Convert to base64 for a more compact URL-friendly string
+  general_purpose::URL_SAFE_NO_PAD.encode(id.as_bytes())
+}

--- a/crates/api/api_crud/src/invite/create.rs
+++ b/crates/api/api_crud/src/invite/create.rs
@@ -7,6 +7,7 @@ use lemmy_db_views_local_user_invite::{
   api::{CreateInvitation, CreateInvitationResponse},
   impls::LocalUserInviteQuery,
 };
+use lemmy_db_views_site::SiteView;
 use lemmy_utils::error::{LemmyErrorType, LemmyResult};
 use uuid::Uuid;
 
@@ -18,6 +19,7 @@ pub async fn create_invitation(
   let pool = &mut context.pool();
 
   let local_user_id = local_user_view.local_user.id;
+  let local_site = SiteView::read_local(pool).await?.local_site;
 
   let active_invite_count = LocalUserInviteQuery {
     local_user_id,
@@ -26,9 +28,8 @@ pub async fn create_invitation(
   .count(pool)
   .await?;
 
-  if let Some(max) = context.settings().max_invites_per_user_allowed
-    && is_admin(&local_user_view).is_err()
-    && active_invite_count >= i64::from(max)
+  if is_admin(&local_user_view).is_err()
+    && active_invite_count >= i64::from(local_site.max_invites_per_user_allowed)
   {
     return Err(LemmyErrorType::TooManyInvites.into());
   }

--- a/crates/api/api_crud/src/invite/create.rs
+++ b/crates/api/api_crud/src/invite/create.rs
@@ -1,5 +1,4 @@
 use actix_web::web::{Data, Json};
-use base64::{Engine, engine::general_purpose};
 use lemmy_api_utils::{context::LemmyContext, utils::is_admin};
 use lemmy_db_schema::source::local_user_invite::{LocalUserInvite, LocalUserInviteInsertForm};
 use lemmy_db_views_local_user::LocalUserView;
@@ -9,7 +8,7 @@ use lemmy_db_views_local_user_invite::{
 };
 use lemmy_db_views_site::SiteView;
 use lemmy_utils::error::{LemmyErrorType, LemmyResult};
-use uuid::Uuid;
+use rand::{RngExt, distr::Alphanumeric};
 
 pub async fn create_invitation(
   Json(data): Json<CreateInvitation>,
@@ -49,7 +48,9 @@ pub async fn create_invitation(
 }
 
 fn generate_invite_token() -> String {
-  let id = Uuid::new_v4();
-  // Convert to base64 for a more compact URL-friendly string
-  general_purpose::URL_SAFE_NO_PAD.encode(id.as_bytes())
+  rand::rng()
+    .sample_iter(Alphanumeric)
+    .take(12)
+    .map(char::from)
+    .collect()
 }

--- a/crates/api/api_crud/src/invite/create.rs
+++ b/crates/api/api_crud/src/invite/create.rs
@@ -27,6 +27,7 @@ pub async fn create_invitation(
   .count(pool)
   .await?;
 
+  // admins bypass the max invite per user limit
   if is_admin(&local_user_view).is_err()
     && active_invite_count >= i64::from(local_site.max_invites_per_user_allowed)
   {

--- a/crates/api/api_crud/src/invite/list.rs
+++ b/crates/api/api_crud/src/invite/list.rs
@@ -1,6 +1,5 @@
 use actix_web::web::{Data, Json, Query};
-use lemmy_api_utils::{context::LemmyContext, utils::is_admin};
-use lemmy_db_schema::InvitationListingType;
+use lemmy_api_utils::context::LemmyContext;
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_db_views_local_user_invite::{
   api::{ListInvitations, LocalUserInviteView},
@@ -14,17 +13,11 @@ pub async fn list_invitations(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<PagedResponse<LocalUserInviteView>>> {
-  if let Some(InvitationListingType::All) = data.type_ {
-    is_admin(&local_user_view)?
-  }
-
   let pool = &mut context.pool();
   let settings = context.settings();
 
   let paged = LocalUserInviteQuery {
-    local_user_id: Some(local_user_view.local_user.id),
-    listing_type: data.type_,
-    status: data.status,
+    local_user_id: local_user_view.local_user.id,
     page_cursor: data.page_cursor.clone(),
     limit: data.limit,
   }

--- a/crates/api/api_crud/src/invite/list.rs
+++ b/crates/api/api_crud/src/invite/list.rs
@@ -1,10 +1,8 @@
 use actix_web::web::{Data, Json, Query};
 use lemmy_api_utils::context::LemmyContext;
+use lemmy_db_schema::source::local_user_invite::LocalUserInvite;
 use lemmy_db_views_local_user::LocalUserView;
-use lemmy_db_views_local_user_invite::{
-  api::{ListInvitations, LocalUserInviteView},
-  impls::LocalUserInviteQuery,
-};
+use lemmy_db_views_local_user_invite::{api::ListInvitations, impls::LocalUserInviteQuery};
 use lemmy_diesel_utils::pagination::PagedResponse;
 use lemmy_utils::error::LemmyResult;
 
@@ -12,9 +10,8 @@ pub async fn list_invitations(
   data: Query<ListInvitations>,
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
-) -> LemmyResult<Json<PagedResponse<LocalUserInviteView>>> {
+) -> LemmyResult<Json<PagedResponse<LocalUserInvite>>> {
   let pool = &mut context.pool();
-  let settings = context.settings();
 
   let paged = LocalUserInviteQuery {
     local_user_id: local_user_view.local_user.id,
@@ -24,21 +21,5 @@ pub async fn list_invitations(
   .list(pool)
   .await?;
 
-  let items = paged
-    .items
-    .into_iter()
-    .map(|invite| {
-      let invite_link = invite.get_invite_url(settings)?;
-      Ok(LocalUserInviteView {
-        invite,
-        invite_link,
-      })
-    })
-    .collect::<LemmyResult<Vec<LocalUserInviteView>>>()?;
-
-  Ok(Json(PagedResponse {
-    items,
-    next_page: paged.next_page,
-    prev_page: paged.prev_page,
-  }))
+  Ok(Json(paged))
 }

--- a/crates/api/api_crud/src/invite/list.rs
+++ b/crates/api/api_crud/src/invite/list.rs
@@ -1,0 +1,51 @@
+use actix_web::web::{Data, Json, Query};
+use lemmy_api_utils::{context::LemmyContext, utils::is_admin};
+use lemmy_db_schema::InvitationListingType;
+use lemmy_db_views_local_user::LocalUserView;
+use lemmy_db_views_local_user_invite::{
+  api::{ListInvitations, LocalUserInviteView},
+  impls::LocalUserInviteQuery,
+};
+use lemmy_diesel_utils::pagination::PagedResponse;
+use lemmy_utils::error::LemmyResult;
+
+pub async fn list_invitations(
+  data: Query<ListInvitations>,
+  context: Data<LemmyContext>,
+  local_user_view: LocalUserView,
+) -> LemmyResult<Json<PagedResponse<LocalUserInviteView>>> {
+  if let Some(InvitationListingType::All) = data.type_ {
+    is_admin(&local_user_view)?
+  }
+
+  let pool = &mut context.pool();
+  let settings = context.settings();
+
+  let paged = LocalUserInviteQuery {
+    local_user_id: Some(local_user_view.local_user.id),
+    listing_type: data.type_,
+    status: data.status,
+    page_cursor: data.page_cursor.clone(),
+    limit: data.limit,
+  }
+  .list(pool)
+  .await?;
+
+  let items = paged
+    .items
+    .into_iter()
+    .map(|invite| {
+      let invite_link = invite.get_invite_url(&settings);
+      LocalUserInviteView {
+        invite,
+        invite_link,
+      }
+    })
+    .collect();
+
+  Ok(Json(PagedResponse {
+    items,
+    next_page: paged.next_page,
+    prev_page: paged.prev_page,
+  }))
+}

--- a/crates/api/api_crud/src/invite/list.rs
+++ b/crates/api/api_crud/src/invite/list.rs
@@ -35,13 +35,13 @@ pub async fn list_invitations(
     .items
     .into_iter()
     .map(|invite| {
-      let invite_link = invite.get_invite_url(&settings);
-      LocalUserInviteView {
+      let invite_link = invite.get_invite_url(settings)?;
+      Ok(LocalUserInviteView {
         invite,
         invite_link,
-      }
+      })
     })
-    .collect();
+    .collect::<LemmyResult<Vec<LocalUserInviteView>>>()?;
 
   Ok(Json(PagedResponse {
     items,

--- a/crates/api/api_crud/src/invite/mod.rs
+++ b/crates/api/api_crud/src/invite/mod.rs
@@ -1,0 +1,3 @@
+pub mod create;
+pub mod list;
+pub mod revoke;

--- a/crates/api/api_crud/src/invite/revoke.rs
+++ b/crates/api/api_crud/src/invite/revoke.rs
@@ -1,0 +1,34 @@
+use actix_web::web::{Data, Json};
+use lemmy_api_utils::context::LemmyContext;
+use lemmy_db_schema::source::local_user_invite::{LocalUserInvite, LocalUserInviteUpdateForm};
+use lemmy_db_schema_file::enums::LocalUserInviteStatus;
+use lemmy_db_views_local_user::LocalUserView;
+use lemmy_db_views_local_user_invite::api::RevokeInvitation;
+use lemmy_db_views_site::api::SuccessResponse;
+use lemmy_utils::error::{LemmyErrorType, LemmyResult};
+
+pub async fn revoke_invitation(
+  Json(data): Json<RevokeInvitation>,
+  context: Data<LemmyContext>,
+  local_user_view: LocalUserView,
+) -> LemmyResult<Json<SuccessResponse>> {
+  let pool = &mut context.pool();
+
+  let local_user_id = local_user_view.local_user.id;
+
+  let user_invitation =
+    LocalUserInvite::read_by_token_and_user(pool, &local_user_id, &data.token).await?;
+
+  if user_invitation.status != LocalUserInviteStatus::Active {
+    return Err(LemmyErrorType::InviteAlreadyRevokedOrExhausted.into());
+  }
+
+  let update = LocalUserInviteUpdateForm {
+    uses_count: None,
+    status: Some(LocalUserInviteStatus::Revoked),
+  };
+
+  LocalUserInvite::update(pool, user_invitation.id, &update).await?;
+
+  Ok(Json(SuccessResponse::default()))
+}

--- a/crates/api/api_crud/src/invite/revoke.rs
+++ b/crates/api/api_crud/src/invite/revoke.rs
@@ -4,7 +4,7 @@ use lemmy_db_schema::source::local_user_invite::LocalUserInvite;
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_db_views_local_user_invite::api::RevokeInvitation;
 use lemmy_db_views_site::api::SuccessResponse;
-use lemmy_utils::error::LemmyResult;
+use lemmy_utils::error::{LemmyErrorType, LemmyResult};
 
 pub async fn revoke_invitation(
   Json(data): Json<RevokeInvitation>,
@@ -15,7 +15,13 @@ pub async fn revoke_invitation(
 
   let local_user_id = local_user_view.local_user.id;
 
-  LocalUserInvite::delete_by_token_and_user(pool, &local_user_id, &data.token).await?;
+  let invite = LocalUserInvite::read_by_token(pool, &data.token).await?;
+
+  if local_user_id != invite.local_user_id {
+    return Err(LemmyErrorType::InvalidInviteToken.into());
+  }
+
+  LocalUserInvite::delete_by_token(pool, &data.token).await?;
 
   Ok(Json(SuccessResponse::default()))
 }

--- a/crates/api/api_crud/src/invite/revoke.rs
+++ b/crates/api/api_crud/src/invite/revoke.rs
@@ -1,11 +1,10 @@
 use actix_web::web::{Data, Json};
 use lemmy_api_utils::context::LemmyContext;
-use lemmy_db_schema::source::local_user_invite::{LocalUserInvite, LocalUserInviteUpdateForm};
-use lemmy_db_schema_file::enums::LocalUserInviteStatus;
+use lemmy_db_schema::source::local_user_invite::LocalUserInvite;
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_db_views_local_user_invite::api::RevokeInvitation;
 use lemmy_db_views_site::api::SuccessResponse;
-use lemmy_utils::error::{LemmyErrorType, LemmyResult};
+use lemmy_utils::error::LemmyResult;
 
 pub async fn revoke_invitation(
   Json(data): Json<RevokeInvitation>,
@@ -16,19 +15,7 @@ pub async fn revoke_invitation(
 
   let local_user_id = local_user_view.local_user.id;
 
-  let user_invitation =
-    LocalUserInvite::read_by_token_and_user(pool, &local_user_id, &data.token).await?;
-
-  if user_invitation.status != LocalUserInviteStatus::Active {
-    return Err(LemmyErrorType::InviteAlreadyRevokedOrExhausted.into());
-  }
-
-  let update = LocalUserInviteUpdateForm {
-    uses_count: None,
-    status: Some(LocalUserInviteStatus::Revoked),
-  };
-
-  LocalUserInvite::update(pool, user_invitation.id, &update).await?;
+  LocalUserInvite::delete_by_token_and_user(pool, &local_user_id, &data.token).await?;
 
   Ok(Json(SuccessResponse::default()))
 }

--- a/crates/api/api_crud/src/invite/revoke.rs
+++ b/crates/api/api_crud/src/invite/revoke.rs
@@ -13,15 +13,21 @@ pub async fn revoke_invitation(
 ) -> LemmyResult<Json<SuccessResponse>> {
   let pool = &mut context.pool();
 
-  let local_user_id = local_user_view.local_user.id;
-
   let invite = LocalUserInvite::read_by_token(pool, &data.token).await?;
 
-  if local_user_id != invite.local_user_id {
-    return Err(LemmyErrorType::InvalidInviteToken.into());
-  }
+  check_valid_invite(&invite, &local_user_view)?;
 
   LocalUserInvite::delete_by_token(pool, &data.token).await?;
 
   Ok(Json(SuccessResponse::default()))
+}
+
+fn check_valid_invite(
+  invite: &LocalUserInvite,
+  local_user_view: &LocalUserView,
+) -> LemmyResult<()> {
+  if local_user_view.local_user.id != invite.local_user_id {
+    return Err(LemmyErrorType::InvalidInviteToken.into());
+  }
+  Ok(())
 }

--- a/crates/api/api_crud/src/lib.rs
+++ b/crates/api/api_crud/src/lib.rs
@@ -4,6 +4,7 @@ use lemmy_db_schema::source::community::{Community, CommunityActions};
 pub mod comment;
 pub mod community;
 pub mod custom_emoji;
+pub mod invite;
 pub mod multi_community;
 pub mod oauth_provider;
 pub mod post;

--- a/crates/api/api_crud/src/site/create.rs
+++ b/crates/api/api_crud/src/site/create.rs
@@ -133,6 +133,7 @@ pub async fn create_site(
     image_max_upload_size: data.image_max_upload_size,
     image_allow_video_uploads: data.image_allow_video_uploads,
     image_upload_disabled: data.image_upload_disabled,
+    max_invites_per_user_allowed: data.max_invites_per_user_allowed,
   };
 
   LocalSite::update(&mut context.pool(), &local_site_form).await?;

--- a/crates/api/api_crud/src/site/update.rs
+++ b/crates/api/api_crud/src/site/update.rs
@@ -140,6 +140,7 @@ pub async fn edit_site(
     image_max_upload_size: data.image_max_upload_size,
     image_allow_video_uploads: data.image_allow_video_uploads,
     image_upload_disabled: data.image_upload_disabled,
+    max_invites_per_user_allowed: data.max_invites_per_user_allowed,
   };
 
   let update_local_site = LocalSite::update(&mut context.pool(), &local_site_form)

--- a/crates/api/api_crud/src/user/create.rs
+++ b/crates/api/api_crud/src/user/create.rs
@@ -40,7 +40,7 @@ use lemmy_db_schema::{
   },
   traits::{ApubActor, Likeable},
 };
-use lemmy_db_schema_file::enums::{LocalUserInviteStatus, RegistrationMode};
+use lemmy_db_schema_file::enums::RegistrationMode;
 use lemmy_db_views_community::CommunityView;
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_db_views_person::PersonView;
@@ -197,19 +197,18 @@ pub async fn register(
 
         if let Some(inv) = local_user_invite {
           let new_uses_count = inv.uses_count + 1;
-          let status = inv
-            .max_uses
-            .filter(|&m| new_uses_count >= m)
-            .map(|_| LocalUserInviteStatus::Exhausted);
-          LocalUserInvite::update(
-            &mut conn.into(),
-            inv.id,
-            &LocalUserInviteUpdateForm {
-              uses_count: Some(new_uses_count),
-              status,
-            },
-          )
-          .await?;
+          if inv.max_uses.map(|m| new_uses_count >= m).unwrap_or(false) {
+            LocalUserInvite::delete_by_token(&mut conn.into(), &inv.token).await?;
+          } else {
+            LocalUserInvite::update(
+              &mut conn.into(),
+              inv.id,
+              &LocalUserInviteUpdateForm {
+                uses_count: Some(new_uses_count),
+              },
+            )
+            .await?;
+          }
         }
 
         Ok(LocalUserView {

--- a/crates/api/api_crud/src/user/create.rs
+++ b/crates/api/api_crud/src/user/create.rs
@@ -96,7 +96,7 @@ pub async fn register(
     let token = token.ok_or(LemmyErrorType::MissingInviteToken)?;
     let inv = LocalUserInvite::read_by_token(pool, token)
       .await
-      .map_err(|_| LemmyError::from(LemmyErrorType::InvalidInviteToken))?;
+      .map_err(|_e| LemmyError::from(LemmyErrorType::InvalidInviteToken))?;
     if !inv.is_active() {
       return Err(LemmyErrorType::InvalidInviteToken.into());
     }

--- a/crates/api/api_crud/src/user/create.rs
+++ b/crates/api/api_crud/src/user/create.rs
@@ -1,5 +1,7 @@
 use activitypub_federation::{
-  config::Data, fetch::object_id::ObjectId, http_signatures::generate_actor_keypair,
+  config::Data,
+  fetch::object_id::ObjectId,
+  http_signatures::generate_actor_keypair,
 };
 use actix_web::{HttpRequest, rt::time::sleep, web::Json};
 use diesel_async::{AsyncPgConnection, scoped_futures::ScopedFutureExt};
@@ -8,9 +10,16 @@ use lemmy_api_utils::{
   context::LemmyContext,
   plugins::{is_captcha_plugin_loaded, plugin_validate_captcha},
   utils::{
-    check_email_verified, check_local_user_valid, check_registration_application,
-    generate_featured_url, generate_followers_url, generate_inbox_url, generate_moderators_url,
-    honeypot_check, password_length_check, slur_regex,
+    check_email_verified,
+    check_local_user_valid,
+    check_registration_application,
+    generate_featured_url,
+    generate_followers_url,
+    generate_inbox_url,
+    generate_moderators_url,
+    honeypot_check,
+    password_length_check,
+    slur_regex,
   },
 };
 use lemmy_apub_objects::objects::community::ApubCommunity;
@@ -42,7 +51,8 @@ use lemmy_db_views_site::{
 };
 use lemmy_diesel_utils::{connection::get_conn, pagination::PagedResponse, traits::Crud};
 use lemmy_email::{
-  account::send_verification_email_if_required, admin::send_new_applicant_email_to_admins,
+  account::send_verification_email_if_required,
+  admin::send_new_applicant_email_to_admins,
   user_language,
 };
 use lemmy_utils::{

--- a/crates/api/api_crud/src/user/create.rs
+++ b/crates/api/api_crud/src/user/create.rs
@@ -31,6 +31,7 @@ use lemmy_db_schema::{
     language::Language,
     local_site::LocalSite,
     local_user::{LocalUser, LocalUserInsertForm},
+    local_user_invite::{LocalUserInvite, LocalUserInviteUpdateForm},
     oauth_account::{OAuthAccount, OAuthAccountInsertForm},
     oauth_provider::AdminOAuthProvider,
     person::{Person, PersonInsertForm},
@@ -39,7 +40,7 @@ use lemmy_db_schema::{
   },
   traits::{ApubActor, Likeable},
 };
-use lemmy_db_schema_file::enums::RegistrationMode;
+use lemmy_db_schema_file::enums::{LocalUserInviteStatus, RegistrationMode};
 use lemmy_db_views_community::CommunityView;
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_db_views_person::PersonView;
@@ -89,6 +90,20 @@ pub async fn register(
   let local_site = site_view.local_site.clone();
   let require_registration_application =
     local_site.registration_mode == RegistrationMode::RequireApplication;
+  let token = data.token.as_deref();
+
+  let local_user_invite = if local_site.registration_mode == RegistrationMode::RequireInvitation {
+    let token = token.ok_or(LemmyErrorType::MissingInviteToken)?;
+    let inv = LocalUserInvite::read_by_token(pool, token)
+      .await
+      .map_err(|_| LemmyError::from(LemmyErrorType::InvalidInviteToken))?;
+    if inv.status != LocalUserInviteStatus::Active || !inv.is_active() {
+      return Err(LemmyErrorType::InvalidInviteToken.into());
+    }
+    Some(inv)
+  } else {
+    None
+  };
 
   if local_site.registration_mode == RegistrationMode::Closed {
     return Err(LemmyErrorType::RegistrationClosed.into());
@@ -154,6 +169,7 @@ pub async fn register(
           email: tx_data.email.as_deref().map(str::to_lowercase),
           show_nsfw: Some(show_nsfw),
           accepted_application,
+          invited_by_local_user_id: local_user_invite.as_ref().map(|inv| inv.local_user_id),
           ..LocalUserInsertForm::new(person.id, Some(tx_data.password.to_string()))
         };
 
@@ -177,6 +193,23 @@ pub async fn register(
           };
 
           RegistrationApplication::create(&mut conn.into(), &form).await?;
+        }
+
+        if let Some(inv) = local_user_invite {
+          let new_uses_count = inv.uses_count + 1;
+          let status = inv
+            .max_uses
+            .filter(|&m| new_uses_count >= m)
+            .map(|_| LocalUserInviteStatus::Exhausted);
+          LocalUserInvite::update(
+            &mut conn.into(),
+            inv.id,
+            &LocalUserInviteUpdateForm {
+              uses_count: Some(new_uses_count),
+              status,
+            },
+          )
+          .await?;
         }
 
         Ok(LocalUserView {

--- a/crates/api/api_crud/src/user/create.rs
+++ b/crates/api/api_crud/src/user/create.rs
@@ -1,7 +1,5 @@
 use activitypub_federation::{
-  config::Data,
-  fetch::object_id::ObjectId,
-  http_signatures::generate_actor_keypair,
+  config::Data, fetch::object_id::ObjectId, http_signatures::generate_actor_keypair,
 };
 use actix_web::{HttpRequest, rt::time::sleep, web::Json};
 use diesel_async::{AsyncPgConnection, scoped_futures::ScopedFutureExt};
@@ -10,16 +8,9 @@ use lemmy_api_utils::{
   context::LemmyContext,
   plugins::{is_captcha_plugin_loaded, plugin_validate_captcha},
   utils::{
-    check_email_verified,
-    check_local_user_valid,
-    check_registration_application,
-    generate_featured_url,
-    generate_followers_url,
-    generate_inbox_url,
-    generate_moderators_url,
-    honeypot_check,
-    password_length_check,
-    slur_regex,
+    check_email_verified, check_local_user_valid, check_registration_application,
+    generate_featured_url, generate_followers_url, generate_inbox_url, generate_moderators_url,
+    honeypot_check, password_length_check, slur_regex,
   },
 };
 use lemmy_apub_objects::objects::community::ApubCommunity;
@@ -51,8 +42,7 @@ use lemmy_db_views_site::{
 };
 use lemmy_diesel_utils::{connection::get_conn, pagination::PagedResponse, traits::Crud};
 use lemmy_email::{
-  account::send_verification_email_if_required,
-  admin::send_new_applicant_email_to_admins,
+  account::send_verification_email_if_required, admin::send_new_applicant_email_to_admins,
   user_language,
 };
 use lemmy_utils::{
@@ -97,7 +87,7 @@ pub async fn register(
     let inv = LocalUserInvite::read_by_token(pool, token)
       .await
       .map_err(|_| LemmyError::from(LemmyErrorType::InvalidInviteToken))?;
-    if inv.status != LocalUserInviteStatus::Active || !inv.is_active() {
+    if !inv.is_active() {
       return Err(LemmyErrorType::InvalidInviteToken.into());
     }
     Some(inv)

--- a/crates/api/api_crud/src/user/create.rs
+++ b/crates/api/api_crud/src/user/create.rs
@@ -97,7 +97,7 @@ pub async fn register(
     let inv = LocalUserInvite::read_by_token(pool, token)
       .await
       .map_err(|_e| LemmyError::from(LemmyErrorType::InvalidInviteToken))?;
-    if !inv.is_active() {
+    if !inv.is_expired() {
       return Err(LemmyErrorType::InvalidInviteToken.into());
     }
     Some(inv)

--- a/crates/api/routes/src/lib.rs
+++ b/crates/api/routes/src/lib.rs
@@ -127,6 +127,7 @@ use lemmy_api_crud::{
     list::list_custom_emojis,
     update::edit_custom_emoji,
   },
+  invite::{create::create_invitation, list::list_invitations, revoke::revoke_invitation},
   multi_community::{
     create::create_multi_community,
     create_entry::create_multi_community_entry,
@@ -408,7 +409,13 @@ pub fn config(cfg: &mut ServiceConfig, rate_limit: &RateLimit) {
             resource("/data/export")
               .wrap(rate_limit.import_user_settings())
               .route(get().to(export_user_data)),
-          ),
+          )
+          .service(
+            scope("/invite")
+              .route("", post().to(create_invitation))
+              .route("/revoke", post().to(revoke_invitation)),
+          )
+          .route("/invites", get().to(list_invitations)),
       )
       // Person / User actions
       .service(

--- a/crates/api/routes/src/lib.rs
+++ b/crates/api/routes/src/lib.rs
@@ -413,9 +413,9 @@ pub fn config(cfg: &mut ServiceConfig, rate_limit: &RateLimit) {
           .service(
             scope("/invite")
               .route("", post().to(create_invitation))
-              .route("/revoke", post().to(revoke_invitation)),
-          )
-          .route("/invites", get().to(list_invitations)),
+              .route("", delete().to(revoke_invitation))
+              .route("/list", get().to(list_invitations)),
+          ),
       )
       // Person / User actions
       .service(

--- a/crates/api/routes_v3/src/convert.rs
+++ b/crates/api/routes_v3/src/convert.rs
@@ -637,6 +637,7 @@ pub(crate) fn convert_local_site(local_site: LocalSite) -> LocalSiteV3 {
     RegistrationMode::Closed => RegistrationModeV3::Closed,
     RegistrationMode::RequireApplication => RegistrationModeV3::RequireApplication,
     RegistrationMode::Open => RegistrationModeV3::Open,
+    RegistrationMode::RequireInvitation => RegistrationModeV3::Closed,
   };
   LocalSiteV3 {
     id: Default::default(),

--- a/crates/db_schema/src/impls/local_user_invite.rs
+++ b/crates/db_schema/src/impls/local_user_invite.rs
@@ -1,5 +1,5 @@
 use crate::{
-  newtypes::{InvitationId, LocalUserId},
+  newtypes::InvitationId,
   source::local_user_invite::{
     LocalUserInvite,
     LocalUserInviteInsertForm,
@@ -70,22 +70,6 @@ impl LocalUserInvite {
       .get_result::<Self>(conn)
       .await
       .with_lemmy_type(LemmyErrorType::NotFound)
-  }
-
-  pub async fn delete_by_token_and_user(
-    pool: &mut DbPool<'_>,
-    local_user_id: &LocalUserId,
-    token: &str,
-  ) -> LemmyResult<Self> {
-    let conn = &mut get_conn(pool).await?;
-    diesel::delete(
-      local_user_invite::table
-        .filter(local_user_invite::local_user_id.eq(local_user_id))
-        .filter(local_user_invite::token.eq(token)),
-    )
-    .get_result::<Self>(conn)
-    .await
-    .with_lemmy_type(LemmyErrorType::NotFound)
   }
 }
 

--- a/crates/db_schema/src/impls/local_user_invite.rs
+++ b/crates/db_schema/src/impls/local_user_invite.rs
@@ -104,12 +104,11 @@ impl LocalUserInvite {
   pub fn is_active(&self) -> bool {
     self.status == LocalUserInviteStatus::Active && !self.is_exhausted() && !self.is_expired()
   }
-  pub fn get_invite_url(&self, settings: &Settings) -> Url {
+  pub fn get_invite_url(&self, settings: &Settings) -> LemmyResult<Url> {
     let protocol_and_hostname = settings.get_protocol_and_hostname();
-    Url::parse(&format!(
+    Ok(Url::parse(&format!(
       "{}/signup?token={}",
       protocol_and_hostname, self.token
-    ))
-    .unwrap()
+    ))?)
   }
 }

--- a/crates/db_schema/src/impls/local_user_invite.rs
+++ b/crates/db_schema/src/impls/local_user_invite.rs
@@ -9,7 +9,7 @@ use crate::{
 use chrono::Utc;
 use diesel::{ExpressionMethods, QueryDsl, insert_into};
 use diesel_async::RunQueryDsl;
-use lemmy_db_schema_file::{enums::LocalUserInviteStatus, schema::local_user_invite};
+use lemmy_db_schema_file::schema::local_user_invite;
 use lemmy_diesel_utils::{
   connection::{DbPool, get_conn},
   pagination::{CursorData, PaginationCursorConversion},
@@ -77,6 +77,30 @@ impl LocalUserInvite {
       .await
       .with_lemmy_type(LemmyErrorType::NotFound)
   }
+
+  pub async fn delete_by_token(pool: &mut DbPool<'_>, token: &str) -> LemmyResult<Self> {
+    let conn = &mut get_conn(pool).await?;
+    diesel::delete(local_user_invite::table.filter(local_user_invite::token.eq(token)))
+      .get_result::<Self>(conn)
+      .await
+      .with_lemmy_type(LemmyErrorType::NotFound)
+  }
+
+  pub async fn delete_by_token_and_user(
+    pool: &mut DbPool<'_>,
+    local_user_id: &LocalUserId,
+    token: &str,
+  ) -> LemmyResult<Self> {
+    let conn = &mut get_conn(pool).await?;
+    diesel::delete(
+      local_user_invite::table
+        .filter(local_user_invite::local_user_id.eq(local_user_id))
+        .filter(local_user_invite::token.eq(token)),
+    )
+    .get_result::<Self>(conn)
+    .await
+    .with_lemmy_type(LemmyErrorType::NotFound)
+  }
 }
 
 impl PaginationCursorConversion for LocalUserInvite {
@@ -102,7 +126,7 @@ impl LocalUserInvite {
     self.expires_at.map(|d| d < Utc::now()).unwrap_or(false)
   }
   pub fn is_active(&self) -> bool {
-    self.status == LocalUserInviteStatus::Active && !self.is_exhausted() && !self.is_expired()
+    !self.is_exhausted() && !self.is_expired()
   }
   pub fn get_invite_url(&self, settings: &Settings) -> LemmyResult<Url> {
     let protocol_and_hostname = settings.get_protocol_and_hostname();

--- a/crates/db_schema/src/impls/local_user_invite.rs
+++ b/crates/db_schema/src/impls/local_user_invite.rs
@@ -1,0 +1,115 @@
+use crate::{
+  newtypes::{InvitationId, LocalUserId},
+  source::local_user_invite::{
+    LocalUserInvite,
+    LocalUserInviteInsertForm,
+    LocalUserInviteUpdateForm,
+  },
+};
+use chrono::Utc;
+use diesel::{ExpressionMethods, QueryDsl, insert_into};
+use diesel_async::RunQueryDsl;
+use lemmy_db_schema_file::{enums::LocalUserInviteStatus, schema::local_user_invite};
+use lemmy_diesel_utils::{
+  connection::{DbPool, get_conn},
+  pagination::{CursorData, PaginationCursorConversion},
+};
+use lemmy_utils::{
+  error::{LemmyErrorExt, LemmyErrorType, LemmyResult},
+  settings::structs::Settings,
+};
+use url::Url;
+
+impl LocalUserInvite {
+  pub async fn read(pool: &mut DbPool<'_>, id: InvitationId) -> LemmyResult<Self> {
+    let conn = &mut get_conn(pool).await?;
+    local_user_invite::table
+      .find(id)
+      .first(conn)
+      .await
+      .with_lemmy_type(LemmyErrorType::NotFound)
+  }
+
+  pub async fn create(
+    pool: &mut DbPool<'_>,
+    form: &LocalUserInviteInsertForm,
+  ) -> LemmyResult<Self> {
+    let conn = &mut get_conn(pool).await?;
+    insert_into(local_user_invite::table)
+      .values(form)
+      .get_result::<Self>(conn)
+      .await
+      .with_lemmy_type(LemmyErrorType::CouldntCreate)
+  }
+
+  pub async fn update(
+    pool: &mut DbPool<'_>,
+    id: InvitationId,
+    form: &LocalUserInviteUpdateForm,
+  ) -> LemmyResult<Self> {
+    let conn = &mut get_conn(pool).await?;
+    diesel::update(local_user_invite::table.find(id))
+      .set(form)
+      .get_result::<Self>(conn)
+      .await
+      .with_lemmy_type(LemmyErrorType::CouldntUpdate)
+  }
+
+  pub async fn read_by_token(pool: &mut DbPool<'_>, token: &str) -> LemmyResult<Self> {
+    let conn = &mut get_conn(pool).await?;
+    local_user_invite::table
+      .filter(local_user_invite::token.eq(token))
+      .first(conn)
+      .await
+      .with_lemmy_type(LemmyErrorType::NotFound)
+  }
+
+  pub async fn read_by_token_and_user(
+    pool: &mut DbPool<'_>,
+    local_user_id: &LocalUserId,
+    token: &str,
+  ) -> LemmyResult<Self> {
+    let conn = &mut get_conn(pool).await?;
+    local_user_invite::table
+      .filter(local_user_invite::local_user_id.eq(local_user_id))
+      .filter(local_user_invite::token.eq(token))
+      .first(conn)
+      .await
+      .with_lemmy_type(LemmyErrorType::NotFound)
+  }
+}
+
+impl PaginationCursorConversion for LocalUserInvite {
+  type PaginatedType = LocalUserInvite;
+
+  fn to_cursor(&self) -> CursorData {
+    CursorData::new_id(self.id.0)
+  }
+
+  async fn from_cursor(
+    cursor: CursorData,
+    pool: &mut DbPool<'_>,
+  ) -> LemmyResult<Self::PaginatedType> {
+    LocalUserInvite::read(pool, InvitationId(cursor.id()?)).await
+  }
+}
+
+impl LocalUserInvite {
+  pub fn is_exhausted(&self) -> bool {
+    self.max_uses.map(|m| self.uses_count >= m).unwrap_or(false)
+  }
+  pub fn is_expired(&self) -> bool {
+    self.expires_at.map(|d| d < Utc::now()).unwrap_or(false)
+  }
+  pub fn is_active(&self) -> bool {
+    self.status == LocalUserInviteStatus::Active && !self.is_exhausted() && !self.is_expired()
+  }
+  pub fn get_invite_url(&self, settings: &Settings) -> Url {
+    let protocol_and_hostname = settings.get_protocol_and_hostname();
+    Url::parse(&format!(
+      "{}/signup?token={}",
+      protocol_and_hostname, self.token
+    ))
+    .unwrap()
+  }
+}

--- a/crates/db_schema/src/impls/local_user_invite.rs
+++ b/crates/db_schema/src/impls/local_user_invite.rs
@@ -64,20 +64,6 @@ impl LocalUserInvite {
       .with_lemmy_type(LemmyErrorType::NotFound)
   }
 
-  pub async fn read_by_token_and_user(
-    pool: &mut DbPool<'_>,
-    local_user_id: &LocalUserId,
-    token: &str,
-  ) -> LemmyResult<Self> {
-    let conn = &mut get_conn(pool).await?;
-    local_user_invite::table
-      .filter(local_user_invite::local_user_id.eq(local_user_id))
-      .filter(local_user_invite::token.eq(token))
-      .first(conn)
-      .await
-      .with_lemmy_type(LemmyErrorType::NotFound)
-  }
-
   pub async fn delete_by_token(pool: &mut DbPool<'_>, token: &str) -> LemmyResult<Self> {
     let conn = &mut get_conn(pool).await?;
     diesel::delete(local_user_invite::table.filter(local_user_invite::token.eq(token)))

--- a/crates/db_schema/src/impls/local_user_invite.rs
+++ b/crates/db_schema/src/impls/local_user_invite.rs
@@ -21,15 +21,6 @@ use lemmy_utils::{
 use url::Url;
 
 impl LocalUserInvite {
-  pub async fn read(pool: &mut DbPool<'_>, id: InvitationId) -> LemmyResult<Self> {
-    let conn = &mut get_conn(pool).await?;
-    local_user_invite::table
-      .find(id)
-      .first(conn)
-      .await
-      .with_lemmy_type(LemmyErrorType::NotFound)
-  }
-
   pub async fn create(
     pool: &mut DbPool<'_>,
     form: &LocalUserInviteInsertForm,
@@ -77,26 +68,20 @@ impl PaginationCursorConversion for LocalUserInvite {
   type PaginatedType = LocalUserInvite;
 
   fn to_cursor(&self) -> CursorData {
-    CursorData::new_id(self.id.0)
+    CursorData::new_plain(self.token.clone())
   }
 
   async fn from_cursor(
     cursor: CursorData,
     pool: &mut DbPool<'_>,
   ) -> LemmyResult<Self::PaginatedType> {
-    LocalUserInvite::read(pool, InvitationId(cursor.id()?)).await
+    LocalUserInvite::read_by_token(pool, &cursor.plain()).await
   }
 }
 
 impl LocalUserInvite {
-  pub fn is_exhausted(&self) -> bool {
-    self.max_uses.map(|m| self.uses_count >= m).unwrap_or(false)
-  }
   pub fn is_expired(&self) -> bool {
     self.expires_at.map(|d| d < Utc::now()).unwrap_or(false)
-  }
-  pub fn is_active(&self) -> bool {
-    !self.is_exhausted() && !self.is_expired()
   }
   pub fn get_invite_url(&self, settings: &Settings) -> LemmyResult<Url> {
     let protocol_and_hostname = settings.get_protocol_and_hostname();
@@ -104,5 +89,143 @@ impl LocalUserInvite {
       "{}/signup?token={}",
       protocol_and_hostname, self.token
     ))?)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::{
+    newtypes::{InvitationId, LocalUserId},
+    source::{
+      instance::Instance,
+      local_user::{LocalUser, LocalUserInsertForm},
+      local_user_invite::{LocalUserInvite, LocalUserInviteInsertForm, LocalUserInviteUpdateForm},
+      person::{Person, PersonInsertForm},
+    },
+  };
+  use chrono::{Duration, Utc};
+  use lemmy_diesel_utils::{connection::build_db_pool_for_tests, traits::Crud};
+  use lemmy_utils::{error::LemmyResult, settings::structs::Settings};
+  use pretty_assertions::assert_eq;
+  use serial_test::serial;
+
+  fn make_invite(
+    token: &str,
+    max_uses: Option<i32>,
+    uses_count: i32,
+    expired: bool,
+  ) -> LocalUserInvite {
+    LocalUserInvite {
+      id: InvitationId(1),
+      token: token.to_string(),
+      local_user_id: LocalUserId(1),
+      max_uses,
+      uses_count,
+      expires_at: expired.then(|| Utc::now() - Duration::hours(1)),
+      published_at: Utc::now(),
+    }
+  }
+
+  #[test]
+  fn test_is_expired() {
+    let past = LocalUserInvite {
+      expires_at: Some(Utc::now() - Duration::seconds(1)),
+      ..make_invite("t", None, 0, false)
+    };
+    let future = LocalUserInvite {
+      expires_at: Some(Utc::now() + Duration::hours(1)),
+      ..make_invite("t", None, 0, false)
+    };
+    let no_expiry = make_invite("t", None, 0, false);
+    assert!(past.is_expired());
+    assert!(!future.is_expired());
+    assert!(!no_expiry.is_expired());
+  }
+
+  #[test]
+  fn test_get_invite_url() -> LemmyResult<()> {
+    let mut settings = Settings::default();
+    settings.hostname = "example.com".to_string();
+    settings.tls_enabled = true;
+    let invite = make_invite("abc123", None, 0, false);
+    let url = invite.get_invite_url(&settings)?;
+    assert_eq!(url.as_str(), "https://example.com/signup?token=abc123");
+    Ok(())
+  }
+
+  #[tokio::test]
+  #[serial]
+  async fn test_create_read_delete() -> LemmyResult<()> {
+    let pool = &build_db_pool_for_tests();
+    let pool = &mut pool.into();
+
+    let inserted_instance = Instance::read_or_create(pool, "my_domain.tld").await?;
+    let new_person = PersonInsertForm::test_form(inserted_instance.id, "invite_tester");
+    let inserted_person = Person::create(pool, &new_person).await?;
+    let new_local_user = LocalUserInsertForm::test_form(inserted_person.id);
+    let inserted_local_user = LocalUser::create(pool, &new_local_user, vec![]).await?;
+
+    let token = "test_invite_token_abc";
+    let form = LocalUserInviteInsertForm {
+      token: token.to_string(),
+      local_user_id: inserted_local_user.id,
+      max_uses: Some(10),
+      expires_at: None,
+    };
+    let inserted = LocalUserInvite::create(pool, &form).await?;
+
+    assert_eq!(inserted.token, token);
+    assert_eq!(inserted.local_user_id, inserted_local_user.id);
+    assert_eq!(inserted.max_uses, Some(10));
+    assert_eq!(inserted.uses_count, 0);
+    assert!(inserted.expires_at.is_none());
+
+    let read = LocalUserInvite::read_by_token(pool, token).await?;
+    assert_eq!(read.id, inserted.id);
+    assert_eq!(read.token, inserted.token);
+
+    let deleted = LocalUserInvite::delete_by_token(pool, token).await?;
+    assert_eq!(deleted.id, inserted.id);
+
+    let read_after_delete = LocalUserInvite::read_by_token(pool, token).await;
+    assert!(read_after_delete.is_err());
+
+    Person::delete(pool, inserted_person.id).await?;
+    Instance::delete(pool, inserted_instance.id).await?;
+    Ok(())
+  }
+
+  #[tokio::test]
+  #[serial]
+  async fn test_update_uses_count() -> LemmyResult<()> {
+    let pool = &build_db_pool_for_tests();
+    let pool = &mut pool.into();
+
+    let inserted_instance = Instance::read_or_create(pool, "my_domain.tld").await?;
+    let new_person = PersonInsertForm::test_form(inserted_instance.id, "invite_updater");
+    let inserted_person = Person::create(pool, &new_person).await?;
+    let new_local_user = LocalUserInsertForm::test_form(inserted_person.id);
+    let inserted_local_user = LocalUser::create(pool, &new_local_user, vec![]).await?;
+
+    let token = "test_update_token_xyz";
+    let form = LocalUserInviteInsertForm {
+      token: token.to_string(),
+      local_user_id: inserted_local_user.id,
+      max_uses: Some(3),
+      expires_at: None,
+    };
+    let inserted = LocalUserInvite::create(pool, &form).await?;
+    assert_eq!(inserted.uses_count, 0);
+
+    let update_form = LocalUserInviteUpdateForm {
+      uses_count: Some(2),
+    };
+    let updated = LocalUserInvite::update(pool, inserted.id, &update_form).await?;
+    assert_eq!(updated.uses_count, 2);
+
+    LocalUserInvite::delete_by_token(pool, token).await?;
+    Person::delete(pool, inserted_person.id).await?;
+    Instance::delete(pool, inserted_instance.id).await?;
+    Ok(())
   }
 }

--- a/crates/db_schema/src/impls/mod.rs
+++ b/crates/db_schema/src/impls/mod.rs
@@ -19,6 +19,7 @@ pub mod local_site;
 pub mod local_site_rate_limit;
 pub mod local_site_url_blocklist;
 pub mod local_user;
+pub mod local_user_invite;
 pub mod login_token;
 pub mod modlog;
 pub mod multi_community;

--- a/crates/db_schema/src/lib.rs
+++ b/crates/db_schema/src/lib.rs
@@ -148,6 +148,17 @@ pub enum PersonListingType {
   Local,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, Default, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(export))]
+pub enum InvitationListingType {
+  /// only the caller's invitations
+  #[default]
+  Own,
+  /// all invitations, admin only
+  All,
+}
 #[derive(
   EnumString, Display, Debug, Serialize, Deserialize, Default, Clone, Copy, PartialEq, Eq, Hash,
 )]

--- a/crates/db_schema/src/lib.rs
+++ b/crates/db_schema/src/lib.rs
@@ -148,17 +148,6 @@ pub enum PersonListingType {
   Local,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Copy, Default, PartialEq, Eq, Hash)]
-#[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
-#[cfg_attr(feature = "ts-rs", ts(export))]
-pub enum InvitationListingType {
-  /// only the caller's invitations
-  #[default]
-  Own,
-  /// all invitations, admin only
-  All,
-}
 #[derive(
   EnumString, Display, Debug, Serialize, Deserialize, Default, Clone, Copy, PartialEq, Eq, Hash,
 )]

--- a/crates/db_schema/src/newtypes.rs
+++ b/crates/db_schema/src/newtypes.rs
@@ -29,6 +29,13 @@ impl fmt::Display for CommentId {
   }
 }
 
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "full", derive(DieselNewType))]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
+/// The invitation id.
+pub struct InvitationId(pub i32);
+
 pub enum PostOrCommentId {
   Post(PostId),
   Comment(CommentId),

--- a/crates/db_schema/src/source/local_site.rs
+++ b/crates/db_schema/src/source/local_site.rs
@@ -113,6 +113,8 @@ pub struct LocalSite {
   /// This affects post and comment images, but not avatars and banners.
   pub image_allow_video_uploads: bool,
   pub image_upload_disabled: bool,
+  /// How many active invite links a user can have
+  pub max_invites_per_user_allowed: i32,
 }
 
 #[derive(Clone, derive_new::new)]
@@ -191,6 +193,8 @@ pub struct LocalSiteInsertForm {
   pub image_allow_video_uploads: Option<bool>,
   #[new(default)]
   pub image_upload_disabled: Option<bool>,
+  #[new(default)]
+  pub max_invites_per_user_allowed: Option<i32>,
 }
 
 #[derive(Clone, Default)]
@@ -234,4 +238,5 @@ pub struct LocalSiteUpdateForm {
   pub image_max_upload_size: Option<i32>,
   pub image_allow_video_uploads: Option<bool>,
   pub image_upload_disabled: Option<bool>,
+  pub max_invites_per_user_allowed: Option<i32>,
 }

--- a/crates/db_schema/src/source/local_user.rs
+++ b/crates/db_schema/src/source/local_user.rs
@@ -78,6 +78,7 @@ pub struct LocalUser {
   pub show_upvote_percentage: bool,
   pub show_person_votes: bool,
   pub default_items_per_page: i32,
+  pub invited_by_local_user_id: Option<LocalUserId>,
 }
 
 #[derive(Clone, derive_new::new)]
@@ -150,6 +151,8 @@ pub struct LocalUserInsertForm {
   pub show_upvote_percentage: Option<bool>,
   #[new(default)]
   pub show_person_votes: Option<bool>,
+  #[new(default)]
+  pub invited_by_local_user_id: Option<LocalUserId>,
 }
 
 #[derive(Clone, Default)]

--- a/crates/db_schema/src/source/local_user_invite.rs
+++ b/crates/db_schema/src/source/local_user_invite.rs
@@ -2,7 +2,7 @@ use crate::newtypes::{InvitationId, LocalUserId};
 use chrono::{DateTime, Utc};
 #[cfg(feature = "full")]
 use i_love_jesus::CursorKeysModule;
-use lemmy_db_schema_file::{enums::LocalUserInviteStatus, schema::local_user_invite};
+use lemmy_db_schema_file::schema::local_user_invite;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
@@ -23,7 +23,6 @@ pub struct LocalUserInvite {
   pub max_uses: Option<i32>,
   pub uses_count: i32,
   pub expires_at: Option<DateTime<Utc>>,
-  pub status: LocalUserInviteStatus,
   pub published_at: DateTime<Utc>,
 }
 
@@ -34,12 +33,10 @@ pub struct LocalUserInviteInsertForm {
   pub local_user_id: LocalUserId,
   pub max_uses: Option<i32>,
   pub expires_at: Option<DateTime<Utc>>,
-  pub status: LocalUserInviteStatus,
 }
 
 #[cfg_attr(feature = "full", derive(AsChangeset))]
 #[cfg_attr(feature = "full", diesel(table_name = local_user_invite))]
 pub struct LocalUserInviteUpdateForm {
   pub uses_count: Option<i32>,
-  pub status: Option<LocalUserInviteStatus>,
 }

--- a/crates/db_schema/src/source/local_user_invite.rs
+++ b/crates/db_schema/src/source/local_user_invite.rs
@@ -1,0 +1,44 @@
+use crate::newtypes::{InvitationId, LocalUserId};
+use chrono::{DateTime, Utc};
+#[cfg(feature = "full")]
+use i_love_jesus::CursorKeysModule;
+use lemmy_db_schema_file::{enums::LocalUserInviteStatus, schema::local_user_invite};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+#[cfg_attr(
+  feature = "full",
+  derive(Queryable, Selectable, Identifiable, CursorKeysModule)
+)]
+#[cfg_attr(feature = "full", diesel(table_name = local_user_invite))]
+#[cfg_attr(feature = "full", diesel(check_for_backend(diesel::pg::Pg)))]
+#[cfg_attr(feature = "full", cursor_keys_module(name = invitation_keys))]
+pub struct LocalUserInvite {
+  #[serde(skip_serializing)]
+  pub id: InvitationId,
+  pub token: String,
+  #[serde(skip_serializing)]
+  pub local_user_id: LocalUserId,
+  pub max_uses: Option<i32>,
+  pub uses_count: i32,
+  pub expires_at: Option<DateTime<Utc>>,
+  pub status: LocalUserInviteStatus,
+  pub published_at: DateTime<Utc>,
+}
+
+#[cfg_attr(feature = "full", derive(Insertable))]
+#[cfg_attr(feature = "full", diesel(table_name = local_user_invite))]
+pub struct LocalUserInviteInsertForm {
+  pub token: String,
+  pub local_user_id: LocalUserId,
+  pub max_uses: Option<i32>,
+  pub expires_at: Option<DateTime<Utc>>,
+  pub status: LocalUserInviteStatus,
+}
+
+#[cfg_attr(feature = "full", derive(AsChangeset))]
+#[cfg_attr(feature = "full", diesel(table_name = local_user_invite))]
+pub struct LocalUserInviteUpdateForm {
+  pub uses_count: Option<i32>,
+  pub status: Option<LocalUserInviteStatus>,
+}

--- a/crates/db_schema/src/source/local_user_invite.rs
+++ b/crates/db_schema/src/source/local_user_invite.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 )]
 #[cfg_attr(feature = "full", diesel(table_name = local_user_invite))]
 #[cfg_attr(feature = "full", diesel(check_for_backend(diesel::pg::Pg)))]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "full", cursor_keys_module(name = invitation_keys))]
 pub struct LocalUserInvite {
   #[serde(skip_serializing)]

--- a/crates/db_schema/src/source/local_user_invite.rs
+++ b/crates/db_schema/src/source/local_user_invite.rs
@@ -2,6 +2,7 @@ use crate::newtypes::{InvitationId, LocalUserId};
 use chrono::{DateTime, Utc};
 #[cfg(feature = "full")]
 use i_love_jesus::CursorKeysModule;
+#[cfg(feature = "full")]
 use lemmy_db_schema_file::schema::local_user_invite;
 use serde::{Deserialize, Serialize};
 

--- a/crates/db_schema/src/source/local_user_invite.rs
+++ b/crates/db_schema/src/source/local_user_invite.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "full", diesel(table_name = local_user_invite))]
 #[cfg_attr(feature = "full", diesel(check_for_backend(diesel::pg::Pg)))]
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
 #[cfg_attr(feature = "full", cursor_keys_module(name = invitation_keys))]
 pub struct LocalUserInvite {
   #[serde(skip_serializing)]

--- a/crates/db_schema/src/source/mod.rs
+++ b/crates/db_schema/src/source/mod.rs
@@ -26,6 +26,7 @@ pub mod local_site;
 pub mod local_site_rate_limit;
 pub mod local_site_url_blocklist;
 pub mod local_user;
+pub mod local_user_invite;
 pub mod login_token;
 pub mod modlog;
 pub mod multi_community;

--- a/crates/db_schema_file/src/enums.rs
+++ b/crates/db_schema_file/src/enums.rs
@@ -95,27 +95,6 @@ pub enum RegistrationMode {
   Open,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Default, Hash)]
-#[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "full", derive(DbEnum))]
-#[cfg_attr(
-  feature = "full",
-  ExistingTypePath = "crate::schema::sql_types::LocalUserInviteStatus"
-)]
-#[cfg_attr(feature = "full", DbValueStyle = "verbatim")]
-#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
-#[cfg_attr(feature = "ts-rs", ts(export))]
-/// The status of an invitation link.
-pub enum LocalUserInviteStatus {
-  #[default]
-  Active,
-  /// Manually revoked by the creator or an admin.
-  Revoked,
-  /// All uses have been consumed.
-  Exhausted,
-  Expired,
-}
-
 #[derive(Debug, Serialize, Deserialize, Default, Clone, Copy, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "full", derive(DbEnum))]

--- a/crates/db_schema_file/src/enums.rs
+++ b/crates/db_schema_file/src/enums.rs
@@ -88,9 +88,32 @@ pub enum RegistrationMode {
   Closed,
   /// Open, but pending approval of a registration application.
   RequireApplication,
+  /// Require invite links.
+  RequireInvitation,
   /// Open to all.
   #[default]
   Open,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Default, Hash)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "full", derive(DbEnum))]
+#[cfg_attr(
+  feature = "full",
+  ExistingTypePath = "crate::schema::sql_types::LocalUserInviteStatus"
+)]
+#[cfg_attr(feature = "full", DbValueStyle = "verbatim")]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(export))]
+/// The status of an invitation link.
+pub enum LocalUserInviteStatus {
+  #[default]
+  Active,
+  /// Manually revoked by the creator or an admin.
+  Revoked,
+  /// All uses have been consumed.
+  Exhausted,
+  Expired,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/db_schema_file/src/schema.rs
+++ b/crates/db_schema_file/src/schema.rs
@@ -442,6 +442,7 @@ diesel::table! {
         image_max_upload_size -> Int4,
         image_allow_video_uploads -> Bool,
         image_upload_disabled -> Bool,
+        max_invites_per_user_allowed -> Int4
     }
 }
 

--- a/crates/db_schema_file/src/schema.rs
+++ b/crates/db_schema_file/src/schema.rs
@@ -62,10 +62,6 @@ pub mod sql_types {
   pub struct RegistrationModeEnum;
 
   #[derive(diesel::query_builder::QueryId, diesel::sql_types::SqlType)]
-  #[diesel(postgres_type(name = "local_user_invite_status_enum"))]
-  pub struct LocalUserInviteStatus;
-
-  #[derive(diesel::query_builder::QueryId, diesel::sql_types::SqlType)]
   #[diesel(postgres_type(name = "tag_color_enum"))]
   pub struct TagColorEnum;
 
@@ -356,7 +352,6 @@ diesel::table! {
 
 diesel::table! {
     use diesel::sql_types::*;
-    use super::sql_types::LocalUserInviteStatus;
 
     local_user_invite (id) {
         id -> Int4,
@@ -365,7 +360,6 @@ diesel::table! {
         max_uses -> Nullable<Int4>,
         uses_count -> Int4,
         expires_at -> Nullable<Timestamptz>,
-        status -> LocalUserInviteStatus,
         published_at -> Timestamptz,
     }
 }

--- a/crates/db_schema_file/src/schema.rs
+++ b/crates/db_schema_file/src/schema.rs
@@ -62,6 +62,10 @@ pub mod sql_types {
   pub struct RegistrationModeEnum;
 
   #[derive(diesel::query_builder::QueryId, diesel::sql_types::SqlType)]
+  #[diesel(postgres_type(name = "local_user_invite_status_enum"))]
+  pub struct LocalUserInviteStatus;
+
+  #[derive(diesel::query_builder::QueryId, diesel::sql_types::SqlType)]
   #[diesel(postgres_type(name = "tag_color_enum"))]
   pub struct TagColorEnum;
 
@@ -351,6 +355,22 @@ diesel::table! {
 }
 
 diesel::table! {
+    use diesel::sql_types::*;
+    use super::sql_types::LocalUserInviteStatus;
+
+    local_user_invite (id) {
+        id -> Int4,
+        token -> Varchar,
+        local_user_id -> Int4,
+        max_uses -> Nullable<Int4>,
+        uses_count -> Int4,
+        expires_at -> Nullable<Timestamptz>,
+        status -> LocalUserInviteStatus,
+        published_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
     language (id) {
         id -> Int4,
         #[max_length = 3]
@@ -508,6 +528,7 @@ diesel::table! {
         show_upvote_percentage -> Bool,
         show_person_votes -> Bool,
         default_items_per_page -> Int4,
+        invited_by_local_user_id -> Nullable<Int4>,
     }
 }
 

--- a/crates/db_views/local_user_invite/Cargo.toml
+++ b/crates/db_views/local_user_invite/Cargo.toml
@@ -11,7 +11,6 @@ rust-version.workspace = true
 
 [lib]
 doctest = false
-test = false
 
 [lints]
 workspace = true
@@ -40,3 +39,8 @@ serde_with = { workspace = true }
 ts-rs = { workspace = true, optional = true }
 lemmy_diesel_utils = { workspace = true }
 i-love-jesus = { workspace = true, optional = true }
+
+[dev-dependencies]
+serial_test = { workspace = true }
+tokio = { workspace = true }
+pretty_assertions = { workspace = true }

--- a/crates/db_views/local_user_invite/Cargo.toml
+++ b/crates/db_views/local_user_invite/Cargo.toml
@@ -35,7 +35,6 @@ lemmy_db_schema_file = { workspace = true }
 diesel = { workspace = true, optional = true }
 diesel-async = { workspace = true, optional = true }
 chrono = { workspace = true }
-uuid = { workspace = true }
 url = { workspace = true }
 serde = { workspace = true }
 serde_with = { workspace = true }

--- a/crates/db_views/local_user_invite/Cargo.toml
+++ b/crates/db_views/local_user_invite/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "lemmy_db_views_local_user_invite"
+version.workspace = true
+edition.workspace = true
+description.workspace = true
+license.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lib]
+doctest = false
+test = false
+
+[lints]
+workspace = true
+
+[features]
+full = [
+  "lemmy_utils",
+  "diesel",
+  "diesel-async",
+  "i-love-jesus",
+  "lemmy_db_schema/full",
+  "lemmy_db_schema_file/full",
+  "lemmy_diesel_utils/full",
+]
+ts-rs = ["dep:ts-rs", "lemmy_db_schema/ts-rs"]
+
+[dependencies]
+lemmy_db_schema = { workspace = true }
+lemmy_utils = { workspace = true, optional = true }
+lemmy_db_schema_file = { workspace = true }
+diesel = { workspace = true, optional = true }
+diesel-async = { workspace = true, optional = true }
+chrono = { workspace = true }
+uuid = { workspace = true }
+url = { workspace = true }
+serde = { workspace = true }
+serde_with = { workspace = true }
+ts-rs = { workspace = true, optional = true }
+lemmy_diesel_utils = { workspace = true }
+i-love-jesus = { workspace = true, optional = true }

--- a/crates/db_views/local_user_invite/Cargo.toml
+++ b/crates/db_views/local_user_invite/Cargo.toml
@@ -35,7 +35,6 @@ lemmy_db_schema_file = { workspace = true }
 diesel = { workspace = true, optional = true }
 diesel-async = { workspace = true, optional = true }
 chrono = { workspace = true }
-url = { workspace = true }
 serde = { workspace = true }
 serde_with = { workspace = true }
 ts-rs = { workspace = true, optional = true }

--- a/crates/db_views/local_user_invite/src/api.rs
+++ b/crates/db_views/local_user_invite/src/api.rs
@@ -1,6 +1,5 @@
 use chrono::{DateTime, Utc};
-use lemmy_db_schema::{InvitationListingType, source::local_user_invite::LocalUserInvite};
-use lemmy_db_schema_file::enums::LocalUserInviteStatus;
+use lemmy_db_schema::source::local_user_invite::LocalUserInvite;
 use lemmy_diesel_utils::pagination::PaginationCursor;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -46,8 +45,6 @@ pub struct CreateInvitationResponse {
 #[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
 pub struct ListInvitations {
   #[serde(rename = "type")]
-  pub type_: Option<InvitationListingType>,
-  pub status: Option<LocalUserInviteStatus>,
   pub page_cursor: Option<PaginationCursor>,
   pub limit: Option<i64>,
 }

--- a/crates/db_views/local_user_invite/src/api.rs
+++ b/crates/db_views/local_user_invite/src/api.rs
@@ -3,17 +3,6 @@ use lemmy_db_schema::source::local_user_invite::LocalUserInvite;
 use lemmy_diesel_utils::pagination::PaginationCursor;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
-use url::Url;
-
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
-#[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
-pub struct LocalUserInviteView {
-  #[serde(flatten)]
-  pub invite: LocalUserInvite,
-  pub invite_link: Url,
-}
 
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -36,7 +25,7 @@ pub struct RevokeInvitation {
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
 pub struct CreateInvitationResponse {
-  pub invite_link: Url,
+  pub invite: LocalUserInvite,
 }
 
 #[skip_serializing_none]
@@ -44,7 +33,6 @@ pub struct CreateInvitationResponse {
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
 pub struct ListInvitations {
-  #[serde(rename = "type")]
   pub page_cursor: Option<PaginationCursor>,
   pub limit: Option<i64>,
 }

--- a/crates/db_views/local_user_invite/src/api.rs
+++ b/crates/db_views/local_user_invite/src/api.rs
@@ -1,0 +1,53 @@
+use chrono::{DateTime, Utc};
+use lemmy_db_schema::{InvitationListingType, source::local_user_invite::LocalUserInvite};
+use lemmy_db_schema_file::enums::LocalUserInviteStatus;
+use lemmy_diesel_utils::pagination::PaginationCursor;
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+use url::Url;
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
+pub struct LocalUserInviteView {
+  #[serde(flatten)]
+  pub invite: LocalUserInvite,
+  pub invite_link: Url,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
+pub struct CreateInvitation {
+  pub max_uses: Option<i32>,
+  pub expires_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
+pub struct RevokeInvitation {
+  pub token: String,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
+pub struct CreateInvitationResponse {
+  pub invite_link: Url,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
+pub struct ListInvitations {
+  #[serde(rename = "type")]
+  pub type_: Option<InvitationListingType>,
+  pub status: Option<LocalUserInviteStatus>,
+  pub page_cursor: Option<PaginationCursor>,
+  pub limit: Option<i64>,
+}

--- a/crates/db_views/local_user_invite/src/impls.rs
+++ b/crates/db_views/local_user_invite/src/impls.rs
@@ -59,3 +59,122 @@ impl LocalUserInviteQuery {
       .with_lemmy_type(LemmyErrorType::NotFound)
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use crate::impls::LocalUserInviteQuery;
+  use lemmy_db_schema::{
+    newtypes::LocalUserId,
+    source::{
+      instance::Instance,
+      local_user::{LocalUser, LocalUserInsertForm},
+      local_user_invite::{LocalUserInvite, LocalUserInviteInsertForm},
+      person::{Person, PersonInsertForm},
+    },
+  };
+  use lemmy_diesel_utils::{
+    connection::{DbPool, build_db_pool_for_tests},
+    traits::Crud,
+  };
+  use lemmy_utils::error::LemmyResult;
+  use pretty_assertions::assert_eq;
+  use serial_test::serial;
+
+  async fn create_local_user(
+    pool: &mut DbPool<'_>,
+    instance: &Instance,
+    name: &str,
+  ) -> LemmyResult<(Person, LocalUser)> {
+    let person = Person::create(pool, &PersonInsertForm::test_form(instance.id, name)).await?;
+    let local_user =
+      LocalUser::create(pool, &LocalUserInsertForm::test_form(person.id), vec![]).await?;
+    Ok((person, local_user))
+  }
+
+  async fn create_invite(
+    pool: &mut DbPool<'_>,
+    local_user_id: LocalUserId,
+    token: &str,
+  ) -> LemmyResult<LocalUserInvite> {
+    LocalUserInvite::create(
+      pool,
+      &LocalUserInviteInsertForm {
+        token: token.to_string(),
+        local_user_id,
+        max_uses: None,
+        expires_at: None,
+      },
+    )
+    .await
+  }
+
+  async fn list(
+    pool: &mut DbPool<'_>,
+    local_user_id: LocalUserId,
+  ) -> LemmyResult<Vec<LocalUserInvite>> {
+    Ok(
+      LocalUserInviteQuery {
+        local_user_id,
+        ..Default::default()
+      }
+      .list(pool)
+      .await?
+      .items,
+    )
+  }
+
+  async fn count(pool: &mut DbPool<'_>, local_user_id: LocalUserId) -> LemmyResult<i64> {
+    LocalUserInviteQuery {
+      local_user_id,
+      ..Default::default()
+    }
+    .count(pool)
+    .await
+  }
+
+  #[tokio::test]
+  #[serial]
+  async fn test_list_and_count() -> LemmyResult<()> {
+    let pool = &build_db_pool_for_tests();
+    let pool = &mut pool.into();
+
+    let instance = Instance::read_or_create(pool, "my_domain.tld").await?;
+    let (timmy_person, timmy_local_user) = create_local_user(pool, &instance, "timmy_inv").await?;
+
+    let invite_1 = create_invite(pool, timmy_local_user.id, "token_one").await?;
+    let invite_2 = create_invite(pool, timmy_local_user.id, "token_two").await?;
+
+    assert_eq!(list(pool, timmy_local_user.id).await?, [invite_1, invite_2]);
+    assert_eq!(count(pool, timmy_local_user.id).await?, 2);
+
+    Person::delete(pool, timmy_person.id).await?;
+    Instance::delete(pool, instance.id).await?;
+
+    Ok(())
+  }
+
+  #[tokio::test]
+  #[serial]
+  async fn test_list_filters_by_user() -> LemmyResult<()> {
+    let pool = &build_db_pool_for_tests();
+    let pool = &mut pool.into();
+
+    let instance = Instance::read_or_create(pool, "my_domain.tld").await?;
+    let (timmy_person, timmy_local_user) = create_local_user(pool, &instance, "timmy_inv2").await?;
+    let (sara_person, sara_local_user) = create_local_user(pool, &instance, "sara_inv").await?;
+
+    let timmy_invite = create_invite(pool, timmy_local_user.id, "timmy_token").await?;
+    let sara_invite = create_invite(pool, sara_local_user.id, "sara_token").await?;
+
+    assert_eq!(list(pool, timmy_local_user.id).await?, [timmy_invite]);
+    assert_eq!(list(pool, sara_local_user.id).await?, [sara_invite]);
+    assert_eq!(count(pool, timmy_local_user.id).await?, 1);
+    assert_eq!(count(pool, sara_local_user.id).await?, 1);
+
+    Person::delete(pool, timmy_person.id).await?;
+    Person::delete(pool, sara_person.id).await?;
+    Instance::delete(pool, instance.id).await?;
+
+    Ok(())
+  }
+}

--- a/crates/db_views/local_user_invite/src/impls.rs
+++ b/crates/db_views/local_user_invite/src/impls.rs
@@ -2,12 +2,11 @@ use diesel::{ExpressionMethods, QueryDsl, SelectableHelper};
 use diesel_async::RunQueryDsl;
 use i_love_jesus::SortDirection;
 use lemmy_db_schema::{
-  InvitationListingType,
   newtypes::LocalUserId,
   source::local_user_invite::{LocalUserInvite, invitation_keys as key},
   utils::limit_fetch,
 };
-use lemmy_db_schema_file::{enums::LocalUserInviteStatus, schema::local_user_invite};
+use lemmy_db_schema_file::schema::local_user_invite;
 use lemmy_diesel_utils::{
   connection::{DbPool, get_conn},
   pagination::{PagedResponse, PaginationCursor, PaginationCursorConversion, paginate_response},
@@ -16,9 +15,7 @@ use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 #[derive(Default)]
 pub struct LocalUserInviteQuery {
-  pub local_user_id: Option<LocalUserId>,
-  pub listing_type: Option<InvitationListingType>,
-  pub status: Option<LocalUserInviteStatus>,
+  pub local_user_id: LocalUserId,
   pub page_cursor: Option<PaginationCursor>,
   pub limit: Option<i64>,
 }
@@ -32,23 +29,11 @@ impl LocalUserInviteQuery {
       .limit(limit)
       .into_boxed();
 
-    match self.listing_type.unwrap_or_default() {
-      InvitationListingType::Own => {
-        if let Some(local_user_id) = self.local_user_id {
-          query = query.filter(local_user_invite::local_user_id.eq(local_user_id));
-        }
-      }
-      InvitationListingType::All => {}
-    }
-
-    if let Some(status) = self.status {
-      query = query.filter(local_user_invite::status.eq(status));
-    }
+    query = query.filter(local_user_invite::local_user_id.eq(self.local_user_id));
 
     let paginated_query =
       LocalUserInvite::paginate(query, &self.page_cursor, SortDirection::Asc, pool)
         .await?
-        .then_order_by(key::status)
         .then_order_by(key::published_at)
         .then_order_by(key::id);
 
@@ -66,18 +51,7 @@ impl LocalUserInviteQuery {
     let conn = &mut get_conn(pool).await?;
     let mut query = local_user_invite::table.select(count_star()).into_boxed();
 
-    match self.listing_type.unwrap_or_default() {
-      InvitationListingType::Own => {
-        if let Some(local_user_id) = self.local_user_id {
-          query = query.filter(local_user_invite::local_user_id.eq(local_user_id));
-        }
-      }
-      InvitationListingType::All => {}
-    }
-
-    if let Some(status) = self.status {
-      query = query.filter(local_user_invite::status.eq(status));
-    }
+    query = query.filter(local_user_invite::local_user_id.eq(self.local_user_id));
 
     query
       .get_result(conn)

--- a/crates/db_views/local_user_invite/src/impls.rs
+++ b/crates/db_views/local_user_invite/src/impls.rs
@@ -1,0 +1,87 @@
+use diesel::{ExpressionMethods, QueryDsl, SelectableHelper};
+use diesel_async::RunQueryDsl;
+use i_love_jesus::SortDirection;
+use lemmy_db_schema::{
+  InvitationListingType,
+  newtypes::LocalUserId,
+  source::local_user_invite::{LocalUserInvite, invitation_keys as key},
+  utils::limit_fetch,
+};
+use lemmy_db_schema_file::{enums::LocalUserInviteStatus, schema::local_user_invite};
+use lemmy_diesel_utils::{
+  connection::{DbPool, get_conn},
+  pagination::{PagedResponse, PaginationCursor, PaginationCursorConversion, paginate_response},
+};
+use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
+
+#[derive(Default)]
+pub struct LocalUserInviteQuery {
+  pub local_user_id: Option<LocalUserId>,
+  pub listing_type: Option<InvitationListingType>,
+  pub status: Option<LocalUserInviteStatus>,
+  pub page_cursor: Option<PaginationCursor>,
+  pub limit: Option<i64>,
+}
+
+impl LocalUserInviteQuery {
+  pub async fn list(self, pool: &mut DbPool<'_>) -> LemmyResult<PagedResponse<LocalUserInvite>> {
+    let limit = limit_fetch(self.limit, None)?;
+
+    let mut query = local_user_invite::table
+      .select(LocalUserInvite::as_select())
+      .limit(limit)
+      .into_boxed();
+
+    match self.listing_type.unwrap_or_default() {
+      InvitationListingType::Own => {
+        if let Some(local_user_id) = self.local_user_id {
+          query = query.filter(local_user_invite::local_user_id.eq(local_user_id));
+        }
+      }
+      InvitationListingType::All => {}
+    }
+
+    if let Some(status) = self.status {
+      query = query.filter(local_user_invite::status.eq(status));
+    }
+
+    let paginated_query =
+      LocalUserInvite::paginate(query, &self.page_cursor, SortDirection::Asc, pool)
+        .await?
+        .then_order_by(key::status)
+        .then_order_by(key::published_at)
+        .then_order_by(key::id);
+
+    let conn = &mut get_conn(pool).await?;
+    let res = paginated_query
+      .load::<LocalUserInvite>(conn)
+      .await
+      .with_lemmy_type(LemmyErrorType::NotFound)?;
+    paginate_response(res, limit, self.page_cursor)
+  }
+
+  pub async fn count(self, pool: &mut DbPool<'_>) -> LemmyResult<i64> {
+    use diesel::dsl::count_star;
+
+    let conn = &mut get_conn(pool).await?;
+    let mut query = local_user_invite::table.select(count_star()).into_boxed();
+
+    match self.listing_type.unwrap_or_default() {
+      InvitationListingType::Own => {
+        if let Some(local_user_id) = self.local_user_id {
+          query = query.filter(local_user_invite::local_user_id.eq(local_user_id));
+        }
+      }
+      InvitationListingType::All => {}
+    }
+
+    if let Some(status) = self.status {
+      query = query.filter(local_user_invite::status.eq(status));
+    }
+
+    query
+      .get_result(conn)
+      .await
+      .with_lemmy_type(LemmyErrorType::NotFound)
+  }
+}

--- a/crates/db_views/local_user_invite/src/impls.rs
+++ b/crates/db_views/local_user_invite/src/impls.rs
@@ -144,7 +144,7 @@ mod tests {
     let invite_1 = create_invite(pool, timmy_local_user.id, "token_one").await?;
     let invite_2 = create_invite(pool, timmy_local_user.id, "token_two").await?;
 
-    assert_eq!(list(pool, timmy_local_user.id).await?, [invite_1, invite_2]);
+    assert_eq!(list(pool, timmy_local_user.id).await?, [invite_2, invite_1]);
     assert_eq!(count(pool, timmy_local_user.id).await?, 2);
 
     Person::delete(pool, timmy_person.id).await?;

--- a/crates/db_views/local_user_invite/src/impls.rs
+++ b/crates/db_views/local_user_invite/src/impls.rs
@@ -32,7 +32,7 @@ impl LocalUserInviteQuery {
     query = query.filter(local_user_invite::local_user_id.eq(self.local_user_id));
 
     let paginated_query =
-      LocalUserInvite::paginate(query, &self.page_cursor, SortDirection::Asc, pool)
+      LocalUserInvite::paginate(query, &self.page_cursor, SortDirection::Desc, pool)
         .await?
         .then_order_by(key::published_at)
         .then_order_by(key::id);

--- a/crates/db_views/local_user_invite/src/lib.rs
+++ b/crates/db_views/local_user_invite/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod api;
+pub mod impls;

--- a/crates/db_views/local_user_invite/src/lib.rs
+++ b/crates/db_views/local_user_invite/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod api;
+#[cfg(feature = "full")]
 pub mod impls;

--- a/crates/db_views/registration_applications/src/api.rs
+++ b/crates/db_views/registration_applications/src/api.rs
@@ -61,6 +61,8 @@ pub struct Register {
   pub answer: Option<String>,
   /// If this is true the login is valid forever, otherwise it expires after one week.
   pub stay_logged_in: Option<bool>,
+  /// Invitation token
+  pub token: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/crates/db_views/registration_applications/src/impls.rs
+++ b/crates/db_views/registration_applications/src/impls.rs
@@ -263,6 +263,7 @@ mod tests {
         show_score: sara_local_user.show_score,
         show_upvote_percentage: sara_local_user.show_upvote_percentage,
         show_person_votes: sara_local_user.show_person_votes,
+        invited_by_local_user_id: sara_local_user.invited_by_local_user_id,
       },
       creator: Person {
         id: sara_person.id,

--- a/crates/db_views/site/src/api.rs
+++ b/crates/db_views/site/src/api.rs
@@ -168,6 +168,7 @@ pub struct CreateSite {
   pub image_max_upload_size: Option<i32>,
   pub image_allow_video_uploads: Option<bool>,
   pub image_upload_disabled: Option<bool>,
+  pub max_invites_per_user_allowed: Option<i32>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -304,6 +305,7 @@ pub struct EditSite {
   pub image_max_upload_size: Option<i32>,
   pub image_allow_video_uploads: Option<bool>,
   pub image_upload_disabled: Option<bool>,
+  pub max_invites_per_user_allowed: Option<i32>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]

--- a/crates/routes/Cargo.toml
+++ b/crates/routes/Cargo.toml
@@ -58,7 +58,7 @@ prometheus = { version = "0.14.0", features = [
 rss = "2.0.12"
 actix-web-prom = "0.10.0"
 actix-cors = "0.7.1"
-rand = "0.10.0"
+rand = { workspace = true }
 percent-encoding = "2.3.2"
 diesel-uplete.workspace = true
 lemmy_diesel_utils = { workspace = true }

--- a/crates/routes/src/utils/scheduled_tasks.rs
+++ b/crates/routes/src/utils/scheduled_tasks.rs
@@ -30,20 +30,24 @@ use lemmy_db_schema::{
   },
   utils::DELETED_REPLACEMENT_TEXT,
 };
-use lemmy_db_schema_file::schema::{
-  comment,
-  community,
-  community_actions,
-  federation_blocklist,
-  instance,
-  instance_actions,
-  local_site,
-  local_user,
-  person,
-  post,
-  received_activity,
-  sent_activity,
-  site,
+use lemmy_db_schema_file::{
+  enums::LocalUserInviteStatus,
+  schema::{
+    comment,
+    community,
+    community_actions,
+    federation_blocklist,
+    instance,
+    instance_actions,
+    local_site,
+    local_user,
+    local_user_invite,
+    person,
+    post,
+    received_activity,
+    sent_activity,
+    site,
+  },
 };
 use lemmy_db_views_site::SiteView;
 use lemmy_diesel_utils::{
@@ -86,6 +90,7 @@ pub async fn setup(context: Data<LemmyContext>) -> LemmyResult<()> {
   // - Update active daily counts
   // - Expired bans
   // - Expired instance blocks
+  // - Expired invitations
   scheduler.every(CTimeUnits::hour(1)).run(move || {
     let context = context_1.clone();
 
@@ -101,6 +106,10 @@ pub async fn setup(context: Data<LemmyContext>) -> LemmyResult<()> {
       delete_instance_block_when_expired(&mut context.pool())
         .await
         .inspect_err(|e| warn!("Failed to delete expired instance bans: {e}"))
+        .ok();
+      update_invitations_when_expired(&mut context.pool())
+        .await
+        .inspect_err(|e| warn!("Failed to update expired invitations: {e}"))
         .ok();
     }
   });
@@ -547,6 +556,20 @@ async fn delete_instance_block_when_expired(pool: &mut DbPool<'_>) -> LemmyResul
   diesel::delete(
     federation_blocklist::table.filter(federation_blocklist::expires_at.lt(now().nullable())),
   )
+  .execute(conn)
+  .await?;
+  Ok(())
+}
+
+/// Set invitations to Expired
+async fn update_invitations_when_expired(pool: &mut DbPool<'_>) -> LemmyResult<()> {
+  let conn = &mut get_conn(pool).await?;
+  diesel::update(
+    local_user_invite::table
+      .filter(local_user_invite::expires_at.lt(now().nullable()))
+      .filter(local_user_invite::status.eq(LocalUserInviteStatus::Active)),
+  )
+  .set(local_user_invite::status.eq(LocalUserInviteStatus::Expired))
   .execute(conn)
   .await?;
   Ok(())

--- a/crates/routes/src/utils/scheduled_tasks.rs
+++ b/crates/routes/src/utils/scheduled_tasks.rs
@@ -30,24 +30,21 @@ use lemmy_db_schema::{
   },
   utils::DELETED_REPLACEMENT_TEXT,
 };
-use lemmy_db_schema_file::{
-  enums::LocalUserInviteStatus,
-  schema::{
-    comment,
-    community,
-    community_actions,
-    federation_blocklist,
-    instance,
-    instance_actions,
-    local_site,
-    local_user,
-    local_user_invite,
-    person,
-    post,
-    received_activity,
-    sent_activity,
-    site,
-  },
+use lemmy_db_schema_file::schema::{
+  comment,
+  community,
+  community_actions,
+  federation_blocklist,
+  instance,
+  instance_actions,
+  local_site,
+  local_user,
+  local_user_invite,
+  person,
+  post,
+  received_activity,
+  sent_activity,
+  site,
 };
 use lemmy_db_views_site::SiteView;
 use lemmy_diesel_utils::{
@@ -107,9 +104,9 @@ pub async fn setup(context: Data<LemmyContext>) -> LemmyResult<()> {
         .await
         .inspect_err(|e| warn!("Failed to delete expired instance bans: {e}"))
         .ok();
-      update_invitations_when_expired(&mut context.pool())
+      delete_invitations_when_expired(&mut context.pool())
         .await
-        .inspect_err(|e| warn!("Failed to update expired invitations: {e}"))
+        .inspect_err(|e| warn!("Failed to delete expired invitations: {e}"))
         .ok();
     }
   });
@@ -562,14 +559,11 @@ async fn delete_instance_block_when_expired(pool: &mut DbPool<'_>) -> LemmyResul
 }
 
 /// Set invitations to Expired
-async fn update_invitations_when_expired(pool: &mut DbPool<'_>) -> LemmyResult<()> {
+async fn delete_invitations_when_expired(pool: &mut DbPool<'_>) -> LemmyResult<()> {
   let conn = &mut get_conn(pool).await?;
-  diesel::update(
-    local_user_invite::table
-      .filter(local_user_invite::expires_at.lt(now().nullable()))
-      .filter(local_user_invite::status.eq(LocalUserInviteStatus::Active)),
+  diesel::delete(
+    local_user_invite::table.filter(local_user_invite::expires_at.lt(now().nullable())),
   )
-  .set(local_user_invite::status.eq(LocalUserInviteStatus::Expired))
   .execute(conn)
   .await?;
   Ok(())

--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -45,6 +45,8 @@ pub enum LemmyErrorType {
   InstanceIsPrivate,
   /// Password must be between 10 and 60 characters
   InvalidPassword,
+  InvalidInviteToken,
+  InviteAlreadyRevokedOrExhausted,
   SiteDescriptionLengthOverflow,
   HoneypotFailed,
   RegistrationApplicationIsPending,
@@ -82,6 +84,7 @@ pub enum LemmyErrorType {
   CouldntGenerateTotp,
   MissingTotpToken,
   MissingTotpSecret,
+  MissingInviteToken,
   IncorrectTotpToken,
   TotpAlreadyEnabled,
   BlockedUrl,
@@ -98,6 +101,7 @@ pub enum LemmyErrorType {
   /// Thrown when an API call is submitted with more than 1000 array elements, see
   /// [[MAX_API_PARAM_ELEMENTS]]
   TooManyItems,
+  TooManyInvites,
   BanExpirationInPast,
   InvalidUnixTime,
   InvalidBotAction,

--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -46,7 +46,6 @@ pub enum LemmyErrorType {
   /// Password must be between 10 and 60 characters
   InvalidPassword,
   InvalidInviteToken,
-  InviteAlreadyRevokedOrExhausted,
   SiteDescriptionLengthOverflow,
   HoneypotFailed,
   RegistrationApplicationIsPending,

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -54,6 +54,8 @@ pub struct Settings {
   pub json_logging: bool,
   /// Data for loading Lemmy plugins
   pub plugins: Vec<PluginSettings>,
+  /// How many active invite links a user can have
+  pub max_invites_per_user_allowed: Option<u16>,
 }
 
 impl Settings {

--- a/crates/utils/src/settings/structs.rs
+++ b/crates/utils/src/settings/structs.rs
@@ -54,8 +54,6 @@ pub struct Settings {
   pub json_logging: bool,
   /// Data for loading Lemmy plugins
   pub plugins: Vec<PluginSettings>,
-  /// How many active invite links a user can have
-  pub max_invites_per_user_allowed: Option<u16>,
 }
 
 impl Settings {

--- a/migrations/2026-04-16-000000-0000_add_invitation_table/down.sql
+++ b/migrations/2026-04-16-000000-0000_add_invitation_table/down.sql
@@ -6,3 +6,32 @@ ALTER TABLE local_user
 
 DROP TABLE local_user_invite;
 
+-- PostgreSQL doesn't support removing enum values directly, so recreate the type.
+-- First migrate any RequireInvitation rows to Closed.
+UPDATE
+    local_site
+SET
+    registration_mode = 'Closed'
+WHERE
+    registration_mode = 'RequireInvitation';
+
+CREATE TYPE registration_mode_enum_new AS ENUM (
+    'Closed',
+    'RequireApplication',
+    'Open'
+);
+
+ALTER TABLE local_site
+    ALTER COLUMN registration_mode DROP DEFAULT;
+
+ALTER TABLE local_site
+    ALTER COLUMN registration_mode TYPE registration_mode_enum_new
+    USING registration_mode::text::registration_mode_enum_new;
+
+DROP TYPE registration_mode_enum;
+
+ALTER TYPE registration_mode_enum_new RENAME TO registration_mode_enum;
+
+ALTER TABLE local_site
+    ALTER COLUMN registration_mode SET DEFAULT 'RequireApplication';
+

--- a/migrations/2026-04-16-000000-0000_add_invitation_table/down.sql
+++ b/migrations/2026-04-16-000000-0000_add_invitation_table/down.sql
@@ -1,3 +1,7 @@
-ALTER TABLE local_user DROP COLUMN invited_by;
+ALTER TABLE local_user
+    DROP COLUMN invited_by;
+
 DROP TABLE local_user_invite;
+
 DROP TYPE local_user_invitate_status_enum;
+

--- a/migrations/2026-04-16-000000-0000_add_invitation_table/down.sql
+++ b/migrations/2026-04-16-000000-0000_add_invitation_table/down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE local_user DROP COLUMN invited_by;
+DROP TABLE local_user_invite;
+DROP TYPE local_user_invitate_status_enum;

--- a/migrations/2026-04-16-000000-0000_add_invitation_table/down.sql
+++ b/migrations/2026-04-16-000000-0000_add_invitation_table/down.sql
@@ -3,5 +3,3 @@ ALTER TABLE local_user
 
 DROP TABLE local_user_invite;
 
-DROP TYPE local_user_invitate_status_enum;
-

--- a/migrations/2026-04-16-000000-0000_add_invitation_table/down.sql
+++ b/migrations/2026-04-16-000000-0000_add_invitation_table/down.sql
@@ -1,5 +1,8 @@
+ALTER TABLE local_site
+    DROP COLUMN max_invites_per_user_allowed;
+
 ALTER TABLE local_user
-    DROP COLUMN invited_by;
+    DROP COLUMN invited_by_local_user_id;
 
 DROP TABLE local_user_invite;
 

--- a/migrations/2026-04-16-000000-0000_add_invitation_table/up.sql
+++ b/migrations/2026-04-16-000000-0000_add_invitation_table/up.sql
@@ -1,17 +1,24 @@
-ALTER TYPE registration_mode_enum ADD VALUE 'RequireInvitation';
+ALTER TYPE registration_mode_enum
+    ADD VALUE 'RequireInvitation';
 
-CREATE TYPE local_user_invite_status_enum AS ENUM ('Active', 'Revoked', 'Exhausted', 'Expired');
-
-CREATE TABLE local_user_invite (
-  id          serial PRIMARY KEY,
-  token text NOT NULL UNIQUE,
-  local_user_id  int NOT NULL REFERENCES local_user (id) ON DELETE CASCADE,
-  max_uses    int,
-  uses_count  int NOT NULL DEFAULT 0,
-  expires_at  timestamptz,
-  status      local_user_invite_status_enum NOT NULL DEFAULT 'Active',
-  published_at timestamptz NOT NULL DEFAULT now()
+CREATE TYPE local_user_invite_status_enum AS ENUM (
+    'Active',
+    'Revoked',
+    'Exhausted',
+    'Expired'
 );
 
-ALTER TABLE local_user ADD COLUMN invited_by_local_user_id int REFERENCES local_user (id) ON DELETE SET NULL;
+CREATE TABLE local_user_invite (
+    id serial PRIMARY KEY,
+    token text NOT NULL UNIQUE,
+    local_user_id int NOT NULL REFERENCES local_user (id) ON DELETE CASCADE,
+    max_uses int,
+    uses_count int NOT NULL DEFAULT 0,
+    expires_at timestamptz,
+    status local_user_invite_status_enum NOT NULL DEFAULT 'Active',
+    published_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE local_user
+    ADD COLUMN invited_by_local_user_id int REFERENCES local_user (id) ON DELETE SET NULL;
 

--- a/migrations/2026-04-16-000000-0000_add_invitation_table/up.sql
+++ b/migrations/2026-04-16-000000-0000_add_invitation_table/up.sql
@@ -1,0 +1,17 @@
+ALTER TYPE registration_mode_enum ADD VALUE 'RequireInvitation';
+
+CREATE TYPE local_user_invite_status_enum AS ENUM ('Active', 'Revoked', 'Exhausted', 'Expired');
+
+CREATE TABLE local_user_invite (
+  id          serial PRIMARY KEY,
+  token text NOT NULL UNIQUE,
+  local_user_id  int NOT NULL REFERENCES local_user (id) ON DELETE CASCADE,
+  max_uses    int,
+  uses_count  int NOT NULL DEFAULT 0,
+  expires_at  timestamptz,
+  status      local_user_invite_status_enum NOT NULL DEFAULT 'Active',
+  published_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE local_user ADD COLUMN invited_by_local_user_id int REFERENCES local_user (id) ON DELETE SET NULL;
+

--- a/migrations/2026-04-16-000000-0000_add_invitation_table/up.sql
+++ b/migrations/2026-04-16-000000-0000_add_invitation_table/up.sql
@@ -14,3 +14,6 @@ CREATE TABLE local_user_invite (
 ALTER TABLE local_user
     ADD COLUMN invited_by_local_user_id int REFERENCES local_user (id) ON DELETE SET NULL;
 
+ALTER TABLE local_site
+    ADD COLUMN max_invites_per_user_allowed int NOT NULL DEFAULT 10;
+

--- a/migrations/2026-04-16-000000-0000_add_invitation_table/up.sql
+++ b/migrations/2026-04-16-000000-0000_add_invitation_table/up.sql
@@ -11,8 +11,12 @@ CREATE TABLE local_user_invite (
     published_at timestamptz NOT NULL DEFAULT now()
 );
 
+CREATE INDEX idx_local_user_invite_local_user_id ON local_user_invite (local_user_id);
+
 ALTER TABLE local_user
     ADD COLUMN invited_by_local_user_id int REFERENCES local_user (id) ON DELETE SET NULL;
+
+CREATE INDEX idx_local_user_invited_by_local_user_id ON local_user (invited_by_local_user_id);
 
 ALTER TABLE local_site
     ADD COLUMN max_invites_per_user_allowed int NOT NULL DEFAULT 10;

--- a/migrations/2026-04-16-000000-0000_add_invitation_table/up.sql
+++ b/migrations/2026-04-16-000000-0000_add_invitation_table/up.sql
@@ -1,13 +1,6 @@
 ALTER TYPE registration_mode_enum
     ADD VALUE 'RequireInvitation';
 
-CREATE TYPE local_user_invite_status_enum AS ENUM (
-    'Active',
-    'Revoked',
-    'Exhausted',
-    'Expired'
-);
-
 CREATE TABLE local_user_invite (
     id serial PRIMARY KEY,
     token text NOT NULL UNIQUE,
@@ -15,7 +8,6 @@ CREATE TABLE local_user_invite (
     max_uses int,
     uses_count int NOT NULL DEFAULT 0,
     expires_at timestamptz,
-    status local_user_invite_status_enum NOT NULL DEFAULT 'Active',
     published_at timestamptz NOT NULL DEFAULT now()
 );
 


### PR DESCRIPTION
## Summary

Adds an invite-link-based registration system to Lemmy, giving instance admins a new way to control who can register.

- New `RequireInvitation` registration mode — admins can set the instance to require a valid invite link for registration (alongside the existing `Open`, `RequireApplication`, and `Closed` modes).
- `local_user_invite` table — stores invite links with optional `max_uses`, `expires_at`, a `uses_count`, and a `status` (`Active`, `Revoked`, `Exhausted`, `Expired`). Each invite is tied to the user who created it.
- `invited_by_local_user_id` column on `local_user` — tracks who invited each user at registration time.

- Three new API endpoints:
  - `POST /api/v4/account/invite` — any authenticated user can create an invite link (with optional use cap and expiry).
  - `GET /api/v4/account/invite/list` — list your own invitations; 
  - `DELETE /api/v4/account/invite` — revoke one of your own active invitations; returns an error if already revoked or exhausted.
- Per-user invite cap — new `max_invites_per_user_allowed` config setting (`optional u16`) limits how many active invite links a **non-admin** user can hold at once. **Admins bypass this limit**.
- Scheduled expiry task — the hourly scheduled task now also sets `Active` invites whose `expires_at` has passed to `Expired`.

## Database migration                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
`migrations/2026-04-16-000000-0000_add_invitation_table/up.sql`:                                                                                                                                                                                                                                                                                                                                                                                                                             
- Adds `RequireInvitation` value to the `registration_mode_enum type`.
- Creates the `local_user_invite_status_enum` type and `local_user_invite` table.                                                                                                                                                                                                                                                                                                                                                                                                              
- Adds `invited_by_local_user_id` column to `local_user`.

## New error types                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
| Error | When |                                                                                                                                                                                                                      
|---|---|                                                                                                                                                                                                                             
| `MissingInviteToken` |`RequireInvitation` mode but no `invite_link` supplied at registration |
| `InvalidInviteToken` |Link not found, or its status is not `Active` / it is `Expired`/`Exhausted` |                                                                                                                                     
| `TooManyInvites` |Non-admin user exceeds `max_invites_per_user_allowed` |   

## Testing                                                                                                                                                                                                                               
                
- Set `registration_mode` to `RequireInvitation` via the site settings.                                                                                                                                                                   
- Create an invite link as a logged-in user (`POST /api/v3/invite`). Verify the response includes a `invite_link` URL of the form `{scheme}{hostname}/signup?token={token}`.
- Register a new account using the invite link. Confirm `uses_count` increments and `invited_by_local_user_id` is set on the new `local_user` row.                                                                                          
- Create an invite with `max_uses: 1`, use it once, and verify the status becomes `Exhausted` and a second registration attempt returns `InvalidInviteLink`.                                                                                
- Create an invite with a past `expires_at`, wait for (or manually trigger) the hourly task, and verify status becomes `Expired`.                                                                                                         
- Revoke an active invite and confirm subsequent registration attempts return `InvalidInviteToken`.                                                                                                                                      
- Attempt to revoke an already-revoked or exhausted invite and confirm `InviteAlreadyRevokedOrExhausted` is returned.                                                                                                               
- Set `max_invites_per_user_allowed: 2` in config, create 2 invites as a regular user, and confirm the third attempt returns `TooManyInvites`. Confirm an admin user is not rate-limited.
- Confirm other registration modes are unaffected by this change.

## Config
// How many active invite links a non-admin user may hold at once.
// Omit or set to null for no limit.
```
max_invites_per_user_allowed: 10
```
