### PR TITLE
Fix markdown link rewriting (fixes #6511)

### DIFF
--- a/api_tests/src/post.spec.ts
+++ b/api_tests/src/post.spec.ts
@@ -1071,7 +1071,9 @@ test("Rewrite markdown links", async () => {
   ).then(expectSuccess);
   expect(postRes2.post_view.post).toBeDefined();
   const originalLink = `http://lemmy-beta:8551/post/${postRes1?.post_view.post.id}`;
-  expect(postRes2.post_view.post.body).toBe(`[link](${originalLink})\n${originalLink}\n`);
+  expect(postRes2.post_view.post.body).toBe(
+    `[link](${originalLink})\n${originalLink}\n`,
+  );
 
   // fetch post from the other instance
   const alphaPost = await resolvePost(alpha, postRes2.post_view.post);

--- a/api_tests/src/post.spec.ts
+++ b/api_tests/src/post.spec.ts
@@ -1067,17 +1067,20 @@ test("Rewrite markdown links", async () => {
     beta,
     community!.community.id,
     sampleSite,
-    `[link](${postRes1.post_view.post.ap_id})`,
+    `[link](${postRes1.post_view.post.ap_id})\n${postRes1.post_view.post.ap_id}\n`,
   ).then(expectSuccess);
   expect(postRes2.post_view.post).toBeDefined();
+  const originalLink = `http://lemmy-beta:8551/post/${postRes1?.post_view.post.id}`;
+  expect(postRes2.post_view.post.body).toBe(`[link](${originalLink})\n${originalLink}\n`);
 
-  // fetch both posts from another instance
-  const alphaPost1 = await resolvePost(alpha, postRes1.post_view.post);
-  const alphaPost2 = await resolvePost(alpha, postRes2.post_view.post);
+  // fetch post from the other instance
+  const alphaPost = await resolvePost(alpha, postRes2.post_view.post);
 
   // remote markdown link is replaced with local link
-  expect(alphaPost2?.post.body).toBe(
-    `[link](http://lemmy-alpha:8541/post/${alphaPost1?.post.id})`,
+  const rewrittenLink = `http://lemmy-alpha:8541/post/1`;
+  console.log(alphaPost?.post.body);
+  expect(alphaPost?.post.body).toBe(
+    `[link](${rewrittenLink})\n${rewrittenLink}\n`,
   );
 });
 

--- a/api_tests/src/post.spec.ts
+++ b/api_tests/src/post.spec.ts
@@ -1076,12 +1076,12 @@ test("Rewrite markdown links", async () => {
   );
 
   // fetch post from the other instance
-  const alphaPost = await resolvePost(alpha, postRes2.post_view.post);
+  const alphaPost2 = await resolvePost(alpha, postRes2.post_view.post);
+  const alphaPost1 = await resolvePost(alpha, postRes1.post_view.post);
 
   // remote markdown link is replaced with local link
-  const rewrittenLink = `http://lemmy-alpha:8541/post/1`;
-  console.log(alphaPost?.post.body);
-  expect(alphaPost?.post.body).toBe(
+  const rewrittenLink = `http://lemmy-alpha:8541/post/${alphaPost1?.post.id}`;
+  expect(alphaPost2?.post.body).toBe(
     `[link](${rewrittenLink})\n${rewrittenLink}\n`,
   );
 });

--- a/crates/apub/objects/src/objects/post.rs
+++ b/crates/apub/objects/src/objects/post.rs
@@ -405,7 +405,8 @@ mod tests {
     assert_eq!(post.body.as_ref().map(std::string::String::len), Some(45));
     assert!(!post.locked);
     assert!(!post.featured_community);
-    assert_eq!(context.request_count(), 0);
+    // one request is made trying to resolve post.url into local object
+    assert_eq!(context.request_count(), 1);
 
     test_data.delete(&mut context.pool()).await?;
     Instance::delete_all(&mut context.pool()).await?;

--- a/crates/apub/objects/src/utils/markdown_links.rs
+++ b/crates/apub/objects/src/utils/markdown_links.rs
@@ -53,7 +53,7 @@ pub(crate) async fn to_local_url(url: &str, context: &Data<LemmyContext>) -> Opt
   if object_domain == Some(local_domain) {
     return None;
   }
-  let dereferenced = object_id.dereference_local(context).await.ok()?;
+  let dereferenced = object_id.dereference(context).await.ok()?;
   match dereferenced {
     Left(Left(Left(post))) => post.local_url(context.settings()),
     Left(Left(Right(comment))) => comment.local_url(context.settings()),

--- a/crates/utils/src/utils/markdown/image_links.rs
+++ b/crates/utils/src/utils/markdown/image_links.rs
@@ -106,8 +106,7 @@ trait UrlAndTitle {
 
 impl UrlAndTitle for Image {
   fn start_offset(&self, node_offset: usize) -> usize {
-    let title_len = self.title.as_ref().map(|t| t.len() + 3).unwrap_or_default();
-    node_offset - self.url.len() - 1 - title_len
+    start_offset_impl(&self.title, &self.url, node_offset)
   }
   fn end_offset(&self, node_offset: usize) -> usize {
     node_offset - 1
@@ -115,17 +114,21 @@ impl UrlAndTitle for Image {
 }
 impl UrlAndTitle for Link {
   fn start_offset(&self, node_offset: usize) -> usize {
-    let title_len = self.title.as_ref().map(|t| t.len() + 3).unwrap_or_default();
-    node_offset - self.url.len() - 1 - title_len
+    start_offset_impl(&self.title, &self.url, node_offset)
   }
   fn end_offset(&self, node_offset: usize) -> usize {
     node_offset - 1
   }
 }
 
+fn start_offset_impl(title: &Option<String>, url: &str, node_offset: usize) -> usize {
+  let title_len = title.as_ref().map(|t| t.len() + 3).unwrap_or_default();
+  node_offset - url.len() - 1 - title_len
+}
+
 impl UrlAndTitle for Linkified {
   fn start_offset(&self, node_offset: usize) -> usize {
-    node_offset - self.url.len() +1
+    node_offset - self.url.len() + 1
   }
   fn end_offset(&self, node_offset: usize) -> usize {
     node_offset + 1

--- a/crates/utils/src/utils/markdown/image_links.rs
+++ b/crates/utils/src/utils/markdown/image_links.rs
@@ -4,9 +4,12 @@ use markdown_it::{
   MarkdownIt,
   NodeValue,
   parser::linkfmt::LinkFormatter,
-  plugins::cmark::{
-    block::fence,
-    inline::{image, image::Image},
+  plugins::{
+    cmark::{
+      block::fence,
+      inline::image::{self, Image},
+    },
+    extra::linkify::{self, Linkified},
   },
 };
 use std::sync::LazyLock;
@@ -59,7 +62,10 @@ pub fn markdown_handle_title(src: &str, start: usize, end: usize) -> (&str, Opti
 }
 
 pub fn markdown_find_links(src: &str) -> Vec<(usize, usize)> {
-  find_urls::<Link>(src)
+  let mut res = vec![];
+  res.extend(find_urls::<Linkified>(src));
+  res.extend(find_urls::<Link>(src));
+  res
 }
 
 // Walk the syntax tree to find positions of image or link urls
@@ -69,6 +75,7 @@ fn find_urls<T: NodeValue + UrlAndTitle>(src: &str) -> Vec<(usize, usize)> {
   static PARSER: LazyLock<MarkdownIt> = LazyLock::new(|| {
     let mut p = MarkdownIt::new();
     p.link_formatter = Box::new(NoopLinkFormatter {});
+    linkify::add(&mut p);
     image::add(&mut p);
     fence::add(&mut p);
     link_rule::add(&mut p);
@@ -82,35 +89,46 @@ fn find_urls<T: NodeValue + UrlAndTitle>(src: &str) -> Vec<(usize, usize)> {
       && let Some(srcmap) = node.srcmap
     {
       let (_, node_offset) = srcmap.get_byte_offsets();
-      let start_offset = node_offset - image.url_len() - 1 - image.title_len();
-      let end_offset = node_offset - 1;
 
-      links_offsets.push((start_offset, end_offset));
+      links_offsets.push((
+        image.start_offset(node_offset),
+        image.end_offset(node_offset),
+      ));
     }
   });
   links_offsets
 }
 
 trait UrlAndTitle {
-  fn url_len(&self) -> usize;
-  fn title_len(&self) -> usize;
+  fn start_offset(&self, node_offset: usize) -> usize;
+  fn end_offset(&self, node_offset: usize) -> usize;
 }
 
 impl UrlAndTitle for Image {
-  fn url_len(&self) -> usize {
-    self.url.len()
+  fn start_offset(&self, node_offset: usize) -> usize {
+    let title_len = self.title.as_ref().map(|t| t.len() + 3).unwrap_or_default();
+    node_offset - self.url.len() - 1 - title_len
   }
-
-  fn title_len(&self) -> usize {
-    self.title.as_ref().map(|t| t.len() + 3).unwrap_or_default()
+  fn end_offset(&self, node_offset: usize) -> usize {
+    node_offset - 1
   }
 }
 impl UrlAndTitle for Link {
-  fn url_len(&self) -> usize {
-    self.url.len()
+  fn start_offset(&self, node_offset: usize) -> usize {
+    let title_len = self.title.as_ref().map(|t| t.len() + 3).unwrap_or_default();
+    node_offset - self.url.len() - 1 - title_len
   }
-  fn title_len(&self) -> usize {
-    self.title.as_ref().map(|t| t.len() + 3).unwrap_or_default()
+  fn end_offset(&self, node_offset: usize) -> usize {
+    node_offset - 1
+  }
+}
+
+impl UrlAndTitle for Linkified {
+  fn start_offset(&self, node_offset: usize) -> usize {
+    node_offset - self.url.len() +1
+  }
+  fn end_offset(&self, node_offset: usize) -> usize {
+    node_offset + 1
   }
 }
 


### PR DESCRIPTION
- Resolve links in case they are not locally known yet
- Also rewrite plain links
- Improve test case