### PR TITLE
Adds additional attachments to end of post (fixes #6229)

### DIFF
--- a/crates/apub/apub/assets/lemmy/objects/page_image_and_link.json
+++ b/crates/apub/apub/assets/lemmy/objects/page_image_and_link.json
@@ -1,0 +1,40 @@
+{
+  "id": "https://enterprise.lemmy.ml/post/55999",
+  "type": "Page",
+  "attributedTo": "https://enterprise.lemmy.ml/u/picard",
+  "to": [
+    "https://enterprise.lemmy.ml/c/tenforward",
+    "https://www.w3.org/ns/activitystreams#Public"
+  ],
+  "audience": "https://enterprise.lemmy.ml/c/tenforward",
+  "name": "Post with image and link",
+  "content": "<p>This is a post with both an image and a link attachment</p>\n",
+  "mediaType": "text/html",
+  "source": {
+    "content": "This is a post with both an image and a link attachment",
+    "mediaType": "text/markdown"
+  },
+  "attachment": [
+    {
+      "type": "Image",
+      "url": "https://enterprise.lemmy.ml/pictrs/image/eOtYb9iEiB.png",
+      "mediaType": "image/png"
+    },
+    {
+      "type": "Link",
+      "href": "https://example.com/some-article",
+      "mediaType": "text/html"
+    }
+  ],
+  "image": {
+    "type": "Image",
+    "url": "https://enterprise.lemmy.ml/pictrs/image/eOtYb9iEiB.png"
+  },
+  "sensitive": false,
+  "language": {
+    "identifier": "fr",
+    "name": "Français"
+  },
+  "context": "https://enterprise.lemmy.ml/post/55999/context",
+  "published": "2021-02-26T12:35:34.292626Z"
+}

--- a/crates/apub/objects/src/objects/post.rs
+++ b/crates/apub/objects/src/objects/post.rs
@@ -359,7 +359,7 @@ pub async fn append_attachments_to_body(
     body.push('\n');
 
     for attachment in attachments {
-      if let Ok(markdown) = &attachment.as_markdown(context).await {
+      if let Ok(markdown) = attachment.as_markdown(context).await {
         body.push('\n');
         body.push_str(&markdown);
       }

--- a/crates/apub/objects/src/objects/post.rs
+++ b/crates/apub/objects/src/objects/post.rs
@@ -275,6 +275,9 @@ impl Object for ApubPost {
 
     let body = read_from_string_or_source_opt(&page.content, &page.media_type, &page.source);
     let body =
+      append_attachments_to_body(&body, page.attachment.get(1..).unwrap_or_default(), context)
+        .await;
+    let body =
       process_markdown_opt(&body, &slur_regex, &url_blocklist, &local_site, context).await?;
     let body = markdown_rewrite_remote_links_opt(body, context).await;
     let language_id = Some(
@@ -346,6 +349,25 @@ pub async fn update_apub_post_tags(
   Ok(())
 }
 
+pub async fn append_attachments_to_body(
+  content: &Option<String>,
+  attachments: &[Attachment],
+  context: &Data<LemmyContext>,
+) -> Option<String> {
+  let mut body = content.clone()?;
+  if !attachments.is_empty() {
+    body.push('\n');
+
+    for attachment in attachments {
+      if let Ok(markdown) = &attachment.as_markdown(context).await {
+        body.push('\n');
+        body.push_str(&markdown);
+      }
+    }
+  }
+  Some(body)
+}
+
 pub async fn post_nsfw(
   page: &Page,
   community: &Community,
@@ -404,6 +426,43 @@ mod tests {
     assert!(!post.featured_community);
     // one request is made trying to resolve post.url into local object
     assert_eq!(context.request_count(), 1);
+
+    test_data.delete(&mut context.pool()).await?;
+    Instance::delete_all(&mut context.pool()).await?;
+    Ok(())
+  }
+
+  // Tests that issue 6229 is fixed:
+  // - When a federated post has both an image and a link in its `attachment` array,
+  // - only the first one is used as `post.url`; the second is silently dropped.
+  // Following the issue discussions, the fix is to add the subsequent links at the end of the post
+  // body.
+  #[tokio::test]
+  #[serial]
+  async fn test_parse_post_with_image_and_link() -> LemmyResult<()> {
+    let context = LemmyContext::init_test_context().await;
+    let test_data = TestData::create(&mut context.pool()).await?;
+    parse_lemmy_person(&context).await?;
+    parse_lemmy_community(&context).await?;
+
+    let json = file_to_json_object("../apub/assets/lemmy/objects/page_image_and_link.json")?;
+    let url = Url::parse("https://enterprise.lemmy.ml/post/55999")?;
+    ApubPost::verify(&json, &url, &context).await?;
+    let post = ApubPost::from_json(json, &context).await?;
+
+    assert_eq!(
+      post.url.as_ref().map(|u| u.as_str()),
+      Some("https://enterprise.lemmy.ml/pictrs/image/eOtYb9iEiB.png")
+    );
+
+    assert!(
+      post
+        .body
+        .as_deref()
+        .unwrap_or_default()
+        .contains("https://example.com/some-article"),
+      "link attachment not added to body"
+    );
 
     test_data.delete(&mut context.pool()).await?;
     Instance::delete_all(&mut context.pool()).await?;

--- a/crates/apub/objects/src/objects/post.rs
+++ b/crates/apub/objects/src/objects/post.rs
@@ -432,11 +432,6 @@ mod tests {
     Ok(())
   }
 
-  // Tests that issue 6229 is fixed:
-  // - When a federated post has both an image and a link in its `attachment` array,
-  // - only the first one is used as `post.url`; the second is silently dropped.
-  // Following the issue discussions, the fix is to add the subsequent links at the end of the post
-  // body.
   #[tokio::test]
   #[serial]
   async fn test_parse_post_with_image_and_link() -> LemmyResult<()> {


### PR DESCRIPTION
When activities of posts have both an image and a link attachment, lemmy only takes the image attachment. The link attachment is dropped.

The solution is to add the additional links at the end of the post body (similar to how multiple attachments are handled for comments)

This fixes issue 6229.