### PR TITLE
Remove duplicate check functions (fixes #6311)

### DIFF
--- a/crates/api/api/src/comment/like.rs
+++ b/crates/api/api/src/comment/like.rs
@@ -5,12 +5,7 @@ use lemmy_api_utils::{
   context::LemmyContext,
   plugins::{plugin_hook_after, plugin_hook_before},
   send_activity::{ActivityChannel, SendActivityData},
-  utils::{
-    check_bot_account,
-    check_community_user_action,
-    check_local_user_banned_or_deleted,
-    check_local_vote_mode,
-  },
+  utils::{check_bot_account, check_community_user_action, check_local_vote_mode},
 };
 use lemmy_db_schema::{
   newtypes::PostOrCommentId,
@@ -35,7 +30,6 @@ pub async fn like_comment(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<CommentResponse>> {
-  check_local_user_banned_or_deleted(&local_user_view)?;
   let local_site = SiteView::read_local(&mut context.pool()).await?.local_site;
   let local_instance_id = local_user_view.person.instance_id;
   let comment_id = data.comment_id;

--- a/crates/api/api/src/community/pending_follows/approve.rs
+++ b/crates/api/api/src/community/pending_follows/approve.rs
@@ -10,7 +10,7 @@ use lemmy_db_schema_file::enums::CommunityFollowerState;
 use lemmy_db_views_community::api::ApproveCommunityPendingFollower;
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_db_views_site::api::SuccessResponse;
-use lemmy_utils::error::LemmyResult;
+use lemmy_utils::error::{LemmyErrorType, LemmyResult};
 
 pub async fn post_pending_follows_approve(
   Json(data): Json<ApproveCommunityPendingFollower>,
@@ -21,6 +21,9 @@ pub async fn post_pending_follows_approve(
 
   let community_actions =
     CommunityActions::read(&mut context.pool(), data.community_id, data.follower_id).await?;
+  if community_actions.follow_state != Some(CommunityFollowerState::ApprovalRequired) {
+    return Err(LemmyErrorType::CouldntUpdate.into());
+  }
   let (state, activity_data) = if data.approve {
     (
       CommunityFollowerState::Accepted,

--- a/crates/api/api/src/community/transfer.rs
+++ b/crates/api/api/src/community/transfer.rs
@@ -4,7 +4,7 @@ use diesel_async::scoped_futures::ScopedFutureExt;
 use lemmy_api_utils::{
   context::LemmyContext,
   notify::notify_mod_action,
-  utils::{check_community_user_action, is_admin, is_top_mod},
+  utils::{check_community_mod_action, is_admin, is_top_mod},
 };
 use lemmy_db_schema::source::{
   community::{Community, CommunityActions, CommunityModeratorForm},
@@ -34,7 +34,7 @@ pub async fn transfer_community(
   let mut community_mods =
     CommunityModeratorView::for_community(&mut context.pool(), community.id).await?;
 
-  check_community_user_action(&local_user_view, &community, &mut context.pool()).await?;
+  check_community_mod_action(&local_user_view, &community, false, &mut context.pool()).await?;
 
   // Make sure transferrer is either the top community mod, or an admin
   if !(is_top_mod(&local_user_view, &community_mods).is_ok() || is_admin(&local_user_view).is_ok())

--- a/crates/api/api/src/federation/resolve_object.rs
+++ b/crates/api/api/src/federation/resolve_object.rs
@@ -4,11 +4,11 @@ use activitypub_federation::{
 };
 use actix_web::web::{Json, Query};
 use either::Either::*;
-use lemmy_api_utils::{
-  context::LemmyContext,
-  utils::{check_is_mod_or_admin, check_private_instance},
+use lemmy_api_utils::{context::LemmyContext, utils::check_private_instance};
+use lemmy_apub_objects::{
+  objects::{SearchableObjects, UserOrCommunity},
+  utils::check_is_mod_or_admin,
 };
-use lemmy_apub_objects::objects::{SearchableObjects, UserOrCommunity};
 use lemmy_db_schema_file::PersonId;
 use lemmy_db_views_comment::CommentView;
 use lemmy_db_views_community::{CommunityView, MultiCommunityView};

--- a/crates/api/api/src/post/like.rs
+++ b/crates/api/api/src/post/like.rs
@@ -5,12 +5,7 @@ use lemmy_api_utils::{
   context::LemmyContext,
   plugins::{plugin_hook_after, plugin_hook_before},
   send_activity::{ActivityChannel, SendActivityData},
-  utils::{
-    check_bot_account,
-    check_community_user_action,
-    check_local_user_banned_or_deleted,
-    check_local_vote_mode,
-  },
+  utils::{check_bot_account, check_community_user_action, check_local_vote_mode},
 };
 use lemmy_db_schema::{
   newtypes::PostOrCommentId,
@@ -35,7 +30,6 @@ pub async fn like_post(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<PostResponse>> {
-  check_local_user_banned_or_deleted(&local_user_view)?;
   let local_site = SiteView::read_local(&mut context.pool()).await?.local_site;
   let local_instance_id = local_user_view.person.instance_id;
   let post_id = data.post_id;

--- a/crates/api/api/src/post/mod_update.rs
+++ b/crates/api/api/src/post/mod_update.rs
@@ -6,12 +6,7 @@ use lemmy_api_utils::{
   context::LemmyContext,
   plugins::{plugin_hook_after, plugin_hook_before},
   send_activity::{ActivityChannel, SendActivityData},
-  utils::{
-    check_community_user_action,
-    check_is_mod_or_admin,
-    check_nsfw_allowed,
-    update_post_tags,
-  },
+  utils::{check_community_user_action, check_nsfw_allowed, is_mod_or_admin, update_post_tags},
 };
 use lemmy_db_schema::source::post::{Post, PostUpdateForm};
 use lemmy_db_views_local_user::LocalUserView;
@@ -46,7 +41,7 @@ pub async fn mod_edit_post(
   let community = orig_post.community;
 
   check_community_user_action(&local_user_view, &community, &mut context.pool()).await?;
-  check_is_mod_or_admin(&mut context.pool(), local_user_view.person.id, community.id).await?;
+  is_mod_or_admin(&mut context.pool(), &local_user_view, community.id).await?;
 
   let mut post_form = PostUpdateForm {
     nsfw: data.nsfw,

--- a/crates/api/api/src/reports/community_report/create.rs
+++ b/crates/api/api/src/reports/community_report/create.rs
@@ -6,7 +6,7 @@ use lemmy_api_utils::{
   context::LemmyContext,
   plugins::plugin_hook_after,
   send_activity::{ActivityChannel, SendActivityData},
-  utils::{check_local_user_banned_or_deleted, slur_regex},
+  utils::{check_community_user_action, check_local_user_banned_or_deleted, slur_regex},
 };
 use lemmy_db_schema::{
   source::{
@@ -39,6 +39,7 @@ pub async fn create_community_report(
   let person = &local_user_view.person;
   let community_id = data.community_id;
   let community = Community::read(&mut context.pool(), community_id).await?;
+  check_community_user_action(&local_user_view, &community, &mut context.pool()).await?;
   let site = Site::read_from_instance_id(&mut context.pool(), community.instance_id).await?;
 
   let report_form = CommunityReportForm {

--- a/crates/api/api_crud/src/comment/create.rs
+++ b/crates/api/api_crud/src/comment/create.rs
@@ -8,6 +8,7 @@ use lemmy_api_utils::{
   plugins::{plugin_hook_after, plugin_hook_before},
   send_activity::{ActivityChannel, SendActivityData},
   utils::{
+    check_comment_deleted_or_removed,
     check_comment_depth,
     check_community_user_action,
     check_post_deleted_or_removed,
@@ -102,6 +103,7 @@ pub async fn create_comment(
       return Err(LemmyErrorType::CouldntCreate.into());
     }
     check_comment_depth(parent)?;
+    check_comment_deleted_or_removed(parent)?;
   }
 
   let mut comment_form = CommentInsertForm {

--- a/crates/api/api_crud/src/community/delete.rs
+++ b/crates/api/api_crud/src/community/delete.rs
@@ -4,7 +4,7 @@ use lemmy_api_utils::{
   build_response::build_community_response,
   context::LemmyContext,
   send_activity::{ActivityChannel, SendActivityData},
-  utils::{check_community_mod_action, check_local_user_banned_or_deleted, is_top_mod},
+  utils::{check_community_mod_action, is_top_mod},
 };
 use lemmy_db_schema::source::community::{Community, CommunityUpdateForm};
 use lemmy_db_views_community::api::{CommunityResponse, DeleteCommunity};
@@ -18,7 +18,6 @@ pub async fn delete_community(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<CommunityResponse>> {
-  check_local_user_banned_or_deleted(&local_user_view)?;
   // Fetch the community mods
   let community_mods =
     CommunityModeratorView::for_community(&mut context.pool(), data.community_id).await?;

--- a/crates/api/api_crud/src/community/update.rs
+++ b/crates/api/api_crud/src/community/update.rs
@@ -7,7 +7,6 @@ use lemmy_api_utils::{
   send_activity::{ActivityChannel, SendActivityData},
   utils::{
     check_community_mod_action,
-    check_local_user_banned_or_deleted,
     check_nsfw_allowed,
     get_url_blocklist,
     process_markdown_opt,
@@ -36,7 +35,6 @@ pub async fn edit_community(
   context: Data<LemmyContext>,
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<CommunityResponse>> {
-  check_local_user_banned_or_deleted(&local_user_view)?;
   let local_site = SiteView::read_local(&mut context.pool()).await?.local_site;
 
   let slur_regex = slur_regex(&context).await?;

--- a/crates/api/api_utils/src/utils.rs
+++ b/crates/api/api_utils/src/utils.rs
@@ -75,51 +75,25 @@ use webmention::{Webmention, WebmentionError};
 
 pub const AUTH_COOKIE_NAME: &str = "jwt";
 
-pub async fn check_is_mod_or_admin(
-  pool: &mut DbPool<'_>,
-  person_id: PersonId,
-  community_id: CommunityId,
-) -> LemmyResult<()> {
-  let is_mod = CommunityModeratorView::check_is_community_moderator(pool, community_id, person_id)
-    .await
-    .is_ok();
-  let is_admin = LocalUserView::read_person(pool, person_id)
-    .await
-    .is_ok_and(|t| t.local_user.admin);
-
-  if is_mod || is_admin {
-    Ok(())
-  } else {
-    Err(LemmyErrorType::NotAModOrAdmin.into())
-  }
-}
-
-/// Checks if a person is an admin, or moderator of any community.
-pub(crate) async fn check_is_mod_of_any_or_admin(
-  pool: &mut DbPool<'_>,
-  person_id: PersonId,
-) -> LemmyResult<()> {
-  let is_mod_of_any = CommunityModeratorView::is_community_moderator_of_any(pool, person_id)
-    .await
-    .is_ok();
-  let is_admin = LocalUserView::read_person(pool, person_id)
-    .await
-    .is_ok_and(|t| t.local_user.admin);
-
-  if is_mod_of_any || is_admin {
-    Ok(())
-  } else {
-    Err(LemmyErrorType::NotAModOrAdmin.into())
-  }
-}
-
 pub async fn is_mod_or_admin(
   pool: &mut DbPool<'_>,
   local_user_view: &LocalUserView,
   community_id: CommunityId,
 ) -> LemmyResult<()> {
   check_local_user_banned_or_deleted(local_user_view)?;
-  check_is_mod_or_admin(pool, local_user_view.person.id, community_id).await
+  let is_mod = CommunityModeratorView::check_is_community_moderator(
+    pool,
+    community_id,
+    local_user_view.person.id,
+  )
+  .await
+  .is_ok();
+
+  if is_mod || local_user_view.local_user.admin {
+    Ok(())
+  } else {
+    Err(LemmyErrorType::NotAModOrAdmin.into())
+  }
 }
 
 pub async fn is_mod_or_admin_opt(
@@ -148,7 +122,15 @@ pub async fn check_community_mod_of_any_or_admin_action(
   let person = &local_user_view.person;
 
   check_local_user_banned_or_deleted(local_user_view)?;
-  check_is_mod_of_any_or_admin(pool, person.id).await
+  let is_mod_of_any = CommunityModeratorView::is_community_moderator_of_any(pool, person.id)
+    .await
+    .is_ok();
+
+  if is_mod_of_any || local_user_view.local_user.admin {
+    Ok(())
+  } else {
+    Err(LemmyErrorType::NotAModOrAdmin.into())
+  }
 }
 
 pub fn is_admin(local_user_view: &LocalUserView) -> LemmyResult<()> {

--- a/crates/apub/activities/src/block/block_user.rs
+++ b/crates/apub/activities/src/block/block_user.rs
@@ -3,7 +3,6 @@ use crate::{
   MOD_ACTION_DEFAULT_REASON,
   activity_lists::AnnouncableActivities,
   block::{SiteOrCommunity, generate_cc},
-  check_community_deleted_or_removed,
   community::send_activity_in_community,
   generate_activity_id,
   protocol::block::block_user::BlockUser,
@@ -19,7 +18,11 @@ use chrono::{DateTime, Utc};
 use lemmy_api_utils::{
   context::LemmyContext,
   notify::notify_mod_action,
-  utils::{remove_or_restore_user_data, remove_or_restore_user_data_in_community},
+  utils::{
+    check_community_deleted_removed,
+    remove_or_restore_user_data,
+    remove_or_restore_user_data_in_community,
+  },
 };
 use lemmy_apub_objects::{
   objects::person::ApubPerson,
@@ -119,7 +122,7 @@ impl Activity for BlockUser {
       SiteOrCommunity::Right(community) => {
         verify_visibility(&self.to, &self.cc, &community)?;
         verify_mod_action(&self.actor, self.object.inner(), &community, context).await?;
-        check_community_deleted_or_removed(&community)?;
+        check_community_deleted_removed(&community)?;
       }
     }
     Ok(())

--- a/crates/apub/activities/src/community/collection_add.rs
+++ b/crates/apub/activities/src/community/collection_add.rs
@@ -1,6 +1,5 @@
 use crate::{
   activity_lists::AnnouncableActivities,
-  check_community_deleted_or_removed,
   community::send_activity_in_community,
   generate_activity_id,
   protocol::community::{collection_add::CollectionAdd, collection_remove::CollectionRemove},
@@ -14,7 +13,7 @@ use activitypub_federation::{
 use lemmy_api_utils::{
   context::LemmyContext,
   notify::notify_mod_action,
-  utils::{generate_featured_url, generate_moderators_url},
+  utils::{check_community_deleted_removed, generate_featured_url, generate_moderators_url},
 };
 use lemmy_apub_objects::{
   objects::{community::ApubCommunity, person::ApubPerson, post::ApubPost},
@@ -110,7 +109,7 @@ impl Activity for CollectionAdd {
     let community = self.community(context).await?;
     verify_visibility(&self.to, &self.cc, &community)?;
     verify_mod_action(&self.actor, &self.object, &community, context).await?;
-    check_community_deleted_or_removed(&community)?;
+    check_community_deleted_removed(&community)?;
     Ok(())
   }
 

--- a/crates/apub/activities/src/community/collection_remove.rs
+++ b/crates/apub/activities/src/community/collection_remove.rs
@@ -1,6 +1,5 @@
 use crate::{
   activity_lists::AnnouncableActivities,
-  check_community_deleted_or_removed,
   community::send_activity_in_community,
   generate_activity_id,
   protocol::community::collection_remove::CollectionRemove,
@@ -14,7 +13,7 @@ use activitypub_federation::{
 use lemmy_api_utils::{
   context::LemmyContext,
   notify::notify_mod_action,
-  utils::{generate_featured_url, generate_moderators_url},
+  utils::{check_community_deleted_removed, generate_featured_url, generate_moderators_url},
 };
 use lemmy_apub_objects::{
   objects::{community::ApubCommunity, person::ApubPerson, post::ApubPost},
@@ -108,7 +107,7 @@ impl Activity for CollectionRemove {
     let community = self.community(context).await?;
     verify_visibility(&self.to, &self.cc, &community)?;
     verify_mod_action(&self.actor, &self.object, &community, context).await?;
-    check_community_deleted_or_removed(&community)?;
+    check_community_deleted_removed(&community)?;
     Ok(())
   }
 

--- a/crates/apub/activities/src/community/lock.rs
+++ b/crates/apub/activities/src/community/lock.rs
@@ -1,7 +1,6 @@
 use crate::{
   MOD_ACTION_DEFAULT_REASON,
   activity_lists::AnnouncableActivities,
-  check_community_deleted_or_removed,
   community::send_activity_in_community,
   generate_activity_id,
   post_or_comment_community,
@@ -16,7 +15,11 @@ use activitypub_federation::{
   kinds::activity::UndoType,
   traits::Activity,
 };
-use lemmy_api_utils::{context::LemmyContext, notify::notify_mod_action};
+use lemmy_api_utils::{
+  context::LemmyContext,
+  notify::notify_mod_action,
+  utils::check_community_deleted_removed,
+};
 use lemmy_apub_objects::{
   objects::{PostOrComment, community::ApubCommunity},
   utils::{
@@ -51,7 +54,7 @@ impl Activity for LockPageOrNote {
   async fn verify(&self, context: &Data<Self::DataType>) -> Result<(), Self::Error> {
     let community = self.community(context).await?;
     verify_visibility(&self.to, &self.cc, &community)?;
-    check_community_deleted_or_removed(&community)?;
+    check_community_deleted_removed(&community)?;
     verify_mod_action(&self.actor, self.object.inner(), &community, context).await?;
     Ok(())
   }
@@ -108,7 +111,7 @@ impl Activity for UndoLockPageOrNote {
     let object = self.object.dereference(context).await?;
     let community = object.community(context).await?;
     verify_visibility(&self.to, &self.cc, &community)?;
-    check_community_deleted_or_removed(&community)?;
+    check_community_deleted_removed(&community)?;
     verify_mod_action(&self.actor, object.object.inner(), &community, context).await?;
     Ok(())
   }

--- a/crates/apub/activities/src/community/report.rs
+++ b/crates/apub/activities/src/community/report.rs
@@ -1,7 +1,6 @@
 use super::{local_community, report_inboxes};
 use crate::{
   activity_lists::AnnouncableActivities,
-  check_community_deleted_or_removed,
   generate_activity_id,
   protocol::community::{
     announce::AnnounceActivity,
@@ -106,7 +105,7 @@ impl Activity for Report {
         let community: ApubCommunity = Community::read(&mut context.pool(), post.community_id)
           .await?
           .into();
-        check_community_deleted_or_removed(&community)?;
+        check_community_deleted_removed(&community)?;
         verify_person_in_community(&self.actor, &community, context).await?;
         check_post_deleted_or_removed(&post)?;
       }
@@ -116,7 +115,7 @@ impl Activity for Report {
           .await?
           .into();
         verify_person_in_community(&self.actor, &community, context).await?;
-        check_community_deleted_or_removed(&community)?;
+        check_community_deleted_removed(&community)?;
         check_comment_deleted_or_removed(&comment)?;
       }
       ReportableObjects::Right(Either::Left(community)) => {

--- a/crates/apub/activities/src/community/update.rs
+++ b/crates/apub/activities/src/community/update.rs
@@ -1,5 +1,4 @@
 use crate::{
-  check_community_deleted_or_removed,
   community::{AnnouncableActivities, send_activity_in_community},
   generate_activity_id,
   protocol::community::update::Update,
@@ -12,7 +11,7 @@ use activitypub_federation::{
   traits::{Activity, Object},
 };
 use either::Either;
-use lemmy_api_utils::context::LemmyContext;
+use lemmy_api_utils::{context::LemmyContext, utils::check_community_deleted_removed};
 use lemmy_apub_objects::{
   objects::{community::ApubCommunity, multi_community::ApubMultiCommunity, person::ApubPerson},
   utils::{
@@ -107,7 +106,7 @@ impl Activity for Update {
           .as_ref()
           .either(|l| l.id.inner(), |r| r.id.inner());
         verify_mod_action(&self.actor, object_id, &community, context).await?;
-        check_community_deleted_or_removed(&community)?;
+        check_community_deleted_removed(&community)?;
         ApubCommunity::verify(c, &community.ap_id.clone().into(), context).await?;
       }
       Either::Right(m) => {

--- a/crates/apub/activities/src/community/warn.rs
+++ b/crates/apub/activities/src/community/warn.rs
@@ -1,5 +1,4 @@
 use crate::{
-  check_community_deleted_or_removed,
   community::verify_mod_or_admin_action,
   generate_activity_id,
   protocol::community::warn::{Warn, WarnType},
@@ -7,7 +6,11 @@ use crate::{
 };
 use activitypub_federation::{config::Data, fetch::object_id::ObjectId, traits::Activity};
 use either::Either;
-use lemmy_api_utils::{context::LemmyContext, notify::notify_mod_action};
+use lemmy_api_utils::{
+  context::LemmyContext,
+  notify::notify_mod_action,
+  utils::check_community_deleted_removed,
+};
 use lemmy_apub_objects::{
   objects::{PostOrComment, person::ApubPerson},
   utils::protocol::InCommunity,
@@ -84,7 +87,7 @@ impl Activity for Warn {
 
   async fn verify(&self, context: &Data<Self::DataType>) -> LemmyResult<()> {
     let community = self.community(context).await?;
-    check_community_deleted_or_removed(&community)?;
+    check_community_deleted_removed(&community)?;
     verify_mod_or_admin_action(
       &self.actor,
       self.object.inner(),

--- a/crates/apub/activities/src/create_or_update/comment.rs
+++ b/crates/apub/activities/src/create_or_update/comment.rs
@@ -1,6 +1,5 @@
 use crate::{
   activity_lists::AnnouncableActivities,
-  check_community_deleted_or_removed,
   community::send_activity_in_community,
   create_or_update::{parse_apub_mentions, tagged_user_inboxes},
   generate_activity_id,
@@ -14,7 +13,7 @@ use activitypub_federation::{
 use lemmy_api_utils::{
   context::LemmyContext,
   notify::NotifyData,
-  utils::{check_is_mod_or_admin, check_post_deleted_or_removed},
+  utils::{check_community_deleted_removed, check_is_mod_or_admin, check_post_deleted_or_removed},
 };
 use lemmy_apub_objects::{
   objects::{comment::ApubComment, community::ApubCommunity, person::ApubPerson},
@@ -100,7 +99,7 @@ impl Activity for CreateOrUpdateNote {
 
     verify_person_in_community(&self.actor, &community, context).await?;
     verify_domains_match(self.actor.inner(), self.object.id.inner())?;
-    check_community_deleted_or_removed(&community)?;
+    check_community_deleted_removed(&community)?;
     check_post_deleted_or_removed(&post)?;
     verify_urls_match(self.actor.inner(), self.object.attributed_to.inner())?;
 

--- a/crates/apub/activities/src/create_or_update/comment.rs
+++ b/crates/apub/activities/src/create_or_update/comment.rs
@@ -13,7 +13,11 @@ use activitypub_federation::{
 use lemmy_api_utils::{
   context::LemmyContext,
   notify::NotifyData,
-  utils::{check_community_deleted_removed, check_post_deleted_or_removed},
+  utils::{
+    check_comment_deleted_or_removed,
+    check_community_deleted_removed,
+    check_post_deleted_or_removed,
+  },
 };
 use lemmy_apub_objects::{
   objects::{comment::ApubComment, community::ApubCommunity, person::ApubPerson},
@@ -94,7 +98,7 @@ impl Activity for CreateOrUpdateNote {
   }
 
   async fn verify(&self, context: &Data<Self::DataType>) -> LemmyResult<()> {
-    let post = self.object.get_parents(context).await?.0;
+    let (post, parent_comment) = self.object.get_parents(context).await?;
     let community = self.community(context).await?;
     verify_visibility(&self.to, &self.cc, &community)?;
 
@@ -102,6 +106,9 @@ impl Activity for CreateOrUpdateNote {
     verify_domains_match(self.actor.inner(), self.object.id.inner())?;
     check_community_deleted_removed(&community)?;
     check_post_deleted_or_removed(&post)?;
+    if let Some(parent_comment) = parent_comment {
+      check_comment_deleted_or_removed(&parent_comment.0)?;
+    }
     verify_urls_match(self.actor.inner(), self.object.attributed_to.inner())?;
 
     ApubComment::verify(&self.object, self.actor.inner(), context).await?;

--- a/crates/apub/activities/src/create_or_update/comment.rs
+++ b/crates/apub/activities/src/create_or_update/comment.rs
@@ -13,11 +13,12 @@ use activitypub_federation::{
 use lemmy_api_utils::{
   context::LemmyContext,
   notify::NotifyData,
-  utils::{check_community_deleted_removed, check_is_mod_or_admin, check_post_deleted_or_removed},
+  utils::{check_community_deleted_removed, check_post_deleted_or_removed},
 };
 use lemmy_apub_objects::{
   objects::{comment::ApubComment, community::ApubCommunity, person::ApubPerson},
   utils::{
+    check_is_mod_or_admin,
     functions::{generate_to, verify_person_in_community, verify_visibility},
     protocol::InCommunity,
   },

--- a/crates/apub/activities/src/create_or_update/post.rs
+++ b/crates/apub/activities/src/create_or_update/post.rs
@@ -1,6 +1,5 @@
 use crate::{
   activity_lists::AnnouncableActivities,
-  check_community_deleted_or_removed,
   community::send_activity_in_community,
   create_or_update::{parse_apub_mentions, tagged_user_inboxes},
   generate_activity_id,
@@ -12,7 +11,11 @@ use activitypub_federation::{
   traits::{Activity, Object},
 };
 use chrono::Utc;
-use lemmy_api_utils::{context::LemmyContext, notify::NotifyData};
+use lemmy_api_utils::{
+  context::LemmyContext,
+  notify::NotifyData,
+  utils::check_community_deleted_removed,
+};
 use lemmy_apub_objects::{
   objects::{
     community::ApubCommunity,
@@ -95,7 +98,7 @@ impl Activity for CreateOrUpdatePage {
   async fn verify(&self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     let community = self.community(context).await?;
     verify_visibility(&self.to, &self.cc, &community)?;
-    check_community_deleted_or_removed(&community)?;
+    check_community_deleted_removed(&community)?;
     verify_domains_match(self.actor.inner(), self.object.id.inner())?;
     ApubPost::verify(&self.object, self.actor.inner(), context).await?;
     Ok(())

--- a/crates/apub/activities/src/deletion/mod.rs
+++ b/crates/apub/activities/src/deletion/mod.rs
@@ -1,6 +1,5 @@
 use crate::{
   activity_lists::AnnouncableActivities,
-  check_community_deleted_or_removed,
   community::send_activity_in_community,
   protocol::deletion::{delete::Delete, undo_delete::UndoDelete},
   send_lemmy_activity,
@@ -16,7 +15,7 @@ use activitypub_federation::{
 use lemmy_api_utils::{
   context::LemmyContext,
   plugins::{plugin_hook_after, plugin_hook_before},
-  utils::purge_user_account,
+  utils::{check_community_deleted_removed, purge_user_account},
 };
 use lemmy_apub_objects::{
   objects::{
@@ -274,7 +273,7 @@ async fn verify_delete_post_or_comment(
   is_mod_action: bool,
   context: &Data<LemmyContext>,
 ) -> LemmyResult<()> {
-  check_community_deleted_or_removed(community)?;
+  check_community_deleted_removed(community)?;
   if is_mod_action {
     verify_mod_action(actor, object_id, community, context).await?;
   } else {

--- a/crates/apub/activities/src/following/accept.rs
+++ b/crates/apub/activities/src/following/accept.rs
@@ -1,5 +1,4 @@
 use crate::{
-  check_community_deleted_or_removed,
   generate_activity_id,
   protocol::{
     IdOrNestedObject,
@@ -13,7 +12,7 @@ use activitypub_federation::{
   protocol::verification::verify_urls_match,
   traits::{Activity, Actor, Object},
 };
-use lemmy_api_utils::context::LemmyContext;
+use lemmy_api_utils::{context::LemmyContext, utils::check_community_deleted_removed};
 use lemmy_db_schema::{
   source::{activity::ActivitySendTargets, community::CommunityActions},
   traits::Followable,
@@ -64,7 +63,7 @@ impl Activity for AcceptFollow {
   async fn receive(self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     let object = self.object.dereference(context).await?;
     let community = self.actor.dereference(context).await?;
-    check_community_deleted_or_removed(&community)?;
+    check_community_deleted_removed(&community)?;
     let actor = object.actor.dereference(context).await?;
     let person = actor.left().ok_or(UntranslatedError::Unreachable)?;
     // This will throw an error if no follow was requested

--- a/crates/apub/activities/src/following/follow.rs
+++ b/crates/apub/activities/src/following/follow.rs
@@ -1,5 +1,4 @@
 use crate::{
-  check_community_deleted_or_removed,
   generate_activity_id,
   protocol::following::{accept::AcceptFollow, follow::Follow},
   send_lemmy_activity,
@@ -11,7 +10,7 @@ use activitypub_federation::{
   traits::{Activity, Actor, Object},
 };
 use either::Either::*;
-use lemmy_api_utils::context::LemmyContext;
+use lemmy_api_utils::{context::LemmyContext, utils::check_community_deleted_removed};
 use lemmy_apub_objects::objects::{CommunityOrMulti, person::ApubPerson};
 use lemmy_db_schema::{
   source::{
@@ -93,7 +92,7 @@ impl Activity for Follow {
     if let (Right(community), Right(Left(follower))) = (&actor, &object)
       && (community.visibility == Public || community.visibility == Unlisted)
     {
-      check_community_deleted_or_removed(community)?;
+      check_community_deleted_removed(community)?;
       CommunityCommunityFollow::follow(&mut context.pool(), community.id, follower.id).await?;
       AcceptFollow::send(self, context).await?;
       return Ok(());
@@ -111,7 +110,7 @@ impl Activity for Follow {
         AcceptFollow::send(self, context).await?;
       }
       Right(Left(c)) => {
-        check_community_deleted_or_removed(&c)?;
+        check_community_deleted_removed(&c)?;
         CommunityPersonBanView::check(&mut context.pool(), person.id, c.id).await?;
         if c.visibility == CommunityVisibility::Private {
           let instance = Instance::read(&mut context.pool(), person.instance_id).await?;

--- a/crates/apub/activities/src/following/reject.rs
+++ b/crates/apub/activities/src/following/reject.rs
@@ -1,6 +1,5 @@
 use super::send_activity_from_user_or_community_or_multi;
 use crate::{
-  check_community_deleted_or_removed,
   generate_activity_id,
   protocol::{
     IdOrNestedObject,
@@ -13,7 +12,7 @@ use activitypub_federation::{
   protocol::verification::verify_urls_match,
   traits::{Activity, Actor, Object},
 };
-use lemmy_api_utils::context::LemmyContext;
+use lemmy_api_utils::{context::LemmyContext, utils::check_community_deleted_removed};
 use lemmy_db_schema::{
   source::{activity::ActivitySendTargets, community::CommunityActions},
   traits::Followable,
@@ -63,7 +62,7 @@ impl Activity for RejectFollow {
 
   async fn receive(self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     let community = self.actor.dereference(context).await?;
-    check_community_deleted_or_removed(&community)?;
+    check_community_deleted_removed(&community)?;
     let object = self.object.dereference(context).await?;
     let actor = object.actor.dereference(context).await?;
     let person = actor.left().ok_or(UntranslatedError::Unreachable)?;

--- a/crates/apub/activities/src/following/undo_follow.rs
+++ b/crates/apub/activities/src/following/undo_follow.rs
@@ -1,5 +1,4 @@
 use crate::{
-  check_community_deleted_or_removed,
   generate_activity_id,
   protocol::{
     IdOrNestedObject,
@@ -14,7 +13,7 @@ use activitypub_federation::{
   traits::{Activity, Actor, Object},
 };
 use either::Either::*;
-use lemmy_api_utils::context::LemmyContext;
+use lemmy_api_utils::{context::LemmyContext, utils::check_community_deleted_removed};
 use lemmy_apub_objects::objects::{CommunityOrMulti, person::ApubPerson};
 use lemmy_db_schema::{
   source::{
@@ -79,7 +78,7 @@ impl Activity for UndoFollow {
 
     // Handle remote community unfollowing a local community
     if let (Right(community), Right(Left(follower))) = (&actor, &object) {
-      check_community_deleted_or_removed(community)?;
+      check_community_deleted_removed(community)?;
       CommunityCommunityFollow::unfollow(&mut context.pool(), community.id, follower.id).await?;
       return Ok(());
     }

--- a/crates/apub/activities/src/lib.rs
+++ b/crates/apub/activities/src/lib.rs
@@ -44,7 +44,7 @@ use lemmy_db_schema::source::{
 use lemmy_db_views_post::PostView;
 use lemmy_db_views_site::SiteView;
 use lemmy_diesel_utils::traits::Crud;
-use lemmy_utils::error::{LemmyError, LemmyResult, UntranslatedError};
+use lemmy_utils::error::{LemmyError, LemmyResult};
 use serde::Serialize;
 use tracing::info;
 use url::{ParseError, Url};
@@ -70,14 +70,6 @@ async fn verify_person(
   let person = person_id.dereference(context).await?;
   InstanceActions::check_ban(&mut context.pool(), person.id, person.instance_id).await?;
   Ok(())
-}
-
-pub(crate) fn check_community_deleted_or_removed(community: &Community) -> LemmyResult<()> {
-  if community.deleted || community.removed {
-    Err(UntranslatedError::CannotCreatePostOrCommentInDeletedOrRemovedCommunity.into())
-  } else {
-    Ok(())
-  }
 }
 
 /// Generate a unique ID for an activity, in the format:

--- a/crates/apub/activities/src/voting/undo_vote.rs
+++ b/crates/apub/activities/src/voting/undo_vote.rs
@@ -1,5 +1,4 @@
 use crate::{
-  check_community_deleted_or_removed,
   generate_activity_id,
   protocol::{
     IdOrNestedObject,
@@ -13,7 +12,7 @@ use activitypub_federation::{
   protocol::verification::verify_urls_match,
   traits::{Activity, Object},
 };
-use lemmy_api_utils::context::LemmyContext;
+use lemmy_api_utils::{context::LemmyContext, utils::check_community_deleted_removed};
 use lemmy_apub_objects::{
   objects::{PostOrComment, community::ApubCommunity, person::ApubPerson},
   utils::{functions::verify_person_in_community, protocol::InCommunity},
@@ -54,7 +53,7 @@ impl Activity for UndoVote {
   async fn verify(&self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     let object = self.object.dereference(context).await?;
     let community = object.community(context).await?;
-    check_community_deleted_or_removed(&community)?;
+    check_community_deleted_removed(&community)?;
     verify_person_in_community(&self.actor, &community, context).await?;
     verify_urls_match(self.actor.inner(), object.actor.inner())?;
     object.verify(context).await?;

--- a/crates/apub/activities/src/voting/vote.rs
+++ b/crates/apub/activities/src/voting/vote.rs
@@ -1,5 +1,4 @@
 use crate::{
-  check_community_deleted_or_removed,
   generate_activity_id,
   protocol::voting::vote::{Vote, VoteType},
   voting::{undo_vote_comment, undo_vote_post, vote_comment, vote_post},
@@ -9,7 +8,10 @@ use activitypub_federation::{
   fetch::object_id::ObjectId,
   traits::{Activity, Object},
 };
-use lemmy_api_utils::{context::LemmyContext, utils::check_bot_account};
+use lemmy_api_utils::{
+  context::LemmyContext,
+  utils::{check_bot_account, check_community_deleted_removed},
+};
 use lemmy_apub_objects::{
   objects::{PostOrComment, community::ApubCommunity, person::ApubPerson},
   utils::{functions::verify_person_in_community, protocol::InCommunity},
@@ -52,7 +54,7 @@ impl Activity for Vote {
 
   async fn verify(&self, context: &Data<LemmyContext>) -> LemmyResult<()> {
     let community = self.community(context).await?;
-    check_community_deleted_or_removed(&community)?;
+    check_community_deleted_removed(&community)?;
     verify_person_in_community(&self.actor, &community, context).await?;
     Ok(())
   }

--- a/crates/apub/objects/src/objects/comment.rs
+++ b/crates/apub/objects/src/objects/comment.rs
@@ -1,6 +1,7 @@
 use crate::{
   protocol::note::Note,
   utils::{
+    check_is_mod_or_admin,
     functions::{
       append_attachments_to_comment,
       check_apub_id_valid_with_strictness,
@@ -28,7 +29,7 @@ use chrono::{DateTime, Utc};
 use lemmy_api_utils::{
   context::LemmyContext,
   plugins::{plugin_hook_after, plugin_hook_before},
-  utils::{check_is_mod_or_admin, get_url_blocklist, process_markdown, slur_regex},
+  utils::{get_url_blocklist, process_markdown, slur_regex},
 };
 use lemmy_db_schema::source::{
   comment::{Comment, CommentInsertForm, CommentUpdateForm},

--- a/crates/apub/objects/src/utils/functions.rs
+++ b/crates/apub/objects/src/utils/functions.rs
@@ -2,6 +2,7 @@ use super::protocol::Source;
 use crate::{
   objects::{community::ApubCommunity, instance::ApubSite, person::ApubPerson},
   protocol::{group::Group, page::Attachment},
+  utils::check_is_mod_or_admin,
 };
 use activitypub_federation::{
   config::Data,
@@ -11,7 +12,7 @@ use activitypub_federation::{
 };
 use either::Either;
 use html2md::parse_html;
-use lemmy_api_utils::{context::LemmyContext, utils::check_is_mod_or_admin};
+use lemmy_api_utils::context::LemmyContext;
 use lemmy_db_schema::source::{
   community::Community,
   instance::{Instance, InstanceActions},

--- a/crates/apub/objects/src/utils/mod.rs
+++ b/crates/apub/objects/src/utils/mod.rs
@@ -1,3 +1,28 @@
+use lemmy_db_schema_file::{CommunityId, PersonId};
+use lemmy_db_views_community_moderator::CommunityModeratorView;
+use lemmy_db_views_local_user::LocalUserView;
+use lemmy_diesel_utils::connection::DbPool;
+use lemmy_utils::error::{LemmyErrorType, LemmyResult};
+
+pub async fn check_is_mod_or_admin(
+  pool: &mut DbPool<'_>,
+  person_id: PersonId,
+  community_id: CommunityId,
+) -> LemmyResult<()> {
+  let is_mod = CommunityModeratorView::check_is_community_moderator(pool, community_id, person_id)
+    .await
+    .is_ok();
+  let is_admin = LocalUserView::read_person(pool, person_id)
+    .await
+    .is_ok_and(|t| t.local_user.admin);
+
+  if is_mod || is_admin {
+    Ok(())
+  } else {
+    Err(LemmyErrorType::NotAModOrAdmin.into())
+  }
+}
+
 pub mod functions;
 pub mod markdown_links;
 pub mod mentions;


### PR DESCRIPTION
Had LLM analyze the codebase. It found two identical functions `check_community_deleted_or_removed()` and `check_community_deleted_removed()`. Also there were some unnecessary calls for `check_local_user_banned_or_deleted()` where `check_community_mod_action()` or `check_community_user_action()` are also called.

As for https://github.com/LemmyNet/lemmy/issues/6311 The function `check_is_mod_or_admin` is used for federation where LocalUserView is not available. `is_mod_or_admin` is used from the API. I separated these and moved the first one into federation code. This avoids an unnecessary read of LocalUserView which is already available in api code.

In the last commit I removed some checks that were missing.