### PR TITLE
Check multi-community read for private instance.

### DIFF
--- a/crates/api/api/src/federation/read_community.rs
+++ b/crates/api/api/src/federation/read_community.rs
@@ -22,10 +22,6 @@ pub async fn get_community(
 ) -> LemmyResult<Json<GetCommunityResponse>> {
   let local_site = SiteView::read_local(&mut context.pool()).await?.local_site;
 
-  if data.name.is_none() && data.id.is_none() {
-    return Err(LemmyErrorType::NoIdGiven.into());
-  }
-
   check_private_instance(&local_user_view, &local_site)?;
 
   let local_user = local_user_view.as_ref().map(|u| &u.local_user);

--- a/crates/api/api/src/federation/read_multi_community.rs
+++ b/crates/api/api/src/federation/read_multi_community.rs
@@ -1,7 +1,7 @@
 use crate::federation::fetcher::resolve_multi_community_identifier;
 use activitypub_federation::config::Data;
 use actix_web::web::{Json, Query};
-use lemmy_api_utils::context::LemmyContext;
+use lemmy_api_utils::{context::LemmyContext, utils::check_private_instance};
 use lemmy_db_views_community::{
   MultiCommunityView,
   api::{GetMultiCommunity, GetMultiCommunityResponse},

--- a/crates/api/api/src/federation/read_multi_community.rs
+++ b/crates/api/api/src/federation/read_multi_community.rs
@@ -16,6 +16,16 @@ pub async fn read_multi_community(
   context: Data<LemmyContext>,
   local_user_view: Option<LocalUserView>,
 ) -> LemmyResult<Json<GetMultiCommunityResponse>> {
+  let SiteView {
+    site, local_site, ..
+  } = SiteView::read_local(&mut context.pool()).await?;
+
+  if data.name.is_none() && data.id.is_none() {
+    return Err(LemmyErrorType::NoIdGiven.into());
+  }
+
+  check_private_instance(&local_user_view, &local_site)?;
+
   let my_person_id = local_user_view.as_ref().map(|l| l.person.id);
   let id = resolve_multi_community_identifier(&data.name, data.id, &context, &local_user_view)
     .await?
@@ -23,9 +33,6 @@ pub async fn read_multi_community(
   let multi_community_view =
     MultiCommunityView::read(&mut context.pool(), id, my_person_id).await?;
 
-  let SiteView {
-    site, local_site, ..
-  } = SiteView::read_local(&mut context.pool()).await?;
   let communities = CommunityQuery {
     multi_community_id: Some(id),
     ..Default::default()

--- a/crates/api/api/src/federation/read_multi_community.rs
+++ b/crates/api/api/src/federation/read_multi_community.rs
@@ -20,16 +20,13 @@ pub async fn read_multi_community(
     site, local_site, ..
   } = SiteView::read_local(&mut context.pool()).await?;
 
-  if data.name.is_none() && data.id.is_none() {
-    return Err(LemmyErrorType::NoIdGiven.into());
-  }
-
   check_private_instance(&local_user_view, &local_site)?;
 
   let my_person_id = local_user_view.as_ref().map(|l| l.person.id);
   let id = resolve_multi_community_identifier(&data.name, data.id, &context, &local_user_view)
     .await?
     .ok_or(LemmyErrorType::NoIdGiven)?;
+
   let multi_community_view =
     MultiCommunityView::read(&mut context.pool(), id, my_person_id).await?;
 


### PR DESCRIPTION
Makes sure the local user has access to multi community read if its a private instance.