### PR TITLE
Add domain check when receiving federated ban

### DIFF
--- a/crates/apub/activities/src/block/block_user.rs
+++ b/crates/apub/activities/src/block/block_user.rs
@@ -12,6 +12,7 @@ use crate::{
 use activitypub_federation::{
   config::Data,
   kinds::activity::BlockType,
+  protocol::verification::verify_domains_match,
   traits::{Activity, Actor, Object},
 };
 use chrono::{DateTime, Utc};
@@ -111,8 +112,9 @@ impl Activity for BlockUser {
 
   async fn verify(&self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     match self.target.dereference(context).await? {
-      SiteOrCommunity::Left(_site) => {
+      SiteOrCommunity::Left(site) => {
         verify_is_public(&self.to, &self.cc)?;
+        verify_domains_match(self.actor.inner(), &site.ap_id)?;
       }
       SiteOrCommunity::Right(community) => {
         verify_visibility(&self.to, &self.cc, &community)?;

--- a/crates/apub/activities/src/community/announce.rs
+++ b/crates/apub/activities/src/community/announce.rs
@@ -11,6 +11,7 @@ use crate::{
 use activitypub_federation::{
   config::Data,
   kinds::activity::AnnounceType,
+  protocol::verification::verify_urls_match,
   traits::{Activity, Object},
 };
 use lemmy_api_utils::context::LemmyContext;
@@ -177,6 +178,7 @@ impl Activity for AnnounceActivity {
     }
 
     let community = object.community(context).await?;
+    verify_urls_match(community.ap_id.inner(), self.actor.inner())?;
     verify_visibility(&self.to, &self.cc, &community)?;
     can_accept_activity_in_community(&Some(community), context).await?;
 

--- a/crates/apub/activities/src/community/announce.rs
+++ b/crates/apub/activities/src/community/announce.rs
@@ -154,17 +154,23 @@ impl Activity for AnnounceActivity {
   }
 
   async fn receive(self, context: &Data<Self::DataType>) -> LemmyResult<()> {
+    use AnnouncableActivities::*;
     let object: AnnouncableActivities = self.object.object(context).await?.try_into()?;
 
     match &object {
-      AnnouncableActivities::BlockUser(block) => {
-        // Site bans must not be announced, but sent directly.
+      // Site bans must not be announced, but sent directly.
+      BlockUser(block) => {
         if block.target.dereference(&context).await?.is_left() {
           return Err(UntranslatedError::CannotAnnounceSiteBan.into());
         }
       }
+      UndoBlockUser(block) => {
+        if block.object.target.dereference(&context).await?.is_left() {
+          return Err(UntranslatedError::CannotAnnounceSiteBan.into());
+        }
+      }
       // This is only for sending, not receiving so we reject it.
-      AnnouncableActivities::Page(_) => {
+      Page(_) => {
         return Err(UntranslatedError::CannotReceivePage.into());
       }
       _ => {}

--- a/crates/apub/activities/src/community/announce.rs
+++ b/crates/apub/activities/src/community/announce.rs
@@ -156,9 +156,18 @@ impl Activity for AnnounceActivity {
   async fn receive(self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     let object: AnnouncableActivities = self.object.object(context).await?.try_into()?;
 
-    // This is only for sending, not receiving so we reject it.
-    if let AnnouncableActivities::Page(_) = object {
-      return Err(UntranslatedError::CannotReceivePage.into());
+    match &object {
+      AnnouncableActivities::BlockUser(block) => {
+        // Site bans must not be announced, but sent directly.
+        if block.target.dereference(&context).await?.is_left() {
+          return Err(UntranslatedError::CannotAnnounceSiteBan.into());
+        }
+      }
+      // This is only for sending, not receiving so we reject it.
+      AnnouncableActivities::Page(_) => {
+        return Err(UntranslatedError::CannotReceivePage.into());
+      }
+      _ => {}
     }
 
     let community = object.community(context).await?;

--- a/crates/apub/activities/src/community/announce.rs
+++ b/crates/apub/activities/src/community/announce.rs
@@ -155,26 +155,11 @@ impl Activity for AnnounceActivity {
   }
 
   async fn receive(self, context: &Data<Self::DataType>) -> LemmyResult<()> {
-    use AnnouncableActivities::*;
     let object: AnnouncableActivities = self.object.object(context).await?.try_into()?;
 
-    match &object {
-      // Site bans must not be announced, but sent directly.
-      BlockUser(block) => {
-        if block.target.dereference(&context).await?.is_left() {
-          return Err(UntranslatedError::CannotAnnounceSiteBan.into());
-        }
-      }
-      UndoBlockUser(block) => {
-        if block.object.target.dereference(&context).await?.is_left() {
-          return Err(UntranslatedError::CannotAnnounceSiteBan.into());
-        }
-      }
-      // This is only for sending, not receiving so we reject it.
-      Page(_) => {
-        return Err(UntranslatedError::CannotReceivePage.into());
-      }
-      _ => {}
+    // This is only for sending, not receiving so we reject it.
+    if let AnnouncableActivities::Page(_) = object {
+      return Err(UntranslatedError::CannotReceivePage.into());
     }
 
     let community = object.community(context).await?;

--- a/crates/apub/activities/src/protocol/block/block_user.rs
+++ b/crates/apub/activities/src/protocol/block/block_user.rs
@@ -3,7 +3,7 @@ use activitypub_federation::{
   config::Data,
   fetch::object_id::ObjectId,
   kinds::activity::BlockType,
-  protocol::helpers::deserialize_one_or_many,
+  protocol::{helpers::deserialize_one_or_many, verification::verify_urls_match},
 };
 use anyhow::anyhow;
 use chrono::{DateTime, Utc};
@@ -44,6 +44,7 @@ pub struct BlockUser {
 impl InCommunity for BlockUser {
   async fn community(&self, context: &Data<LemmyContext>) -> LemmyResult<ApubCommunity> {
     if let Some(audience) = &self.audience {
+      verify_urls_match(audience.inner(), self.target.inner())?;
       return audience.dereference(context).await;
     }
     let target = self.target.dereference(context).await?;

--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -157,6 +157,7 @@ pub enum UntranslatedError {
   /// A remote community sent an activity to us, but actually no local user follows the community
   /// so the activity was rejected.
   CommunityHasNoFollowers(String),
+  CannotAnnounceSiteBan,
 }
 
 cfg_select! {

--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -157,7 +157,6 @@ pub enum UntranslatedError {
   /// A remote community sent an activity to us, but actually no local user follows the community
   /// so the activity was rejected.
   CommunityHasNoFollowers(String),
-  CannotAnnounceSiteBan,
 }
 
 cfg_select! {


### PR DESCRIPTION
Seems like this was missing a domain check. Federated bans should only be able to ban users from that same instance, not from the user's home instance.

Needs backport to 0.19.