### PR TITLE
Auto-approve private comm follows for admins/mods

### DIFF
--- a/api_tests/run-federation-test.sh
+++ b/api_tests/run-federation-test.sh
@@ -3,7 +3,7 @@ set -e
 
 export LEMMY_DATABASE_URL=postgres://lemmy:password@localhost:5432
 pushd ..
-cargo build
+cargo build --features plugins
 rm target/lemmy_server || true
 cp target/debug/lemmy_server target/lemmy_server
 killall -s1 lemmy_server || true

--- a/crates/api/api/src/community/follow.rs
+++ b/crates/api/api/src/community/follow.rs
@@ -20,7 +20,7 @@ pub async fn follow_community(
   let community_id = data.community_id;
   let community = Community::read(&mut context.pool(), community_id).await?;
 
-  do_follow_community(community, &local_user_view.person, data.follow, &context).await?;
+  do_follow_community(community, &local_user_view, data.follow, &context).await?;
 
   let community_view = CommunityView::read(
     &mut context.pool(),

--- a/crates/api/api/src/community/mod.rs
+++ b/crates/api/api/src/community/mod.rs
@@ -5,14 +5,12 @@ use lemmy_api_utils::{
   utils::check_community_deleted_removed,
 };
 use lemmy_db_schema::{
-  source::{
-    community::{Community, CommunityActions, CommunityFollowerForm},
-    person::Person,
-  },
+  source::community::{Community, CommunityActions, CommunityFollowerForm},
   traits::Followable,
 };
 use lemmy_db_schema_file::enums::{CommunityFollowerState, CommunityVisibility};
-use lemmy_db_views_community_moderator::CommunityPersonBanView;
+use lemmy_db_views_community_moderator::{CommunityModeratorView, CommunityPersonBanView};
+use lemmy_db_views_local_user::LocalUserView;
 use lemmy_utils::error::LemmyResult;
 
 pub mod add_mod;
@@ -28,20 +26,35 @@ pub mod update_notifications;
 
 pub(super) async fn do_follow_community(
   community: Community,
-  person: &Person,
+  local_user_view: &LocalUserView,
   follow: bool,
   context: &Data<LemmyContext>,
 ) -> LemmyResult<()> {
+  let person_id = local_user_view.person.id;
   if follow {
     // Only run these checks for local community, in case of remote community the local
     // state may be outdated. Can't use check_community_user_action() here as it only allows
     // actions from existing followers for private community (so following would be impossible).
     if community.local {
       check_community_deleted_removed(&community)?;
-      CommunityPersonBanView::check(&mut context.pool(), person.id, community.id).await?;
+      CommunityPersonBanView::check(&mut context.pool(), person_id, community.id).await?;
     }
 
-    let follow_state = if community.visibility == CommunityVisibility::Private {
+    // Mods and local admins can already view private communities without approval, so we can also
+    // approve their follow requests automatically.
+    let is_mod = CommunityModeratorView::check_is_community_moderator(
+      &mut context.pool(),
+      community.id,
+      person_id,
+    )
+    .await
+    .is_ok();
+    let is_local_admin =
+      local_user_view.local_user.admin && local_user_view.person.local && community.local;
+    let approval_required =
+      community.visibility == CommunityVisibility::Private && !is_mod && !is_local_admin;
+
+    let follow_state = if approval_required {
       // Private communities require manual approval
       CommunityFollowerState::ApprovalRequired
     } else if community.local {
@@ -51,18 +64,18 @@ pub(super) async fn do_follow_community(
       // remote follow needs to be federated first
       CommunityFollowerState::Pending
     };
-    let form = CommunityFollowerForm::new(community.id, person.id, follow_state);
+    let form = CommunityFollowerForm::new(community.id, person_id, follow_state);
 
     // Write to db
     CommunityActions::follow(&mut context.pool(), &form).await?;
   } else {
-    CommunityActions::unfollow(&mut context.pool(), person.id, community.id).await?;
+    CommunityActions::unfollow(&mut context.pool(), person_id, community.id).await?;
   }
 
   // Send the federated follow
   if !community.local {
     ActivityChannel::submit_activity(
-      SendActivityData::FollowCommunity(community, person.clone(), follow),
+      SendActivityData::FollowCommunity(community, local_user_view.person.clone(), follow),
       context,
     )?;
   }

--- a/crates/api/api/src/community/update_notifications.rs
+++ b/crates/api/api/src/community/update_notifications.rs
@@ -30,7 +30,7 @@ pub async fn edit_community_notifications(
   {
     let community = Community::read(&mut context.pool(), data.community_id).await?;
     if !community.local {
-      do_follow_community(community, &local_user_view.person, true, &context).await?;
+      do_follow_community(community, &local_user_view, true, &context).await?;
     }
   }
 

--- a/crates/api/api/src/post/update_notifications.rs
+++ b/crates/api/api/src/post/update_notifications.rs
@@ -32,7 +32,7 @@ pub async fn edit_post_notifications(
   if data.mode == PostNotificationsMode::AllComments {
     let community = Community::read(&mut context.pool(), post.community_id).await?;
     if !community.local {
-      do_follow_community(community, &local_user_view.person, true, &context).await?;
+      do_follow_community(community, &local_user_view, true, &context).await?;
     }
   }
   Ok(Json(SuccessResponse::default()))


### PR DESCRIPTION
Noticed that following your own private comm would increment the counter for pending follows, but it wasnt actually shown in the list. No need to wait for manual approval here, we can just do it automatically.