### PR TITLE
Proper fix for accept activity with object id (fixes 6595)

### DIFF
--- a/crates/apub/activities/src/following/accept.rs
+++ b/crates/apub/activities/src/following/accept.rs
@@ -28,8 +28,7 @@ impl AcceptFollow {
     let accept = AcceptFollow {
       actor: target.id().clone().into(),
       to: Some([person.id().clone().into()]),
-      // TODO: revert this
-      object: IdOrNestedObject::Id(follow.id),
+      object: IdOrNestedObject::NestedObject(follow),
       kind: AcceptType::Accept,
       id: generate_activity_id(AcceptType::Accept, context)?,
     };

--- a/crates/apub/activities/src/following/accept.rs
+++ b/crates/apub/activities/src/following/accept.rs
@@ -28,7 +28,8 @@ impl AcceptFollow {
     let accept = AcceptFollow {
       actor: target.id().clone().into(),
       to: Some([person.id().clone().into()]),
-      object: IdOrNestedObject::NestedObject(follow),
+      // TODO: revert this
+      object: IdOrNestedObject::Id(follow.id),
       kind: AcceptType::Accept,
       id: generate_activity_id(AcceptType::Accept, context)?,
     };

--- a/crates/apub/activities/src/protocol/mod.rs
+++ b/crates/apub/activities/src/protocol/mod.rs
@@ -44,7 +44,7 @@ impl<Kind: Id + DeserializeOwned + Send> IdOrNestedObject<Kind> {
         // which is simpler.
         let sent = SentActivity::read_from_apub_id(&mut context.pool(), &i.clone().into()).await;
         if let Ok(sent) = sent {
-          return Ok(serde_json::from_value::<Kind>(sent.data)?);
+          Ok(serde_json::from_value::<Kind>(sent.data)?)
         } else {
           Ok(fetch_object_http(&i, context).await?.object)
         }

--- a/crates/apub/activities/src/protocol/mod.rs
+++ b/crates/apub/activities/src/protocol/mod.rs
@@ -1,6 +1,7 @@
 use activitypub_federation::{config::Data, fetch::fetch_object_http};
 use lemmy_api_utils::context::LemmyContext;
 use lemmy_apub_objects::utils::protocol::Id;
+use lemmy_db_schema::source::activity::SentActivity;
 use lemmy_utils::error::LemmyResult;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use strum::Display;
@@ -36,7 +37,18 @@ impl<Kind: Id + DeserializeOwned + Send> IdOrNestedObject<Kind> {
   pub async fn object(self, context: &Data<LemmyContext>) -> LemmyResult<Kind> {
     match self {
       // TODO: move IdOrNestedObject struct to library and make fetch_object_http private
-      IdOrNestedObject::Id(i) => Ok(fetch_object_http(&i, context).await?.object),
+      IdOrNestedObject::Id(i) => {
+        // Check if object is one of our sent activities. This is necessary because "sensitive"
+        // activities like Follow cannot be fetched over HTTP. In principle we should also check
+        // tables Post, Comment, Community etc. But these items can always be fetched over HTTP
+        // which is simpler.
+        let sent = SentActivity::read_from_apub_id(&mut context.pool(), &i.clone().into()).await;
+        if let Ok(sent) = sent {
+          return Ok(serde_json::from_value::<Kind>(sent.data)?);
+        } else {
+          Ok(fetch_object_http(&i, context).await?.object)
+        }
+      }
       IdOrNestedObject::NestedObject(o) => Ok(o),
     }
   }


### PR DESCRIPTION
Tested it properly this time, by changing `accept.rs` to send the object id instead of the full object (like the issue describes), and making sure that `follow.spec.ts` tests are passing. Unfortunately we dont have a good way to do CI testing for activity formats which are not sent by Lemmy itself.