### PR TITLE
Add ap_id to the fuzzy searching for community and person.

### DIFF
--- a/crates/db_views/community/src/impls.rs
+++ b/crates/db_views/community/src/impls.rs
@@ -198,6 +198,8 @@ impl CommunityQuery<'_> {
 
       let name_or_title_filter = community::name
         .ilike(searcher.clone())
+        // Also include the ap_id to allow for instance searching
+        .or(community::ap_id.ilike(searcher.clone()))
         .or(community::title.ilike(searcher.clone()));
 
       query = if self.search_title_only.unwrap_or_default() {

--- a/crates/db_views/person/src/impls.rs
+++ b/crates/db_views/person/src/impls.rs
@@ -155,6 +155,8 @@ impl PersonQuery<'_> {
 
       let name_or_title_filter = person::name
         .ilike(searcher.clone())
+        // Also include the ap_id to allow for instance searching
+        .or(person::ap_id.ilike(searcher.clone()))
         .or(person::display_name.ilike(searcher.clone()));
 
       query = if self.search_title_only.unwrap_or_default() {


### PR DESCRIPTION
- I tested this, and fuzzy queries do somewhat work, like "lemmy.ml/c/world", "lemmy.world/c/world" will correctly filter the instance for world news.
- Fixes #6374