### PR TITLE
Move bulk database operations to background tasks

### DIFF
--- a/api_tests/src/image.spec.ts
+++ b/api_tests/src/image.spec.ts
@@ -32,6 +32,7 @@ import {
   sampleSite,
   getMyUser,
   expectSuccess,
+  waitUntil,
   waitUntilSuccess,
 } from "./shared";
 
@@ -164,9 +165,14 @@ test("Purge user, uploaded image removed", async () => {
   expect(delete_.success).toBe(true);
 
   // ensure that image is deleted
-  const response2 = await fetch(upload.image_url ?? "");
-  const content2 = await response2.text();
-  expect(content2).toBe("");
+  await waitUntil(
+    async () => {
+      const response2 = await fetch(upload.image_url ?? "");
+      const content2 = await response2.text();
+      return content2;
+    },
+    content => content === "",
+  );
 });
 
 test("Purge post, linked image removed", async () => {

--- a/api_tests/src/post.spec.ts
+++ b/api_tests/src/post.spec.ts
@@ -684,8 +684,9 @@ test("Enforce site ban federation for federated user", async () => {
   expect(banAlphaOnBeta.person_view.banned).toBe(true);
 
   // existing alpha post should be removed on beta
-  const betaRemovedPost = await getPost(beta, searchBeta1!.post.id).then(
-    expectSuccess,
+  const betaRemovedPost = await waitUntilSuccess(
+    () => getPost(beta, searchBeta1!.post.id),
+    s => s.post_view.post.removed,
   );
   expect(betaRemovedPost.post_view.post.removed).toBe(true);
 

--- a/api_tests/src/user.spec.ts
+++ b/api_tests/src/user.spec.ts
@@ -132,10 +132,11 @@ test("Delete user", async () => {
 
   // check that posts and comments are marked as deleted on other instances.
   // use get methods to avoid refetching from origin instance
-  expect(
-    (await getPost(alpha, localPost.id).then(expectSuccess)).post_view.post
-      .deleted,
-  ).toBe(true);
+  const deletedLocalPost = await waitUntilSuccess(
+    () => getPost(alpha, localPost.id),
+    s => s.post_view.post.deleted,
+  );
+  expect(deletedLocalPost.post_view.post.deleted).toBe(true);
   // Make sure the remote post is deleted.
   // TODO this fails occasionally
   // Probably because it could return a not_found

--- a/api_tests/src/user.spec.ts
+++ b/api_tests/src/user.spec.ts
@@ -290,7 +290,10 @@ test("Make sure banned user can delete their account", async () => {
   expect(deleteAccount).toBeDefined();
 
   // Make sure post is gone
-  const postAfterDelete = await getPost(alpha, postId).then(expectSuccess);
+  const postAfterDelete = await waitUntilSuccess(
+    () => getPost(alpha, postId),
+    s => s.post_view.post.deleted,
+  );
   expect(postAfterDelete.post_view.post.deleted).toBe(true);
   expect(postAfterDelete.post_view.post.name).toBe("*Permanently Deleted*");
 });
@@ -340,8 +343,9 @@ test("Admins can view and ban deleted accounts", async () => {
   ).then(expectSuccess);
   expect(banUser.person_view.banned).toBe(true);
   // Make sure the post is removed
-  const postAfterBan = await getPost(beta, postRes.post_view.post.id).then(
-    expectSuccess,
+  const postAfterBan = await waitUntilSuccess(
+    () => getPost(beta, postRes.post_view.post.id),
+    s => s.post_view.post.removed,
   );
   expect(postAfterBan.post_view.post.removed).toBe(true);
 

--- a/api_tests/src/user.spec.ts
+++ b/api_tests/src/user.spec.ts
@@ -25,7 +25,6 @@ import {
   getMyUser,
   getPersonDetails,
   banPersonFromSite,
-  statusNotFound,
   statusUnauthorized,
   listPersonContent,
   password,

--- a/api_tests/src/user.spec.ts
+++ b/api_tests/src/user.spec.ts
@@ -35,6 +35,7 @@ import {
   expectSuccess,
   expectFailure,
   waitUntilSuccess,
+  waitUntil,
 } from "./shared";
 import {
   EditSite,
@@ -125,9 +126,10 @@ test("Delete user", async () => {
     new LemmyError("incorrect_login", statusUnauthorized),
   );
 
-  await jestLemmyError(
+  // User deletion runs as a background task, so wait for it to complete
+  await waitUntil(
     () => getPersonDetails(user, person_id).then(expectFailure),
-    new LemmyError("not_found", statusNotFound),
+    e => e?.name === "not_found",
   );
 
   // check that posts and comments are marked as deleted on other instances.
@@ -152,9 +154,10 @@ test("Delete user", async () => {
     () => alpha.getComment({ id: remoteComment.id }),
     c => c.comment_view.comment.deleted,
   );
-  await jestLemmyError(
+  // User deletion runs as a background task, so wait for it to complete
+  await waitUntil(
     () => getPersonDetails(user, remoteComment.creator_id).then(expectFailure),
-    new LemmyError("not_found", statusNotFound),
+    e => e?.name === "not_found",
   );
 });
 

--- a/crates/api/api/src/community/ban.rs
+++ b/crates/api/api/src/community/ban.rs
@@ -94,6 +94,8 @@ pub async fn ban_from_community(
   notify_mod_action(action.clone(), &context);
 
   // Remove/Restore their data if that's desired
+  // Can't run inside the transaction above because spawn_try_task
+  // gets its own DB connection from the pool
   if data.remove_or_restore_data.unwrap_or(false) {
     let remove_data = data.ban;
     let reason = data.reason.clone();

--- a/crates/api/api/src/community/ban.rs
+++ b/crates/api/api/src/community/ban.rs
@@ -93,9 +93,8 @@ pub async fn ban_from_community(
     .await?;
   notify_mod_action(action.clone(), &context);
 
-  // Remove/Restore their data if that's desired
-  // Can't run inside the transaction above because spawn_try_task
-  // gets its own DB connection from the pool
+  // Remove/Restore their data in background if that's desired
+  // Cant do this inside transaction because `conn` cannot be passed into spawn_try_task.
   if data.remove_or_restore_data.unwrap_or(false) {
     let remove_data = data.ban;
     let reason = data.reason.clone();

--- a/crates/api/api/src/community/ban.rs
+++ b/crates/api/api/src/community/ban.rs
@@ -25,6 +25,7 @@ use lemmy_db_views_person::{PersonView, api::PersonResponse};
 use lemmy_diesel_utils::{connection::get_conn, traits::Crud};
 use lemmy_utils::{
   error::{LemmyErrorType, LemmyResult},
+  spawn_try_task,
   utils::validation::is_valid_body_field,
 };
 
@@ -85,28 +86,32 @@ pub async fn ban_from_community(
         );
         let action = Modlog::create(&mut conn.into(), &[form]).await?;
 
-        // Remove/Restore their data if that's desired
-        let ban_id = action.first().ok_or(LemmyErrorType::NotFound)?.id;
-        if tx_data.remove_or_restore_data.unwrap_or(false) {
-          let remove_data = tx_data.ban;
-          remove_or_restore_user_data_in_community(
-            tx_data.community_id,
-            my_person_id,
-            banned_person_id,
-            remove_data,
-            &tx_data.reason,
-            ban_id,
-            &mut conn.into(),
-          )
-          .await?;
-        };
-
         Ok(action)
       }
       .scope_boxed()
     })
     .await?;
   notify_mod_action(action.clone(), &context);
+
+  // Remove/Restore their data if that's desired
+  if data.remove_or_restore_data.unwrap_or(false) {
+    let remove_data = data.ban;
+    let reason = data.reason.clone();
+    let ban_id = action.first().ok_or(LemmyErrorType::NotFound)?.id;
+    let context = context.clone();
+    spawn_try_task(async move {
+      remove_or_restore_user_data_in_community(
+        data.community_id,
+        my_person_id,
+        banned_person_id,
+        remove_data,
+        &reason,
+        ban_id,
+        &mut context.pool(),
+      )
+      .await
+    });
+  }
 
   let person_view = PersonView::read(
     &mut context.pool(),

--- a/crates/api/api/src/local_user/ban_person.rs
+++ b/crates/api/api/src/local_user/ban_person.rs
@@ -21,6 +21,7 @@ use lemmy_db_views_person::{
 };
 use lemmy_utils::{
   error::{LemmyErrorType, LemmyResult},
+  spawn_try_task,
   utils::validation::is_valid_body_field,
 };
 
@@ -67,15 +68,20 @@ pub async fn ban_from_site(
   // Remove their data if that's desired
   if data.remove_or_restore_data.unwrap_or(false) {
     let removed = data.ban;
-    remove_or_restore_user_data(
-      my_person_id,
-      data.person_id,
-      removed,
-      &data.reason,
-      action.first().ok_or(LemmyErrorType::NotFound)?.id,
-      &context,
-    )
-    .await?;
+    let reason = data.reason.clone();
+    let ban_id = action.first().ok_or(LemmyErrorType::NotFound)?.id;
+    let context = context.clone();
+    spawn_try_task(async move {
+      remove_or_restore_user_data(
+        my_person_id,
+        data.person_id,
+        removed,
+        &reason,
+        ban_id,
+        &context,
+      )
+      .await
+    });
   };
 
   let person_view = PersonView::read(

--- a/crates/api/api/src/site/purge/person.rs
+++ b/crates/api/api/src/site/purge/person.rs
@@ -18,7 +18,7 @@ use lemmy_db_views_local_user::LocalUserView;
 use lemmy_db_views_person::api::PurgePerson;
 use lemmy_db_views_site::api::SuccessResponse;
 use lemmy_diesel_utils::traits::Crud;
-use lemmy_utils::error::LemmyResult;
+use lemmy_utils::{error::LemmyResult, spawn_try_task};
 
 pub async fn purge_person(
   Json(data): Json<PurgePerson>,
@@ -53,7 +53,10 @@ pub async fn purge_person(
   )?;
 
   // Clear profile data.
-  purge_user_account(data.person_id, local_instance_id, &context).await?;
+  let context_clone = context.clone();
+  spawn_try_task(async move {
+    purge_user_account(data.person_id, local_instance_id, &context_clone).await
+  });
 
   // Keep person record, but mark as banned to prevent login or refetching from home instance.
   InstanceActions::ban(

--- a/crates/api/api_crud/src/user/delete.rs
+++ b/crates/api/api_crud/src/user/delete.rs
@@ -15,7 +15,10 @@ use lemmy_db_schema::source::{
 };
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_db_views_site::api::{DeleteAccount, DeleteUserForm, SuccessResponse};
-use lemmy_utils::error::{LemmyErrorType, LemmyResult};
+use lemmy_utils::{
+  error::{LemmyErrorType, LemmyResult},
+  spawn_try_task,
+};
 
 pub async fn delete_account(
   Json(data): Json<DeleteAccount>,
@@ -42,7 +45,10 @@ pub async fn delete_account(
 
   form = plugin_hook_before("local_user_before_delete", form).await?;
   if form.delete_content {
-    purge_user_account(local_user_view.person.id, local_instance_id, &context).await?;
+    let context = context.clone();
+    spawn_try_task(async move {
+      purge_user_account(local_user_view.person.id, local_instance_id, &context).await
+    });
   } else {
     // These are already run in purge_user_account,
     // but should be done anyway even if delete_content is false

--- a/crates/apub/activities/src/block/block_user.rs
+++ b/crates/apub/activities/src/block/block_user.rs
@@ -34,7 +34,10 @@ use lemmy_db_schema::{
   },
   traits::Bannable,
 };
-use lemmy_utils::error::{LemmyError, LemmyErrorType, LemmyResult};
+use lemmy_utils::{
+  error::{LemmyError, LemmyErrorType, LemmyResult},
+  spawn_try_task,
+};
 use url::Url;
 
 impl BlockUser {
@@ -150,15 +153,18 @@ impl Activity for BlockUser {
         if self.remove_data.unwrap_or(false) {
           if blocked_person.instance_id == site.instance_id {
             // user banned from home instance, remove all content
-            remove_or_restore_user_data(
-              mod_person.id,
-              blocked_person.id,
-              true,
-              &reason,
-              parent_id,
-              context,
-            )
-            .await?;
+            let context = context.clone();
+            spawn_try_task(async move {
+              remove_or_restore_user_data(
+                mod_person.id,
+                blocked_person.id,
+                true,
+                &reason,
+                parent_id,
+                &context,
+              )
+              .await
+            });
           } else {
             update_removed_for_instance(&blocked_person, &site, true, pool).await?;
           }
@@ -189,16 +195,19 @@ impl Activity for BlockUser {
         notify_mod_action(action, context);
 
         if self.remove_data.unwrap_or(false) {
-          remove_or_restore_user_data_in_community(
-            community.id,
-            mod_person.id,
-            blocked_person.id,
-            true,
-            &reason,
-            parent_id,
-            &mut context.pool(),
-          )
-          .await?;
+          let context = context.clone();
+          spawn_try_task(async move {
+            remove_or_restore_user_data_in_community(
+              community.id,
+              mod_person.id,
+              blocked_person.id,
+              true,
+              &reason,
+              parent_id,
+              &mut context.pool(),
+            )
+            .await
+          });
         }
       }
     }

--- a/crates/apub/activities/src/block/undo_block_user.rs
+++ b/crates/apub/activities/src/block/undo_block_user.rs
@@ -35,7 +35,10 @@ use lemmy_db_schema::{
   },
   traits::Bannable,
 };
-use lemmy_utils::error::{LemmyError, LemmyErrorType, LemmyResult};
+use lemmy_utils::{
+  error::{LemmyError, LemmyErrorType, LemmyResult},
+  spawn_try_task,
+};
 use url::Url;
 
 impl UndoBlockUser {
@@ -121,15 +124,18 @@ impl Activity for UndoBlockUser {
         if self.restore_data.unwrap_or(false) {
           if blocked_person.instance_id == site.instance_id {
             // user unbanned from home instance, restore all content
-            remove_or_restore_user_data(
-              mod_person.id,
-              blocked_person.id,
-              false,
-              &reason,
-              parent_id,
-              context,
-            )
-            .await?;
+            let context = context.clone();
+            spawn_try_task(async move {
+              remove_or_restore_user_data(
+                mod_person.id,
+                blocked_person.id,
+                false,
+                &reason,
+                parent_id,
+                &context,
+              )
+              .await
+            });
           } else {
             update_removed_for_instance(&blocked_person, &site, false, pool).await?;
           }
@@ -154,16 +160,19 @@ impl Activity for UndoBlockUser {
         notify_mod_action(action, context.app_data());
 
         if self.restore_data.unwrap_or(false) {
-          remove_or_restore_user_data_in_community(
-            community.id,
-            mod_person.id,
-            blocked_person.id,
-            false,
-            &reason,
-            parent_id,
-            &mut context.pool(),
-          )
-          .await?;
+          let context = context.clone();
+          spawn_try_task(async move {
+            remove_or_restore_user_data_in_community(
+              community.id,
+              mod_person.id,
+              blocked_person.id,
+              false,
+              &reason,
+              parent_id,
+              &mut context.pool(),
+            )
+            .await
+          });
         }
       }
     }

--- a/crates/apub/activities/src/deletion/mod.rs
+++ b/crates/apub/activities/src/deletion/mod.rs
@@ -48,7 +48,7 @@ use lemmy_db_schema::source::{
 use lemmy_db_schema_file::enums::CommunityVisibility;
 use lemmy_db_views_site::{SiteView, api::DeleteUserForm};
 use lemmy_diesel_utils::traits::Crud;
-use lemmy_utils::error::LemmyResult;
+use lemmy_utils::{error::LemmyResult, spawn_try_task};
 use std::ops::Deref;
 use url::Url;
 
@@ -322,7 +322,10 @@ async fn receive_delete_action(
       };
       form = plugin_hook_before("federated_user_before_delete", form).await?;
       if form.delete_content {
-        purge_user_account(person.id, local_instance_id, context).await?;
+        let context = context.clone();
+        spawn_try_task(
+          async move { purge_user_account(person.id, local_instance_id, &context).await },
+        );
       } else {
         Person::delete_account(&mut context.pool(), person.id, local_instance_id).await?;
       }

--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -164,10 +164,8 @@ pub enum UntranslatedError {
 
 cfg_select! {
   feature = "full" => {
-
+    use serde_with::{DisplayFromStr, serde_as};
     use std::fmt;
-    use serde_with::serde_as;
-    use serde_with::DisplayFromStr;
 
     pub type LemmyResult<T> = Result<T, LemmyError>;
 
@@ -182,20 +180,21 @@ cfg_select! {
       pub caller: Location<'static>,
     }
 
-    /// Maximum number of items in an array passed as API parameter. See [[LemmyErrorType::TooManyItems]]
+    /// Maximum number of items in an array passed as API parameter. See
+    /// [[LemmyErrorType::TooManyItems]]
     pub(crate) const MAX_API_PARAM_ELEMENTS: usize = 10_000;
 
     impl<T> From<T> for LemmyError
     where
       T: Into<anyhow::Error>,
     {
-    #[track_caller]
+      #[track_caller]
       fn from(t: T) -> Self {
         let cause = t.into();
         let error_type = match cause.downcast_ref::<diesel::result::Error>() {
           Some(&diesel::NotFound) => LemmyErrorType::NotFound,
-          _ => LemmyErrorType::Unknown(format!("{}", &cause))
-      };
+          _ => LemmyErrorType::Unknown(format!("{}", &cause)),
+        };
         LemmyError {
           error_type,
           cause,
@@ -207,10 +206,10 @@ cfg_select! {
     impl Debug for LemmyError {
       fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("LemmyError")
-         .field("message", &self.error_type)
-         .field("caller", &format_args!("{}", self.caller))
-         .field("inner", &self.cause)
-         .finish()
+          .field("message", &self.error_type)
+          .field("caller", &format_args!("{}", self.caller))
+          .field("inner", &self.cause)
+          .finish()
       }
     }
 
@@ -238,9 +237,8 @@ cfg_select! {
     }
 
     impl From<LemmyErrorType> for LemmyError {
-    #[track_caller]
+      #[track_caller]
       fn from(error_type: LemmyErrorType) -> Self {
-
         let cause = anyhow::anyhow!("{}", error_type);
         LemmyError {
           error_type,
@@ -251,11 +249,11 @@ cfg_select! {
     }
 
     impl From<UntranslatedError> for LemmyError {
-    #[track_caller]
+      #[track_caller]
       fn from(error_type: UntranslatedError) -> Self {
         let cause = anyhow::anyhow!("{}", error_type);
         LemmyError {
-          error_type: LemmyErrorType::UntranslatedError( Some(error_type) ),
+          error_type: LemmyErrorType::UntranslatedError(Some(error_type)),
           cause,
           caller: *Location::caller(),
         }
@@ -264,7 +262,7 @@ cfg_select! {
 
     impl From<UntranslatedError> for LemmyErrorType {
       fn from(error: UntranslatedError) -> Self {
-        LemmyErrorType::UntranslatedError (Some(error) )
+        LemmyErrorType::UntranslatedError(Some(error))
       }
     }
 
@@ -273,7 +271,7 @@ cfg_select! {
     }
 
     impl<T, E: Into<anyhow::Error>> LemmyErrorExt<T, E> for Result<T, E> {
-    #[track_caller]
+      #[track_caller]
       fn with_lemmy_type(self, error_type: LemmyErrorType) -> LemmyResult<T> {
         self.map_err(|error| LemmyError {
           error_type,
@@ -294,7 +292,8 @@ cfg_select! {
           e
         })
       }
-      // this function can't be an impl From or similar because it would conflict with one of the other broad Into<> implementations
+      // this function can't be an impl From or similar because it would conflict with one of the
+      // other broad Into<> implementations
       fn into_anyhow(self) -> Result<T, anyhow::Error> {
         self.map_err(|e| e.cause)
       }
@@ -304,14 +303,24 @@ cfg_select! {
     mod tests {
       #![allow(clippy::indexing_slicing)]
       use super::*;
-      use actix_web::{body::MessageBody, ResponseError};
+      use actix_web::{ResponseError, body::MessageBody};
       use pretty_assertions::assert_eq;
 
       #[test]
       fn untranslated_error_format() -> LemmyResult<()> {
-        let err = LemmyError::from(UntranslatedError::DomainBlocked("test".to_string())).error_response();
-        let json = String::from_utf8(err.into_body().try_into_bytes().unwrap_or_default().to_vec())?;
-        assert_eq!(&json, r#"{"error":"domain_blocked","message":"test","cause":"DomainBlocked"}"#);
+        let err =
+          LemmyError::from(UntranslatedError::DomainBlocked("test".to_string())).error_response();
+        let json = String::from_utf8(
+          err
+            .into_body()
+            .try_into_bytes()
+            .unwrap_or_default()
+            .to_vec(),
+        )?;
+        assert_eq!(
+          &json,
+          r#"{"error":"domain_blocked","message":"test","cause":"DomainBlocked"}"#
+        );
 
         Ok(())
       }
@@ -319,7 +328,13 @@ cfg_select! {
       #[test]
       fn deserializes_no_message() -> LemmyResult<()> {
         let err = LemmyError::from(LemmyErrorType::BlockedUrl).error_response();
-        let json = String::from_utf8(err.into_body().try_into_bytes().unwrap_or_default().to_vec())?;
+        let json = String::from_utf8(
+          err
+            .into_body()
+            .try_into_bytes()
+            .unwrap_or_default()
+            .to_vec(),
+        )?;
         assert_eq!(&json, r#"{"error":"blocked_url","cause":"BlockedUrl"}"#);
 
         Ok(())
@@ -329,7 +344,13 @@ cfg_select! {
       fn deserializes_with_message() -> LemmyResult<()> {
         let reg_banned = LemmyErrorType::PictrsResponseError(String::from("reason"));
         let err = LemmyError::from(reg_banned).error_response();
-        let json = String::from_utf8(err.into_body().try_into_bytes().unwrap_or_default().to_vec())?;
+        let json = String::from_utf8(
+          err
+            .into_body()
+            .try_into_bytes()
+            .unwrap_or_default()
+            .to_vec(),
+        )?;
         assert_eq!(
           &json,
           r#"{"error":"pictrs_response_error","message":"reason","cause":"PictrsResponseError"}"#
@@ -345,7 +366,10 @@ cfg_select! {
         assert_eq!(404, not_found_error.status_code());
 
         let other_error = LemmyError::from(diesel::result::Error::NotInTransaction);
-        assert!(matches!(other_error.error_type, LemmyErrorType::Unknown{..}));
+        assert!(matches!(
+          other_error.error_type,
+          LemmyErrorType::Unknown { .. }
+        ));
         assert_eq!(400, other_error.status_code());
       }
     }

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -77,12 +77,13 @@ macro_rules! location_info {
 
 cfg_select! {
   feature = "full" => {
-    use moka::future::Cache;use std::fmt::Debug;use std::hash::Hash;
+    use moka::future::Cache;
     use serde_json::Value;
+    use std::{fmt::Debug, hash::Hash};
 
-    /// Only include a basic context to save space and bandwidth. The main context is hosted statically
-    /// on join-lemmy.org. Include activitystreams explicitly for better compat, but this could
-    /// theoretically also be moved.
+    /// Only include a basic context to save space and bandwidth. The main context is hosted
+    /// statically on join-lemmy.org. Include activitystreams explicitly for better compat, but
+    /// this could theoretically also be moved.
     pub static FEDERATION_CONTEXT: LazyLock<Value> = LazyLock::new(|| {
       Value::Array(vec![
         Value::String("https://join-lemmy.org/context.json".to_string()),
@@ -104,7 +105,7 @@ cfg_select! {
           }
         }
         .in_current_span(), /* this makes sure the inner tracing gets the same context as where
-                            * spawn was called */
+                             * spawn was called */
       );
     }
 


### PR DESCRIPTION
Moves `remove_or_restore_user_data`, `remove_or_restore_user_data_in_community`, and `purge_user_account` to background tasks via `spawn_try_task`. Community ban data removal moved out of the DB transaction.

Closes #6364