### PR TITLE
Fixes for unlisted community

### DIFF
--- a/crates/db_schema/src/impls/local_user.rs
+++ b/crates/db_schema/src/impls/local_user.rs
@@ -18,8 +18,7 @@ use diesel::{
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema_file::{
   PersonId,
-  enums::CommunityVisibility,
-  schema::{community, community_actions, local_user, person, registration_application},
+  schema::{community_actions, local_user, person, registration_application},
 };
 use lemmy_diesel_utils::{
   connection::{DbPool, get_conn},
@@ -320,12 +319,6 @@ pub trait LocalUserOptionHelper {
   fn is_admin(&self) -> bool;
   fn show_nsfw(&self, site: &Site) -> bool;
   fn hide_media(&self) -> bool;
-  fn visible_communities_only<Q>(&self, query: Q) -> Q
-  where
-    Q: diesel::query_dsl::methods::FilterDsl<
-        diesel::dsl::Eq<community::visibility, CommunityVisibility>,
-        Output = Q,
-      >;
 }
 
 impl LocalUserOptionHelper for Option<&LocalUser> {
@@ -357,17 +350,6 @@ impl LocalUserOptionHelper for Option<&LocalUser> {
 
   fn hide_media(&self) -> bool {
     self.map(|l| l.hide_media).unwrap_or(false)
-  }
-
-  // TODO: use this function for private community checks, but the generics get extremely confusing
-  fn visible_communities_only<Q>(&self, query: Q) -> Q
-  where
-    Q: diesel::query_dsl::methods::FilterDsl<
-        diesel::dsl::Eq<community::visibility, CommunityVisibility>,
-        Output = Q,
-      >,
-  {
-      query
   }
 }
 

--- a/crates/db_schema/src/impls/local_user.rs
+++ b/crates/db_schema/src/impls/local_user.rs
@@ -367,11 +367,7 @@ impl LocalUserOptionHelper for Option<&LocalUser> {
         Output = Q,
       >,
   {
-    if self.is_none() {
-      query.filter(community::visibility.eq(CommunityVisibility::Public))
-    } else {
       query
-    }
   }
 }
 

--- a/crates/db_schema/src/utils/queries/filters.rs
+++ b/crates/db_schema/src/utils/queries/filters.rs
@@ -1,8 +1,12 @@
-use diesel::{BoolExpressionMethods, ExpressionMethods, helper_types::Eq};
+use diesel::{
+  BoolExpressionMethods,
+  ExpressionMethods,
+  helper_types::{Eq, NotEq, Or},
+};
 use lemmy_db_schema_file::{
   aliases::my_instance_persons_actions,
-  enums::CommunityFollowerState,
-  schema::{community_actions, instance_actions, person_actions},
+  enums::{CommunityFollowerState, CommunityVisibility},
+  schema::{community, community_actions, instance_actions, person_actions},
 };
 
 /// Hide all content from blocked communities and persons. Content from blocked instances is also
@@ -21,9 +25,26 @@ pub fn filter_blocked() -> _ {
     )
 }
 
-type IsSubscribedType =
-  Eq<lemmy_db_schema_file::schema::community_actions::follow_state, Option<CommunityFollowerState>>;
+type IsSubscribedType = Eq<community_actions::follow_state, Option<CommunityFollowerState>>;
 
 pub fn filter_is_subscribed() -> IsSubscribedType {
   community_actions::follow_state.eq(Some(CommunityFollowerState::Accepted))
+}
+
+type CommunityVisibilityType = NotEq<community::visibility, CommunityVisibility>;
+
+type CommunityVisibilityOrSubscribedType = Or<CommunityVisibilityType, IsSubscribedType>;
+
+/// Show only listed or followed communities
+pub fn filter_unlisted_or_followed() -> CommunityVisibilityOrSubscribedType {
+  community::visibility
+    .ne(CommunityVisibility::Unlisted)
+    .or(filter_is_subscribed())
+}
+
+/// Show only non-private or followed communities
+pub fn filter_private_or_followed() -> CommunityVisibilityOrSubscribedType {
+  community::visibility
+    .ne(CommunityVisibility::Private)
+    .or(filter_is_subscribed())
 }

--- a/crates/db_schema/src/utils/queries/filters.rs
+++ b/crates/db_schema/src/utils/queries/filters.rs
@@ -1,12 +1,8 @@
-use diesel::{
-  BoolExpressionMethods,
-  ExpressionMethods,
-  helper_types::{Eq, NotEq},
-};
+use diesel::{BoolExpressionMethods, ExpressionMethods, helper_types::Eq};
 use lemmy_db_schema_file::{
   aliases::my_instance_persons_actions,
-  enums::{CommunityFollowerState, CommunityVisibility},
-  schema::{community, community_actions, instance_actions, person_actions},
+  enums::CommunityFollowerState,
+  schema::{community_actions, instance_actions, person_actions},
 };
 
 /// Hide all content from blocked communities and persons. Content from blocked instances is also
@@ -30,13 +26,4 @@ type IsSubscribedType =
 
 pub fn filter_is_subscribed() -> IsSubscribedType {
   community_actions::follow_state.eq(Some(CommunityFollowerState::Accepted))
-}
-
-type IsNotUnlistedType =
-  NotEq<lemmy_db_schema_file::schema::community::visibility, CommunityVisibility>;
-
-#[diesel::dsl::auto_type]
-pub fn filter_not_unlisted() -> _ {
-  let not_unlisted: IsNotUnlistedType = community::visibility.ne(CommunityVisibility::Unlisted);
-  not_unlisted
 }

--- a/crates/db_views/comment/src/impls.rs
+++ b/crates/db_views/comment/src/impls.rs
@@ -24,7 +24,12 @@ use lemmy_db_schema::{
   },
   utils::{
     limit_fetch,
-    queries::filters::{filter_blocked, filter_is_subscribed},
+    queries::filters::{
+      filter_blocked,
+      filter_is_subscribed,
+      filter_private_or_followed,
+      filter_unlisted_or_followed,
+    },
   },
 };
 use lemmy_db_schema_file::{
@@ -32,7 +37,6 @@ use lemmy_db_schema_file::{
   PersonId,
   enums::{
     CommentSortType::{self, *},
-    CommunityFollowerState,
     CommunityVisibility,
     ListingType,
   },
@@ -48,7 +52,7 @@ use lemmy_db_schema_file::{
     my_local_user_admin_join,
     my_person_actions_join,
   },
-  schema::{comment, community, community_actions, person, post},
+  schema::{comment, community, person, post},
 };
 use lemmy_diesel_utils::{
   connection::{DbPool, get_conn},
@@ -127,11 +131,7 @@ impl CommentView {
     // content, otherwise it is filtered out. Admins can view private community content
     // without restriction.
     if !my_local_user.is_admin() {
-      query = query.filter(
-        community::visibility
-          .ne(CommunityVisibility::Private)
-          .or(community_actions::follow_state.eq(CommunityFollowerState::Accepted)),
-      );
+      query = query.filter(filter_private_or_followed())
     }
     if my_local_user.is_none() {
       query = query.filter(community::visibility.ne(CommunityVisibility::LocalOnlyPrivate));
@@ -215,21 +215,14 @@ impl CommentQuery<'_> {
     query = match listing_type {
       ListingType::Subscribed => query.filter(filter_is_subscribed()),
       ListingType::Local => {
+        // Always filter out unlisted or followed
+        query = query.filter(filter_unlisted_or_followed());
+
         // Only filter by local when there's no post or community given
         if self.post_id.is_none() && self.community_id.is_none() {
-          query
-            .filter(
-              community::visibility
-                .ne(CommunityVisibility::Unlisted)
-                .or(community_actions::follow_state.eq(CommunityFollowerState::Accepted)),
-            )
-            .filter(community::local.eq(true))
+          query.filter(community::local.eq(true))
         } else {
-          query.filter(
-            community::visibility
-              .ne(CommunityVisibility::Unlisted)
-              .or(community_actions::follow_state.eq(CommunityFollowerState::Accepted)),
-          )
+          query
         }
       }
       ListingType::All => query,
@@ -259,19 +252,11 @@ impl CommentQuery<'_> {
     if self.community_id.is_none()
       && (listing_type == ListingType::All || listing_type == ListingType::Local)
     {
-      query = query.filter(
-        community::visibility
-          .ne(CommunityVisibility::Unlisted)
-          .or(community_actions::follow_state.eq(CommunityFollowerState::Accepted)),
-      );
+      query = query.filter(filter_unlisted_or_followed());
     }
 
     if !self.local_user.is_admin() {
-      query = query.filter(
-        community::visibility
-          .ne(CommunityVisibility::Private)
-          .or(community_actions::follow_state.eq(CommunityFollowerState::Accepted)),
-      );
+      query = query.filter(filter_private_or_followed())
     }
     if self.local_user.is_none() {
       query = query.filter(community::visibility.ne(CommunityVisibility::LocalOnlyPrivate));
@@ -408,6 +393,7 @@ mod tests {
     },
     traits::{Bannable, Blockable, Followable, Likeable},
   };
+  use lemmy_db_schema_file::enums::CommunityFollowerState;
   use lemmy_db_views_local_user::LocalUserView;
   use lemmy_diesel_utils::{
     connection::{DbPool, build_db_pool_for_tests},

--- a/crates/db_views/comment/src/impls.rs
+++ b/crates/db_views/comment/src/impls.rs
@@ -122,8 +122,6 @@ impl CommentView {
       .select(Self::as_select())
       .into_boxed();
 
-    query = my_local_user.visible_communities_only(query);
-
     // Check permissions to view private community content.
     // Specifically, if the community is private then only accepted followers may view its
     // content, otherwise it is filtered out. Admins can view private community content
@@ -210,14 +208,17 @@ impl CommentQuery<'_> {
 
     // For posts, we only show hidden if its subscribed, but for comments,
     // we ignore hidden.
-    query = match self.listing_type.unwrap_or_default() {
+    let listing_type = self.listing_type.unwrap_or_default();
+    query = match listing_type {
       ListingType::Subscribed => query.filter(filter_is_subscribed()),
       ListingType::Local => {
         // Only filter by local when there's no post or community given
         if self.post_id.is_none() && self.community_id.is_none() {
-          query.filter(community::local.eq(true))
-        } else {
           query
+            .filter(community::visibility.ne(CommunityVisibility::Unlisted))
+            .filter(community::local.eq(true))
+        } else {
+          query.filter(community::visibility.ne(CommunityVisibility::Unlisted))
         }
       }
       ListingType::All => query,
@@ -243,6 +244,13 @@ impl CommentQuery<'_> {
       }
     };
 
+    // Comments from unlisted communities should not be visible in Local/All feeds
+    if self.community_id.is_none()
+      && (listing_type == ListingType::All || listing_type == ListingType::Local)
+    {
+      query = query.filter(community::visibility.ne(CommunityVisibility::Unlisted));
+    }
+
     if !self.local_user.show_bot_accounts() {
       query = query.filter(person::bot_account.eq(false));
     };
@@ -267,7 +275,6 @@ impl CommentQuery<'_> {
         .filter(community::nsfw.eq(false));
     };
 
-    query = self.local_user.visible_communities_only(query);
     query = query.filter(
       comment::federation_pending
         .eq(false)

--- a/crates/db_views/comment/src/impls.rs
+++ b/crates/db_views/comment/src/impls.rs
@@ -215,7 +215,7 @@ impl CommentQuery<'_> {
     query = match listing_type {
       ListingType::Subscribed => query.filter(filter_is_subscribed()),
       ListingType::Local => {
-        // Always filter out unlisted or followed
+        // Always filter out unlisted comms unless you follow them
         query = query.filter(filter_unlisted_or_followed());
 
         // Only filter by local when there's no post or community given
@@ -225,7 +225,7 @@ impl CommentQuery<'_> {
           query
         }
       }
-      ListingType::All => query,
+      ListingType::All => query.filter(filter_unlisted_or_followed()),
       ListingType::ModeratorView => {
         // Pre-fetch the moderator view community ids, since the join is too costly
         let community_ids = if let Some(my_person_id) = my_person_id {

--- a/crates/db_views/comment/src/impls.rs
+++ b/crates/db_views/comment/src/impls.rs
@@ -133,6 +133,9 @@ impl CommentView {
           .or(community_actions::follow_state.eq(CommunityFollowerState::Accepted)),
       );
     }
+    if my_local_user.is_none() {
+      query = query.filter(community::visibility.ne(CommunityVisibility::LocalOnlyPrivate));
+    }
 
     query
       .first::<Self>(conn)
@@ -251,6 +254,17 @@ impl CommentQuery<'_> {
       query = query.filter(community::visibility.ne(CommunityVisibility::Unlisted));
     }
 
+    if !self.local_user.is_admin() {
+      query = query.filter(
+        community::visibility
+          .ne(CommunityVisibility::Private)
+          .or(community_actions::follow_state.eq(CommunityFollowerState::Accepted)),
+      );
+    }
+    if self.local_user.is_none() {
+      query = query.filter(community::visibility.ne(CommunityVisibility::LocalOnlyPrivate));
+    }
+
     if !self.local_user.show_bot_accounts() {
       query = query.filter(person::bot_account.eq(false));
     };
@@ -280,14 +294,6 @@ impl CommentQuery<'_> {
         .eq(false)
         .or(comment::creator_id.nullable().eq(my_person_id)),
     );
-
-    if !self.local_user.is_admin() {
-      query = query.filter(
-        community::visibility
-          .ne(CommunityVisibility::Private)
-          .or(community_actions::follow_state.eq(CommunityFollowerState::Accepted)),
-      );
-    }
 
     // Filter by the time range
     if let Some(time_range_seconds) = self.time_range_seconds {

--- a/crates/db_views/comment/src/impls.rs
+++ b/crates/db_views/comment/src/impls.rs
@@ -218,10 +218,18 @@ impl CommentQuery<'_> {
         // Only filter by local when there's no post or community given
         if self.post_id.is_none() && self.community_id.is_none() {
           query
-            .filter(community::visibility.ne(CommunityVisibility::Unlisted))
+            .filter(
+              community::visibility
+                .ne(CommunityVisibility::Unlisted)
+                .or(community_actions::follow_state.eq(CommunityFollowerState::Accepted)),
+            )
             .filter(community::local.eq(true))
         } else {
-          query.filter(community::visibility.ne(CommunityVisibility::Unlisted))
+          query.filter(
+            community::visibility
+              .ne(CommunityVisibility::Unlisted)
+              .or(community_actions::follow_state.eq(CommunityFollowerState::Accepted)),
+          )
         }
       }
       ListingType::All => query,
@@ -251,7 +259,11 @@ impl CommentQuery<'_> {
     if self.community_id.is_none()
       && (listing_type == ListingType::All || listing_type == ListingType::Local)
     {
-      query = query.filter(community::visibility.ne(CommunityVisibility::Unlisted));
+      query = query.filter(
+        community::visibility
+          .ne(CommunityVisibility::Unlisted)
+          .or(community_actions::follow_state.eq(CommunityFollowerState::Accepted)),
+      );
     }
 
     if !self.local_user.is_admin() {

--- a/crates/db_views/community/src/impls.rs
+++ b/crates/db_views/community/src/impls.rs
@@ -25,7 +25,7 @@ use lemmy_db_schema::{
 };
 use lemmy_db_schema_file::{
   PersonId,
-  enums::ListingType,
+  enums::{CommunityVisibility, ListingType},
   joins::{
     my_community_actions_join,
     my_instance_communities_actions_join,
@@ -81,6 +81,9 @@ impl CommunityView {
       .filter(community::id.eq(community_id))
       .select(Self::as_select())
       .into_boxed();
+    if my_local_user.is_none() {
+      query = query.filter(community::visibility.ne(CommunityVisibility::LocalOnlyPrivate));
+    }
 
     // Hide deleted and removed for non-admins or mods
     if !is_mod_or_admin {
@@ -142,6 +145,9 @@ impl CommunityQuery<'_> {
     let is_admin = self.local_user.map(|l| l.admin).unwrap_or_default();
     if !is_admin {
       query = query.filter(Community::hide_removed_and_deleted());
+    }
+    if self.local_user.is_none() {
+      query = query.filter(community::visibility.ne(CommunityVisibility::LocalOnlyPrivate));
     }
 
     if let Some(listing_type) = self.listing_type {

--- a/crates/db_views/community/src/impls.rs
+++ b/crates/db_views/community/src/impls.rs
@@ -87,12 +87,8 @@ impl CommunityView {
 
     // Hide deleted and removed for non-admins or mods
     if !is_mod_or_admin {
-      query = query
-        .filter(Community::hide_removed_and_deleted())
-        .filter(filter_not_unlisted());
+      query = query.filter(Community::hide_removed_and_deleted());
     }
-
-    query = my_local_user.visible_communities_only(query);
 
     query
       .first(conn)
@@ -153,11 +149,9 @@ impl CommunityQuery<'_> {
 
     if let Some(listing_type) = self.listing_type {
       query = match listing_type {
-        ListingType::All => query.filter(filter_not_unlisted()),
+        ListingType::All => query,
         ListingType::Subscribed => query.filter(filter_is_subscribed()),
-        ListingType::Local => query
-          .filter(community::local.eq(true))
-          .filter(filter_not_unlisted()),
+        ListingType::Local => query.filter(community::local.eq(true)),
         ListingType::ModeratorView => {
           query.filter(community_actions::became_moderator_at.is_not_null())
         }
@@ -182,8 +176,6 @@ impl CommunityQuery<'_> {
     if !(self.local_user.show_nsfw(site) || self.show_nsfw.unwrap_or_default()) {
       query = query.filter(community::nsfw.eq(false));
     }
-
-    query = self.local_user.visible_communities_only(query);
 
     if let Some(multi_community_id) = self.multi_community_id {
       let communities = multi_community_entry::table

--- a/crates/db_views/community/src/impls.rs
+++ b/crates/db_views/community/src/impls.rs
@@ -21,10 +21,7 @@ use lemmy_db_schema::{
     multi_community::{MultiCommunity, MultiCommunityEntry, multi_community_keys as mkey},
     site::Site,
   },
-  utils::{
-    limit_fetch,
-    queries::filters::{filter_is_subscribed, filter_not_unlisted},
-  },
+  utils::{limit_fetch, queries::filters::filter_is_subscribed},
 };
 use lemmy_db_schema_file::{
   PersonId,

--- a/crates/db_views/community_moderator/src/impls.rs
+++ b/crates/db_views/community_moderator/src/impls.rs
@@ -101,8 +101,6 @@ impl CommunityModeratorView {
       .select(Self::as_select())
       .into_boxed();
 
-    query = local_user.visible_communities_only(query);
-
     // only show deleted communities to creator
     if Some(person_id) != local_user.person_id() {
       query = query.filter(community::deleted.eq(false));

--- a/crates/db_views/modlog/src/impls.rs
+++ b/crates/db_views/modlog/src/impls.rs
@@ -19,10 +19,7 @@ use lemmy_db_schema::{
     modlog::{Modlog, modlog_keys as key},
     multi_community::MultiCommunityEntry,
   },
-  utils::{
-    limit_fetch,
-    queries::filters::{filter_is_subscribed, filter_not_unlisted},
-  },
+  utils::{limit_fetch, queries::filters::filter_is_subscribed},
 };
 use lemmy_db_schema_file::{
   PersonId,
@@ -172,9 +169,7 @@ impl ModlogQuery<'_> {
     query = match self.listing_type.unwrap_or(ListingType::All) {
       ListingType::All => query,
       ListingType::Subscribed => query.filter(filter_is_subscribed()),
-      ListingType::Local => query
-        .filter(community::local.eq(true))
-        .filter(filter_not_unlisted()),
+      ListingType::Local => query.filter(community::local.eq(true)),
       ListingType::ModeratorView => {
         query.filter(community_actions::became_moderator_at.is_not_null())
       }

--- a/crates/db_views/post/src/impls.rs
+++ b/crates/db_views/post/src/impls.rs
@@ -29,10 +29,7 @@ use lemmy_db_schema::{
     post::{Post, PostActions, post_actions_keys as pa_key, post_keys as key},
     site::Site,
   },
-  utils::{
-    limit_fetch,
-    queries::filters::{filter_blocked, filter_not_unlisted},
-  },
+  utils::{limit_fetch, queries::filters::filter_blocked},
 };
 use lemmy_db_schema_file::{
   InstanceId,
@@ -217,8 +214,6 @@ impl PostView {
             .or(community_actions::follow_state.eq(CommunityFollowerState::Accepted)),
         );
     }
-
-    query = my_local_user.visible_communities_only(query);
 
     Commented::new(query)
       .text("PostView::read")
@@ -426,8 +421,17 @@ impl PostQuery<'_> {
 
     // Although the other listing types pre-fetched the communities, you still need to filter by
     // local if necessary.
-    if self.listing_type.unwrap_or_default() == ListingType::Local {
+    let listing_type = self.listing_type.unwrap_or_default();
+    if listing_type == ListingType::Local {
       query = query.filter(community::local.eq(true));
+    }
+
+    // Posts from unlisted communities should not be visible in Local/All feeds
+    if self.community_id.is_none()
+      && self.multi_community_id.is_none()
+      && (listing_type == ListingType::All || listing_type == ListingType::Local)
+    {
+      query = query.filter(community::visibility.ne(CommunityVisibility::Unlisted));
     }
 
     // The search term
@@ -449,11 +453,6 @@ impl PostQuery<'_> {
         let body_or_description_filter = post::body.ilike(searcher.clone());
         query.filter(name_or_title_filter.or(body_or_description_filter))
       }
-    }
-
-    // Hide the unlisted communities for the general types. Subscribed will still show them
-    if [ListingType::Local, ListingType::All].contains(&self.listing_type.unwrap_or_default()) {
-      query = query.filter(filter_not_unlisted());
     }
 
     if !self.show_nsfw.unwrap_or(self.local_user.show_nsfw(site)) {
@@ -490,7 +489,6 @@ impl PostQuery<'_> {
       ));
     }
 
-    query = self.local_user.visible_communities_only(query);
     query = query.filter(
       post::federation_pending
         .eq(false)

--- a/crates/db_views/post/src/impls.rs
+++ b/crates/db_views/post/src/impls.rs
@@ -29,12 +29,15 @@ use lemmy_db_schema::{
     post::{Post, PostActions, post_actions_keys as pa_key, post_keys as key},
     site::Site,
   },
-  utils::{limit_fetch, queries::filters::filter_blocked},
+  utils::{
+    limit_fetch,
+    queries::filters::{filter_blocked, filter_private_or_followed, filter_unlisted_or_followed},
+  },
 };
 use lemmy_db_schema_file::{
   InstanceId,
   PersonId,
-  enums::{CommunityFollowerState, CommunityVisibility, ListingType, PostSortType},
+  enums::{CommunityVisibility, ListingType, PostSortType},
   joins::{
     creator_community_actions_join,
     creator_community_instance_actions_join,
@@ -48,7 +51,7 @@ use lemmy_db_schema_file::{
     my_person_actions_join,
     my_post_actions_join,
   },
-  schema::{community, community_actions, person, post, post_actions},
+  schema::{community, person, post, post_actions},
 };
 use lemmy_diesel_utils::{
   connection::{DbPool, get_conn},
@@ -212,11 +215,7 @@ impl PostView {
             .or(post::comments.gt(0)),
         )
         // private communities can only by browsed by accepted followers
-        .filter(
-          community::visibility
-            .ne(CommunityVisibility::Private)
-            .or(community_actions::follow_state.eq(CommunityFollowerState::Accepted)),
-        );
+        .filter(filter_private_or_followed());
     }
 
     Commented::new(query)
@@ -435,19 +434,11 @@ impl PostQuery<'_> {
       && self.multi_community_id.is_none()
       && (listing_type == ListingType::All || listing_type == ListingType::Local)
     {
-      query = query.filter(
-        community::visibility
-          .ne(CommunityVisibility::Unlisted)
-          .or(community_actions::follow_state.eq(CommunityFollowerState::Accepted)),
-      );
+      query = query.filter(filter_unlisted_or_followed());
     }
     if !self.local_user.is_admin() {
       query = query
-        .filter(
-          community::visibility
-            .ne(CommunityVisibility::Private)
-            .or(community_actions::follow_state.eq(CommunityFollowerState::Accepted)),
-        )
+        .filter(filter_private_or_followed())
         // only show removed posts to admin
         .filter(community::removed.eq(false))
         .filter(community::local_removed.eq(false))

--- a/crates/db_views/post/src/impls.rs
+++ b/crates/db_views/post/src/impls.rs
@@ -181,6 +181,10 @@ impl PostView {
       .select(Self::as_select())
       .into_boxed();
 
+    if my_local_user.is_none() {
+      query = query.filter(community::visibility.ne(CommunityVisibility::LocalOnlyPrivate));
+    }
+
     // Hide deleted and removed for non-admins or mods
     if !is_mod_or_admin {
       query = query
@@ -433,6 +437,21 @@ impl PostQuery<'_> {
     {
       query = query.filter(community::visibility.ne(CommunityVisibility::Unlisted));
     }
+    if !self.local_user.is_admin() {
+      query = query
+        .filter(
+          community::visibility
+            .ne(CommunityVisibility::Private)
+            .or(community_actions::follow_state.eq(CommunityFollowerState::Accepted)),
+        )
+        // only show removed posts to admin
+        .filter(community::removed.eq(false))
+        .filter(community::local_removed.eq(false))
+        .filter(post::removed.eq(false));
+    }
+    if self.local_user.is_none() {
+      query = query.filter(community::visibility.ne(CommunityVisibility::LocalOnlyPrivate));
+    }
 
     // The search term
     if let Some(search_term) = self.search_term {
@@ -494,19 +513,6 @@ impl PostQuery<'_> {
         .eq(false)
         .or(post::creator_id.nullable().eq(my_person_id)),
     );
-
-    if !self.local_user.is_admin() {
-      query = query
-        .filter(
-          community::visibility
-            .ne(CommunityVisibility::Private)
-            .or(community_actions::follow_state.eq(CommunityFollowerState::Accepted)),
-        )
-        // only show removed posts to admin
-        .filter(community::removed.eq(false))
-        .filter(community::local_removed.eq(false))
-        .filter(post::removed.eq(false));
-    }
 
     // Dont filter blocks or missing languages for moderator view type
     if self.listing_type.unwrap_or_default() != ListingType::ModeratorView {

--- a/crates/db_views/post/src/impls.rs
+++ b/crates/db_views/post/src/impls.rs
@@ -435,7 +435,11 @@ impl PostQuery<'_> {
       && self.multi_community_id.is_none()
       && (listing_type == ListingType::All || listing_type == ListingType::Local)
     {
-      query = query.filter(community::visibility.ne(CommunityVisibility::Unlisted));
+      query = query.filter(
+        community::visibility
+          .ne(CommunityVisibility::Unlisted)
+          .or(community_actions::follow_state.eq(CommunityFollowerState::Accepted)),
+      );
     }
     if !self.local_user.is_admin() {
       query = query


### PR DESCRIPTION
This feature is quite broken:
- Posting in unlisted community throws NotFound errror from CommunityView
- Unlisted communities should be shown in community list
- Posts/comments from unlisted community should not be shown in All/Local feeds, but should be shown in subscribed feed and when viewing the community directly