### PR TITLE
Update Rust formatting

### DIFF
--- a/crates/utils/src/utils/markdown/code_links.rs
+++ b/crates/utils/src/utils/markdown/code_links.rs
@@ -19,7 +19,8 @@ pub fn clean_urls_skip_code_links(src: &str) -> String {
   let ast = PARSER.parse(src);
 
   let mut code_offsets: Vec<(usize, usize)> = Vec::new();
-  //we need to exclude code fences (``` ``` and ~~~ ~~~) as well as bacticks inline code (` `) and code blocks (4 spaces)
+  //we need to exclude code fences (``` ``` and ~~~ ~~~) as well as bacticks inline code (` `) and
+  // code blocks (4 spaces)
   ast.walk(|node, _| {
     if (node.cast::<fence::CodeFence>().is_some()
       || node.cast::<code::CodeBlock>().is_some()

--- a/crates/utils/src/utils/validation.rs
+++ b/crates/utils/src/utils/validation.rs
@@ -334,10 +334,22 @@ mod tests {
   use crate::{
     error::{LemmyErrorType, LemmyResult},
     utils::validation::{
-      BIO_MAX_LENGTH, SITE_NAME_MAX_LENGTH, SITE_SUMMARY_MAX_LENGTH, URL_MAX_LENGTH,
-      build_and_check_regex, check_urls_are_valid, is_url_blocked, is_valid_actor_name,
-      is_valid_bio_field, is_valid_display_name, is_valid_matrix_id, is_valid_post_title,
-      is_valid_url, site_name_length_check, summary_length_check, truncate_for_db,
+      BIO_MAX_LENGTH,
+      SITE_NAME_MAX_LENGTH,
+      SITE_SUMMARY_MAX_LENGTH,
+      URL_MAX_LENGTH,
+      build_and_check_regex,
+      check_urls_are_valid,
+      is_url_blocked,
+      is_valid_actor_name,
+      is_valid_bio_field,
+      is_valid_display_name,
+      is_valid_matrix_id,
+      is_valid_post_title,
+      is_valid_url,
+      site_name_length_check,
+      summary_length_check,
+      truncate_for_db,
     },
   };
   use pretty_assertions::assert_eq;


### PR DESCRIPTION
Looks like `cargo fmt` behaviour was changed in the latest nightly which made CI fail for https://github.com/LemmyNet/lemmy/pull/6623. 