### PR TITLE
Proper fix for nested comment fetch (fixes #6435)

### DIFF
--- a/crates/apub/src/objects/comment.rs
+++ b/crates/apub/src/objects/comment.rs
@@ -18,13 +18,7 @@ use activitypub_federation::{
 use chrono::{DateTime, Utc};
 use lemmy_api_common::{
   context::LemmyContext,
-  utils::{
-    check_comment_depth,
-    get_url_blocklist,
-    is_mod_or_admin,
-    local_site_opt_to_slur_regex,
-    process_markdown,
-  },
+  utils::{get_url_blocklist, is_mod_or_admin, local_site_opt_to_slur_regex, process_markdown},
 };
 use lemmy_db_schema::{
   source::{
@@ -42,7 +36,6 @@ use lemmy_utils::{
   utils::markdown::markdown_to_html,
 };
 use std::ops::Deref;
-use tokio::spawn;
 use url::Url;
 
 #[derive(Clone, Debug)]

--- a/crates/apub/src/objects/comment.rs
+++ b/crates/apub/src/objects/comment.rs
@@ -164,7 +164,7 @@ impl Object for ApubComment {
     ))
     .await?;
 
-    let (post, _) = note.get_parents(&context).await?;
+    let (post, _) = note.get_parents(context).await?;
 
     let creator = Box::pin(note.attributed_to.dereference(context)).await?;
     let is_mod_or_admin = is_mod_or_admin(&mut context.pool(), &creator, community.id)

--- a/crates/apub/src/objects/comment.rs
+++ b/crates/apub/src/objects/comment.rs
@@ -171,16 +171,7 @@ impl Object for ApubComment {
     ))
     .await?;
 
-    // When fetching a deeply nested comment we may have also have to fetch dozens of parent
-    // comments which can easily result in stack overflow. So we launch a new task instead
-    // which gives a new stack and avoids overflow. This was successfully tested with a comment
-    // nested 200 deep (max in production is 50).
-    let note2 = note.clone();
-    let context2 = context.reset_request_count();
-    let (post, parent_comment) = spawn(async move { note2.get_parents(&context2).await }).await??;
-    if let Some(c) = &parent_comment {
-      check_comment_depth(c)?;
-    }
+    let (post, _) = note.get_parents(&context).await?;
 
     let creator = Box::pin(note.attributed_to.dereference(context)).await?;
     let is_mod_or_admin = is_mod_or_admin(&mut context.pool(), &creator, community.id)

--- a/crates/apub/src/protocol/objects/note.rs
+++ b/crates/apub/src/protocol/objects/note.rs
@@ -19,7 +19,7 @@ use activitypub_federation::{
   },
 };
 use chrono::{DateTime, Utc};
-use lemmy_api_common::context::LemmyContext;
+use lemmy_api_common::{context::LemmyContext, utils::check_comment_depth};
 use lemmy_db_schema::{
   source::{community::Community, post::Post},
   traits::Crud,
@@ -27,6 +27,7 @@ use lemmy_db_schema::{
 use lemmy_utils::{error::LemmyResult, LemmyErrorType, MAX_COMMENT_DEPTH_LIMIT};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
+use tokio::spawn;
 use url::Url;
 
 #[skip_serializing_none]
@@ -63,21 +64,18 @@ impl Note {
     &self,
     context: &Data<LemmyContext>,
   ) -> LemmyResult<(ApubPost, Option<ApubComment>)> {
-    // We use recursion here to fetch the entire comment chain up to the top-level parent. This is
-    // necessary because we need to know the post and parent comment in order to insert a new
-    // comment. However it can also lead to stack overflow when fetching many comments recursively.
-    // To avoid this we check the request count against max comment depth, which based on testing
-    // can be handled without risking stack overflow. This is not a perfect solution, because in
-    // some cases we have to fetch user profiles too, and reach the limit after only 25 comments
-    // or so.
-    // A cleaner solution would be converting the recursion into a loop, but that is tricky.
-    if context.request_count() > MAX_COMMENT_DEPTH_LIMIT as u32 {
-      Err(LemmyErrorType::MaxCommentDepthReached)?;
-    }
-    let parent = self.in_reply_to.dereference(context).await?;
+    // When fetching a deeply nested comment we may have also have to fetch dozens of parent
+    // comments which can easily result in stack overflow. So we launch a new task instead
+    // which gives a new stack and avoids overflow. This was successfully tested with a comment
+    // nested 200 deep (max in production is 50).
+    let self2 = self.clone();
+    let context2 = context.reset_request_count();
+    let parent = spawn(async move { self2.in_reply_to.dereference(&context2).await }).await??;
+
     match parent {
       PostOrComment::Post(p) => Ok((p.clone(), None)),
       PostOrComment::Comment(c) => {
+        check_comment_depth(&c)?;
         let post_id = c.post_id;
         let post = Post::read(&mut context.pool(), post_id)
           .await?

--- a/crates/apub/src/protocol/objects/note.rs
+++ b/crates/apub/src/protocol/objects/note.rs
@@ -24,7 +24,7 @@ use lemmy_db_schema::{
   source::{community::Community, post::Post},
   traits::Crud,
 };
-use lemmy_utils::{error::LemmyResult, LemmyErrorType, MAX_COMMENT_DEPTH_LIMIT};
+use lemmy_utils::{error::LemmyResult, LemmyErrorType};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use tokio::spawn;


### PR DESCRIPTION
Tested by fetching `https://hexbear.net/comment/7100053` which is nested 50 deep. On the release branch it fails with the same stack overflow as reported in the issue. After this change it is working.

Need to make this change on main branch too.