### PR TITLE
Implement search pagination (fixes #6434)

### DIFF
--- a/crates/api/api/src/federation/search.rs
+++ b/crates/api/api/src/federation/search.rs
@@ -234,8 +234,11 @@ fn from_single_cursor(
         .collect::<Vec<_>>();
       if vec.len() == 2 {
         // if `community_or_creator_included` there are only two cursors
-        res[0] = vec[0].clone();
-        res[1] = vec[1].clone();
+        let v: Result<[Option<PaginationCursor>; 2], _> = vec.try_into();
+        if let Ok(v) = v {
+          res[0] = v[0].clone();
+          res[1] = v[1].clone();
+        }
       } else {
         // otherwise there should be 5 cursors
         let v: Result<[Option<PaginationCursor>; 5], _> = vec.try_into();

--- a/crates/api/api/src/federation/search.rs
+++ b/crates/api/api/src/federation/search.rs
@@ -43,12 +43,13 @@ pub async fn search(
     .ok();
 
   let search_term = Some(data.search_term);
+  let search_type = data.type_.unwrap_or_default();
   let listing_type = Some(ListingType::All);
   let search_title_only = data.title_only;
   let time_range_seconds = data.time_range_seconds;
   let search_url_only = data.post_url_only;
   let show_nsfw = data.show_nsfw;
-  let mut page_cursors = data.page_cursor.iter().flat_map(|c| c.split(","));
+  let page_cursors = from_single_cursor(data.page_cursor, search_type);
   let limit = data.limit;
 
   let community_id = resolve_community_identifier(
@@ -79,7 +80,7 @@ pub async fn search(
     time_range_seconds,
     search_url_only,
     show_nsfw,
-    page_cursor: page_cursors.next().map(Into::into),
+    page_cursor: page_cursors[0].clone(),
     limit,
     ..Default::default()
   };
@@ -92,7 +93,7 @@ pub async fn search(
     creator_id,
     time_range_seconds,
     sort: Some(CommentSortType::New),
-    page_cursor: page_cursors.next().map(Into::into),
+    page_cursor: page_cursors[1].clone(),
     limit,
     ..Default::default()
   };
@@ -103,7 +104,7 @@ pub async fn search(
     local_user,
     listing_type: Some(PersonListingType::All),
     sort: Some(PersonSortType::New),
-    page_cursor: page_cursors.next().map(Into::into),
+    page_cursor: page_cursors[2].clone(),
     limit,
   };
 
@@ -115,7 +116,7 @@ pub async fn search(
     time_range_seconds,
     show_nsfw,
     sort: Some(CommunitySortType::New),
-    page_cursor: page_cursors.next().map(Into::into),
+    page_cursor: page_cursors[3].clone(),
     limit,
     ..Default::default()
   };
@@ -128,7 +129,7 @@ pub async fn search(
     time_range_seconds,
     listing_type: Some(MultiCommunityListingType::All),
     sort: Some(MultiCommunitySortType::New),
-    page_cursor: page_cursors.next().map(Into::into),
+    page_cursor: page_cursors[4].clone(),
     limit,
     ..Default::default()
   };
@@ -142,7 +143,6 @@ pub async fn search(
   let mut next_page = vec![];
   let mut prev_page = vec![];
 
-  let search_type = data.type_.unwrap_or_default();
   let search_all = search_type == SearchType::All;
 
   // If the community or creator is included and it's All search, only search posts and comments
@@ -206,11 +206,49 @@ pub async fn search(
   Ok(Json(res))
 }
 
-fn to_single_cursor(c: Vec<Option<PaginationCursor>>) -> Option<String> {
-  let x = c.into_iter().flatten().collect::<Vec<_>>();
+fn to_single_cursor(cursors: Vec<Option<PaginationCursor>>) -> Option<String> {
+  let x = cursors.into_iter().flatten().collect::<Vec<_>>();
   if x.is_empty() {
     None
   } else {
     Some(x.into_iter().map(|c| c.0).join(","))
   }
+}
+
+fn from_single_cursor(
+  cursor: Option<String>,
+  search_type: SearchType,
+) -> [Option<PaginationCursor>; 5] {
+  use SearchType::*;
+  let mut res = [None, None, None, None, None];
+  if cursor.is_none() {
+    return res;
+  };
+
+  match search_type {
+    All => {
+      let vec = cursor
+        .iter()
+        .flat_map(|c| c.split(","))
+        .map(|c| Some(c.to_string().into()))
+        .collect::<Vec<_>>();
+      if vec.len() == 2 {
+        // if `community_or_creator_included` there are only two cursors
+        res[0] = vec[0].clone();
+        res[1] = vec[1].clone();
+      } else {
+        // otherwise there should be 5 cursors
+        let v: Result<[Option<PaginationCursor>; 5], _> = vec.try_into();
+        if let Ok(v) = v {
+          res = v;
+        }
+      }
+    }
+    Posts => res[0] = cursor.map(Into::into),
+    Comments => res[1] = cursor.map(Into::into),
+    Users => res[2] = cursor.map(Into::into),
+    Communities => res[3] = cursor.map(Into::into),
+    MultiCommunities => res[4] = cursor.map(Into::into),
+  };
+  res
 }

--- a/crates/api/api/src/federation/search.rs
+++ b/crates/api/api/src/federation/search.rs
@@ -48,7 +48,7 @@ pub async fn search(
   let time_range_seconds = data.time_range_seconds;
   let search_url_only = data.post_url_only;
   let show_nsfw = data.show_nsfw;
-  let mut page_cursors = data.page_cursor.iter().map(|c| c.split(",")).flatten();
+  let mut page_cursors = data.page_cursor.iter().flat_map(|c| c.split(","));
   let limit = data.limit;
 
   let community_id = resolve_community_identifier(
@@ -105,7 +105,6 @@ pub async fn search(
     sort: Some(PersonSortType::New),
     page_cursor: page_cursors.next().map(Into::into),
     limit,
-    ..Default::default()
   };
 
   let communities_query = CommunityQuery {
@@ -151,49 +150,46 @@ pub async fn search(
     data.community_id.is_some() || data.community_name.is_some() || data.creator_id.is_some();
   let search_all_no_community_or_creator = search_all && !community_or_creator_included;
 
-  if search_type == SearchType::Posts || search_all {
-    if let Ok(x) = posts_query
+  if (search_type == SearchType::Posts || search_all)
+    && let Ok(x) = posts_query
       .list(&mut context.pool(), &site, &local_site)
       .await
-    {
-      posts = x.items;
-      next_page.push(x.next_page);
-      prev_page.push(x.prev_page);
-    }
+  {
+    posts = x.items;
+    next_page.push(x.next_page);
+    prev_page.push(x.prev_page);
   }
-  if search_type == SearchType::Comments || search_all {
-    if let Ok(x) = comments_query
+  if (search_type == SearchType::Comments || search_all)
+    && let Ok(x) = comments_query
       .list(&mut context.pool(), &site, &local_site)
       .await
-    {
-      comments = x.items;
-      next_page.push(x.next_page);
-      prev_page.push(x.prev_page);
-    }
+  {
+    comments = x.items;
+    next_page.push(x.next_page);
+    prev_page.push(x.prev_page);
   }
-  if search_type == SearchType::Communities || search_all_no_community_or_creator {
-    if let Ok(x) = communities_query
+  if (search_type == SearchType::Communities || search_all_no_community_or_creator)
+    && let Ok(x) = communities_query
       .list(&mut context.pool(), &site, &local_site)
       .await
-    {
-      communities = x.items;
-      next_page.push(x.next_page);
-      prev_page.push(x.prev_page);
-    }
+  {
+    communities = x.items;
+    next_page.push(x.next_page);
+    prev_page.push(x.prev_page);
   }
-  if search_type == SearchType::Users || search_all_no_community_or_creator {
-    if let Ok(x) = persons_query.list(&site, &mut context.pool()).await {
-      persons = x.items;
-      next_page.push(x.next_page);
-      prev_page.push(x.prev_page);
-    }
+  if (search_type == SearchType::Users || search_all_no_community_or_creator)
+    && let Ok(x) = persons_query.list(&site, &mut context.pool()).await
+  {
+    persons = x.items;
+    next_page.push(x.next_page);
+    prev_page.push(x.prev_page);
   }
-  if search_type == SearchType::MultiCommunities || search_all_no_community_or_creator {
-    if let Ok(x) = multi_communities_query.list(&mut context.pool()).await {
-      multi_communities = x.items;
-      next_page.push(x.next_page);
-      prev_page.push(x.prev_page);
-    }
+  if (search_type == SearchType::MultiCommunities || search_all_no_community_or_creator)
+    && let Ok(x) = multi_communities_query.list(&mut context.pool()).await
+  {
+    multi_communities = x.items;
+    next_page.push(x.next_page);
+    prev_page.push(x.prev_page);
   }
 
   let res = SearchResponse {

--- a/crates/api/api/src/federation/search.rs
+++ b/crates/api/api/src/federation/search.rs
@@ -4,6 +4,7 @@ use crate::federation::{
 };
 use activitypub_federation::config::Data;
 use actix_web::web::{Json, Query};
+use itertools::Itertools;
 use lemmy_api_utils::{context::LemmyContext, utils::check_private_instance};
 use lemmy_db_schema::{
   CommunitySortType,
@@ -23,6 +24,7 @@ use lemmy_db_views_site::{
   SiteView,
   api::{Search, SearchResponse},
 };
+use lemmy_diesel_utils::pagination::PaginationCursor;
 use lemmy_utils::error::LemmyResult;
 
 pub async fn search(
@@ -46,6 +48,7 @@ pub async fn search(
   let time_range_seconds = data.time_range_seconds;
   let search_url_only = data.post_url_only;
   let show_nsfw = data.show_nsfw;
+  let mut page_cursors = data.page_cursor.iter().map(|c| c.split(",")).flatten();
   let limit = data.limit;
 
   let community_id = resolve_community_identifier(
@@ -76,6 +79,7 @@ pub async fn search(
     time_range_seconds,
     search_url_only,
     show_nsfw,
+    page_cursor: page_cursors.next().map(Into::into),
     limit,
     ..Default::default()
   };
@@ -87,8 +91,9 @@ pub async fn search(
     community_id,
     creator_id,
     time_range_seconds,
-    limit,
     sort: Some(CommentSortType::New),
+    page_cursor: page_cursors.next().map(Into::into),
+    limit,
     ..Default::default()
   };
 
@@ -96,9 +101,10 @@ pub async fn search(
     search_term: search_term.clone(),
     search_title_only,
     local_user,
-    limit,
     listing_type: Some(PersonListingType::All),
     sort: Some(PersonSortType::New),
+    page_cursor: page_cursors.next().map(Into::into),
+    limit,
     ..Default::default()
   };
 
@@ -109,8 +115,9 @@ pub async fn search(
     listing_type,
     time_range_seconds,
     show_nsfw,
-    limit,
     sort: Some(CommunitySortType::New),
+    page_cursor: page_cursors.next().map(Into::into),
+    limit,
     ..Default::default()
   };
 
@@ -120,9 +127,10 @@ pub async fn search(
     creator_id,
     local_user,
     time_range_seconds,
-    limit,
     listing_type: Some(MultiCommunityListingType::All),
     sort: Some(MultiCommunitySortType::New),
+    page_cursor: page_cursors.next().map(Into::into),
+    limit,
     ..Default::default()
   };
 
@@ -132,50 +140,51 @@ pub async fn search(
   let mut persons = Vec::new();
   let mut multi_communities = Vec::new();
 
-  match data.type_.unwrap_or_default() {
-    SearchType::Posts => {
-      posts = posts_query
-        .list(&mut context.pool(), &site, &local_site)
-        .await?
-        .items;
-    }
-    SearchType::Comments => {
-      comments = comments_query.list(&site, &mut context.pool()).await?.items;
-    }
-    SearchType::Communities => {
-      communities = communities_query
-        .list(&site, &mut context.pool())
-        .await?
-        .items;
-    }
-    SearchType::Users => {
-      persons = persons_query.list(&site, &mut context.pool()).await?.items;
-    }
-    SearchType::MultiCommunities => {
-      multi_communities = multi_communities_query
-        .list(&mut context.pool())
-        .await?
-        .items;
-    }
-    SearchType::All => {
-      // If the community or creator is included, dont search communities or users
-      let community_or_creator_included =
-        data.community_id.is_some() || data.community_name.is_some(); // || data.creator_id.is_some();
+  let mut next_page = vec![];
+  let mut prev_page = vec![];
 
-      posts = posts_query
-        .list(&mut context.pool(), &site, &local_site)
-        .await?
-        .items;
+  let search_type = data.type_.unwrap_or_default();
+  let search_all = search_type == SearchType::All;
 
-      comments = comments_query.list(&site, &mut context.pool()).await?.items;
+  // If the community or creator is included and it's All search, only search posts and comments
+  let community_or_creator_included =
+    data.community_id.is_some() || data.community_name.is_some() || data.creator_id.is_some();
+  let search_all_no_community_or_creator = search_all && !community_or_creator_included;
 
-      if !community_or_creator_included {
-        communities = communities_query
-          .list(&site, &mut context.pool())
-          .await?
-          .items;
-        persons = persons_query.list(&site, &mut context.pool()).await?.items;
-      };
+  if search_type == SearchType::Posts || search_all {
+    let x = posts_query
+      .list(&mut context.pool(), &site, &local_site)
+      .await?;
+    posts = x.items;
+    next_page.push(x.next_page);
+    prev_page.push(x.prev_page);
+  }
+  if search_type == SearchType::Comments || search_all {
+    if let Ok(x) = comments_query.list(&site, &mut context.pool()).await {
+      comments = x.items;
+      next_page.push(x.next_page);
+      prev_page.push(x.prev_page);
+    }
+  }
+  if search_type == SearchType::Communities || search_all_no_community_or_creator {
+    if let Ok(x) = communities_query.list(&site, &mut context.pool()).await {
+      communities = x.items;
+      next_page.push(x.next_page);
+      prev_page.push(x.prev_page);
+    }
+  }
+  if search_type == SearchType::Users || search_all_no_community_or_creator {
+    if let Ok(x) = persons_query.list(&site, &mut context.pool()).await {
+      persons = x.items;
+      next_page.push(x.next_page);
+      prev_page.push(x.prev_page);
+    }
+  }
+  if search_type == SearchType::MultiCommunities || search_all_no_community_or_creator {
+    if let Ok(x) = multi_communities_query.list(&mut context.pool()).await {
+      multi_communities = x.items;
+      next_page.push(x.next_page);
+      prev_page.push(x.prev_page);
     }
   }
 
@@ -186,7 +195,18 @@ pub async fn search(
     communities,
     multi_communities,
     persons,
+    prev_page: to_single_cursor(prev_page),
+    next_page: to_single_cursor(next_page),
   };
 
   Ok(Json(res))
+}
+
+fn to_single_cursor(c: Vec<Option<PaginationCursor>>) -> Option<String> {
+  let x = c.into_iter().flatten().collect::<Vec<_>>();
+  if x.is_empty() {
+    None
+  } else {
+    Some(x.into_iter().map(|c| c.0).join(","))
+  }
 }

--- a/crates/db_schema/src/source/comment.rs
+++ b/crates/db_schema/src/source/comment.rs
@@ -68,6 +68,7 @@ pub struct Comment {
   /// Whether the comment is locked.
   pub locked: bool,
   /// This field is a dupe of post.community_id, but necessary for join performance.
+  #[serde(skip)]
   pub community_id: CommunityId,
 }
 

--- a/crates/db_schema/src/source/notification.rs
+++ b/crates/db_schema/src/source/notification.rs
@@ -31,7 +31,9 @@ pub struct Notification {
   pub private_message_id: Option<PrivateMessageId>,
   pub modlog_id: Option<ModlogId>,
   pub creator_id: PersonId,
+  #[serde(skip)]
   pub instance_id: Option<InstanceId>,
+  #[serde(skip)]
   pub community_id: Option<CommunityId>,
 }
 

--- a/crates/db_views/site/src/api.rs
+++ b/crates/db_views/site/src/api.rs
@@ -704,6 +704,7 @@ pub struct Search {
   pub post_url_only: Option<bool>,
   /// If true, then show the nsfw posts (even if your user setting is to hide them)
   pub show_nsfw: Option<bool>,
+  pub page_cursor: Option<String>,
   pub limit: Option<i64>,
 }
 
@@ -723,6 +724,8 @@ pub struct SearchResponse {
   pub communities: Vec<CommunityView>,
   pub persons: Vec<PersonView>,
   pub multi_communities: Vec<MultiCommunityView>,
+  pub prev_page: Option<String>,
+  pub next_page: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]

--- a/crates/diesel_utils/src/pagination.rs
+++ b/crates/diesel_utils/src/pagination.rs
@@ -133,6 +133,7 @@ pub trait PaginationCursorConversion {
 /// Do not attempt to parse or modify the cursor string. The format is internal and may change in
 /// minor Lemmy versions.
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(not(feature = "full"), derive(Debug))]
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
 pub struct PaginationCursor(pub String);
@@ -160,6 +161,7 @@ impl From<String> for PaginationCursor {
   }
 }
 
+#[cfg(feature = "full")]
 impl Debug for PaginationCursor {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     f.debug_tuple("PaginationCursor")

--- a/crates/diesel_utils/src/pagination.rs
+++ b/crates/diesel_utils/src/pagination.rs
@@ -154,9 +154,9 @@ impl PaginationCursor {
   }
 }
 
-impl From<&str> for PaginationCursor {
-  fn from(value: &str) -> Self {
-    PaginationCursor(value.to_string())
+impl From<String> for PaginationCursor {
+  fn from(value: String) -> Self {
+    PaginationCursor(value)
   }
 }
 

--- a/crates/diesel_utils/src/pagination.rs
+++ b/crates/diesel_utils/src/pagination.rs
@@ -132,10 +132,10 @@ pub trait PaginationCursorConversion {
 ///
 /// Do not attempt to parse or modify the cursor string. The format is internal and may change in
 /// minor Lemmy versions.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
-pub struct PaginationCursor(String);
+pub struct PaginationCursor(pub String);
 
 #[cfg(feature = "full")]
 impl PaginationCursor {
@@ -151,6 +151,20 @@ impl PaginationCursor {
   // only used for PostView optimization
   pub fn is_back(self) -> LemmyResult<bool> {
     Ok(self.into_internal()?.back)
+  }
+}
+
+impl From<&str> for PaginationCursor {
+  fn from(value: &str) -> Self {
+    PaginationCursor(value.to_string())
+  }
+}
+
+impl Debug for PaginationCursor {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_tuple("PaginationCursor")
+      .field(&self.clone().into_internal())
+      .finish()
   }
 }
 


### PR DESCRIPTION
Concatenate the individual page cursors together, so it looks like `BU0KBxiIGgGjd-vicaGadxG6bwc3,BU0KBxiIGgGjd-vilqGadxG6bwc3,BU0KBxiIGgGjd-yKyU0KBxiIGZ,BU0KBxiIGgGjd-uICLvWGKV7yzf`. Seems to work based on simple testing with curl.