### PR TITLE
Dont require registration application when using OAuth

### DIFF
--- a/crates/api/api_crud/src/user/create.rs
+++ b/crates/api/api_crud/src/user/create.rs
@@ -341,8 +341,7 @@ pub async fn authenticate_with_oauth(
     login_response.registration_created = local_site.site_setup
       && require_registration_application
       && !local_user.accepted_application
-      && !local_user.admin
-      && data.answer.is_some();
+      && !local_user.admin;
 
     check_local_user_valid(&user_view)?;
     check_email_verified(&user_view, &site_view)?;
@@ -396,9 +395,6 @@ pub async fn authenticate_with_oauth(
     } else {
       // No user was found by email => Register as new user
 
-      // make sure the registration answer is provided when the registration application is required
-      validate_registration_answer(require_registration_application, &data.answer)?;
-
       let slur_regex = slur_regex(&context).await?;
 
       // Wrap the insert person, insert local user, and create registration,
@@ -416,7 +412,6 @@ pub async fn authenticate_with_oauth(
               .ok_or(LemmyErrorType::RegistrationUsernameRequired)?;
 
             check_slurs(username, &slur_regex)?;
-            check_slurs_opt(&tx_data.answer, &slur_regex)?;
 
             Person::check_username_taken(&mut conn.into(), username).await?;
 
@@ -447,22 +442,6 @@ pub async fn authenticate_with_oauth(
 
             OAuthAccount::create(&mut conn.into(), &oauth_account_form).await?;
 
-            // prevent sign in until application is accepted
-            if login_response.registration_created {
-              // Create the registration application
-              RegistrationApplication::create(
-                &mut conn.into(),
-                &RegistrationApplicationInsertForm {
-                  local_user_id: local_user.id,
-                  // We already check earlier that this Some, however using `ok_or` is cleaner
-                  // than unwrap or expect (which also requires clippy allow).
-                  answer: data
-                    .answer
-                    .ok_or(LemmyErrorType::RegistrationApplicationAnswerRequired)?,
-                },
-              )
-              .await?;
-            }
             Ok(LocalUserView {
               person,
               local_user,

--- a/crates/db_views/site/src/api.rs
+++ b/crates/db_views/site/src/api.rs
@@ -82,8 +82,6 @@ pub struct AuthenticateWithOauth {
   pub show_nsfw: Option<bool>,
   /// Username is mandatory at registration time
   pub username: Option<String>,
-  /// An answer is mandatory if require application is enabled on the server
-  pub answer: Option<String>,
   pub pkce_code_verifier: Option<String>,
   /// If this is true the login is valid forever, otherwise it expires after one week.
   pub stay_logged_in: Option<bool>,


### PR DESCRIPTION
When someone registers via OAuth, we can presumably trust that it is a valid user, and dont need to do a registration application. The alternative would be more complicated, we would have to add a new prompt similar to the one for username in https://github.com/LemmyNet/lemmy-ui/pull/4129.