### PR TITLE
Redirect when fetching remote community/person over apub (fixes #6629)

### DIFF
--- a/api_tests/src/post.spec.ts
+++ b/api_tests/src/post.spec.ts
@@ -1221,7 +1221,7 @@ test("Admin removes post from local user in remote community", async () => {
   );
 });
 
-test.only("Warn about a post", async () => {
+test("Warn about a post", async () => {
   // Create post from alpha
   const alphaCommunity = await resolveBetaCommunity(alpha);
   await followBeta(alpha);

--- a/crates/apub/apub/src/http/community.rs
+++ b/crates/apub/apub/src/http/community.rs
@@ -161,17 +161,13 @@ pub(crate) async fn get_apub_community_featured(
   Ok(create_http_response(featured, &FEDERATION_CONTEXT)?)
 }
 
-#[derive(Deserialize)]
-pub(crate) struct MultiCommunityQuery {
-  multi_name: String,
-}
-
 pub(crate) async fn get_apub_person_multi_community(
-  query: Path<MultiCommunityQuery>,
+  path: Path<ActorPath>,
   context: Data<LemmyContext>,
 ) -> LemmyResult<HttpResponse> {
+  let (name, domain) = path.split_name();
   let multi: ApubMultiCommunity =
-    MultiCommunity::read_from_name(&mut context.pool(), &query.multi_name, None, false)
+    MultiCommunity::read_from_name(&mut context.pool(), name, domain, false)
       .await?
       .ok_or(LemmyErrorType::NotFound)?
       .into();
@@ -180,10 +176,10 @@ pub(crate) async fn get_apub_person_multi_community(
 }
 
 pub(crate) async fn get_apub_person_multi_community_follows(
-  query: Path<MultiCommunityQuery>,
+  path: Path<ActorPath>,
   context: Data<LemmyContext>,
 ) -> LemmyResult<HttpResponse> {
-  let multi = MultiCommunity::read_from_name(&mut context.pool(), &query.multi_name, None, false)
+  let multi = MultiCommunity::read_from_name(&mut context.pool(), &path.name, None, false)
     .await?
     .ok_or(LemmyErrorType::NotFound)?
     .into();

--- a/crates/apub/apub/src/http/community.rs
+++ b/crates/apub/apub/src/http/community.rs
@@ -1,4 +1,4 @@
-use super::check_community_content_fetchable;
+use super::{ActorPath, check_community_content_fetchable};
 use crate::{
   collections::{
     community_featured::ApubCommunityFeatured,
@@ -42,25 +42,16 @@ use lemmy_utils::{
 use serde::Deserialize;
 
 #[derive(Deserialize, Clone)]
-pub(crate) struct CommunityPath {
-  community_name: String,
-}
-
-#[derive(Deserialize, Clone)]
 pub(crate) struct CommunityIsFollowerQuery {
   is_follower: Option<ObjectId<SiteOrMultiOrCommunityOrUser>>,
 }
 
 /// Return the ActivityPub json representation of a community over HTTP.
 pub(crate) async fn get_apub_community_http(
-  info: Path<CommunityPath>,
+  info: Path<ActorPath>,
   context: Data<LemmyContext>,
 ) -> LemmyResult<HttpResponse> {
-  let (name, domain) = if let Some((n, d)) = info.community_name.split_once('@') {
-    (n, Some(d))
-  } else {
-    (info.community_name.as_str(), None::<&str>)
-  };
+  let (name, domain) = info.split_name();
   let community: ApubCommunity = Community::read_from_name(&mut context.pool(), name, domain, true)
     .await?
     .ok_or(LemmyErrorType::NotFound)?
@@ -73,12 +64,12 @@ pub(crate) async fn get_apub_community_http(
 
 /// Returns an empty followers collection, only populating the size (for privacy).
 pub(crate) async fn get_apub_community_followers(
-  info: Path<CommunityPath>,
+  info: Path<ActorPath>,
   query: Query<CommunityIsFollowerQuery>,
   context: Data<LemmyContext>,
   request: HttpRequest,
 ) -> LemmyResult<HttpResponse> {
-  let community = Community::read_from_name(&mut context.pool(), &info.community_name, None, false)
+  let community = Community::read_from_name(&mut context.pool(), &info.name, None, false)
     .await?
     .ok_or(LemmyErrorType::NotFound)?;
   if let Some(is_follower) = &query.is_follower {
@@ -126,12 +117,12 @@ async fn check_is_follower(
 /// Returns the community outbox, which is populated by a maximum of 20 posts (but no other
 /// activities like votes or comments).
 pub(crate) async fn get_apub_community_outbox(
-  info: Path<CommunityPath>,
+  info: Path<ActorPath>,
   context: Data<LemmyContext>,
   request: HttpRequest,
 ) -> LemmyResult<HttpResponse> {
   let community: ApubCommunity =
-    Community::read_from_name(&mut context.pool(), &info.community_name, None, false)
+    Community::read_from_name(&mut context.pool(), &info.name, None, false)
       .await?
       .ok_or(LemmyErrorType::NotFound)?
       .into();
@@ -141,11 +132,11 @@ pub(crate) async fn get_apub_community_outbox(
 }
 
 pub(crate) async fn get_apub_community_moderators(
-  info: Path<CommunityPath>,
+  info: Path<ActorPath>,
   context: Data<LemmyContext>,
 ) -> LemmyResult<HttpResponse> {
   let community: ApubCommunity =
-    Community::read_from_name(&mut context.pool(), &info.community_name, None, false)
+    Community::read_from_name(&mut context.pool(), &info.name, None, false)
       .await?
       .ok_or(LemmyErrorType::NotFound)?
       .into();
@@ -156,12 +147,12 @@ pub(crate) async fn get_apub_community_moderators(
 
 /// Returns collection of featured (stickied) posts.
 pub(crate) async fn get_apub_community_featured(
-  info: Path<CommunityPath>,
+  info: Path<ActorPath>,
   context: Data<LemmyContext>,
   request: HttpRequest,
 ) -> LemmyResult<HttpResponse> {
   let community: ApubCommunity =
-    Community::read_from_name(&mut context.pool(), &info.community_name, None, false)
+    Community::read_from_name(&mut context.pool(), &info.name, None, false)
       .await?
       .ok_or(LemmyErrorType::NotFound)?
       .into();
@@ -254,7 +245,7 @@ pub(crate) mod tests {
     deleted: bool,
     visibility: CommunityVisibility,
     context: &Data<LemmyContext>,
-  ) -> LemmyResult<(TestData, Community, Path<CommunityPath>)> {
+  ) -> LemmyResult<(TestData, Community, Path<ActorPath>)> {
     let data = TestData::create(&mut context.pool()).await?;
 
     let community_form = CommunityInsertForm {
@@ -268,8 +259,8 @@ pub(crate) mod tests {
       )
     };
     let community = Community::create(&mut context.pool(), &community_form).await?;
-    let path: Path<CommunityPath> = CommunityPath {
-      community_name: community.name.clone(),
+    let path: Path<ActorPath> = ActorPath {
+      name: community.name.clone(),
     }
     .into();
     Ok((data, community, path))
@@ -289,8 +280,8 @@ pub(crate) mod tests {
     let request = TestRequest::default().to_http_request();
 
     // fetch invalid community
-    let query = CommunityPath {
-      community_name: "asd".to_string(),
+    let query = ActorPath {
+      name: "asd".to_string(),
     };
     let res = get_apub_community_http(query.into(), context.clone()).await;
     assert!(res.is_err());

--- a/crates/apub/apub/src/http/community.rs
+++ b/crates/apub/apub/src/http/community.rs
@@ -51,16 +51,20 @@ pub(crate) struct CommunityIsFollowerQuery {
   is_follower: Option<ObjectId<SiteOrMultiOrCommunityOrUser>>,
 }
 
-/// Return the ActivityPub json representation of a local community over HTTP.
+/// Return the ActivityPub json representation of a community over HTTP.
 pub(crate) async fn get_apub_community_http(
   info: Path<CommunityPath>,
   context: Data<LemmyContext>,
 ) -> LemmyResult<HttpResponse> {
-  let community: ApubCommunity =
-    Community::read_from_name(&mut context.pool(), &info.community_name, None, true)
-      .await?
-      .ok_or(LemmyErrorType::NotFound)?
-      .into();
+  let (name, domain) = if let Some((n, d)) = info.community_name.split_once('@') {
+    (n, Some(d))
+  } else {
+    (info.community_name.as_str(), None::<&str>)
+  };
+  let community: ApubCommunity = Community::read_from_name(&mut context.pool(), name, domain, true)
+    .await?
+    .ok_or(LemmyErrorType::NotFound)?
+    .into();
 
   check_community_fetchable(&community)?;
 

--- a/crates/apub/apub/src/http/mod.rs
+++ b/crates/apub/apub/src/http/mod.rs
@@ -90,6 +90,24 @@ struct ActivityQuery {
   id: String,
 }
 
+/// Path parameter for ActivityPub actors (persons and communities), which may be qualified with a
+/// domain (e.g. `name@domain`) to reference a remote actor.
+#[derive(Deserialize, Clone)]
+pub(crate) struct ActorPath {
+  name: String,
+}
+
+impl ActorPath {
+  /// Split the actor name into its local name and optional domain.
+  pub(crate) fn split_name(&self) -> (&str, Option<&str>) {
+    if let Some((n, d)) = self.name.split_once('@') {
+      (n, Some(d))
+    } else {
+      (self.name.as_str(), None)
+    }
+  }
+}
+
 /// Return the ActivityPub json representation of a local activity over HTTP.
 async fn get_activity(
   info: web::Path<ActivityQuery>,

--- a/crates/apub/apub/src/http/person.rs
+++ b/crates/apub/apub/src/http/person.rs
@@ -1,3 +1,4 @@
+use super::ActorPath;
 use crate::protocol::collections::url_collection::UrlCollection;
 use activitypub_federation::{config::Data, traits::Object};
 use actix_web::{HttpResponse, web::Path};
@@ -8,23 +9,13 @@ use lemmy_utils::{
   FEDERATION_CONTEXT,
   error::{LemmyErrorType, LemmyResult},
 };
-use serde::Deserialize;
-
-#[derive(Deserialize)]
-pub(crate) struct PersonQuery {
-  user_name: String,
-}
 
 /// Return the ActivityPub json representation of a person over HTTP.
 pub(crate) async fn get_apub_person_http(
-  info: Path<PersonQuery>,
+  info: Path<ActorPath>,
   context: Data<LemmyContext>,
 ) -> LemmyResult<HttpResponse> {
-  let (name, domain) = if let Some((n, d)) = info.user_name.split_once('@') {
-    (n, Some(d))
-  } else {
-    (info.user_name.as_str(), None::<&str>)
-  };
+  let (name, domain) = info.split_name();
   // This needs to be able to read deleted persons, so that it can send tombstones
   let person: ApubPerson = Person::read_from_name(&mut context.pool(), name, domain, true)
     .await?
@@ -35,10 +26,10 @@ pub(crate) async fn get_apub_person_http(
 }
 
 pub(crate) async fn get_apub_person_outbox(
-  info: Path<PersonQuery>,
+  info: Path<ActorPath>,
   context: Data<LemmyContext>,
 ) -> LemmyResult<HttpResponse> {
-  let person = Person::read_from_name(&mut context.pool(), &info.user_name, None, false)
+  let person = Person::read_from_name(&mut context.pool(), &info.name, None, false)
     .await?
     .ok_or(LemmyErrorType::NotFound)?;
   let outbox_id = generate_outbox_url(&person.ap_id)?.to_string();

--- a/crates/apub/apub/src/http/person.rs
+++ b/crates/apub/apub/src/http/person.rs
@@ -15,14 +15,18 @@ pub(crate) struct PersonQuery {
   user_name: String,
 }
 
-/// Return the ActivityPub json representation of a local person over HTTP.
+/// Return the ActivityPub json representation of a person over HTTP.
 pub(crate) async fn get_apub_person_http(
   info: Path<PersonQuery>,
   context: Data<LemmyContext>,
 ) -> LemmyResult<HttpResponse> {
-  let user_name = info.into_inner().user_name;
+  let (name, domain) = if let Some((n, d)) = info.user_name.split_once('@') {
+    (n, Some(d))
+  } else {
+    (info.user_name.as_str(), None::<&str>)
+  };
   // This needs to be able to read deleted persons, so that it can send tombstones
-  let person: ApubPerson = Person::read_from_name(&mut context.pool(), &user_name, None, true)
+  let person: ApubPerson = Person::read_from_name(&mut context.pool(), name, domain, true)
     .await?
     .ok_or(LemmyErrorType::NotFound)?
     .into();

--- a/crates/apub/apub/src/http/routes.rs
+++ b/crates/apub/apub/src/http/routes.rs
@@ -26,41 +26,29 @@ pub fn config(cfg: &mut web::ServiceConfig) {
   cfg
     .route("/", web::get().to(get_apub_site_http))
     .route("/site_outbox", web::get().to(get_apub_site_outbox))
+    .route("/c/{name}", web::get().to(get_apub_community_http))
     .route(
-      "/c/{community_name}",
-      web::get().to(get_apub_community_http),
-    )
-    .route(
-      "/c/{community_name}/followers",
+      "/c/{name}/followers",
       web::get().to(get_apub_community_followers),
     )
+    .route("/c/{name}/outbox", web::get().to(get_apub_community_outbox))
     .route(
-      "/c/{community_name}/outbox",
-      web::get().to(get_apub_community_outbox),
-    )
-    .route(
-      "/c/{community_name}/featured",
+      "/c/{name}/featured",
       web::get().to(get_apub_community_featured),
     )
     .route(
-      "/c/{community_name}/moderators",
+      "/c/{name}/moderators",
       web::get().to(get_apub_community_moderators),
     )
     .route(
-      "/c/{community_name}/tag/{tag_name}",
+      "/c/{name}/tag/{tag_name}",
       web::get().to(get_apub_community_tag_http),
     )
-    .route("/u/{user_name}", web::get().to(get_apub_person_http))
+    .route("/u/{name}", web::get().to(get_apub_person_http))
+    .route("/u/{name}/outbox", web::get().to(get_apub_person_outbox))
+    .route("/m/{name}", web::get().to(get_apub_person_multi_community))
     .route(
-      "/u/{user_name}/outbox",
-      web::get().to(get_apub_person_outbox),
-    )
-    .route(
-      "/m/{multi_name}",
-      web::get().to(get_apub_person_multi_community),
-    )
-    .route(
-      "/m/{multi_name}/following",
+      "/m/{name}/following",
       web::get().to(get_apub_person_multi_community_follows),
     )
     .route("/post/{post_id}", web::get().to(get_apub_post))

--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -164,10 +164,8 @@ pub enum UntranslatedError {
 
 cfg_select! {
   feature = "full" => {
-
+    use serde_with::{DisplayFromStr, serde_as};
     use std::fmt;
-    use serde_with::serde_as;
-    use serde_with::DisplayFromStr;
 
     pub type LemmyResult<T> = Result<T, LemmyError>;
 
@@ -182,20 +180,21 @@ cfg_select! {
       pub caller: Location<'static>,
     }
 
-    /// Maximum number of items in an array passed as API parameter. See [[LemmyErrorType::TooManyItems]]
+    /// Maximum number of items in an array passed as API parameter. See
+    /// [[LemmyErrorType::TooManyItems]]
     pub(crate) const MAX_API_PARAM_ELEMENTS: usize = 10_000;
 
     impl<T> From<T> for LemmyError
     where
       T: Into<anyhow::Error>,
     {
-    #[track_caller]
+      #[track_caller]
       fn from(t: T) -> Self {
         let cause = t.into();
         let error_type = match cause.downcast_ref::<diesel::result::Error>() {
           Some(&diesel::NotFound) => LemmyErrorType::NotFound,
-          _ => LemmyErrorType::Unknown(format!("{}", &cause))
-      };
+          _ => LemmyErrorType::Unknown(format!("{}", &cause)),
+        };
         LemmyError {
           error_type,
           cause,
@@ -207,10 +206,10 @@ cfg_select! {
     impl Debug for LemmyError {
       fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("LemmyError")
-         .field("message", &self.error_type)
-         .field("caller", &format_args!("{}", self.caller))
-         .field("inner", &self.cause)
-         .finish()
+          .field("message", &self.error_type)
+          .field("caller", &format_args!("{}", self.caller))
+          .field("inner", &self.cause)
+          .finish()
       }
     }
 
@@ -238,9 +237,8 @@ cfg_select! {
     }
 
     impl From<LemmyErrorType> for LemmyError {
-    #[track_caller]
+      #[track_caller]
       fn from(error_type: LemmyErrorType) -> Self {
-
         let cause = anyhow::anyhow!("{}", error_type);
         LemmyError {
           error_type,
@@ -251,11 +249,11 @@ cfg_select! {
     }
 
     impl From<UntranslatedError> for LemmyError {
-    #[track_caller]
+      #[track_caller]
       fn from(error_type: UntranslatedError) -> Self {
         let cause = anyhow::anyhow!("{}", error_type);
         LemmyError {
-          error_type: LemmyErrorType::UntranslatedError( Some(error_type) ),
+          error_type: LemmyErrorType::UntranslatedError(Some(error_type)),
           cause,
           caller: *Location::caller(),
         }
@@ -264,7 +262,7 @@ cfg_select! {
 
     impl From<UntranslatedError> for LemmyErrorType {
       fn from(error: UntranslatedError) -> Self {
-        LemmyErrorType::UntranslatedError (Some(error) )
+        LemmyErrorType::UntranslatedError(Some(error))
       }
     }
 
@@ -273,7 +271,7 @@ cfg_select! {
     }
 
     impl<T, E: Into<anyhow::Error>> LemmyErrorExt<T, E> for Result<T, E> {
-    #[track_caller]
+      #[track_caller]
       fn with_lemmy_type(self, error_type: LemmyErrorType) -> LemmyResult<T> {
         self.map_err(|error| LemmyError {
           error_type,
@@ -294,7 +292,8 @@ cfg_select! {
           e
         })
       }
-      // this function can't be an impl From or similar because it would conflict with one of the other broad Into<> implementations
+      // this function can't be an impl From or similar because it would conflict with one of the
+      // other broad Into<> implementations
       fn into_anyhow(self) -> Result<T, anyhow::Error> {
         self.map_err(|e| e.cause)
       }
@@ -304,14 +303,24 @@ cfg_select! {
     mod tests {
       #![allow(clippy::indexing_slicing)]
       use super::*;
-      use actix_web::{body::MessageBody, ResponseError};
+      use actix_web::{ResponseError, body::MessageBody};
       use pretty_assertions::assert_eq;
 
       #[test]
       fn untranslated_error_format() -> LemmyResult<()> {
-        let err = LemmyError::from(UntranslatedError::DomainBlocked("test".to_string())).error_response();
-        let json = String::from_utf8(err.into_body().try_into_bytes().unwrap_or_default().to_vec())?;
-        assert_eq!(&json, r#"{"error":"domain_blocked","message":"test","cause":"DomainBlocked"}"#);
+        let err =
+          LemmyError::from(UntranslatedError::DomainBlocked("test".to_string())).error_response();
+        let json = String::from_utf8(
+          err
+            .into_body()
+            .try_into_bytes()
+            .unwrap_or_default()
+            .to_vec(),
+        )?;
+        assert_eq!(
+          &json,
+          r#"{"error":"domain_blocked","message":"test","cause":"DomainBlocked"}"#
+        );
 
         Ok(())
       }
@@ -319,7 +328,13 @@ cfg_select! {
       #[test]
       fn deserializes_no_message() -> LemmyResult<()> {
         let err = LemmyError::from(LemmyErrorType::BlockedUrl).error_response();
-        let json = String::from_utf8(err.into_body().try_into_bytes().unwrap_or_default().to_vec())?;
+        let json = String::from_utf8(
+          err
+            .into_body()
+            .try_into_bytes()
+            .unwrap_or_default()
+            .to_vec(),
+        )?;
         assert_eq!(&json, r#"{"error":"blocked_url","cause":"BlockedUrl"}"#);
 
         Ok(())
@@ -329,7 +344,13 @@ cfg_select! {
       fn deserializes_with_message() -> LemmyResult<()> {
         let reg_banned = LemmyErrorType::PictrsResponseError(String::from("reason"));
         let err = LemmyError::from(reg_banned).error_response();
-        let json = String::from_utf8(err.into_body().try_into_bytes().unwrap_or_default().to_vec())?;
+        let json = String::from_utf8(
+          err
+            .into_body()
+            .try_into_bytes()
+            .unwrap_or_default()
+            .to_vec(),
+        )?;
         assert_eq!(
           &json,
           r#"{"error":"pictrs_response_error","message":"reason","cause":"PictrsResponseError"}"#
@@ -345,7 +366,10 @@ cfg_select! {
         assert_eq!(404, not_found_error.status_code());
 
         let other_error = LemmyError::from(diesel::result::Error::NotInTransaction);
-        assert!(matches!(other_error.error_type, LemmyErrorType::Unknown{..}));
+        assert!(matches!(
+          other_error.error_type,
+          LemmyErrorType::Unknown { .. }
+        ));
         assert_eq!(400, other_error.status_code());
       }
     }

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -77,12 +77,13 @@ macro_rules! location_info {
 
 cfg_select! {
   feature = "full" => {
-    use moka::future::Cache;use std::fmt::Debug;use std::hash::Hash;
+    use moka::future::Cache;
     use serde_json::Value;
+    use std::{fmt::Debug, hash::Hash};
 
-    /// Only include a basic context to save space and bandwidth. The main context is hosted statically
-    /// on join-lemmy.org. Include activitystreams explicitly for better compat, but this could
-    /// theoretically also be moved.
+    /// Only include a basic context to save space and bandwidth. The main context is hosted
+    /// statically on join-lemmy.org. Include activitystreams explicitly for better compat, but
+    /// this could theoretically also be moved.
     pub static FEDERATION_CONTEXT: LazyLock<Value> = LazyLock::new(|| {
       Value::Array(vec![
         Value::String("https://join-lemmy.org/context.json".to_string()),
@@ -104,7 +105,7 @@ cfg_select! {
           }
         }
         .in_current_span(), /* this makes sure the inner tracing gets the same context as where
-                            * spawn was called */
+                             * spawn was called */
       );
     }
 


### PR DESCRIPTION
`.http_response` automatically sends a redirect forremote communities/persons, but for that to work we need to read them correctly from db.

https://docs.rs/activitypub_federation/0.7.0-beta.11/src/activitypub_federation/traits/mod.rs.html#198