### PR TITLE
Feature flag for plugins

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -128,7 +128,7 @@ steps:
       CARGO_HOME: .cargo_home
       RUSTUP_HOME: .rustup_home
     commands:
-      - cargo build
+      - cargo build --all-features
       - mv target/debug/lemmy_server target/lemmy_server
     when: *slow_check_paths
 
@@ -191,6 +191,8 @@ steps:
     commands:
       - "! cargo tree -p lemmy_api_common --no-default-features -i diesel"
       - "! cargo tree -i aws-lc-sys"
+      - "! cargo tree -i extism"
+      - "cargo tree --all-features -i extism"
     when: *slow_check_paths
 
   check_crates_io_publish:

--- a/crates/api/api/src/local_user/get_captcha.rs
+++ b/crates/api/api/src/local_user/get_captcha.rs
@@ -7,7 +7,7 @@ use actix_web::{
   },
   web::Json,
 };
-use lemmy_api_utils::plugins::{is_captcha_plugin_loaded, plugin_get_captcha};
+use lemmy_api_utils::plugins::{LemmyPlugins, plugin_get_captcha};
 use lemmy_db_views_site::api::GetCaptchaResponse;
 use lemmy_utils::error::LemmyResult;
 
@@ -15,7 +15,7 @@ pub async fn get_captcha() -> LemmyResult<HttpResponse> {
   let mut res = HttpResponseBuilder::new(StatusCode::OK);
   res.insert_header(CacheControl(vec![CacheDirective::NoStore]));
 
-  if !is_captcha_plugin_loaded() {
+  if !LemmyPlugins::get_or_init().is_captcha_plugin_loaded() {
     return Ok(res.json(Json(GetCaptchaResponse { ok: None })));
   }
 

--- a/crates/api/api_crud/src/site/read.rs
+++ b/crates/api/api_crud/src/site/read.rs
@@ -1,8 +1,5 @@
 use actix_web::web::{Data, Json};
-use lemmy_api_utils::{
-  context::LemmyContext,
-  plugins::{is_captcha_plugin_loaded, plugin_metadata},
-};
+use lemmy_api_utils::{context::LemmyContext, plugins::LemmyPlugins};
 use lemmy_db_schema::source::{
   actor_language::SiteLanguage,
   language::Language,
@@ -64,8 +61,8 @@ async fn read_site(context: &LemmyContext) -> LemmyResult<GetSiteResponse> {
     tagline,
     oauth_providers,
     admin_oauth_providers,
-    active_plugins: plugin_metadata(),
+    active_plugins: LemmyPlugins::metadata(),
     last_application_duration_seconds,
-    captcha_enabled: is_captcha_plugin_loaded(),
+    captcha_enabled: LemmyPlugins::get_or_init().is_captcha_plugin_loaded(),
   })
 }

--- a/crates/api/api_crud/src/user/create.rs
+++ b/crates/api/api_crud/src/user/create.rs
@@ -8,7 +8,7 @@ use diesel_async::{AsyncPgConnection, scoped_futures::ScopedFutureExt};
 use lemmy_api_utils::{
   claims::Claims,
   context::LemmyContext,
-  plugins::{is_captcha_plugin_loaded, plugin_validate_captcha},
+  plugins::{LemmyPlugins, plugin_validate_captcha},
   utils::{
     check_email_verified,
     check_local_user_banned_or_deleted,
@@ -126,7 +126,7 @@ pub async fn register(
     return Err(LemmyErrorType::PasswordsDoNotMatch.into());
   }
 
-  if local_site.site_setup && is_captcha_plugin_loaded() {
+  if local_site.site_setup && LemmyPlugins::get_or_init().is_captcha_plugin_loaded() {
     let answer = data.captcha_answer.clone().unwrap_or_default();
     let uuid = data.captcha_uuid.clone().unwrap_or_default();
     plugin_validate_captcha(answer, uuid).await?;

--- a/crates/api/api_utils/Cargo.toml
+++ b/crates/api/api_utils/Cargo.toml
@@ -32,6 +32,13 @@ full = [
   "lemmy_db_views_notification/full",
   "lemmy_db_views_registration_applications/full",
 ]
+plugins = [
+  "extism",
+  "extism-convert",
+  "extism-manifest",
+  "lemmy_db_views_site/plugins",
+  "lemmy_db_views_registration_applications/plugins",
+]
 
 [dependencies]
 lemmy_db_schema = { workspace = true }
@@ -53,9 +60,9 @@ serde = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 lemmy_utils = { workspace = true }
-extism = { workspace = true }
-extism-convert = { workspace = true }
-extism-manifest = "1.20.0"
+extism = { workspace = true, optional = true }
+extism-convert = { workspace = true, optional = true }
+extism-manifest = { version = "1.20.0", optional = true }
 reqwest-middleware = { workspace = true }
 activitypub_federation = { workspace = true }
 mime = { version = "0.3.17" }

--- a/crates/api/api_utils/src/plugins.rs
+++ b/crates/api/api_utils/src/plugins.rs
@@ -1,40 +1,28 @@
-use crate::context::LemmyContext;
-use anyhow::anyhow;
-use extism::{
-  FromBytesOwned,
-  Manifest,
-  PluginBuilder,
-  Pool,
-  PoolPlugin,
-  ToBytes,
-  Wasm,
-  WasmMetadata,
+use crate::{
+  context::LemmyContext,
+  plugins::internal::{call_captcha_plugin, run_plugin_hook_after, run_plugin_hook_before},
 };
-use extism_convert::Json;
-use extism_manifest::HttpRequest;
 use lemmy_db_schema::source::{notification::Notification, person::Person};
 use lemmy_db_views_notification::NotificationView;
 use lemmy_db_views_registration_applications::api::CaptchaAnswer;
-use lemmy_db_views_site::api::{CaptchaResponse, PluginMetadata};
+use lemmy_db_views_site::api::CaptchaResponse;
 use lemmy_diesel_utils::traits::Crud;
-use lemmy_utils::{
-  VERSION,
-  error::{LemmyError, LemmyErrorType, LemmyResult},
-  settings::{SETTINGS, structs::PluginSettings},
-};
+use lemmy_utils::error::LemmyResult;
 use serde::{Deserialize, Serialize};
-use std::{
-  env::var,
-  ops::Deref,
-  path::PathBuf,
-  sync::{LazyLock, OnceLock},
-  time::Duration,
-};
 use tokio::task::spawn_blocking;
-use tracing::{error, warn};
-use url::Url;
 
-const GET_PLUGIN_TIMEOUT: Duration = Duration::from_secs(1);
+/// Call a plugin hook which can rewrite data
+pub async fn plugin_hook_before<T>(name: &'static str, data: T) -> LemmyResult<T>
+where
+  T: Clone + Serialize + for<'a> Deserialize<'a> + Sync + Send + 'static,
+{
+  let plugins = LemmyPlugins::get_or_init();
+  if !plugins.function_exists(name) {
+    return Ok(data);
+  }
+
+  run_plugin_hook_before(plugins, name, data).await
+}
 
 /// Call a plugin hook without rewriting data
 pub fn plugin_hook_after<T>(name: &'static str, data: &T)
@@ -78,242 +66,315 @@ pub async fn plugin_validate_captcha(answer: String, uuid: String) -> LemmyResul
   call_captcha_plugin("validate_captcha", CaptchaAnswer { answer, uuid }).await
 }
 
-async fn call_captcha_plugin<
-  'a,
-  T: ToBytes<'a> + Send + 'static,
-  R: FromBytesOwned + Send + 'static,
->(
-  name: &'static str,
-  params: T,
-) -> LemmyResult<R> {
-  let plugins = LemmyPlugins::get_or_init();
-  let Some(captcha_plugin) = plugins.captcha_plugin else {
-    return Err(LemmyErrorType::PluginError("plugin not loaded".to_string()).into());
-  };
-
-  spawn_blocking(move || {
-    if let Some(mut p) = captcha_plugin.pool.get(GET_PLUGIN_TIMEOUT)? {
-      let res = p
-        .call(name, params)
-        .map_err(|e| LemmyErrorType::PluginError(e.to_string()))?;
-      return Ok(res);
-    }
-    Err(LemmyErrorType::PluginError("plugin not loaded".to_string()).into())
-  })
-  .await?
-}
-
-pub fn is_captcha_plugin_loaded() -> bool {
-  LemmyPlugins::get_or_init().captcha_plugin.is_some()
-}
-
-fn run_plugin_hook_after<T>(name: &'static str, data: T) -> LemmyResult<()>
-where
-  T: Clone + Serialize + for<'b> Deserialize<'b>,
-{
-  let plugins = LemmyPlugins::get_or_init();
-  for p in plugins.plugins {
-    if let Some(mut plugin) = p.get(name)? {
-      let params: Json<T> = data.clone().into();
-      plugin
-        .call::<Json<T>, ()>(name, params)
-        .map_err(|e| LemmyErrorType::PluginError(e.to_string()))?;
-    }
-  }
-  Ok(())
-}
-
-/// Call a plugin hook which can rewrite data
-pub async fn plugin_hook_before<T>(name: &'static str, data: T) -> LemmyResult<T>
-where
-  T: Clone + Serialize + for<'a> Deserialize<'a> + Sync + Send + 'static,
-{
-  let plugins = LemmyPlugins::get_or_init();
-  if !plugins.function_exists(name) {
-    return Ok(data);
-  }
-
-  spawn_blocking(move || {
-    let mut res: Json<T> = data.into();
-    for p in plugins.plugins {
-      if let Some(mut plugin) = p.get(name)? {
-        let r = plugin
-          .call(name, res)
-          .map_err(|e| LemmyErrorType::PluginError(e.to_string()))?;
-        res = r;
-      }
-    }
-    Ok::<_, LemmyError>(res.0)
-  })
-  .await?
-}
-
-pub fn plugin_metadata() -> Vec<PluginMetadata> {
-  static METADATA: OnceLock<Vec<PluginMetadata>> = OnceLock::new();
-  if let Some(m) = METADATA.get() {
-    m.clone()
-  } else {
-    // Loading metadata can take multiple seconds. Do this in background task to avoid blocking
-    // /api/v4/site endpoint.
-    std::thread::spawn(|| {
-      METADATA.get_or_init(|| {
-        let mut metadata = vec![];
-        for plugin in LemmyPlugins::get_or_init().plugins {
-          let run = match plugin.pool.get(GET_PLUGIN_TIMEOUT) {
-            Ok(p) => p,
-            Err(e) => {
-              error!("Failed to load plugin {}: {e}", plugin.filename);
-              continue;
-            }
-          };
-          let m = run.and_then(|mut run| run.call("metadata", 0).ok());
-          if let Some(m) = m {
-            metadata.push(m);
-          } else {
-            // Failed to load plugin metadata, use placeholder
-            metadata.push(PluginMetadata {
-              name: plugin.filename,
-              url: None,
-              description: None,
-            });
-          }
-        }
-        metadata
-      });
-    });
-    // Return empty metadata until loading is finished
-    vec![]
-  }
-}
-
 #[derive(Clone)]
 pub struct LemmyPlugins {
-  plugins: Vec<LemmyPlugin>,
-  captcha_plugin: Option<LemmyPlugin>,
+  #[cfg(feature = "plugins")]
+  plugins: Vec<internal::LemmyPlugin>,
+  #[cfg(feature = "plugins")]
+  captcha_plugin: Option<internal::LemmyPlugin>,
 }
 
-#[derive(Clone)]
-struct LemmyPlugin {
-  pool: Pool,
-  filename: String,
-}
+#[cfg(not(feature = "plugins"))]
+mod internal {
+  use crate::plugins::LemmyPlugins;
+  use lemmy_db_views_site::api::PluginMetadata;
+  use lemmy_utils::error::LemmyResult;
 
-impl LemmyPlugin {
-  fn init(settings: PluginSettings) -> LemmyResult<Self> {
-    let hash = if cfg!(debug_assertions) || var("DANGER_PLUGIN_SKIP_HASH_CHECK").is_ok() {
-      None
-    } else {
-      // if no hash was provided in config, set a dummy value here to enforce hash check
-      Some(settings.hash.unwrap_or_else(|| "dummy".to_string()))
-    };
-    let meta = WasmMetadata { hash, name: None };
-    let (wasm, filename) = if settings.file.starts_with("http") {
-      let name: Option<String> = Url::parse(&settings.file)?
-        .path_segments()
-        .and_then(|mut p| p.next_back())
-        .map(std::string::ToString::to_string);
-      let req = HttpRequest {
-        url: settings.file.clone(),
-        headers: Default::default(),
-        method: None,
-      };
-      (Wasm::Url { req, meta }, name)
-    } else {
-      let path = PathBuf::from(settings.file.clone());
-      let name: Option<String> = path.file_name().map(|n| n.to_string_lossy().to_string());
-      (Wasm::File { path, meta }, name)
-    };
-    let mut manifest = Manifest {
-      wasm: vec![wasm],
-      config: settings.config,
-      allowed_hosts: settings.allowed_hosts,
-      memory: Default::default(),
-      allowed_paths: None,
-      timeout_ms: None,
-    };
-    manifest.config.insert(
-      "lemmy_url".to_string(),
-      format!("http://{}:{}/", SETTINGS.bind, SETTINGS.port),
-    );
-    manifest
-      .config
-      .insert("lemmy_version".to_string(), VERSION.to_string());
-    let builder = move || PluginBuilder::new(manifest.clone()).with_wasi(true).build();
-    let pool = Pool::new(builder);
-    if let Some(mut p) = pool.get(GET_PLUGIN_TIMEOUT)?
-      && p.function_exists("init")
-    {
-      p.call::<_, ()>("init", ())?;
+  impl LemmyPlugins {
+    pub fn get_or_init() -> LemmyPlugins {
+      LemmyPlugins {}
     }
-    Ok(LemmyPlugin {
-      pool,
-      filename: filename.unwrap_or(settings.file),
-    })
+    pub(super) fn function_exists(&self, _name: &'static str) -> bool {
+      false
+    }
+    pub fn metadata() -> Vec<PluginMetadata> {
+      vec![]
+    }
+    pub fn is_captcha_plugin_loaded(&self) -> bool {
+      false
+    }
   }
-
-  #[expect(clippy::if_then_some_else_none)]
-  fn get(&self, name: &'static str) -> LemmyResult<Option<PoolPlugin>> {
-    let p = self
-      .pool
-      .get(GET_PLUGIN_TIMEOUT)?
-      .ok_or(anyhow!("plugin timeout"))?;
-
-    Ok(if p.function_exists(name) {
-      Some(p)
-    } else {
-      None
-    })
+  pub(super) async fn call_captcha_plugin<'a, T: Send + 'static, R: Send + 'static>(
+    _name: &'static str,
+    _params: T,
+  ) -> LemmyResult<R> {
+    todo!()
+  }
+  pub(super) fn run_plugin_hook_after<T>(_name: &'static str, _data: T) -> LemmyResult<()> {
+    Ok(())
+  }
+  pub(super) async fn run_plugin_hook_before<T>(
+    _plugins: LemmyPlugins,
+    _name: &'static str,
+    data: T,
+  ) -> LemmyResult<T> {
+    Ok(data)
   }
 }
 
-impl LemmyPlugins {
-  /// Load and initialize all plugins
-  pub fn get_or_init() -> Self {
-    static PLUGINS: LazyLock<LemmyPlugins> = LazyLock::new(|| {
-      let mut plugins: Vec<_> = SETTINGS
-        .plugins
-        .iter()
-        .flat_map(|p| {
-          LemmyPlugin::init(p.clone())
-            .inspect_err(|e| warn!("Failed to load plugin {}: {e}", p.file))
-            .ok()
-        })
-        .collect();
+#[cfg(feature = "plugins")]
+mod internal {
+  use crate::plugins::LemmyPlugins;
+  use anyhow::anyhow;
+  use extism::{
+    FromBytesOwned,
+    Manifest,
+    PluginBuilder,
+    Pool,
+    PoolPlugin,
+    ToBytes,
+    Wasm,
+    WasmMetadata,
+  };
+  use extism_convert::Json;
+  use extism_manifest::HttpRequest;
+  use lemmy_db_views_site::api::PluginMetadata;
+  use lemmy_utils::{
+    VERSION,
+    error::{LemmyError, LemmyErrorType, LemmyResult},
+    settings::{SETTINGS, structs::PluginSettings},
+  };
+  use serde::{Deserialize, Serialize};
+  use std::{
+    env::var,
+    ops::Deref,
+    path::PathBuf,
+    sync::{LazyLock, OnceLock},
+    time::Duration,
+  };
+  use tokio::task::spawn_blocking;
+  use tracing::{error, warn};
+  use url::Url;
 
-      let mut captcha_plugin = None;
-      for (i, p) in plugins.iter().enumerate() {
-        let is_captcha = p
-          .pool
-          .function_exists("validate_captcha", GET_PLUGIN_TIMEOUT)
-          .unwrap_or_default()
-          && p
-            .pool
-            .function_exists("validate_captcha", GET_PLUGIN_TIMEOUT)
-            .unwrap_or_default();
-        if is_captcha {
-          captcha_plugin = Some(plugins.remove(i));
-          break;
+  const GET_PLUGIN_TIMEOUT: Duration = Duration::from_secs(1);
+
+  pub(super) async fn call_captcha_plugin<
+    'a,
+    T: ToBytes<'a> + Send + 'static,
+    R: FromBytesOwned + Send + 'static,
+  >(
+    name: &'static str,
+    params: T,
+  ) -> LemmyResult<R> {
+    let plugins = LemmyPlugins::get_or_init();
+    let Some(captcha_plugin) = plugins.captcha_plugin else {
+      return Err(LemmyErrorType::PluginError("plugin not loaded".to_string()).into());
+    };
+
+    spawn_blocking(move || {
+      if let Some(mut p) = captcha_plugin.pool.get(GET_PLUGIN_TIMEOUT)? {
+        let res = p
+          .call(name, params)
+          .map_err(|e| LemmyErrorType::PluginError(e.to_string()))?;
+        return Ok(res);
+      }
+      Err(LemmyErrorType::PluginError("plugin not loaded".to_string()).into())
+    })
+    .await?
+  }
+
+  pub(super) fn run_plugin_hook_after<T>(name: &'static str, data: T) -> LemmyResult<()>
+  where
+    T: Clone + Serialize + for<'b> Deserialize<'b>,
+  {
+    let plugins = LemmyPlugins::get_or_init();
+    for p in plugins.plugins {
+      if let Some(mut plugin) = p.get(name)? {
+        let params: Json<T> = data.clone().into();
+        plugin
+          .call::<Json<T>, ()>(name, params)
+          .map_err(|e| LemmyErrorType::PluginError(e.to_string()))?;
+      }
+    }
+    Ok(())
+  }
+
+  pub(super) async fn run_plugin_hook_before<T>(
+    plugins: LemmyPlugins,
+    name: &'static str,
+    data: T,
+  ) -> Result<T, lemmy_utils::error::LemmyError>
+  where
+    T: Clone + Serialize + for<'a> Deserialize<'a> + Sync + Send + 'static,
+  {
+    spawn_blocking(move || {
+      let mut res: Json<T> = data.into();
+      for p in plugins.plugins {
+        if let Some(mut plugin) = p.get(name)? {
+          let r = plugin
+            .call(name, res)
+            .map_err(|e| LemmyErrorType::PluginError(e.to_string()))?;
+          res = r;
         }
       }
-
-      // Need to put captcha plugin back in so it can be shown in the active plugins list.
-      if let Some(captcha_plugin) = &captcha_plugin {
-        plugins.push(captcha_plugin.clone());
-      }
-      LemmyPlugins {
-        plugins,
-        captcha_plugin,
-      }
-    });
-    PLUGINS.deref().clone()
+      Ok::<_, LemmyError>(res.0)
+    })
+    .await?
   }
 
-  /// Return early if no plugin is loaded for the given hook name
-  fn function_exists(&self, name: &'static str) -> bool {
-    self.plugins.iter().any(|p| {
-      p.pool
-        .function_exists(name, GET_PLUGIN_TIMEOUT)
-        .unwrap_or(false)
-    })
+  #[derive(Clone)]
+  pub(super) struct LemmyPlugin {
+    pool: Pool,
+    filename: String,
+  }
+
+  impl LemmyPlugin {
+    fn init(settings: PluginSettings) -> LemmyResult<Self> {
+      let hash = if cfg!(debug_assertions) || var("DANGER_PLUGIN_SKIP_HASH_CHECK").is_ok() {
+        None
+      } else {
+        // if no hash was provided in config, set a dummy value here to enforce hash check
+        Some(settings.hash.unwrap_or_else(|| "dummy".to_string()))
+      };
+      let meta = WasmMetadata { hash, name: None };
+      let (wasm, filename) = if settings.file.starts_with("http") {
+        let name: Option<String> = Url::parse(&settings.file)?
+          .path_segments()
+          .and_then(|mut p| p.next_back())
+          .map(std::string::ToString::to_string);
+        let req = HttpRequest {
+          url: settings.file.clone(),
+          headers: Default::default(),
+          method: None,
+        };
+        (Wasm::Url { req, meta }, name)
+      } else {
+        let path = PathBuf::from(settings.file.clone());
+        let name: Option<String> = path.file_name().map(|n| n.to_string_lossy().to_string());
+        (Wasm::File { path, meta }, name)
+      };
+      let mut manifest = Manifest {
+        wasm: vec![wasm],
+        config: settings.config,
+        allowed_hosts: settings.allowed_hosts,
+        memory: Default::default(),
+        allowed_paths: None,
+        timeout_ms: None,
+      };
+      manifest.config.insert(
+        "lemmy_url".to_string(),
+        format!("http://{}:{}/", SETTINGS.bind, SETTINGS.port),
+      );
+      manifest
+        .config
+        .insert("lemmy_version".to_string(), VERSION.to_string());
+      let builder = move || PluginBuilder::new(manifest.clone()).with_wasi(true).build();
+      let pool = Pool::new(builder);
+      if let Some(mut p) = pool.get(GET_PLUGIN_TIMEOUT)?
+        && p.function_exists("init")
+      {
+        p.call::<_, ()>("init", ())?;
+      }
+      Ok(LemmyPlugin {
+        pool,
+        filename: filename.unwrap_or(settings.file),
+      })
+    }
+
+    #[expect(clippy::if_then_some_else_none)]
+    fn get(&self, name: &'static str) -> LemmyResult<Option<PoolPlugin>> {
+      let p = self
+        .pool
+        .get(GET_PLUGIN_TIMEOUT)?
+        .ok_or(anyhow!("plugin timeout"))?;
+
+      Ok(if p.function_exists(name) {
+        Some(p)
+      } else {
+        None
+      })
+    }
+  }
+
+  impl LemmyPlugins {
+    /// Load and initialize all plugins
+    pub fn get_or_init() -> Self {
+      static PLUGINS: LazyLock<LemmyPlugins> = LazyLock::new(|| {
+        let mut plugins: Vec<_> = SETTINGS
+          .plugins
+          .iter()
+          .flat_map(|p| {
+            LemmyPlugin::init(p.clone())
+              .inspect_err(|e| warn!("Failed to load plugin {}: {e}", p.file))
+              .ok()
+          })
+          .collect();
+
+        let mut captcha_plugin = None;
+        for (i, p) in plugins.iter().enumerate() {
+          let is_captcha = p
+            .pool
+            .function_exists("validate_captcha", GET_PLUGIN_TIMEOUT)
+            .unwrap_or_default()
+            && p
+              .pool
+              .function_exists("validate_captcha", GET_PLUGIN_TIMEOUT)
+              .unwrap_or_default();
+          if is_captcha {
+            captcha_plugin = Some(plugins.remove(i));
+            break;
+          }
+        }
+
+        // Need to put captcha plugin back in so it can be shown in the active plugins list.
+        if let Some(captcha_plugin) = &captcha_plugin {
+          plugins.push(captcha_plugin.clone());
+        }
+        LemmyPlugins {
+          plugins,
+          captcha_plugin,
+        }
+      });
+      PLUGINS.deref().clone()
+    }
+    pub fn metadata() -> Vec<PluginMetadata> {
+      static METADATA: OnceLock<Vec<PluginMetadata>> = OnceLock::new();
+      if let Some(m) = METADATA.get() {
+        m.clone()
+      } else {
+        // Loading metadata can take multiple seconds. Do this in background task to avoid blocking
+        // /api/v4/site endpoint.
+        std::thread::spawn(|| {
+          METADATA.get_or_init(|| {
+            let mut metadata = vec![];
+            for plugin in LemmyPlugins::get_or_init().plugins {
+              let run = match plugin.pool.get(GET_PLUGIN_TIMEOUT) {
+                Ok(p) => p,
+                Err(e) => {
+                  error!("Failed to load plugin {}: {e}", plugin.filename);
+                  continue;
+                }
+              };
+              let m = run.and_then(|mut run| run.call("metadata", 0).ok());
+              if let Some(m) = m {
+                metadata.push(m);
+              } else {
+                // Failed to load plugin metadata, use placeholder
+                metadata.push(PluginMetadata {
+                  name: plugin.filename,
+                  url: None,
+                  description: None,
+                });
+              }
+            }
+            metadata
+          });
+        });
+        // Return empty metadata until loading is finished
+        vec![]
+      }
+    }
+
+    /// Return early if no plugin is loaded for the given hook name
+    pub(super) fn function_exists(&self, name: &'static str) -> bool {
+      self.plugins.iter().any(|p| {
+        p.pool
+          .function_exists(name, GET_PLUGIN_TIMEOUT)
+          .unwrap_or(false)
+      })
+    }
+    pub fn is_captcha_plugin_loaded(&self) -> bool {
+      self.captcha_plugin.is_some()
+    }
   }
 }

--- a/crates/api/api_utils/src/plugins.rs
+++ b/crates/api/api_utils/src/plugins.rs
@@ -9,7 +9,6 @@ use lemmy_db_views_site::api::CaptchaResponse;
 use lemmy_diesel_utils::traits::Crud;
 use lemmy_utils::error::LemmyResult;
 use serde::{Deserialize, Serialize};
-use std::process::exit;
 use tokio::task::spawn_blocking;
 
 /// Call a plugin hook which can rewrite data
@@ -89,7 +88,7 @@ mod internal {
     pub fn get_or_init() -> LemmyPlugins {
       if !SETTINGS.plugins.is_empty() {
         error!("Plugins not supported, recompile with `--features plugins`");
-        exit(1);
+        std::process::exit(1);
       }
       LemmyPlugins {}
     }

--- a/crates/api/api_utils/src/plugins.rs
+++ b/crates/api/api_utils/src/plugins.rs
@@ -9,6 +9,7 @@ use lemmy_db_views_site::api::CaptchaResponse;
 use lemmy_diesel_utils::traits::Crud;
 use lemmy_utils::error::LemmyResult;
 use serde::{Deserialize, Serialize};
+use std::process::exit;
 use tokio::task::spawn_blocking;
 
 /// Call a plugin hook which can rewrite data
@@ -76,12 +77,20 @@ pub struct LemmyPlugins {
 
 #[cfg(not(feature = "plugins"))]
 mod internal {
-  use crate::plugins::LemmyPlugins;
+  use super::*;
   use lemmy_db_views_site::api::PluginMetadata;
-  use lemmy_utils::error::LemmyResult;
+  use lemmy_utils::{
+    error::{LemmyResult, UntranslatedError},
+    settings::SETTINGS,
+  };
+  use tracing::error;
 
   impl LemmyPlugins {
     pub fn get_or_init() -> LemmyPlugins {
+      if !SETTINGS.plugins.is_empty() {
+        error!("Plugins not supported, recompile with `--features plugins`");
+        exit(1);
+      }
       LemmyPlugins {}
     }
     pub(super) fn function_exists(&self, _name: &'static str) -> bool {
@@ -98,7 +107,7 @@ mod internal {
     _name: &'static str,
     _params: T,
   ) -> LemmyResult<R> {
-    todo!()
+    Err(UntranslatedError::Unreachable.into())
   }
   pub(super) fn run_plugin_hook_after<T>(_name: &'static str, _data: T) -> LemmyResult<()> {
     Ok(())

--- a/crates/api/routes_v3/src/convert.rs
+++ b/crates/api/routes_v3/src/convert.rs
@@ -55,7 +55,7 @@ use lemmy_api_019::{
     SearchResponse as SearchResponseV3,
   },
 };
-use lemmy_api_utils::plugins::is_captcha_plugin_loaded;
+use lemmy_api_utils::plugins::LemmyPlugins;
 use lemmy_db_schema::{
   CommunitySortType,
   newtypes::LanguageId,
@@ -657,7 +657,7 @@ pub(crate) fn convert_local_site(local_site: LocalSite) -> LocalSiteV3 {
     slur_filter_regex,
     actor_name_max_length: 20,
     federation_enabled,
-    captcha_enabled: is_captcha_plugin_loaded(),
+    captcha_enabled: LemmyPlugins::get_or_init().is_captcha_plugin_loaded(),
     captcha_difficulty: String::new(),
     published: published_at,
     updated: updated_at,

--- a/crates/db_views/registration_applications/Cargo.toml
+++ b/crates/db_views/registration_applications/Cargo.toml
@@ -23,9 +23,8 @@ full = [
   "i-love-jesus",
   "lemmy_db_schema/full",
   "lemmy_db_schema_file/full",
-  "extism",
-  "extism-convert",
 ]
+plugins = ["extism", "extism-convert"]
 ts-rs = ["dep:ts-rs", "lemmy_db_schema/ts-rs"]
 
 [dependencies]

--- a/crates/db_views/registration_applications/src/api.rs
+++ b/crates/db_views/registration_applications/src/api.rs
@@ -4,7 +4,7 @@ use lemmy_db_schema_file::PersonId;
 use lemmy_diesel_utils::{pagination::PaginationCursor, sensitive::SensitiveString};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
-#[cfg(feature = "full")]
+#[cfg(feature = "plugins")]
 use {extism::ToBytes, extism_convert::Json};
 
 #[skip_serializing_none]
@@ -66,8 +66,8 @@ pub struct Register {
 }
 
 #[derive(Serialize, Deserialize)]
-#[cfg_attr(feature = "full", derive(ToBytes,))]
-#[cfg_attr(feature = "full", encoding(Json))]
+#[cfg_attr(feature = "plugins", derive(ToBytes,))]
+#[cfg_attr(feature = "plugins", encoding(Json))]
 pub struct CaptchaAnswer {
   pub answer: String,
   pub uuid: String,

--- a/crates/db_views/site/Cargo.toml
+++ b/crates/db_views/site/Cargo.toml
@@ -27,10 +27,10 @@ full = [
   "lemmy_db_views_post/full",
   "lemmy_db_views_comment/full",
   "anyhow",
-  "extism",
   "i-love-jesus",
   "activitypub_federation",
 ]
+plugins = ["extism", "extism-convert"]
 ts-rs = [
   "dep:ts-rs",
   "lemmy_db_schema/ts-rs",
@@ -63,7 +63,7 @@ serde_with = { workspace = true }
 ts-rs = { workspace = true, optional = true }
 url = { workspace = true }
 extism = { workspace = true, optional = true }
-extism-convert = { workspace = true }
+extism-convert = { workspace = true, optional = true }
 anyhow = { workspace = true, optional = true }
 i-love-jesus = { workspace = true, optional = true }
 activitypub_federation = { workspace = true, optional = true }

--- a/crates/db_views/site/src/api.rs
+++ b/crates/db_views/site/src/api.rs
@@ -1,9 +1,6 @@
 use crate::{ResolveObjectView, SiteView};
 #[cfg(feature = "full")]
 use activitypub_federation::protocol::helpers::deserialize_skip_error;
-#[cfg(feature = "full")]
-use extism::FromBytes;
-use extism_convert::Json;
 use lemmy_db_schema::{
   SearchType,
   newtypes::{CommunityId, LanguageId, MultiCommunityId, OAuthProviderId, TaglineId},
@@ -47,6 +44,8 @@ use lemmy_diesel_utils::{pagination::PaginationCursor, sensitive::SensitiveStrin
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use url::Url;
+#[cfg(feature = "plugins")]
+use {extism::FromBytes, extism_convert::Json};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
@@ -367,8 +366,8 @@ pub struct SiteResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
-#[cfg_attr(feature = "full", derive(FromBytes))]
-#[cfg_attr(feature = "full", encoding(Json))]
+#[cfg_attr(feature = "plugins", derive(FromBytes))]
+#[cfg_attr(feature = "plugins", encoding(Json))]
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
 /// A captcha response.
@@ -657,8 +656,8 @@ pub struct EditTagline {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[cfg_attr(feature = "full", derive(FromBytes))]
-#[cfg_attr(feature = "full", encoding(Json))]
+#[cfg_attr(feature = "plugins", derive(FromBytes))]
+#[cfg_attr(feature = "plugins", encoding(Json))]
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
 pub struct PluginMetadata {

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -20,6 +20,7 @@ workspace = true
 
 [features]
 default = []
+plugins = ["lemmy_api_utils/plugins"]
 
 [dependencies]
 lemmy_api = { workspace = true }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,7 +31,7 @@ COPY --from=planner /lemmy/recipe.json recipe.json
 # Build dependencies - this is the caching Docker layer!
 RUN if [ "${RUST_RELEASE_MODE}" = "release" ]; \
   then \
-  cargo chef cook --recipe-path recipe.json --release; \
+  cargo chef cook --recipe-path recipe.json --release --all-features; \
   else \
   cargo chef cook --recipe-path recipe.json; \
   fi 
@@ -42,7 +42,7 @@ COPY . .
 
 RUN if [ "${RUST_RELEASE_MODE}" = "release" ]; \
   then \
-  cargo build --features "${CARGO_BUILD_FEATURES}" --release; \
+  cargo build --features "${CARGO_BUILD_FEATURES}" --release --all-features; \
   mv target/release/lemmy_server .; \
   else \
   cargo build --features "${CARGO_BUILD_FEATURES}"; \


### PR DESCRIPTION
95% of development has nothing to do with plugins. Yet we keep compiling all the plugin dependencies every time which takes a lot of time and disk space. Instead we can put plugins behind a feature flag, and only compile them for CI, release builds and actual plugin development.


|| Dependency count| Target folder size|Clean build time |
|-| ------------- | ------------- |-|
|With plugins|  900|  4,7G |5m 36s |
|No plugins|723 | 4,0G  |5m 10s|