### PR TITLE
Add child_count to modlog, used for bulk_action_parents.

### DIFF
--- a/crates/db_schema/src/impls/modlog.rs
+++ b/crates/db_schema/src/impls/modlog.rs
@@ -8,7 +8,7 @@ use crate::{
   },
 };
 use chrono::{DateTime, Utc};
-use diesel::dsl::insert_into;
+use diesel::{QueryDsl, dsl::insert_into};
 use diesel_async::RunQueryDsl;
 #[cfg(feature = "full")]
 use lemmy_db_schema_file::schema::modlog;
@@ -17,6 +17,15 @@ use lemmy_diesel_utils::connection::{DbPool, get_conn};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 
 impl Modlog {
+  pub async fn read(pool: &mut DbPool<'_>, id: ModlogId) -> LemmyResult<Self> {
+    let conn = &mut get_conn(pool).await?;
+    modlog::table
+      .find(id)
+      .first(conn)
+      .await
+      .with_lemmy_type(LemmyErrorType::NotFound)
+  }
+
   pub async fn create<'a>(
     pool: &mut DbPool<'_>,
     form: &[ModlogInsertForm<'a>],

--- a/crates/db_schema/src/source/modlog.rs
+++ b/crates/db_schema/src/source/modlog.rs
@@ -63,6 +63,4 @@ pub struct ModlogInsertForm<'a> {
   pub(crate) target_instance_id: Option<InstanceId>,
   #[new(default)]
   pub(crate) expires_at: Option<DateTime<Utc>>,
-  #[new(default)]
-  pub child_count: i32,
 }

--- a/crates/db_schema/src/source/modlog.rs
+++ b/crates/db_schema/src/source/modlog.rs
@@ -37,6 +37,7 @@ pub struct Modlog {
   pub expires_at: Option<DateTime<Utc>>,
   pub published_at: DateTime<Utc>,
   pub bulk_action_parent_id: Option<ModlogId>,
+  pub child_count: i32,
 }
 
 #[derive(derive_new::new)]
@@ -62,4 +63,6 @@ pub struct ModlogInsertForm<'a> {
   pub(crate) target_instance_id: Option<InstanceId>,
   #[new(default)]
   pub(crate) expires_at: Option<DateTime<Utc>>,
+  #[new(default)]
+  pub child_count: i32,
 }

--- a/crates/db_schema_file/src/schema.rs
+++ b/crates/db_schema_file/src/schema.rs
@@ -351,20 +351,6 @@ diesel::table! {
 }
 
 diesel::table! {
-    use diesel::sql_types::*;
-
-    local_user_invite (id) {
-        id -> Int4,
-        token -> Varchar,
-        local_user_id -> Int4,
-        max_uses -> Nullable<Int4>,
-        uses_count -> Int4,
-        expires_at -> Nullable<Timestamptz>,
-        published_at -> Timestamptz,
-    }
-}
-
-diesel::table! {
     language (id) {
         id -> Int4,
         #[max_length = 3]
@@ -442,7 +428,7 @@ diesel::table! {
         image_max_upload_size -> Int4,
         image_allow_video_uploads -> Bool,
         image_upload_disabled -> Bool,
-        max_invites_per_user_allowed -> Int4
+        max_invites_per_user_allowed -> Int4,
     }
 }
 
@@ -528,6 +514,18 @@ diesel::table! {
 }
 
 diesel::table! {
+    local_user_invite (id) {
+        id -> Int4,
+        token -> Text,
+        local_user_id -> Int4,
+        max_uses -> Nullable<Int4>,
+        uses_count -> Int4,
+        expires_at -> Nullable<Timestamptz>,
+        published_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
     local_user_keyword_block (local_user_id, keyword) {
         local_user_id -> Int4,
         #[max_length = 50]
@@ -570,6 +568,7 @@ diesel::table! {
         expires_at -> Nullable<Timestamptz>,
         published_at -> Timestamptz,
         bulk_action_parent_id -> Nullable<Int4>,
+        child_count -> Int4,
     }
 }
 
@@ -1020,6 +1019,7 @@ diesel::joinable!(local_site -> person (system_account));
 diesel::joinable!(local_site -> site (site_id));
 diesel::joinable!(local_site_rate_limit -> local_site (local_site_id));
 diesel::joinable!(local_user -> person (person_id));
+diesel::joinable!(local_user_invite -> local_user (local_user_id));
 diesel::joinable!(local_user_keyword_block -> local_user (local_user_id));
 diesel::joinable!(local_user_language -> language (language_id));
 diesel::joinable!(local_user_language -> local_user (local_user_id));
@@ -1097,6 +1097,7 @@ diesel::allow_tables_to_appear_in_same_query!(
   local_site,
   local_site_rate_limit,
   local_user,
+  local_user_invite,
   local_user_keyword_block,
   local_user_language,
   login_token,

--- a/crates/db_views/modlog/src/impls.rs
+++ b/crates/db_views/modlog/src/impls.rs
@@ -942,6 +942,7 @@ mod tests {
     .items;
     assert_eq!(1, modlog.len());
     assert!(modlog[0].modlog.bulk_action_parent_id.is_none());
+    assert_eq!(0, modlog[0].modlog.child_count);
 
     cleanup(data, pool).await?;
 
@@ -978,6 +979,10 @@ mod tests {
       Some(parent_id),
     );
     Modlog::create(pool, &[post_form_1, post_form_2]).await?;
+
+    // Read that ban, to make sure it has 2 children
+    let ban_action = Modlog::read(pool, parent_id).await?;
+    assert_eq!(2, ban_action.child_count);
 
     // Create one individual (non-bulk) post removal for mixed-dataset tests
     let individual_form =
@@ -1067,6 +1072,10 @@ mod tests {
     );
     Modlog::create(pool, &[post_form_1, post_form_2]).await?;
 
+    // Read that ban, to make sure it has 2 children
+    let parent_a = Modlog::read(pool, parent_a_id).await?;
+    assert_eq!(2, parent_a.child_count);
+
     // Two comment removals linked to parent B
     let comment_form_1 = ModlogInsertForm::mod_remove_comment(
       data.timmy.id,
@@ -1085,6 +1094,10 @@ mod tests {
       Some(parent_b_id),
     );
     Modlog::create(pool, &[comment_form_1, comment_form_2]).await?;
+
+    // Read that ban, to make sure it has 2 children
+    let parent_b = Modlog::read(pool, parent_b_id).await?;
+    assert_eq!(2, parent_b.child_count);
 
     // Filter by parent A
     let children_of_a = ModlogQuery {

--- a/crates/diesel_utils/replaceable_schema/triggers.sql
+++ b/crates/diesel_utils/replaceable_schema/triggers.sql
@@ -1081,3 +1081,23 @@ CREATE TRIGGER multi_community_remove_subscribers
     FOR EACH ROW
     WHEN (OLD.follow_state = 'Accepted')
     EXECUTE FUNCTION r.multicommunity_subscribers_decrement ();
+-- Increment modlog.child_count for bulk_action_parents
+CREATE FUNCTION r.modlog_child_count_increment ()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    UPDATE
+        modlog
+    SET
+        child_count = child_count + 1
+    WHERE
+        id = NEW.bulk_action_parent_id;
+    RETURN NULL;
+END
+$$;
+CREATE TRIGGER modlog_bulk_action_parent_insert
+    AFTER INSERT ON modlog
+    FOR EACH ROW
+    WHEN (NEW.bulk_action_parent_id IS NOT NULL)
+    EXECUTE FUNCTION r.modlog_child_count_increment ();

--- a/crates/diesel_utils/replaceable_schema/triggers.sql
+++ b/crates/diesel_utils/replaceable_schema/triggers.sql
@@ -1101,3 +1101,23 @@ CREATE TRIGGER modlog_bulk_action_parent_insert
     FOR EACH ROW
     WHEN (NEW.bulk_action_parent_id IS NOT NULL)
     EXECUTE FUNCTION r.modlog_child_count_increment ();
+-- Decrement modlog.child_count for bulk_action_parents on delete
+CREATE FUNCTION r.modlog_child_count_decrement ()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    UPDATE
+        modlog
+    SET
+        child_count = child_count - 1
+    WHERE
+        id = OLD.bulk_action_parent_id;
+    RETURN NULL;
+END
+$$;
+CREATE TRIGGER modlog_bulk_action_parent_delete
+    AFTER DELETE ON modlog
+    FOR EACH ROW
+    WHEN (OLD.bulk_action_parent_id IS NOT NULL)
+    EXECUTE FUNCTION r.modlog_child_count_decrement ();

--- a/migrations/2026-06-03-220228-0000_add_modlog_child_count/down.sql
+++ b/migrations/2026-06-03-220228-0000_add_modlog_child_count/down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE modlog
+    DROP COLUMN child_count;
+

--- a/migrations/2026-06-03-220228-0000_add_modlog_child_count/up.sql
+++ b/migrations/2026-06-03-220228-0000_add_modlog_child_count/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE modlog
+    ADD COLUMN child_count integer NOT NULL DEFAULT 0;
+


### PR DESCRIPTION
- Adds a child_count column to modlog, default 0.
- Adds an SQL trigger, that increments the modlog child count for the parent.
- Adds a few tests to make sure that inserted children are correctly incrementing this count.
- Fixes #6563