### PR TITLE
Fixes for Oauth (ref #6609)

### DIFF
--- a/crates/api/api_crud/src/user/create.rs
+++ b/crates/api/api_crud/src/user/create.rs
@@ -287,11 +287,6 @@ pub async fn authenticate_with_oauth(
     return Err(LemmyErrorType::OauthAuthorizationInvalid.into());
   }
 
-  // validate the PKCE challenge
-  if let Some(code_verifier) = &data.pkce_code_verifier {
-    check_code_verifier(code_verifier)?;
-  }
-
   // Fetch the OAUTH provider and make sure it's enabled
   let oauth_provider_id = data.oauth_provider_id;
   let oauth_provider = AdminOAuthProvider::read(pool, oauth_provider_id)
@@ -301,6 +296,15 @@ pub async fn authenticate_with_oauth(
 
   if !oauth_provider.enabled {
     return Err(LemmyErrorType::OauthAuthorizationInvalid.into());
+  }
+
+  // validate the PKCE challenge
+  if oauth_provider.use_pkce {
+    let code_verifier = data
+      .pkce_code_verifier
+      .as_deref()
+      .ok_or(LemmyErrorType::OauthAuthorizationInvalid)?;
+    check_code_verifier(code_verifier)?;
   }
 
   let token_response = oauth_request_access_token(

--- a/crates/api/api_crud/src/user/create.rs
+++ b/crates/api/api_crud/src/user/create.rs
@@ -278,12 +278,12 @@ pub async fn authenticate_with_oauth(
     return Err(LemmyErrorType::OauthAuthorizationInvalid.into());
   }
 
-  // validate the redirect_uri
-  let redirect_uri = &data.redirect_uri;
-  if redirect_uri.host_str().unwrap_or("").is_empty()
-    || !redirect_uri.path().eq(&String::from("/oauth/callback"))
-    || !redirect_uri.query().unwrap_or("").is_empty()
-  {
+  // redirect_uri must point exactly at this instance's oauth callback
+  let expected_redirect_uri = format!(
+    "{}/oauth/callback",
+    context.settings().get_protocol_and_hostname()
+  );
+  if data.redirect_uri.as_str() != expected_redirect_uri {
     return Err(LemmyErrorType::OauthAuthorizationInvalid.into());
   }
 
@@ -312,7 +312,7 @@ pub async fn authenticate_with_oauth(
     &oauth_provider,
     &data.code,
     data.pkce_code_verifier.as_deref(),
-    redirect_uri.as_str(),
+    data.redirect_uri.as_str(),
   )
   .await?;
 

--- a/crates/api/api_crud/src/user/create.rs
+++ b/crates/api/api_crud/src/user/create.rs
@@ -662,13 +662,10 @@ async fn oidc_get_user_info(
 }
 
 fn read_user_info(user_info: &serde_json::Value, key: &str) -> Option<String> {
-  if let Some(value) = user_info.get(key) {
-    serde_json::from_value::<Option<String>>(value.clone())
-      .ok()
-      .flatten()
-      .filter(|s| !s.is_empty())
-  } else {
-    None
+  match user_info.get(key)? {
+    serde_json::Value::String(s) if !s.is_empty() => Some(s.clone()),
+    serde_json::Value::Number(n) => Some(n.to_string()),
+    _ => None,
   }
 }
 

--- a/crates/api/api_crud/src/user/create.rs
+++ b/crates/api/api_crud/src/user/create.rs
@@ -402,7 +402,13 @@ pub async fn authenticate_with_oauth(
       }
     } else {
       // No user was found by email => Register as new user
-      login_response.registration_created = local_site.site_setup && require_registration_application;
+      login_response.registration_created =
+        local_site.site_setup && require_registration_application;
+
+      // Check if verification email can be sent before submitting transaction
+      if local_site.email_verification_required && email.is_none() {
+        return Err(LemmyErrorType::EmailRequired.into());
+      }
 
       // make sure the registration answer is provided when the registration application is required
       validate_registration_answer(require_registration_application, &data.answer)?;

--- a/crates/api/api_crud/src/user/create.rs
+++ b/crates/api/api_crud/src/user/create.rs
@@ -351,7 +351,6 @@ pub async fn authenticate_with_oauth(
     local_user
   } else {
     // user has never previously registered using oauth
-    login_response.registration_created = local_site.site_setup && require_registration_application;
 
     // prevent registration if registration is closed
     if local_site.registration_mode == RegistrationMode::Closed {
@@ -403,6 +402,7 @@ pub async fn authenticate_with_oauth(
       }
     } else {
       // No user was found by email => Register as new user
+      login_response.registration_created = local_site.site_setup && require_registration_application;
 
       // make sure the registration answer is provided when the registration application is required
       validate_registration_answer(require_registration_application, &data.answer)?;

--- a/crates/api/api_crud/src/user/create.rs
+++ b/crates/api/api_crud/src/user/create.rs
@@ -666,6 +666,7 @@ fn read_user_info(user_info: &serde_json::Value, key: &str) -> Option<String> {
     serde_json::from_value::<Option<String>>(value.clone())
       .ok()
       .flatten()
+      .filter(|s| !s.is_empty())
   } else {
     None
   }


### PR DESCRIPTION
- `read_user_info()` should never return Some(""), but convert it to None 
- `id_claim` can be an int, for example the [github id](https://docs.github.com/en/rest/users/users?apiVersion=2026-03-10#get-the-authenticated-user).
- `use_pkce` was not enforced
- `login_response.registration_created` was set when linking to an existing account via email. Moved it so that its only set when new account is created
- Check if verification email can be sent before submitting transaction
- stricter validation of redirect uri