### PR TITLE
Update `activitypub_federation` for `Public`/`as:Public` aliases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "8f27d075294830fcab6f66e320dab524bc6d048f4a151698e153205559113772"
 
 [[package]]
 name = "activitypub_federation"
-version = "0.7.0-beta.10"
+version = "0.7.0-beta.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "476db0775128bc3d3a1226e40ed0da86bce49b8bc0e13516599a4225d0363a47"
+checksum = "20222f29f14358d3baeb0ffdec08f99bd0f56b6b59504f33556d97db720de748"
 dependencies = [
  "activitystreams-kinds",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ lemmy_db_views_report_combined = { version = "=1.0.0-test-arm-qemu.0", path = ".
 lemmy_db_views_report_combined_sql = { version = "=1.0.0-test-arm-qemu.0", path = "./crates/db_views/report_combined_sql" }
 lemmy_db_views_site = { version = "=1.0.0-test-arm-qemu.0", path = "./crates/db_views/site" }
 lemmy_db_views_vote = { version = "=1.0.0-test-arm-qemu.0", path = "./crates/db_views/vote" }
-activitypub_federation = { version = "0.7.0-beta.10", default-features = false, features = [
+activitypub_federation = { version = "0.7.0-beta.11", default-features = false, features = [
   "actix-web",
 ] }
 diesel = { version = "2.3.7", features = [


### PR DESCRIPTION
Fixes #6465.

This PR updates Lemmy to `activitypub_federation` `0.7.0-beta.11`, which includes support for `Public` and `as:Public` recipient aliases in `deserialize_one_or_many()`.

With that upstream fix now merged and published, no Lemmy-side deserialization changes are needed here.

Upstream PR: <https://github.com/LemmyNet/activitypub-federation-rust/pull/165>.

> [!NOTE]
> This patch was developed with assistance from GPT-5.4. I reviewed the final changes myself, verified the dependency update locally, and ran the relevant checks before updating this PR.