### PR TITLE
Fixes for search pagination

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,9 +174,10 @@ url = { version = "2.5.8", features = ["serde"] }
 reqwest = { version = "0.13.2", default-features = false, features = [
   "gzip",
   "json",
+  "form",
   "rustls-no-provider",
 ] }
-reqwest-middleware = "0.5.1"
+reqwest-middleware = { version = "0.5.1", features = ["form", "query"] }
 reqwest-tracing = "0.7.0"
 clokwerk = "0.4.0"
 doku = { version = "0.21.1", features = ["url-2"] }

--- a/crates/api/api/src/federation/search.rs
+++ b/crates/api/api/src/federation/search.rs
@@ -263,76 +263,80 @@ fn from_single_cursor(
   res
 }
 
-#[test]
-fn test_from_single_cursor() {
-  let a = None;
-  let a_res = [None, None, None, None, None];
-  assert_eq!(a_res, from_single_cursor(a, SearchType::All));
+#[cfg(test)]
+mod test {
+  use super::*;
+  #[test]
+  fn test_from_single_cursor() {
+    let a = None;
+    let a_res = [None, None, None, None, None];
+    assert_eq!(a_res, from_single_cursor(a, SearchType::All));
 
-  let b = Some("a,b,c,d,e".to_string());
-  let b_res = [
-    Some(PaginationCursor("a".to_string())),
-    Some(PaginationCursor("b".to_string())),
-    Some(PaginationCursor("c".to_string())),
-    Some(PaginationCursor("d".to_string())),
-    Some(PaginationCursor("e".to_string())),
-  ];
-  assert_eq!(b_res, from_single_cursor(b, SearchType::All));
+    let b = Some("a,b,c,d,e".to_string());
+    let b_res = [
+      Some(PaginationCursor("a".to_string())),
+      Some(PaginationCursor("b".to_string())),
+      Some(PaginationCursor("c".to_string())),
+      Some(PaginationCursor("d".to_string())),
+      Some(PaginationCursor("e".to_string())),
+    ];
+    assert_eq!(b_res, from_single_cursor(b, SearchType::All));
 
-  let c = Some("none,b,none,none,none".to_string());
-  let c_res = [
-    None,
-    Some(PaginationCursor("b".to_string())),
-    None,
-    None,
-    None,
-  ];
-  assert_eq!(c_res, from_single_cursor(c, SearchType::All));
+    let c = Some("none,b,none,none,none".to_string());
+    let c_res = [
+      None,
+      Some(PaginationCursor("b".to_string())),
+      None,
+      None,
+      None,
+    ];
+    assert_eq!(c_res, from_single_cursor(c, SearchType::All));
 
-  let d = Some("p".to_string());
-  let d_res = [
-    Some(PaginationCursor("p".to_string())),
-    None,
-    None,
-    None,
-    None,
-  ];
-  assert_eq!(d_res, from_single_cursor(d, SearchType::Posts));
-}
+    let d = Some("p".to_string());
+    let d_res = [
+      Some(PaginationCursor("p".to_string())),
+      None,
+      None,
+      None,
+      None,
+    ];
+    assert_eq!(d_res, from_single_cursor(d, SearchType::Posts));
+  }
 
-#[test]
-fn test_to_single_cursor() {
-  let a = [None, None, None, None, None];
-  let a_res = Some("none,none,none,none,none".to_string());
-  assert_eq!(a_res, to_single_cursor(a, SearchType::All));
+  #[test]
+  fn test_to_single_cursor() {
+    let a = [None, None, None, None, None];
+    let a_res = Some("none,none,none,none,none".to_string());
+    assert_eq!(a_res, to_single_cursor(a, SearchType::All));
 
-  let b = [
-    Some(PaginationCursor("a".to_string())),
-    Some(PaginationCursor("b".to_string())),
-    Some(PaginationCursor("c".to_string())),
-    Some(PaginationCursor("d".to_string())),
-    Some(PaginationCursor("e".to_string())),
-  ];
-  let b_res = Some("a,b,c,d,e".to_string());
-  assert_eq!(b_res, to_single_cursor(b, SearchType::All));
+    let b = [
+      Some(PaginationCursor("a".to_string())),
+      Some(PaginationCursor("b".to_string())),
+      Some(PaginationCursor("c".to_string())),
+      Some(PaginationCursor("d".to_string())),
+      Some(PaginationCursor("e".to_string())),
+    ];
+    let b_res = Some("a,b,c,d,e".to_string());
+    assert_eq!(b_res, to_single_cursor(b, SearchType::All));
 
-  let c = [
-    None,
-    Some(PaginationCursor("b".to_string())),
-    None,
-    None,
-    None,
-  ];
-  let c_res = Some("none,b,none,none,none".to_string());
-  assert_eq!(c_res, to_single_cursor(c, SearchType::All));
+    let c = [
+      None,
+      Some(PaginationCursor("b".to_string())),
+      None,
+      None,
+      None,
+    ];
+    let c_res = Some("none,b,none,none,none".to_string());
+    assert_eq!(c_res, to_single_cursor(c, SearchType::All));
 
-  let d = [
-    Some(PaginationCursor("p".to_string())),
-    None,
-    None,
-    None,
-    None,
-  ];
-  let d_res = Some("p".to_string());
-  assert_eq!(d_res, to_single_cursor(d, SearchType::Posts));
+    let d = [
+      Some(PaginationCursor("p".to_string())),
+      None,
+      None,
+      None,
+      None,
+    ];
+    let d_res = Some("p".to_string());
+    assert_eq!(d_res, to_single_cursor(d, SearchType::Posts));
+  }
 }

--- a/crates/api/api/src/federation/search.rs
+++ b/crates/api/api/src/federation/search.rs
@@ -140,8 +140,8 @@ pub async fn search(
   let mut persons = Vec::new();
   let mut multi_communities = Vec::new();
 
-  let mut next_page = vec![];
-  let mut prev_page = vec![];
+  let mut next_page: [_; 5] = Default::default();
+  let mut prev_page: [_; 5] = Default::default();
 
   let search_all = search_type == SearchType::All;
 
@@ -156,8 +156,8 @@ pub async fn search(
       .await
   {
     posts = x.items;
-    next_page.push(x.next_page);
-    prev_page.push(x.prev_page);
+    next_page[0] = x.next_page;
+    prev_page[0] = x.prev_page;
   }
   if (search_type == SearchType::Comments || search_all)
     && let Ok(x) = comments_query
@@ -165,8 +165,8 @@ pub async fn search(
       .await
   {
     comments = x.items;
-    next_page.push(x.next_page);
-    prev_page.push(x.prev_page);
+    next_page[1] = x.next_page;
+    prev_page[1] = x.prev_page;
   }
   if (search_type == SearchType::Communities || search_all_no_community_or_creator)
     && let Ok(x) = communities_query
@@ -174,22 +174,22 @@ pub async fn search(
       .await
   {
     communities = x.items;
-    next_page.push(x.next_page);
-    prev_page.push(x.prev_page);
+    next_page[2] = x.next_page;
+    prev_page[2] = x.prev_page;
   }
   if (search_type == SearchType::Users || search_all_no_community_or_creator)
     && let Ok(x) = persons_query.list(&site, &mut context.pool()).await
   {
     persons = x.items;
-    next_page.push(x.next_page);
-    prev_page.push(x.prev_page);
+    next_page[3] = x.next_page;
+    prev_page[3] = x.prev_page;
   }
   if (search_type == SearchType::MultiCommunities || search_all_no_community_or_creator)
     && let Ok(x) = multi_communities_query.list(&mut context.pool()).await
   {
     multi_communities = x.items;
-    next_page.push(x.next_page);
-    prev_page.push(x.prev_page);
+    next_page[4] = x.next_page;
+    prev_page[4] = x.prev_page;
   }
 
   let res = SearchResponse {
@@ -199,19 +199,30 @@ pub async fn search(
     communities,
     multi_communities,
     persons,
-    prev_page: to_single_cursor(prev_page),
-    next_page: to_single_cursor(next_page),
+    prev_page: to_single_cursor(prev_page, search_type),
+    next_page: to_single_cursor(next_page, search_type),
   };
 
   Ok(Json(res))
 }
 
-fn to_single_cursor(cursors: Vec<Option<PaginationCursor>>) -> Option<String> {
-  let x = cursors.into_iter().flatten().collect::<Vec<_>>();
-  if x.is_empty() {
-    None
+fn to_single_cursor(
+  cursors: [Option<PaginationCursor>; 5],
+  search_type: SearchType,
+) -> Option<String> {
+  if search_type == SearchType::All {
+    Some(
+      cursors
+        .into_iter()
+        .map(|c| c.map(|c| c.0).unwrap_or("none".to_string()))
+        .join(","),
+    )
   } else {
-    Some(x.into_iter().map(|c| c.0).join(","))
+    cursors
+      .into_iter()
+      .find(Option::is_some)
+      .flatten()
+      .map(|c| c.0)
   }
 }
 
@@ -230,21 +241,17 @@ fn from_single_cursor(
       let vec = cursor
         .iter()
         .flat_map(|c| c.split(","))
-        .map(|c| Some(c.to_string().into()))
-        .collect::<Vec<_>>();
-      if vec.len() == 2 {
-        // if `community_or_creator_included` there are only two cursors
-        let v: Result<[Option<PaginationCursor>; 2], _> = vec.try_into();
-        if let Ok(v) = v {
-          res[0] = v[0].clone();
-          res[1] = v[1].clone();
-        }
-      } else {
-        // otherwise there should be 5 cursors
-        let v: Result<[Option<PaginationCursor>; 5], _> = vec.try_into();
-        if let Ok(v) = v {
-          res = v;
-        }
+        .map(|c| {
+          if c == "none" {
+            None
+          } else {
+            Some(PaginationCursor(c.to_string()))
+          }
+        })
+        .collect::<Vec<Option<PaginationCursor>>>();
+      let v: Result<[Option<PaginationCursor>; 5], _> = vec.try_into();
+      if let Ok(v) = v {
+        res = v;
       }
     }
     Posts => res[0] = cursor.map(Into::into),
@@ -254,4 +261,78 @@ fn from_single_cursor(
     MultiCommunities => res[4] = cursor.map(Into::into),
   };
   res
+}
+
+#[test]
+fn test_from_single_cursor() {
+  let a = None;
+  let a_res = [None, None, None, None, None];
+  assert_eq!(a_res, from_single_cursor(a, SearchType::All));
+
+  let b = Some("a,b,c,d,e".to_string());
+  let b_res = [
+    Some(PaginationCursor("a".to_string())),
+    Some(PaginationCursor("b".to_string())),
+    Some(PaginationCursor("c".to_string())),
+    Some(PaginationCursor("d".to_string())),
+    Some(PaginationCursor("e".to_string())),
+  ];
+  assert_eq!(b_res, from_single_cursor(b, SearchType::All));
+
+  let c = Some("none,b,none,none,none".to_string());
+  let c_res = [
+    None,
+    Some(PaginationCursor("b".to_string())),
+    None,
+    None,
+    None,
+  ];
+  assert_eq!(c_res, from_single_cursor(c, SearchType::All));
+
+  let d = Some("p".to_string());
+  let d_res = [
+    Some(PaginationCursor("p".to_string())),
+    None,
+    None,
+    None,
+    None,
+  ];
+  assert_eq!(d_res, from_single_cursor(d, SearchType::Posts));
+}
+
+#[test]
+fn test_to_single_cursor() {
+  let a = [None, None, None, None, None];
+  let a_res = Some("none,none,none,none,none".to_string());
+  assert_eq!(a_res, to_single_cursor(a, SearchType::All));
+
+  let b = [
+    Some(PaginationCursor("a".to_string())),
+    Some(PaginationCursor("b".to_string())),
+    Some(PaginationCursor("c".to_string())),
+    Some(PaginationCursor("d".to_string())),
+    Some(PaginationCursor("e".to_string())),
+  ];
+  let b_res = Some("a,b,c,d,e".to_string());
+  assert_eq!(b_res, to_single_cursor(b, SearchType::All));
+
+  let c = [
+    None,
+    Some(PaginationCursor("b".to_string())),
+    None,
+    None,
+    None,
+  ];
+  let c_res = Some("none,b,none,none,none".to_string());
+  assert_eq!(c_res, to_single_cursor(c, SearchType::All));
+
+  let d = [
+    Some(PaginationCursor("p".to_string())),
+    None,
+    None,
+    None,
+    None,
+  ];
+  let d_res = Some("p".to_string());
+  assert_eq!(d_res, to_single_cursor(d, SearchType::Posts));
 }

--- a/crates/api/api/src/federation/search.rs
+++ b/crates/api/api/src/federation/search.rs
@@ -49,7 +49,7 @@ pub async fn search(
   let time_range_seconds = data.time_range_seconds;
   let search_url_only = data.post_url_only;
   let show_nsfw = data.show_nsfw;
-  let page_cursors = from_single_cursor(data.page_cursor, search_type);
+  let page_cursors = from_single_cursor(data.page_cursor.clone(), search_type);
   let limit = data.limit;
 
   let community_id = resolve_community_identifier(
@@ -70,6 +70,7 @@ pub async fn search(
 
   let local_user = local_user_view.as_ref().map(|u| &u.local_user);
 
+  let pool = &mut context.pool();
   let posts_query = PostQuery {
     search_term: search_term.clone(),
     search_title_only,
@@ -83,8 +84,10 @@ pub async fn search(
     page_cursor: page_cursors[0].clone(),
     limit,
     ..Default::default()
-  };
+  }
+  .list(pool, &site, &local_site);
 
+  let pool = &mut context.pool();
   let comments_query = CommentQuery {
     search_term: search_term.clone(),
     local_user,
@@ -96,8 +99,10 @@ pub async fn search(
     page_cursor: page_cursors[1].clone(),
     limit,
     ..Default::default()
-  };
+  }
+  .list(pool, &site, &local_site);
 
+  let pool = &mut context.pool();
   let persons_query = PersonQuery {
     search_term: search_term.clone(),
     search_title_only,
@@ -106,8 +111,10 @@ pub async fn search(
     sort: Some(PersonSortType::New),
     page_cursor: page_cursors[2].clone(),
     limit,
-  };
+  }
+  .list(&site, pool);
 
+  let pool = &mut context.pool();
   let communities_query = CommunityQuery {
     search_term: search_term.clone(),
     search_title_only,
@@ -119,8 +126,10 @@ pub async fn search(
     page_cursor: page_cursors[3].clone(),
     limit,
     ..Default::default()
-  };
+  }
+  .list(pool, &site, &local_site);
 
+  let pool = &mut context.pool();
   let multi_communities_query = MultiCommunityQuery {
     search_term,
     search_title_only,
@@ -132,7 +141,8 @@ pub async fn search(
     page_cursor: page_cursors[4].clone(),
     limit,
     ..Default::default()
-  };
+  }
+  .list(pool);
 
   let mut posts = Vec::new();
   let mut comments = Vec::new();
@@ -151,41 +161,40 @@ pub async fn search(
   let search_all_no_community_or_creator = search_all && !community_or_creator_included;
 
   if (search_type == SearchType::Posts || search_all)
-    && let Ok(x) = posts_query
-      .list(&mut context.pool(), &site, &local_site)
-      .await
+    && (data.page_cursor.is_none() || page_cursors[0].is_some())
+    && let Ok(x) = posts_query.await
   {
     posts = x.items;
     next_page[0] = x.next_page;
     prev_page[0] = x.prev_page;
   }
   if (search_type == SearchType::Comments || search_all)
-    && let Ok(x) = comments_query
-      .list(&mut context.pool(), &site, &local_site)
-      .await
+    && (data.page_cursor.is_none() || page_cursors[1].is_some())
+    && let Ok(x) = comments_query.await
   {
     comments = x.items;
     next_page[1] = x.next_page;
     prev_page[1] = x.prev_page;
   }
-  if (search_type == SearchType::Communities || search_all_no_community_or_creator)
-    && let Ok(x) = communities_query
-      .list(&mut context.pool(), &site, &local_site)
-      .await
+  if (search_type == SearchType::Users || search_all_no_community_or_creator)
+    && (data.page_cursor.is_none() || page_cursors[2].is_some())
+    && let Ok(x) = persons_query.await
   {
-    communities = x.items;
+    persons = x.items;
     next_page[2] = x.next_page;
     prev_page[2] = x.prev_page;
   }
-  if (search_type == SearchType::Users || search_all_no_community_or_creator)
-    && let Ok(x) = persons_query.list(&site, &mut context.pool()).await
+  if (search_type == SearchType::Communities || search_all_no_community_or_creator)
+    && (data.page_cursor.is_none() || page_cursors[3].is_some())
+    && let Ok(x) = communities_query.await
   {
-    persons = x.items;
+    communities = x.items;
     next_page[3] = x.next_page;
     prev_page[3] = x.prev_page;
   }
   if (search_type == SearchType::MultiCommunities || search_all_no_community_or_creator)
-    && let Ok(x) = multi_communities_query.list(&mut context.pool()).await
+    && (data.page_cursor.is_none() || page_cursors[4].is_some())
+    && let Ok(x) = multi_communities_query.await
   {
     multi_communities = x.items;
     next_page[4] = x.next_page;

--- a/crates/api/routes_v3/src/handlers.rs
+++ b/crates/api/routes_v3/src/handlers.rs
@@ -393,7 +393,7 @@ pub(crate) async fn search_v3(
     title_only,
     ..Default::default()
   };
-  let data = search(Query(form), context, local_user_view).await?;
+  let data = Box::pin(search(Query(form), context, local_user_view)).await?;
   Ok(Json(convert_search_response(data.0, type_)))
 }
 

--- a/crates/diesel_utils/src/pagination.rs
+++ b/crates/diesel_utils/src/pagination.rs
@@ -23,7 +23,7 @@ use {
 /// with randomized character order, to prevent clients from parsing or modifying cursor data.
 #[cfg(feature = "full")]
 #[expect(clippy::expect_used)]
-static BASE64_ENGINE: LazyLock<GeneralPurpose> = LazyLock::new(|| {
+pub static BASE64_ENGINE: LazyLock<GeneralPurpose> = LazyLock::new(|| {
   let alphabet = Alphabet::new("AphruVFwvCetlckdZ2g-foxXBGNbyHnD96qUj3KL_YsE7P1OQiaIR0z4T58mMWJS")
     .expect("create base64 alphabet");
   GeneralPurpose::new(&alphabet, NO_PAD)

--- a/crates/routes/Cargo.toml
+++ b/crates/routes/Cargo.toml
@@ -42,7 +42,7 @@ actix-web = { workspace = true, features = ["cookies"] }
 chrono = { workspace = true }
 futures = { workspace = true }
 reqwest = { workspace = true, features = ["stream"] }
-reqwest-middleware = { workspace = true, features = ["form", "query"] }
+reqwest-middleware = { workspace = true }
 serde = { workspace = true }
 url = { workspace = true }
 tracing = { workspace = true }


### PR DESCRIPTION
The previous code wasnt working properly, so I fixed it and added some test cases.

There is still a problem when using `SearchType::All` and reaching the last element for a certain type (eg the last comment result). Then the comment cursor will be None, and it will start over from the first comment again. So its basically going in circles. Need to add something indicating that we reached the last page, but not sure how. A cursor with string `last`?

Also search pagination cursors should be encoded just like normal cursors, to prevent clients from relying on a specific format.