### PR TITLE
Proper fix for nested comment fetch

### DIFF
--- a/crates/apub/objects/src/objects/comment.rs
+++ b/crates/apub/objects/src/objects/comment.rs
@@ -28,13 +28,7 @@ use chrono::{DateTime, Utc};
 use lemmy_api_utils::{
   context::LemmyContext,
   plugins::{plugin_hook_after, plugin_hook_before},
-  utils::{
-    check_comment_depth,
-    check_is_mod_or_admin,
-    get_url_blocklist,
-    process_markdown,
-    slur_regex,
-  },
+  utils::{check_is_mod_or_admin, get_url_blocklist, process_markdown, slur_regex},
 };
 use lemmy_db_schema::source::{
   comment::{Comment, CommentInsertForm, CommentUpdateForm},
@@ -49,7 +43,6 @@ use lemmy_utils::{
   utils::markdown::markdown_to_html,
 };
 use std::ops::Deref;
-use tokio::spawn;
 use url::Url;
 
 #[derive(Clone, Debug)]
@@ -181,16 +174,7 @@ impl Object for ApubComment {
     ))
     .await?;
 
-    // When fetching a deeply nested comment we may have also have to fetch dozens of parent
-    // comments which can easily result in stack overflow. So we launch a new task instead
-    // which gives a new stack and avoids overflow. This was successfully tested with a comment
-    // nested 200 deep (max in production is 50).
-    let note2 = note.clone();
-    let context2 = context.clone();
-    let (post, parent_comment) = spawn(async move { note2.get_parents(&context2).await }).await??;
-    if let Some(c) = &parent_comment {
-      check_comment_depth(c)?;
-    }
+    let (post, parent_comment) = note.get_parents(&context).await?;
 
     let creator = Box::pin(note.attributed_to.dereference(context)).await?;
 

--- a/crates/apub/objects/src/objects/comment.rs
+++ b/crates/apub/objects/src/objects/comment.rs
@@ -174,7 +174,7 @@ impl Object for ApubComment {
     ))
     .await?;
 
-    let (post, parent_comment) = note.get_parents(&context).await?;
+    let (post, parent_comment) = note.get_parents(context).await?;
 
     let creator = Box::pin(note.attributed_to.dereference(context)).await?;
 

--- a/crates/apub/objects/src/protocol/note.rs
+++ b/crates/apub/objects/src/protocol/note.rs
@@ -19,7 +19,7 @@ use activitypub_federation::{
   },
 };
 use chrono::{DateTime, Utc};
-use lemmy_api_utils::context::LemmyContext;
+use lemmy_api_utils::{context::LemmyContext, utils::check_comment_depth};
 use lemmy_db_schema::source::{community::Community, post::Post};
 use lemmy_diesel_utils::traits::Crud;
 use lemmy_utils::{
@@ -80,9 +80,6 @@ impl Note {
     // `async fn foo(...) -> T` to `fn foo(...) -> impl Future<Output = T>`. Between each level of
     // recursion, there must be the beginning of at least one `async` block or `async fn`,
     // otherwise there might be multiple levels of recursion before the first poll.
-    if context.request_count() > MAX_COMMENT_DEPTH_LIMIT.try_into()? {
-      return Err(LemmyErrorType::MaxCommentDepthReached.into());
-    }
     let parent = tokio::spawn({
       let in_reply_to = self.in_reply_to.clone();
       let context = context.clone();
@@ -94,6 +91,7 @@ impl Note {
     match parent {
       PostOrComment::Left(p) => Ok((p.clone(), None)),
       PostOrComment::Right(c) => {
+        check_comment_depth(&c)?;
         let post_id = c.post_id;
         let post = Post::read(&mut context.pool(), post_id).await?;
         Ok((post.into(), Some(c.clone())))

--- a/crates/apub/objects/src/protocol/note.rs
+++ b/crates/apub/objects/src/protocol/note.rs
@@ -22,10 +22,7 @@ use chrono::{DateTime, Utc};
 use lemmy_api_utils::{context::LemmyContext, utils::check_comment_depth};
 use lemmy_db_schema::source::{community::Community, post::Post};
 use lemmy_diesel_utils::traits::Crud;
-use lemmy_utils::{
-  MAX_COMMENT_DEPTH_LIMIT,
-  error::{LemmyErrorType, LemmyResult},
-};
+use lemmy_utils::error::LemmyResult;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use url::Url;


### PR DESCRIPTION
Similar adjustments as https://github.com/LemmyNet/lemmy/pull/6451 for main branch. Can successfully fetch `https://hexbear.net/comment/7100053` now.