### PR TITLE
Skip links cleaning in code blocks

### DIFF
--- a/crates/api/api_utils/src/utils.rs
+++ b/crates/api/api_utils/src/utils.rs
@@ -56,9 +56,13 @@ use lemmy_utils::{
   settings::SETTINGS,
   spawn_try_task,
   utils::{
-    markdown::{image_links::markdown_rewrite_image_links, markdown_check_for_blocked_urls},
+    markdown::{
+      code_links::clean_urls_skip_code_links,
+      image_links::markdown_rewrite_image_links,
+      markdown_check_for_blocked_urls,
+    },
     slurs::remove_slurs,
-    validation::{build_and_check_regex, clean_urls_in_text},
+    validation::build_and_check_regex,
   },
 };
 use moka::future::Cache;
@@ -841,7 +845,7 @@ pub async fn process_markdown(
   context: &Data<LemmyContext>,
 ) -> LemmyResult<String> {
   let text = remove_slurs(text, slur_regex);
-  let text = clean_urls_in_text(&text);
+  let text = clean_urls_skip_code_links(&text);
 
   markdown_check_for_blocked_urls(&text, url_blocklist)?;
 

--- a/crates/db_views/post/src/impls.rs
+++ b/crates/db_views/post/src/impls.rs
@@ -67,7 +67,7 @@ use lemmy_diesel_utils::{
 };
 use lemmy_utils::{
   error::{LemmyErrorExt, LemmyErrorType, LemmyResult},
-  utils::validation::clean_url,
+  utils::markdown::clean_url,
 };
 use tracing::debug;
 use url::Url;

--- a/crates/diesel_utils/src/utils.rs
+++ b/crates/diesel_utils/src/utils.rs
@@ -14,7 +14,7 @@ use futures_util::future::BoxFuture;
 use i_love_jesus::CursorKey;
 use lemmy_utils::{
   error::{LemmyErrorExt, LemmyErrorType, LemmyResult},
-  utils::validation::clean_url,
+  utils::markdown::clean_url,
 };
 use url::Url;
 

--- a/crates/utils/src/utils/markdown/code_links.rs
+++ b/crates/utils/src/utils/markdown/code_links.rs
@@ -1,0 +1,65 @@
+use crate::utils::validation::clean_urls_in_text;
+use markdown_it::{
+  MarkdownIt,
+  plugins::cmark::{
+    block::{code, fence},
+    inline::backticks,
+  },
+};
+use std::sync::LazyLock;
+
+pub fn clean_urls_skip_code_links(src: &str) -> String {
+  static PARSER: LazyLock<MarkdownIt> = LazyLock::new(|| {
+    let mut p = MarkdownIt::new();
+    fence::add(&mut p);
+    code::add(&mut p);
+    backticks::add(&mut p);
+    p
+  });
+  let ast = PARSER.parse(src);
+
+  let mut code_offsets: Vec<(usize, usize)> = Vec::new();
+  //we need to exclude code fences (``` ``` and ~~~ ~~~) as well as bacticks inline code (` `) and code blocks (4 spaces)
+  ast.walk(|node, _| {
+    if (node.cast::<fence::CodeFence>().is_some()
+      || node.cast::<code::CodeBlock>().is_some()
+      || node.cast::<backticks::CodeInline>().is_some())
+      && let Some(srcmap) = node.srcmap
+    {
+      code_offsets.push(srcmap.get_byte_offsets());
+    }
+  });
+  let mut output_string = String::with_capacity(src.len());
+  let mut index = 0;
+  for (code_start, code_end) in code_offsets {
+    if let Some(slice_before_code) = src.get(index..code_start) {
+      output_string.push_str(&clean_urls_in_text(slice_before_code));
+    }
+    if let Some(slice_code) = src.get(code_start..code_end) {
+      output_string.push_str(slice_code);
+    }
+    index = code_end;
+  }
+
+  // if no fences or bacticks => same as using pure clean_urls_in_text()
+  if let Some(slice_after_code) = src.get(index..) {
+    output_string.push_str(&clean_urls_in_text(slice_after_code));
+  };
+  output_string
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use pretty_assertions::assert_eq;
+
+  const SOURCE: &str = "https://example.com/path/123?utm_content=buffercf3b2&utm_medium=social&user+name=random+user&id=123\n\n[link](https://example.com/path/123?utm_content=buffercf3b2&utm_medium=social&user+name=random+user&id=123)\n\n```javascript\nconst url = `https://example.com?foo=${bar}`\n```\n`const url = \"https://example.com?foo=${bar}\"`\n\n    const url = `https://example.com/?foo=${bar}`    \n";
+
+  const SOURCE_LINKS_CLEANED: &str = "https://example.com/path/123?user+name=random+user&id=123\n\n[link](https://example.com/path/123?user+name=random+user&id=123)\n\n```javascript\nconst url = `https://example.com?foo=${bar}`\n```\n`const url = \"https://example.com?foo=${bar}\"`\n\n    const url = `https://example.com/?foo=${bar}`    \n";
+
+  #[test]
+  fn test_clean_urls_skip_code_links() {
+    let cleaned = clean_urls_skip_code_links(SOURCE);
+    assert_eq!(SOURCE_LINKS_CLEANED.to_string(), cleaned);
+  }
+}

--- a/crates/utils/src/utils/markdown/code_links.rs
+++ b/crates/utils/src/utils/markdown/code_links.rs
@@ -53,9 +53,33 @@ mod tests {
   use super::clean_urls_skip_code_links;
   use pretty_assertions::assert_eq;
 
-  const SOURCE: &str = "https://example.com/path/123?utm_content=buffercf3b2&utm_medium=social&user+name=random+user&id=123\n\n[link](https://example.com/path/123?utm_content=buffercf3b2&utm_medium=social&user+name=random+user&id=123)\n\n```javascript\nconst url = `https://example.com?foo=${bar}`\n```\n`const url = \"https://example.com?foo=${bar}\"`\n\n    const url = `https://example.com/?foo=${bar}`    \n";
+  const SOURCE: &str = r#"
+https://example.com/path/123?utm_content=buffercf3b2&utm_medium=social&user+name=random+user&id=123
 
-  const SOURCE_LINKS_CLEANED: &str = "https://example.com/path/123?user+name=random+user&id=123\n\n[link](https://example.com/path/123?user+name=random+user&id=123)\n\n```javascript\nconst url = `https://example.com?foo=${bar}`\n```\n`const url = \"https://example.com?foo=${bar}\"`\n\n    const url = `https://example.com/?foo=${bar}`    \n";
+[link](https://example.com/path/123?utm_content=buffercf3b2&utm_medium=social&user+name=random+user&id=123)
+
+```javascript
+const url = `https://example.com?foo=${bar}`
+```
+
+`const url = "https://example.com?foo=${bar}"`
+
+    const url = `https://example.com?foo=${bar}`
+"#;
+
+  const SOURCE_LINKS_CLEANED: &str = r#"
+https://example.com/path/123?user+name=random+user&id=123
+
+[link](https://example.com/path/123?user+name=random+user&id=123)
+
+```javascript
+const url = `https://example.com?foo=${bar}`
+```
+
+`const url = "https://example.com?foo=${bar}"`
+
+    const url = `https://example.com?foo=${bar}`
+"#;
 
   #[test]
   fn test_clean_urls_skip_code_links() {

--- a/crates/utils/src/utils/markdown/code_links.rs
+++ b/crates/utils/src/utils/markdown/code_links.rs
@@ -1,4 +1,4 @@
-use crate::utils::validation::clean_urls_in_text;
+use super::clean_urls_in_text;
 use markdown_it::{
   MarkdownIt,
   plugins::cmark::{
@@ -50,7 +50,7 @@ pub fn clean_urls_skip_code_links(src: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-  use super::*;
+  use super::clean_urls_skip_code_links;
   use pretty_assertions::assert_eq;
 
   const SOURCE: &str = "https://example.com/path/123?utm_content=buffercf3b2&utm_medium=social&user+name=random+user&id=123\n\n[link](https://example.com/path/123?utm_content=buffercf3b2&utm_medium=social&user+name=random+user&id=123)\n\n```javascript\nconst url = `https://example.com?foo=${bar}`\n```\n`const url = \"https://example.com?foo=${bar}\"`\n\n    const url = `https://example.com/?foo=${bar}`    \n";

--- a/crates/utils/src/utils/markdown/mod.rs
+++ b/crates/utils/src/utils/markdown/mod.rs
@@ -3,6 +3,7 @@ use markdown_it::MarkdownIt;
 use regex::RegexSet;
 use std::sync::LazyLock;
 
+pub mod code_links;
 mod identifier_rule;
 pub mod image_links;
 mod link_rule;

--- a/crates/utils/src/utils/markdown/mod.rs
+++ b/crates/utils/src/utils/markdown/mod.rs
@@ -1,12 +1,17 @@
 use crate::error::{LemmyErrorType, LemmyResult};
+use clearurls::UrlCleaner;
 use markdown_it::MarkdownIt;
 use regex::RegexSet;
 use std::sync::LazyLock;
-
 pub mod code_links;
 mod identifier_rule;
 pub mod image_links;
 mod link_rule;
+use url::Url;
+
+#[expect(clippy::expect_used)]
+static URL_CLEANER: LazyLock<UrlCleaner> =
+  LazyLock::new(|| UrlCleaner::from_embedded_rules().expect("compile clearurls"));
 
 static MARKDOWN_PARSER: LazyLock<MarkdownIt> = LazyLock::new(|| {
   let mut parser = MarkdownIt::new();
@@ -32,6 +37,24 @@ pub fn markdown_check_for_blocked_urls(text: &str, blocklist: &RegexSet) -> Lemm
     return Err(LemmyErrorType::BlockedUrl.into());
   }
   Ok(())
+}
+
+/// Cleans a url of tracking parameters.
+pub fn clean_url(url: &Url) -> Url {
+  match URL_CLEANER.clear_single_url(url) {
+    Ok(res) => res.into_owned(),
+    // If there are any errors, just return the original url
+    Err(_) => url.clone(),
+  }
+}
+
+/// Cleans all the links in a string of tracking parameters.
+fn clean_urls_in_text(text: &str) -> String {
+  match URL_CLEANER.clear_text(text) {
+    Ok(res) => res.into_owned(),
+    // If there are any errors, just return the original text
+    Err(_) => text.to_owned(),
+  }
 }
 
 #[cfg(test)]
@@ -235,6 +258,37 @@ mod tests {
     assert!(markdown_check_for_blocked_urls("check out rt.computer", &set).is_ok());
     // TODO: the following should not be matched, scunthorpe problem.
     assert!(markdown_check_for_blocked_urls("rt.com.example.com", &set).is_err());
+
+    Ok(())
+  }
+
+  const URL_WITH_TRACKING: &str = "https://example.com/path/123?utm_content=buffercf3b2&utm_medium=social&user+name=random+user&id=123";
+  const URL_TRACKING_REMOVED: &str = "https://example.com/path/123?user+name=random+user&id=123";
+
+  #[test]
+  fn test_clean_url_params() -> LemmyResult<()> {
+    let url = Url::parse(URL_WITH_TRACKING)?;
+    let cleaned = clean_url(&url);
+    let expected = Url::parse(URL_TRACKING_REMOVED)?;
+    assert_eq!(expected.to_string(), cleaned.to_string());
+
+    let url = Url::parse("https://example.com/path/123")?;
+    let cleaned = clean_url(&url);
+    assert_eq!(url.to_string(), cleaned.to_string());
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_clean_body() -> LemmyResult<()> {
+    let text = format!("[a link]({URL_WITH_TRACKING})");
+    let cleaned = clean_urls_in_text(&text);
+    let expected = format!("[a link]({URL_TRACKING_REMOVED})");
+    assert_eq!(expected.clone(), cleaned.clone());
+
+    let text = "[a link](https://example.com/path/123)";
+    let cleaned = clean_urls_in_text(text);
+    assert_eq!(text.to_string(), cleaned);
 
     Ok(())
   }

--- a/crates/utils/src/utils/validation.rs
+++ b/crates/utils/src/utils/validation.rs
@@ -1,5 +1,4 @@
 use crate::error::{LemmyErrorExt, LemmyErrorType, LemmyResult, MAX_API_PARAM_ELEMENTS};
-use clearurls::UrlCleaner;
 use invisible_characters::INVISIBLE_CHARS;
 use itertools::Itertools;
 use regex::{Regex, RegexBuilder, RegexSet};
@@ -14,9 +13,6 @@ static VALID_MATRIX_ID_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     .expect("compile regex")
 });
 // taken from https://en.wikipedia.org/wiki/UTM_parameters
-#[expect(clippy::expect_used)]
-static URL_CLEANER: LazyLock<UrlCleaner> =
-  LazyLock::new(|| UrlCleaner::from_embedded_rules().expect("compile clearurls"));
 const ALLOWED_POST_URL_SCHEMES: [&str; 3] = ["http", "https", "magnet"];
 
 const BODY_MAX_LENGTH: usize = 10000;
@@ -197,24 +193,6 @@ pub fn build_and_check_regex(regex_str_opt: Option<&str>) -> LemmyResult<Regex> 
   }
 }
 
-/// Cleans a url of tracking parameters.
-pub fn clean_url(url: &Url) -> Url {
-  match URL_CLEANER.clear_single_url(url) {
-    Ok(res) => res.into_owned(),
-    // If there are any errors, just return the original url
-    Err(_) => url.clone(),
-  }
-}
-
-/// Cleans all the links in a string of tracking parameters.
-pub fn clean_urls_in_text(text: &str) -> String {
-  match URL_CLEANER.clear_text(text) {
-    Ok(res) => res.into_owned(),
-    // If there are any errors, just return the original text
-    Err(_) => text.to_owned(),
-  }
-}
-
 pub fn is_valid_url(url: &Url) -> LemmyResult<()> {
   if !ALLOWED_POST_URL_SCHEMES.contains(&url.scheme()) {
     return Err(LemmyErrorType::InvalidUrlScheme.into());
@@ -360,59 +338,14 @@ mod tests {
   use crate::{
     error::{LemmyErrorType, LemmyResult},
     utils::validation::{
-      BIO_MAX_LENGTH,
-      SITE_NAME_MAX_LENGTH,
-      SITE_SUMMARY_MAX_LENGTH,
-      URL_MAX_LENGTH,
-      build_and_check_regex,
-      check_urls_are_valid,
-      clean_url,
-      clean_urls_in_text,
-      is_url_blocked,
-      is_valid_actor_name,
-      is_valid_bio_field,
-      is_valid_display_name,
-      is_valid_matrix_id,
-      is_valid_post_title,
-      is_valid_url,
-      site_name_length_check,
-      summary_length_check,
-      truncate_for_db,
+      BIO_MAX_LENGTH, SITE_NAME_MAX_LENGTH, SITE_SUMMARY_MAX_LENGTH, URL_MAX_LENGTH,
+      build_and_check_regex, check_urls_are_valid, is_url_blocked, is_valid_actor_name,
+      is_valid_bio_field, is_valid_display_name, is_valid_matrix_id, is_valid_post_title,
+      is_valid_url, site_name_length_check, summary_length_check, truncate_for_db,
     },
   };
   use pretty_assertions::assert_eq;
   use url::Url;
-
-  const URL_WITH_TRACKING: &str = "https://example.com/path/123?utm_content=buffercf3b2&utm_medium=social&user+name=random+user&id=123";
-  const URL_TRACKING_REMOVED: &str = "https://example.com/path/123?user+name=random+user&id=123";
-
-  #[test]
-  fn test_clean_url_params() -> LemmyResult<()> {
-    let url = Url::parse(URL_WITH_TRACKING)?;
-    let cleaned = clean_url(&url);
-    let expected = Url::parse(URL_TRACKING_REMOVED)?;
-    assert_eq!(expected.to_string(), cleaned.to_string());
-
-    let url = Url::parse("https://example.com/path/123")?;
-    let cleaned = clean_url(&url);
-    assert_eq!(url.to_string(), cleaned.to_string());
-
-    Ok(())
-  }
-
-  #[test]
-  fn test_clean_body() -> LemmyResult<()> {
-    let text = format!("[a link]({URL_WITH_TRACKING})");
-    let cleaned = clean_urls_in_text(&text);
-    let expected = format!("[a link]({URL_TRACKING_REMOVED})");
-    assert_eq!(expected.clone(), cleaned.clone());
-
-    let text = "[a link](https://example.com/path/123)";
-    let cleaned = clean_urls_in_text(text);
-    assert_eq!(text.to_string(), cleaned);
-
-    Ok(())
-  }
 
   #[test]
   fn regex_checks() {


### PR DESCRIPTION
fixes #5972 

`clean_urls_skip_code_links()` is added, it finds in markdown text code fences, code blocks and inline bacticks, skips url cleaning in these blocks. 
A simple test is added as well.