### PR TITLE
Import settings from Lemmy 0.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4092,6 +4092,7 @@ dependencies = [
 name = "lemmy_db_views_site"
 version = "1.0.0-beta.0"
 dependencies = [
+ "activitypub_federation",
  "anyhow",
  "diesel",
  "diesel-async",

--- a/crates/api/api/src/federation/user_settings_backup.rs
+++ b/crates/api/api/src/federation/user_settings_backup.rs
@@ -449,4 +449,22 @@ pub(crate) mod tests {
     data.delete(&mut context.pool()).await?;
     Ok(())
   }
+
+  #[tokio::test]
+  #[serial]
+  async fn import_019_backup() -> LemmyResult<()> {
+    let context = LemmyContext::init_test_context().await;
+    let pool = &mut context.pool();
+    let data = TestData::create(pool).await?;
+
+    let import_user = LocalUserView::create_test_user(pool, "bobby", "bio", false).await?;
+
+    let backup = serde_json::from_str(
+      r#"{"display_name":null,"bio":null,"avatar":null,"banner":null,"matrix_id":null,"bot_account":false,"settings":{"id":1,"person_id":2,"show_nsfw":true,"theme":"browser","default_sort_type":"Active","default_listing_type":"Local","interface_language":"es","show_avatars":true,"send_notifications_to_email":false,"show_scores":true,"show_bot_accounts":true,"show_read_posts":true,"email_verified":false,"accepted_application":true,"open_links_in_new_tab":false,"blur_nsfw":true,"auto_expand":false,"infinite_scroll_enabled":false,"admin":true,"post_listing_mode":"List","totp_2fa_enabled":false,"enable_keyboard_navigation":false,"enable_animated_images":true,"collapse_bot_comments":false,"last_donation_notification":"2025-06-05T07:39:54.282106Z"},"vote_display_mode_settings":{"local_user_id":1,"score":false,"upvotes":true,"downvotes":true,"upvote_percentage":false},"followed_communities":["https://voyager.lemmy.ml/c/test","https://ds9.lemmy.ml/c/test","https://enterprise.lemmy.ml/c/test","https://enterprise.lemmy.ml/c/%D8%AA%D8%AC%D8%B1%D9%8A%D8%A8","https://enterprise.lemmy.ml/c/testmod","https://enterprise.lemmy.ml/c/test1","https://enterprise.lemmy.ml/c/main","https://voyager.lemmy.ml/c/test_comm_1"],"saved_posts":[],"saved_comments":[],"blocked_communities":[],"blocked_users":[],"blocked_instances":[]}"#,
+    )?;
+    import_user_settings(Json(backup), import_user.clone(), context.clone()).await?;
+
+    data.delete(&mut context.pool()).await?;
+    Ok(())
+  }
 }

--- a/crates/db_views/site/Cargo.toml
+++ b/crates/db_views/site/Cargo.toml
@@ -29,6 +29,7 @@ full = [
   "anyhow",
   "extism",
   "i-love-jesus",
+  "activitypub_federation"
 ]
 ts-rs = [
   "dep:ts-rs",
@@ -65,6 +66,7 @@ extism = { workspace = true, optional = true }
 extism-convert = { workspace = true }
 anyhow = { workspace = true, optional = true }
 i-love-jesus = { workspace = true, optional = true }
+activitypub_federation = { workspace = true, optional = true }
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/crates/db_views/site/Cargo.toml
+++ b/crates/db_views/site/Cargo.toml
@@ -29,7 +29,7 @@ full = [
   "anyhow",
   "extism",
   "i-love-jesus",
-  "activitypub_federation"
+  "activitypub_federation",
 ]
 ts-rs = [
   "dep:ts-rs",

--- a/crates/db_views/site/src/api.rs
+++ b/crates/db_views/site/src/api.rs
@@ -1,4 +1,5 @@
 use crate::{ResolveObjectView, SiteView};
+#[cfg(feature = "full")]
 use activitypub_federation::protocol::helpers::deserialize_skip_error;
 #[cfg(feature = "full")]
 use extism::FromBytes;
@@ -757,7 +758,10 @@ pub struct UserSettingsBackup {
   pub banner: Option<Url>,
   pub matrix_id: Option<String>,
   pub bot_account: Option<bool>,
-  #[serde(deserialize_with = "deserialize_skip_error", default)]
+  #[cfg_attr(
+    feature = "full",
+    serde(deserialize_with = "deserialize_skip_error", default)
+  )]
   // TODO: might be worth making a separate struct for settings backup, to avoid breakage in case
   //       fields are renamed, and to avoid storing unnecessary fields like person_id or email
   pub settings: Option<LocalUser>,

--- a/crates/db_views/site/src/api.rs
+++ b/crates/db_views/site/src/api.rs
@@ -1,4 +1,5 @@
 use crate::{ResolveObjectView, SiteView};
+use activitypub_federation::protocol::helpers::deserialize_skip_error;
 #[cfg(feature = "full")]
 use extism::FromBytes;
 use extism_convert::Json;
@@ -747,7 +748,6 @@ pub enum PostOrCommentOrPrivateMessage {
 /// Be careful with any changes to this struct, to avoid breaking changes which could prevent
 /// importing older backups.
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
-#[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
 pub struct UserSettingsBackup {
@@ -757,6 +757,7 @@ pub struct UserSettingsBackup {
   pub banner: Option<Url>,
   pub matrix_id: Option<String>,
   pub bot_account: Option<bool>,
+  #[serde(deserialize_with = "deserialize_skip_error", default)]
   // TODO: might be worth making a separate struct for settings backup, to avoid breakage in case
   //       fields are renamed, and to avoid storing unnecessary fields like person_id or email
   pub settings: Option<LocalUser>,


### PR DESCRIPTION
```
unknown variant `Local`, expected one of `all`, `local`, `subscribed`, `moderator_view`, `suggested`
```

Its currently failing because we changed enums from PascalCase to snake_case. To make this work probably requires a custom deserializer for these enums which can handle both cases. Or a separate struct and separate enum definitions as mentioned here:
https://github.com/LemmyNet/lemmy/blob/main/crates/db_views/site/src/api.rs#L762

For now I made a simple fix which ignores local user settings entirely if there are any invalid values.