### PR TITLE
Use correct Activitypub id for private community follow Accept/Reject (fixes #6561)

### DIFF
--- a/crates/api/api/src/community/pending_follows/approve.rs
+++ b/crates/api/api/src/community/pending_follows/approve.rs
@@ -19,15 +19,29 @@ pub async fn post_pending_follows_approve(
 ) -> LemmyResult<Json<SuccessResponse>> {
   is_mod_or_admin(&mut context.pool(), &local_user_view, data.community_id).await?;
 
+  let community_actions = CommunityActions::read(
+    &mut context.pool(),
+    data.community_id,
+    local_user_view.person.id,
+  )
+  .await?;
   let (state, activity_data) = if data.approve {
     (
       CommunityFollowerState::Accepted,
-      SendActivityData::AcceptFollower(data.community_id, data.follower_id),
+      SendActivityData::PrivateCommunityAcceptFollower {
+        community_id: data.community_id,
+        person_id: data.follower_id,
+        follow_activity_id: community_actions.follow_activity_id,
+      },
     )
   } else {
     (
       CommunityFollowerState::Denied,
-      SendActivityData::RejectFollower(data.community_id, data.follower_id),
+      SendActivityData::PrivateCommunityRejectFollower {
+        community_id: data.community_id,
+        person_id: data.follower_id,
+        follow_activity_id: community_actions.follow_activity_id,
+      },
     )
   };
   CommunityActions::approve_private_community_follower(

--- a/crates/api/api_utils/src/send_activity.rs
+++ b/crates/api/api_utils/src/send_activity.rs
@@ -63,8 +63,16 @@ pub enum SendActivityData {
   },
   FollowCommunity(Community, Person, bool),
   FollowMultiCommunity(MultiCommunity, Person, bool),
-  AcceptFollower(CommunityId, PersonId),
-  RejectFollower(CommunityId, PersonId),
+  PrivateCommunityAcceptFollower {
+    community_id: CommunityId,
+    person_id: PersonId,
+    follow_activity_id: Option<DbUrl>,
+  },
+  PrivateCommunityRejectFollower {
+    community_id: CommunityId,
+    person_id: PersonId,
+    follow_activity_id: Option<DbUrl>,
+  },
   UpdateCommunity(Person, Community),
   DeleteCommunity(Person, Community, bool),
   RemoveCommunity {

--- a/crates/apub/activities/src/following/follow.rs
+++ b/crates/apub/activities/src/following/follow.rs
@@ -128,7 +128,10 @@ impl Activity for Follow {
           // Dont allow following local-only community via federation.
           LocalOnlyPrivate | LocalOnlyPublic => return Err(LemmyErrorType::NotFound.into()),
         };
-        let form = CommunityFollowerForm::new(c.id, person.id, follow_state);
+        let form = CommunityFollowerForm {
+          follow_activity_id: Some(self.id.clone().into()),
+          ..CommunityFollowerForm::new(c.id, person.id, follow_state)
+        };
         CommunityActions::follow(&mut context.pool(), &form).await?;
         if c.visibility == CommunityVisibility::Public {
           AcceptFollow::send(self, context).await?;

--- a/crates/apub/activities/src/following/mod.rs
+++ b/crates/apub/activities/src/following/mod.rs
@@ -14,7 +14,7 @@ use lemmy_db_schema::{
   source::{activity::ActivitySendTargets, community::Community, person::Person},
 };
 use lemmy_db_schema_file::PersonId;
-use lemmy_diesel_utils::traits::Crud;
+use lemmy_diesel_utils::{dburl::DbUrl, traits::Crud};
 use lemmy_utils::error::{LemmyError, LemmyResult};
 use serde::Serialize;
 
@@ -40,18 +40,23 @@ pub async fn send_follow(
 pub async fn send_accept_or_reject_follow(
   community_id: CommunityId,
   person_id: PersonId,
+  follow_activity_id: Option<DbUrl>,
   accepted: bool,
   context: &Data<LemmyContext>,
 ) -> LemmyResult<()> {
   let community = Community::read(&mut context.pool(), community_id).await?;
   let person = Person::read(&mut context.pool(), person_id).await?;
 
+  // This fallback should never be needed as we always store `community_actions.follow_activity_id`.
+  // But it needs to be an option so the type system thinks it can be missing
+  let fallback_id = generate_activity_id(FollowType::Follow, context)?;
+
   let follow = Follow {
     actor: person.ap_id.into(),
     to: Some([community.ap_id.clone().into()]),
     object: community.ap_id.into(),
     kind: FollowType::Follow,
-    id: generate_activity_id(FollowType::Follow, context)?,
+    id: follow_activity_id.map(Into::into).unwrap_or(fallback_id),
   };
   if accepted {
     AcceptFollow::send(follow, context).await

--- a/crates/apub/activities/src/lib.rs
+++ b/crates/apub/activities/src/lib.rs
@@ -373,11 +373,21 @@ pub async fn match_outgoing_activities(
         )
         .await
       }
-      AcceptFollower(community_id, person_id) => {
-        send_accept_or_reject_follow(community_id, person_id, true, &context).await
+      PrivateCommunityAcceptFollower {
+        community_id,
+        person_id,
+        follow_activity_id,
+      } => {
+        send_accept_or_reject_follow(community_id, person_id, follow_activity_id, true, &context)
+          .await
       }
-      RejectFollower(community_id, person_id) => {
-        send_accept_or_reject_follow(community_id, person_id, false, &context).await
+      PrivateCommunityRejectFollower {
+        community_id,
+        person_id,
+        follow_activity_id,
+      } => {
+        send_accept_or_reject_follow(community_id, person_id, follow_activity_id, false, &context)
+          .await
       }
       UpdateMultiCommunity(multi, actor) => {
         send_update_multi_community(multi, actor, context).await

--- a/crates/db_schema/src/impls/community.rs
+++ b/crates/db_schema/src/impls/community.rs
@@ -377,6 +377,7 @@ impl CommunityActions {
       .set((
         community_actions::follow_state.eq(state),
         community_actions::follow_approver_id.eq(approver_id),
+        community_actions::follow_activity_id.eq(None::<DbUrl>),
       ))
       .execute(conn)
       .await?;

--- a/crates/db_schema/src/source/community.rs
+++ b/crates/db_schema/src/source/community.rs
@@ -212,6 +212,10 @@ pub struct CommunityActions {
   #[serde(skip)]
   pub follow_approver_id: Option<PersonId>,
   pub notifications: Option<CommunityNotificationsMode>,
+  /// For remote users following a local private community, store the ID of the follow activity.
+  /// This is so we can send the correct ID back when the follow is accepted or rejected later.
+  /// For follows to non-private communities this is not needed as the accept is sent back
+  /// immediately.
   #[serde(skip)]
   pub follow_activity_id: Option<DbUrl>,
 }
@@ -247,6 +251,7 @@ pub struct CommunityFollowerForm {
   pub follow_state: CommunityFollowerState,
   #[new(default)]
   pub follow_approver_id: Option<PersonId>,
+  /// Only needed when remote user follows a local, private community.
   #[new(default)]
   pub follow_activity_id: Option<DbUrl>,
   #[new(value = "Utc::now()")]

--- a/crates/db_schema/src/source/community.rs
+++ b/crates/db_schema/src/source/community.rs
@@ -212,6 +212,8 @@ pub struct CommunityActions {
   #[serde(skip)]
   pub follow_approver_id: Option<PersonId>,
   pub notifications: Option<CommunityNotificationsMode>,
+  #[serde(skip)]
+  pub follow_activity_id: Option<DbUrl>,
 }
 
 #[derive(Clone, derive_new::new)]
@@ -245,6 +247,8 @@ pub struct CommunityFollowerForm {
   pub follow_state: CommunityFollowerState,
   #[new(default)]
   pub follow_approver_id: Option<PersonId>,
+  #[new(default)]
+  pub follow_activity_id: Option<DbUrl>,
   #[new(value = "Utc::now()")]
   pub followed_at: DateTime<Utc>,
 }

--- a/crates/db_schema_file/src/schema.rs
+++ b/crates/db_schema_file/src/schema.rs
@@ -198,6 +198,7 @@ diesel::table! {
         follow_state -> Nullable<CommunityFollowerState>,
         follow_approver_id -> Nullable<Int4>,
         notifications -> Nullable<CommunityNotificationsModeEnum>,
+        follow_activity_id -> Nullable<Text>
     }
 }
 

--- a/migrations/2026-06-02-122008-0000_follow-accept-id/down.sql
+++ b/migrations/2026-06-02-122008-0000_follow-accept-id/down.sql
@@ -1,3 +1,3 @@
 ALTER TABLE community_actions
-    DROP COLUMN;
+    DROP COLUMN follow_activity_id;
 

--- a/migrations/2026-06-02-122008-0000_follow-accept-id/down.sql
+++ b/migrations/2026-06-02-122008-0000_follow-accept-id/down.sql
@@ -1,0 +1,1 @@
+alter table community_actions drop column;

--- a/migrations/2026-06-02-122008-0000_follow-accept-id/down.sql
+++ b/migrations/2026-06-02-122008-0000_follow-accept-id/down.sql
@@ -1,1 +1,3 @@
-alter table community_actions drop column;
+ALTER TABLE community_actions
+    DROP COLUMN;
+

--- a/migrations/2026-06-02-122008-0000_follow-accept-id/up.sql
+++ b/migrations/2026-06-02-122008-0000_follow-accept-id/up.sql
@@ -1,1 +1,3 @@
-alter table community_actions add column follow_activity_id text;
+ALTER TABLE community_actions
+    ADD COLUMN follow_activity_id text;
+

--- a/migrations/2026-06-02-122008-0000_follow-accept-id/up.sql
+++ b/migrations/2026-06-02-122008-0000_follow-accept-id/up.sql
@@ -1,0 +1,1 @@
+alter table community_actions add column follow_activity_id text;


### PR DESCRIPTION
For remote users following a local private community, store the ID of the follow activity. This is so we can send the correct ID back when the follow is accepted or rejected later. For follows to non-private communities this is not needed as the accept is sent back immediately.