### PR TITLE
Add ability to set redirect_url for communities

### DIFF
--- a/crates/api/api/src/federation/read_community.rs
+++ b/crates/api/api/src/federation/read_community.rs
@@ -1,6 +1,6 @@
 use crate::federation::fetcher::resolve_community_identifier;
 use activitypub_federation::config::Data;
-use actix_web::web::{Json, Query};
+use actix_web::{HttpResponse, web::Query};
 use lemmy_api_utils::{
   context::LemmyContext,
   utils::{check_private_instance, is_mod_or_admin_opt, read_site_for_actor},
@@ -19,7 +19,7 @@ pub async fn get_community(
   Query(data): Query<GetCommunity>,
   context: Data<LemmyContext>,
   local_user_view: Option<LocalUserView>,
-) -> LemmyResult<Json<GetCommunityResponse>> {
+) -> LemmyResult<HttpResponse> {
   let local_site = SiteView::read_local(&mut context.pool()).await?.local_site;
 
   check_private_instance(&local_user_view, &local_site)?;
@@ -45,6 +45,14 @@ pub async fn get_community(
     is_mod_or_admin,
   )
   .await?;
+  // If this community has a redirect URL set, return HTTP 301 redirect
+  if let Some(redirect_url) = &community_view.community.redirect_url{
+    return Ok(
+      HttpResponse::MovedPermanently()
+        .append_header(("Location", redirect_url.to_string()))
+        .finish(),
+    );
+  }
 
   let moderators = CommunityModeratorView::for_community(&mut context.pool(), community_id).await?;
 
@@ -53,10 +61,13 @@ pub async fn get_community(
   let community_id = community_view.community.id;
   let discussion_languages = CommunityLanguage::read(&mut context.pool(), community_id).await?;
 
-  Ok(Json(GetCommunityResponse {
-    community_view,
-    site,
-    moderators,
-    discussion_languages,
-  }))
+  Ok(
+    HttpResponse::Ok()
+      .json(GetCommunityResponse {
+        community_view,
+        site,
+        moderators,
+        discussion_languages,
+      })
+  )
 }

--- a/crates/db_schema/src/source/community.rs
+++ b/crates/db_schema/src/source/community.rs
@@ -94,6 +94,9 @@ pub struct Community {
   pub report_count: i16,
   pub unresolved_report_count: i16,
   pub local_removed: bool,
+  /// If set, requests for this (local, empty) community redirect to this URL instead,
+  /// pointing users to the canonical/remote community.
+  pub redirect_url: Option<DbUrl>,
 }
 
 #[derive(Debug, Clone, derive_new::new)]
@@ -145,6 +148,8 @@ pub struct CommunityInsertForm {
   pub summary: Option<String>,
   #[new(default)]
   pub local_removed: Option<bool>,
+  #[new(default)]
+  pub redirect_url: Option<DbUrl>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -173,6 +178,7 @@ pub struct CommunityUpdateForm {
   pub visibility: Option<CommunityVisibility>,
   pub summary: Option<Option<String>>,
   pub local_removed: Option<bool>,
+  pub redirect_url: Option<Option<DbUrl>>,
 }
 
 #[skip_serializing_none]

--- a/crates/db_schema_file/src/schema.rs
+++ b/crates/db_schema_file/src/schema.rs
@@ -179,6 +179,8 @@ diesel::table! {
         report_count -> Int2,
         unresolved_report_count -> Int2,
         local_removed -> Bool,
+        #[max_length = 255]
+        redirect_url -> Nullable<Varchar>,
     }
 }
 
@@ -198,7 +200,7 @@ diesel::table! {
         follow_state -> Nullable<CommunityFollowerState>,
         follow_approver_id -> Nullable<Int4>,
         notifications -> Nullable<CommunityNotificationsModeEnum>,
-        follow_activity_id -> Nullable<Text>
+        follow_activity_id -> Nullable<Text>,
     }
 }
 

--- a/migrations/2026-06-30-052955_add-community-redirect-url/down.sql
+++ b/migrations/2026-06-30-052955_add-community-redirect-url/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE community
+    DROP COLUMN redirect_url;

--- a/migrations/2026-06-30-052955_add-community-redirect-url/up.sql
+++ b/migrations/2026-06-30-052955_add-community-redirect-url/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE community
+    ADD redirect_url varchar(255);


### PR DESCRIPTION
Closes #3048

Adds an optional `redirect_url` field to communities. When set, GET requests
to `/api/v4/community` for that community return an HTTP 301 redirect to the
given URL instead of the community data.

This allows instance admins to redirect an empty local community to its
canonical/remote equivalent instead of hosting a duplicate.

## Changes
- Added `redirect_url` column to the `community` table
- Added `redirect_url` field to `Community`, `CommunityInsertForm` and `CommunityUpdateForm`
- Updated `get_community` handler to return a 301 redirect when `redirect_url` is set