### PR TITLE
Move newtypes.rs from lemmy_db_schema to lemmy_db_schema_file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3697,7 +3697,6 @@ dependencies = [
  "derive-new",
  "diesel",
  "diesel-async",
- "diesel-derive-newtype",
  "diesel-uplete",
  "diesel_ltree",
  "i-love-jesus",

--- a/crates/api/api/src/comment/like.rs
+++ b/crates/api/api/src/comment/like.rs
@@ -8,7 +8,6 @@ use lemmy_api_utils::{
   utils::{check_bot_account, check_community_user_action, check_local_vote_mode},
 };
 use lemmy_db_schema::{
-  newtypes::PostOrCommentId,
   source::{
     comment::{CommentActions, CommentLikeForm},
     notification::Notification,
@@ -16,6 +15,7 @@ use lemmy_db_schema::{
   },
   traits::Likeable,
 };
+use lemmy_db_schema_file::newtypes::PostOrCommentId;
 use lemmy_db_views_comment::{
   CommentView,
   api::{CommentResponse, CreateCommentLike},

--- a/crates/api/api/src/federation/fetcher.rs
+++ b/crates/api/api/src/federation/fetcher.rs
@@ -9,11 +9,13 @@ use itertools::Itertools;
 use lemmy_api_utils::context::LemmyContext;
 use lemmy_apub_objects::objects::{community::ApubCommunity, multi_community::ApubMultiCommunity};
 use lemmy_db_schema::{
-  newtypes::{CommunityId, MultiCommunityId},
   source::{community::Community, multi_community::MultiCommunity, person::Person},
   traits::ApubActor,
 };
-use lemmy_db_schema_file::PersonId;
+use lemmy_db_schema_file::{
+  PersonId,
+  newtypes::{CommunityId, MultiCommunityId},
+};
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_utils::error::{LemmyError, LemmyErrorType, LemmyResult};
 

--- a/crates/api/api/src/federation/list_posts.rs
+++ b/crates/api/api/src/federation/list_posts.rs
@@ -12,10 +12,8 @@ use crate::federation::{
 use activitypub_federation::config::Data;
 use actix_web::web::{Json, Query};
 use lemmy_api_utils::{context::LemmyContext, utils::check_private_instance};
-use lemmy_db_schema::{
-  newtypes::PostId,
-  source::{keyword_block::LocalUserKeywordBlock, post::PostActions},
-};
+use lemmy_db_schema::source::{keyword_block::LocalUserKeywordBlock, post::PostActions};
+use lemmy_db_schema_file::newtypes::PostId;
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_db_views_post::{PostView, api::GetPosts, impls::PostQuery};
 use lemmy_db_views_site::SiteView;

--- a/crates/api/api/src/federation/mod.rs
+++ b/crates/api/api/src/federation/mod.rs
@@ -1,9 +1,9 @@
 use lemmy_apub_objects::objects::person::ApubPerson;
-use lemmy_db_schema::{
+use lemmy_db_schema::source::{local_site::LocalSite, local_user::LocalUser};
+use lemmy_db_schema_file::{
+  enums::{CommentSortType, ListingType, PostSortType},
   newtypes::CommunityId,
-  source::{local_site::LocalSite, local_user::LocalUser},
 };
-use lemmy_db_schema_file::enums::{CommentSortType, ListingType, PostSortType};
 
 mod fetcher;
 pub mod list_comments;

--- a/crates/api/api/src/federation/user_settings_backup.rs
+++ b/crates/api/api/src/federation/user_settings_backup.rs
@@ -321,7 +321,6 @@ pub(crate) mod tests {
   use actix_web::web::Json;
   use lemmy_api_utils::context::LemmyContext;
   use lemmy_db_schema::{
-    newtypes::LanguageId,
     source::{
       community::{Community, CommunityActions, CommunityFollowerForm, CommunityInsertForm},
       person::Person,
@@ -329,6 +328,7 @@ pub(crate) mod tests {
     test_data::TestData,
     traits::Followable,
   };
+  use lemmy_db_schema_file::newtypes::LanguageId;
   use lemmy_db_views_community_follower::CommunityFollowerView;
   use lemmy_db_views_local_user::LocalUserView;
   use lemmy_diesel_utils::traits::Crud;

--- a/crates/api/api/src/lib.rs
+++ b/crates/api/api/src/lib.rs
@@ -1,5 +1,5 @@
 use lemmy_api_utils::{context::LemmyContext, utils::is_mod_or_admin_opt};
-use lemmy_db_schema::newtypes::CommunityId;
+use lemmy_db_schema_file::newtypes::CommunityId;
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_utils::{
   error::{LemmyErrorExt, LemmyErrorType, LemmyResult},

--- a/crates/api/api/src/post/like.rs
+++ b/crates/api/api/src/post/like.rs
@@ -8,7 +8,6 @@ use lemmy_api_utils::{
   utils::{check_bot_account, check_community_user_action, check_local_vote_mode},
 };
 use lemmy_db_schema::{
-  newtypes::PostOrCommentId,
   source::{
     notification::Notification,
     person::PersonActions,
@@ -16,6 +15,7 @@ use lemmy_db_schema::{
   },
   traits::Likeable,
 };
+use lemmy_db_schema_file::newtypes::PostOrCommentId;
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_db_views_post::{
   PostView,

--- a/crates/api/api_common/src/comment.rs
+++ b/crates/api/api_common/src/comment.rs
@@ -1,7 +1,5 @@
-pub use lemmy_db_schema::{
-  newtypes::CommentId,
-  source::comment::{Comment, CommentActions, CommentInsertForm},
-};
+pub use lemmy_db_schema::source::comment::{Comment, CommentActions, CommentInsertForm};
+pub use lemmy_db_schema_file::newtypes::CommentId;
 pub use lemmy_db_views_comment::{
   CommentSlimView,
   CommentView,

--- a/crates/api/api_common/src/community.rs
+++ b/crates/api/api_common/src/community.rs
@@ -1,12 +1,12 @@
-pub use lemmy_db_schema::{
-  newtypes::{CommunityId, CommunityTagId, MultiCommunityId},
-  source::{
-    community::{Community, CommunityActions},
-    community_tag::{CommunityTag, CommunityTagsView},
-    multi_community::{MultiCommunity, MultiCommunityFollow},
-  },
+pub use lemmy_db_schema::source::{
+  community::{Community, CommunityActions},
+  community_tag::{CommunityTag, CommunityTagsView},
+  multi_community::{MultiCommunity, MultiCommunityFollow},
 };
-pub use lemmy_db_schema_file::enums::CommunityVisibility;
+pub use lemmy_db_schema_file::{
+  enums::CommunityVisibility,
+  newtypes::{CommunityId, CommunityTagId, MultiCommunityId},
+};
 pub use lemmy_db_views_community::{
   CommunityView,
   MultiCommunityView,

--- a/crates/api/api_common/src/custom_emoji.rs
+++ b/crates/api/api_common/src/custom_emoji.rs
@@ -1,7 +1,8 @@
-pub use lemmy_db_schema::{
-  newtypes::CustomEmojiId,
-  source::{custom_emoji::CustomEmoji, custom_emoji_keyword::CustomEmojiKeyword},
+pub use lemmy_db_schema::source::{
+  custom_emoji::CustomEmoji,
+  custom_emoji_keyword::CustomEmojiKeyword,
 };
+pub use lemmy_db_schema_file::newtypes::CustomEmojiId;
 pub use lemmy_db_views_custom_emoji::{
   CustomEmojiView,
   api::{

--- a/crates/api/api_common/src/federation.rs
+++ b/crates/api/api_common/src/federation.rs
@@ -1,13 +1,10 @@
-pub use lemmy_db_schema::{
-  newtypes::ActivityId,
-  source::{
-    federation_allowlist::FederationAllowList,
-    federation_blocklist::FederationBlockList,
-    federation_queue_state::FederationQueueState,
-    instance::{Instance, InstanceActions},
-  },
+pub use lemmy_db_schema::source::{
+  federation_allowlist::FederationAllowList,
+  federation_blocklist::FederationBlockList,
+  federation_queue_state::FederationQueueState,
+  instance::{Instance, InstanceActions},
 };
-pub use lemmy_db_schema_file::{InstanceId, enums::FederationMode};
+pub use lemmy_db_schema_file::{InstanceId, enums::FederationMode, newtypes::ActivityId};
 pub use lemmy_db_views_site::{
   FederatedInstanceView,
   api::{

--- a/crates/api/api_common/src/language.rs
+++ b/crates/api/api_common/src/language.rs
@@ -1,1 +1,2 @@
-pub use lemmy_db_schema::{newtypes::LanguageId, source::language::Language};
+pub use lemmy_db_schema::source::language::Language;
+pub use lemmy_db_schema_file::newtypes::LanguageId;

--- a/crates/api/api_common/src/notification.rs
+++ b/crates/api/api_common/src/notification.rs
@@ -1,8 +1,5 @@
-pub use lemmy_db_schema::{
-  NotificationTypeFilter,
-  newtypes::NotificationId,
-  source::notification::Notification,
-};
+pub use lemmy_db_schema::{NotificationTypeFilter, source::notification::Notification};
+pub use lemmy_db_schema_file::newtypes::NotificationId;
 pub use lemmy_db_views_notification::{
   ListNotifications,
   NotificationView,

--- a/crates/api/api_common/src/oauth.rs
+++ b/crates/api/api_common/src/oauth.rs
@@ -1,10 +1,8 @@
-pub use lemmy_db_schema::{
-  newtypes::OAuthProviderId,
-  source::{
-    oauth_account::OAuthAccount,
-    oauth_provider::{AdminOAuthProvider, PublicOAuthProvider},
-  },
+pub use lemmy_db_schema::source::{
+  oauth_account::OAuthAccount,
+  oauth_provider::{AdminOAuthProvider, PublicOAuthProvider},
 };
+pub use lemmy_db_schema_file::newtypes::OAuthProviderId;
 pub use lemmy_db_views_site::api::{
   AuthenticateWithOauth,
   CreateOAuthProvider,

--- a/crates/api/api_common/src/person.rs
+++ b/crates/api/api_common/src/person.rs
@@ -1,12 +1,11 @@
 pub use lemmy_db_schema::{
   PersonContentType,
-  newtypes::LocalUserId,
   source::{
     local_user::LocalUser,
     person::{Person, PersonActions},
   },
 };
-pub use lemmy_db_schema_file::PersonId;
+pub use lemmy_db_schema_file::{PersonId, newtypes::LocalUserId};
 pub use lemmy_db_views_local_user::LocalUserView;
 pub use lemmy_db_views_person::{
   PersonView,
@@ -14,15 +13,13 @@ pub use lemmy_db_views_person::{
 };
 
 pub mod actions {
-  pub use lemmy_db_schema::newtypes::PersonContentCombinedId;
+  pub use lemmy_db_schema_file::newtypes::PersonContentCombinedId;
   pub use lemmy_db_views_person::api::{BlockPerson, NotePerson};
   pub use lemmy_db_views_person_content_combined::ListPersonContent;
 
   pub mod moderation {
-    pub use lemmy_db_schema::{
-      newtypes::RegistrationApplicationId,
-      source::registration_application::RegistrationApplication,
-    };
+    pub use lemmy_db_schema::source::registration_application::RegistrationApplication;
+    pub use lemmy_db_schema_file::newtypes::RegistrationApplicationId;
     pub use lemmy_db_views_person::api::{BanPerson, PurgePerson};
     pub use lemmy_db_views_registration_applications::{
       RegistrationApplicationView,

--- a/crates/api/api_common/src/post.rs
+++ b/crates/api/api_common/src/post.rs
@@ -1,9 +1,11 @@
 pub use lemmy_db_schema::{
   PostFeatureType,
-  newtypes::PostId,
   source::post::{Post, PostActions, PostInsertForm, PostLikeForm},
 };
-pub use lemmy_db_schema_file::enums::{PostListingMode, PostNotificationsMode};
+pub use lemmy_db_schema_file::{
+  enums::{PostListingMode, PostNotificationsMode},
+  newtypes::PostId,
+};
 pub use lemmy_db_views_post::{
   PostView,
   api::{

--- a/crates/api/api_common/src/private_message.rs
+++ b/crates/api/api_common/src/private_message.rs
@@ -1,6 +1,6 @@
-pub use lemmy_db_schema::{newtypes::PrivateMessageId, source::private_message::PrivateMessage};
+pub use lemmy_db_schema::source::private_message::PrivateMessage;
+pub use lemmy_db_schema_file::newtypes::PrivateMessageId;
 pub use lemmy_db_views_private_message::{PrivateMessageView, api::PrivateMessageResponse};
-
 pub mod actions {
   pub use lemmy_db_views_private_message::api::{
     CreatePrivateMessage,

--- a/crates/api/api_common/src/report.rs
+++ b/crates/api/api_common/src/report.rs
@@ -1,12 +1,17 @@
 pub use lemmy_db_schema::{
   ReportType,
-  newtypes::{CommentReportId, CommunityReportId, PostReportId, PrivateMessageReportId},
   source::{
     comment_report::CommentReport,
     community_report::CommunityReport,
     post_report::PostReport,
     private_message_report::PrivateMessageReport,
   },
+};
+pub use lemmy_db_schema_file::newtypes::{
+  CommentReportId,
+  CommunityReportId,
+  PostReportId,
+  PrivateMessageReportId,
 };
 pub use lemmy_db_views_report_combined::{
   CommentReportView,

--- a/crates/api/api_common/src/site.rs
+++ b/crates/api/api_common/src/site.rs
@@ -1,13 +1,13 @@
-pub use lemmy_db_schema::{
-  newtypes::{LocalSiteId, SiteId},
-  source::{
-    local_site::LocalSite,
-    local_site_rate_limit::LocalSiteRateLimit,
-    local_site_url_blocklist::LocalSiteUrlBlocklist,
-    site::Site,
-  },
+pub use lemmy_db_schema::source::{
+  local_site::LocalSite,
+  local_site_rate_limit::LocalSiteRateLimit,
+  local_site_url_blocklist::LocalSiteUrlBlocklist,
+  site::Site,
 };
-pub use lemmy_db_schema_file::enums::RegistrationMode;
+pub use lemmy_db_schema_file::{
+  enums::RegistrationMode,
+  newtypes::{LocalSiteId, SiteId},
+};
 pub use lemmy_db_views_site::{
   SiteView,
   api::{GetSiteResponse, PostOrCommentOrPrivateMessage, SiteResponse, UnreadCountsResponse},

--- a/crates/api/api_common/src/tagline.rs
+++ b/crates/api/api_common/src/tagline.rs
@@ -1,4 +1,5 @@
-pub use lemmy_db_schema::{newtypes::TaglineId, source::tagline::Tagline};
+pub use lemmy_db_schema::source::tagline::Tagline;
+pub use lemmy_db_schema_file::newtypes::TaglineId;
 pub use lemmy_db_views_site::api::{ListTaglines, TaglineResponse};
 
 pub mod administration {

--- a/crates/api/api_crud/src/site/create.rs
+++ b/crates/api/api_crud/src/site/create.rs
@@ -14,14 +14,12 @@ use lemmy_api_utils::{
     slur_regex,
   },
 };
-use lemmy_db_schema::{
-  newtypes::MultiCommunityId,
-  source::{
-    local_site::{LocalSite, LocalSiteUpdateForm},
-    local_site_rate_limit::{LocalSiteRateLimit, LocalSiteRateLimitUpdateForm},
-    site::{Site, SiteUpdateForm},
-  },
+use lemmy_db_schema::source::{
+  local_site::{LocalSite, LocalSiteUpdateForm},
+  local_site_rate_limit::{LocalSiteRateLimit, LocalSiteRateLimitUpdateForm},
+  site::{Site, SiteUpdateForm},
 };
+use lemmy_db_schema_file::newtypes::MultiCommunityId;
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_db_views_site::{
   SiteView,

--- a/crates/api/api_crud/src/site/update.rs
+++ b/crates/api/api_crud/src/site/update.rs
@@ -13,18 +13,15 @@ use lemmy_api_utils::{
     slur_regex,
   },
 };
-use lemmy_db_schema::{
-  newtypes::MultiCommunityId,
-  source::{
-    actor_language::SiteLanguage,
-    local_site::{LocalSite, LocalSiteUpdateForm},
-    local_site_rate_limit::{LocalSiteRateLimit, LocalSiteRateLimitUpdateForm},
-    local_site_url_blocklist::LocalSiteUrlBlocklist,
-    local_user::LocalUser,
-    site::{Site, SiteUpdateForm},
-  },
+use lemmy_db_schema::source::{
+  actor_language::SiteLanguage,
+  local_site::{LocalSite, LocalSiteUpdateForm},
+  local_site_rate_limit::{LocalSiteRateLimit, LocalSiteRateLimitUpdateForm},
+  local_site_url_blocklist::LocalSiteUrlBlocklist,
+  local_user::LocalUser,
+  site::{Site, SiteUpdateForm},
 };
-use lemmy_db_schema_file::enums::RegistrationMode;
+use lemmy_db_schema_file::{enums::RegistrationMode, newtypes::MultiCommunityId};
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_db_views_site::{
   SiteView,

--- a/crates/api/api_crud/src/user/create.rs
+++ b/crates/api/api_crud/src/user/create.rs
@@ -24,7 +24,6 @@ use lemmy_api_utils::{
 };
 use lemmy_apub_objects::objects::community::ApubCommunity;
 use lemmy_db_schema::{
-  newtypes::OAuthProviderId,
   source::{
     actor_language::SiteLanguage,
     community::{Community, CommunityActions, CommunityInsertForm, CommunityModeratorForm},
@@ -40,7 +39,7 @@ use lemmy_db_schema::{
   },
   traits::{ApubActor, Likeable},
 };
-use lemmy_db_schema_file::enums::RegistrationMode;
+use lemmy_db_schema_file::{enums::RegistrationMode, newtypes::OAuthProviderId};
 use lemmy_db_views_community::CommunityView;
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_db_views_person::PersonView;

--- a/crates/api/api_utils/src/build_response.rs
+++ b/crates/api/api_utils/src/build_response.rs
@@ -1,10 +1,10 @@
 use crate::{context::LemmyContext, utils::is_mod_or_admin};
 use actix_web::web::Json;
-use lemmy_db_schema::{
+use lemmy_db_schema::source::actor_language::CommunityLanguage;
+use lemmy_db_schema_file::{
+  InstanceId,
   newtypes::{CommentId, CommunityId, PostId},
-  source::actor_language::CommunityLanguage,
 };
-use lemmy_db_schema_file::InstanceId;
 use lemmy_db_views_comment::{CommentView, api::CommentResponse};
 use lemmy_db_views_community::{CommunityView, api::CommunityResponse};
 use lemmy_db_views_local_user::LocalUserView;

--- a/crates/api/api_utils/src/claims.rs
+++ b/crates/api/api_utils/src/claims.rs
@@ -2,10 +2,8 @@ use crate::context::LemmyContext;
 use actix_web::{HttpRequest, http::header::USER_AGENT};
 use chrono::{DateTime, Duration, Utc};
 use jsonwebtoken::{DecodingKey, EncodingKey, Header, Validation, decode, encode};
-use lemmy_db_schema::{
-  newtypes::LocalUserId,
-  source::login_token::{LoginToken, LoginTokenCreateForm},
-};
+use lemmy_db_schema::source::login_token::{LoginToken, LoginTokenCreateForm};
+use lemmy_db_schema_file::newtypes::LocalUserId;
 use lemmy_diesel_utils::sensitive::SensitiveString;
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 use serde::{Deserialize, Serialize};

--- a/crates/api/api_utils/src/send_activity.rs
+++ b/crates/api/api_utils/src/send_activity.rs
@@ -1,19 +1,16 @@
 use crate::context::LemmyContext;
 use activitypub_federation::config::Data;
 use either::Either;
-use lemmy_db_schema::{
-  newtypes::CommunityId,
-  source::{
-    comment::Comment,
-    community::Community,
-    multi_community::MultiCommunity,
-    person::Person,
-    post::Post,
-    private_message::PrivateMessage,
-    site::Site,
-  },
+use lemmy_db_schema::source::{
+  comment::Comment,
+  community::Community,
+  multi_community::MultiCommunity,
+  person::Person,
+  post::Post,
+  private_message::PrivateMessage,
+  site::Site,
 };
-use lemmy_db_schema_file::PersonId;
+use lemmy_db_schema_file::{PersonId, newtypes::CommunityId};
 use lemmy_db_views_comment::CommentView;
 use lemmy_db_views_community::api::BanFromCommunity;
 use lemmy_db_views_post::PostView;

--- a/crates/api/api_utils/src/utils.rs
+++ b/crates/api/api_utils/src/utils.rs
@@ -9,7 +9,6 @@ use actix_web_httpauth::headers::authorization::{Authorization, Bearer};
 use chrono::{DateTime, Days, Local, TimeZone, Utc};
 use enum_map::{EnumMap, enum_map};
 use lemmy_db_schema::{
-  newtypes::{CommunityId, CommunityTagId, ModlogId, PostId, PostOrCommentId},
   source::{
     comment::{Comment, CommentActions, CommentLikeForm},
     community::{Community, CommunityActions, CommunityUpdateForm},
@@ -33,6 +32,7 @@ use lemmy_db_schema_file::{
   InstanceId,
   PersonId,
   enums::{FederationMode, ImageMode, RegistrationMode},
+  newtypes::{CommunityId, CommunityTagId, ModlogId, PostId, PostOrCommentId},
 };
 use lemmy_db_views_community_follower_approval::PendingFollowerView;
 use lemmy_db_views_community_moderator::{CommunityModeratorView, CommunityPersonBanView};
@@ -1032,10 +1032,8 @@ pub async fn update_post_tags(
 mod tests {
   use super::*;
   use diesel_ltree::Ltree;
-  use lemmy_db_schema::{
-    newtypes::{CommentId, LanguageId},
-    test_data::TestData,
-  };
+  use lemmy_db_schema::test_data::TestData;
+  use lemmy_db_schema_file::newtypes::{CommentId, LanguageId};
   use pretty_assertions::assert_eq;
   use serial_test::serial;
 

--- a/crates/api/routes_v3/src/convert.rs
+++ b/crates/api/routes_v3/src/convert.rs
@@ -58,7 +58,6 @@ use lemmy_api_019::{
 use lemmy_api_utils::plugins::LemmyPlugins;
 use lemmy_db_schema::{
   CommunitySortType,
-  newtypes::LanguageId,
   source::{
     comment::Comment,
     community::Community,
@@ -69,12 +68,9 @@ use lemmy_db_schema::{
     site::Site,
   },
 };
-use lemmy_db_schema_file::enums::{
-  CommentSortType,
-  CommunityFollowerState,
-  ListingType,
-  PostSortType,
-  RegistrationMode,
+use lemmy_db_schema_file::{
+  enums::{CommentSortType, CommunityFollowerState, ListingType, PostSortType, RegistrationMode},
+  newtypes::LanguageId,
 };
 use lemmy_db_views_comment::{CommentView, api::CommentResponse};
 use lemmy_db_views_community::CommunityView;

--- a/crates/api/routes_v3/src/handlers.rs
+++ b/crates/api/routes_v3/src/handlers.rs
@@ -107,7 +107,7 @@ use lemmy_api_crud::{
   user::{create::register, my_user::get_my_user},
 };
 use lemmy_api_utils::context::LemmyContext;
-use lemmy_db_schema::newtypes::{CommentId, CommunityId, LanguageId, PostId};
+use lemmy_db_schema_file::newtypes::{CommentId, CommunityId, LanguageId, PostId};
 use lemmy_db_views_comment::api::{
   CreateComment,
   CreateCommentLike,

--- a/crates/apub/activities/src/block/mod.rs
+++ b/crates/apub/activities/src/block/mod.rs
@@ -6,10 +6,14 @@ use lemmy_apub_objects::{
   objects::{community::ApubCommunity, instance::ApubSite},
   utils::functions::generate_to,
 };
-use lemmy_db_schema::{
-  newtypes::CommunityId,
-  source::{comment::Comment, community::Community, person::Person, post::Post, site::Site},
+use lemmy_db_schema::source::{
+  comment::Comment,
+  community::Community,
+  person::Person,
+  post::Post,
+  site::Site,
 };
+use lemmy_db_schema_file::newtypes::CommunityId;
 use lemmy_db_views_community::api::BanFromCommunity;
 use lemmy_db_views_site::SiteView;
 use lemmy_diesel_utils::{connection::DbPool, traits::Crud};

--- a/crates/apub/activities/src/community/collection_add.rs
+++ b/crates/apub/activities/src/community/collection_add.rs
@@ -24,7 +24,6 @@ use lemmy_apub_objects::{
 };
 use lemmy_db_schema::{
   impls::community::CollectionType,
-  newtypes::CommunityId,
   source::{
     activity::ActivitySendTargets,
     community::{Community, CommunityActions, CommunityModeratorForm},
@@ -33,7 +32,7 @@ use lemmy_db_schema::{
     post::{Post, PostUpdateForm},
   },
 };
-use lemmy_db_schema_file::PersonId;
+use lemmy_db_schema_file::{PersonId, newtypes::CommunityId};
 use lemmy_diesel_utils::traits::Crud;
 use lemmy_utils::error::{LemmyError, LemmyResult, UntranslatedError};
 use url::Url;

--- a/crates/apub/activities/src/following/mod.rs
+++ b/crates/apub/activities/src/following/mod.rs
@@ -9,11 +9,12 @@ use activitypub_federation::{config::Data, kinds::activity::FollowType, traits::
 use either::Either::*;
 use lemmy_api_utils::context::LemmyContext;
 use lemmy_apub_objects::objects::{CommunityOrMulti, UserOrCommunityOrMulti, person::ApubPerson};
-use lemmy_db_schema::{
-  newtypes::CommunityId,
-  source::{activity::ActivitySendTargets, community::Community, person::Person},
+use lemmy_db_schema::source::{
+  activity::ActivitySendTargets,
+  community::Community,
+  person::Person,
 };
-use lemmy_db_schema_file::PersonId;
+use lemmy_db_schema_file::{PersonId, newtypes::CommunityId};
 use lemmy_diesel_utils::{dburl::DbUrl, traits::Crud};
 use lemmy_utils::error::{LemmyError, LemmyResult};
 use serde::Serialize;

--- a/crates/apub/apub/src/http/comment.rs
+++ b/crates/apub/apub/src/http/comment.rs
@@ -4,10 +4,8 @@ use activitypub_federation::{config::Data, traits::Object};
 use actix_web::{HttpRequest, HttpResponse, web::Path};
 use lemmy_api_utils::context::LemmyContext;
 use lemmy_apub_objects::{objects::comment::ApubComment, utils::functions::context_url};
-use lemmy_db_schema::{
-  newtypes::CommentId,
-  source::{comment::Comment, community::Community, post::Post},
-};
+use lemmy_db_schema::source::{comment::Comment, community::Community, post::Post};
+use lemmy_db_schema_file::newtypes::CommentId;
 use lemmy_diesel_utils::traits::Crud;
 use lemmy_utils::{
   FEDERATION_CONTEXT,

--- a/crates/apub/apub/src/http/post.rs
+++ b/crates/apub/apub/src/http/post.rs
@@ -4,10 +4,8 @@ use activitypub_federation::{config::Data, traits::Object};
 use actix_web::{HttpRequest, HttpResponse, web};
 use lemmy_api_utils::context::LemmyContext;
 use lemmy_apub_objects::{objects::post::ApubPost, utils::functions::context_url};
-use lemmy_db_schema::{
-  newtypes::PostId,
-  source::{community::Community, post::Post},
-};
+use lemmy_db_schema::source::{community::Community, post::Post};
+use lemmy_db_schema_file::newtypes::PostId;
 use lemmy_diesel_utils::traits::Crud;
 use lemmy_utils::{
   FEDERATION_CONTEXT,

--- a/crates/apub/objects/src/objects/multi_community_collection.rs
+++ b/crates/apub/objects/src/objects/multi_community_collection.rs
@@ -11,14 +11,13 @@ use lemmy_api_utils::{
   send_activity::{ActivityChannel, SendActivityData},
 };
 use lemmy_db_schema::{
-  newtypes::CommunityId,
   source::{
     community::{CommunityActions, CommunityFollowerForm},
     multi_community::MultiCommunity,
   },
   traits::Followable,
 };
-use lemmy_db_schema_file::enums::CommunityFollowerState;
+use lemmy_db_schema_file::{enums::CommunityFollowerState, newtypes::CommunityId};
 use lemmy_db_views_site::SiteView;
 use lemmy_utils::error::{LemmyError, LemmyResult};
 use tracing::info;

--- a/crates/apub/objects/src/protocol/tags.rs
+++ b/crates/apub/objects/src/protocol/tags.rs
@@ -1,10 +1,7 @@
 use crate::objects::UserOrCommunity;
 use activitypub_federation::{fetch::object_id::ObjectId, kinds::link::MentionType};
-use lemmy_db_schema::{
-  newtypes::CommunityId,
-  source::community_tag::{CommunityTag, CommunityTagInsertForm},
-};
-use lemmy_db_schema_file::enums::TagColor;
+use lemmy_db_schema::source::community_tag::{CommunityTag, CommunityTagInsertForm};
+use lemmy_db_schema_file::{enums::TagColor, newtypes::CommunityId};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use url::Url;

--- a/crates/apub/objects/src/utils/mod.rs
+++ b/crates/apub/objects/src/utils/mod.rs
@@ -1,4 +1,4 @@
-use lemmy_db_schema_file::{CommunityId, PersonId};
+use lemmy_db_schema_file::{PersonId, newtypes::CommunityId};
 use lemmy_db_views_community_moderator::CommunityModeratorView;
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_diesel_utils::connection::DbPool;

--- a/crates/apub/objects/src/utils/protocol.rs
+++ b/crates/apub/objects/src/utils/protocol.rs
@@ -6,11 +6,8 @@ use activitypub_federation::{
   protocol::{tombstone::Tombstone, values::MediaTypeMarkdown},
 };
 use lemmy_api_utils::context::LemmyContext;
-use lemmy_db_schema::{
-  impls::actor_language::UNDETERMINED_ID,
-  newtypes::LanguageId,
-  source::language::Language,
-};
+use lemmy_db_schema::{impls::actor_language::UNDETERMINED_ID, source::language::Language};
+use lemmy_db_schema_file::newtypes::LanguageId;
 use lemmy_diesel_utils::{connection::DbPool, dburl::DbUrl};
 use lemmy_utils::error::LemmyResult;
 use serde::{Deserialize, Serialize};

--- a/crates/apub/send/src/inboxes.rs
+++ b/crates/apub/send/src/inboxes.rs
@@ -1,10 +1,7 @@
 use crate::util::LEMMY_TEST_FAST_FEDERATION;
 use chrono::{DateTime, TimeZone, Utc};
-use lemmy_db_schema::{
-  newtypes::CommunityId,
-  source::{activity::SentActivity, site::Site},
-};
-use lemmy_db_schema_file::InstanceId;
+use lemmy_db_schema::source::{activity::SentActivity, site::Site};
+use lemmy_db_schema_file::{InstanceId, newtypes::CommunityId};
 use lemmy_db_views_community_follower::CommunityFollowerView;
 use lemmy_diesel_utils::{
   connection::{ActualDbPool, DbPool},
@@ -223,11 +220,12 @@ impl<T: DataSource> CommunityInboxCollector<T> {
 #[expect(clippy::indexing_slicing)]
 mod tests {
   use super::*;
-  use lemmy_db_schema::{
+  use lemmy_db_schema::source::activity::SentActivity;
+  use lemmy_db_schema_file::{
+    InstanceId,
+    enums::ActorType,
     newtypes::{ActivityId, CommunityId, SiteId},
-    source::activity::SentActivity,
   };
-  use lemmy_db_schema_file::{InstanceId, enums::ActorType};
   use lemmy_utils::error::LemmyResult;
   use mockall::mock;
   use serde_json::json;

--- a/crates/apub/send/src/send.rs
+++ b/crates/apub/send/src/send.rs
@@ -8,7 +8,8 @@ use activitypub_federation::{
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use lemmy_api_utils::context::LemmyContext;
-use lemmy_db_schema::{newtypes::ActivityId, source::activity::SentActivity};
+use lemmy_db_schema::source::activity::SentActivity;
+use lemmy_db_schema_file::newtypes::ActivityId;
 use lemmy_utils::{
   FEDERATION_CONTEXT,
   error::{LemmyError, LemmyResult},

--- a/crates/apub/send/src/stats.rs
+++ b/crates/apub/send/src/stats.rs
@@ -1,7 +1,6 @@
 use crate::util::{FederationQueueStateWithDomain, get_latest_activity_id};
 use chrono::Local;
-use lemmy_db_schema::newtypes::ActivityId;
-use lemmy_db_schema_file::InstanceId;
+use lemmy_db_schema_file::{InstanceId, newtypes::ActivityId};
 use lemmy_diesel_utils::connection::{ActualDbPool, DbPool};
 use lemmy_utils::{error::LemmyResult, federate_retry_sleep_duration};
 use std::{collections::HashMap, time::Duration};

--- a/crates/apub/send/src/util.rs
+++ b/crates/apub/send/src/util.rs
@@ -4,7 +4,6 @@ use diesel_async::RunQueryDsl;
 use either::Either::*;
 use lemmy_apub_objects::objects::SiteOrMultiOrCommunityOrUser;
 use lemmy_db_schema::{
-  newtypes::ActivityId,
   source::{
     activity::SentActivity,
     community::Community,
@@ -15,7 +14,7 @@ use lemmy_db_schema::{
   },
   traits::ApubActor,
 };
-use lemmy_db_schema_file::enums::ActorType;
+use lemmy_db_schema_file::{enums::ActorType, newtypes::ActivityId};
 use lemmy_diesel_utils::connection::{DbPool, get_conn};
 use lemmy_utils::error::LemmyError;
 use moka::future::Cache;

--- a/crates/apub/send/src/worker.rs
+++ b/crates/apub/send/src/worker.rs
@@ -12,13 +12,11 @@ use activitypub_federation::config::FederationConfig;
 use anyhow::{Context, Result};
 use chrono::{DateTime, Days, TimeZone, Utc};
 use lemmy_api_utils::context::LemmyContext;
-use lemmy_db_schema::{
-  newtypes::ActivityId,
-  source::{
-    federation_queue_state::FederationQueueState,
-    instance::{Instance, InstanceForm},
-  },
+use lemmy_db_schema::source::{
+  federation_queue_state::FederationQueueState,
+  instance::{Instance, InstanceForm},
 };
+use lemmy_db_schema_file::newtypes::ActivityId;
 use lemmy_diesel_utils::connection::{ActualDbPool, DbPool};
 use lemmy_utils::{
   error::LemmyResult,

--- a/crates/db_schema/Cargo.toml
+++ b/crates/db_schema/Cargo.toml
@@ -21,7 +21,6 @@ workspace = true
 full = [
   "lemmy_utils/full",
   "diesel",
-  "diesel-derive-newtype",
   "bcrypt",
   "lemmy_utils",
   "serde_json",
@@ -47,7 +46,6 @@ lemmy_db_schema_file = { workspace = true }
 lemmy_diesel_utils = { workspace = true }
 bcrypt = { workspace = true, optional = true }
 diesel = { workspace = true, optional = true }
-diesel-derive-newtype = { workspace = true, optional = true }
 diesel-async = { workspace = true, optional = true }
 diesel-uplete = { workspace = true, optional = true }
 diesel_ltree = { workspace = true, optional = true }

--- a/crates/db_schema/src/impls/activity.rs
+++ b/crates/db_schema/src/impls/activity.rs
@@ -1,10 +1,10 @@
 use crate::{
   diesel::OptionalExtension,
-  newtypes::ActivityId,
   source::activity::{ReceivedActivity, SentActivity, SentActivityForm},
 };
 use diesel::{ExpressionMethods, QueryDsl, dsl::insert_into};
 use diesel_async::RunQueryDsl;
+use lemmy_db_schema_file::newtypes::ActivityId;
 use lemmy_diesel_utils::{
   connection::{DbPool, get_conn},
   dburl::DbUrl,

--- a/crates/db_schema/src/impls/actor_language.rs
+++ b/crates/db_schema/src/impls/actor_language.rs
@@ -1,6 +1,5 @@
 use crate::{
   diesel::JoinOnDsl,
-  newtypes::{CommunityId, LanguageId, LocalUserId, SiteId},
   source::{
     actor_language::{
       CommunityLanguage,
@@ -18,6 +17,7 @@ use diesel::{ExpressionMethods, QueryDsl, delete, dsl::exists, insert_into, sele
 use diesel_async::{AsyncPgConnection, RunQueryDsl, scoped_futures::ScopedFutureExt};
 use lemmy_db_schema_file::{
   InstanceId,
+  newtypes::{CommunityId, LanguageId, LocalUserId, SiteId},
   schema::{community_language, local_site, local_user_language, site, site_language},
 };
 use lemmy_diesel_utils::connection::{DbPool, get_conn};

--- a/crates/db_schema/src/impls/comment.rs
+++ b/crates/db_schema/src/impls/comment.rs
@@ -1,6 +1,5 @@
 use crate::{
   diesel::{DecoratableTarget, OptionalExtension},
-  newtypes::{CommentId, CommunityId, PostId},
   source::comment::{
     Comment,
     CommentActions,
@@ -27,6 +26,7 @@ use diesel_uplete::{UpleteCount, uplete};
 use lemmy_db_schema_file::{
   InstanceId,
   PersonId,
+  newtypes::{CommentId, CommunityId, PostId},
   schema::{comment, comment_actions, community, post},
 };
 use lemmy_diesel_utils::{
@@ -442,7 +442,6 @@ mod tests {
 
   use super::*;
   use crate::{
-    newtypes::LanguageId,
     source::{
       community::{Community, CommunityInsertForm},
       instance::Instance,
@@ -453,6 +452,7 @@ mod tests {
     utils::RANK_DEFAULT,
   };
   use diesel_ltree::Ltree;
+  use lemmy_db_schema_file::newtypes::LanguageId;
   use lemmy_diesel_utils::{connection::build_db_pool_for_tests, traits::Crud};
   use lemmy_utils::error::LemmyResult;
   use pretty_assertions::assert_eq;

--- a/crates/db_schema/src/impls/comment_report.rs
+++ b/crates/db_schema/src/impls/comment_report.rs
@@ -1,5 +1,4 @@
 use crate::{
-  newtypes::{CommentId, CommentReportId, PostId},
   source::comment_report::{CommentReport, CommentReportForm, UpdateCommentReportForm},
   traits::Reportable,
 };
@@ -15,6 +14,7 @@ use diesel_async::RunQueryDsl;
 use diesel_ltree::{Ltree, LtreeExtensions};
 use lemmy_db_schema_file::{
   PersonId,
+  newtypes::{CommentId, CommentReportId, PostId},
   schema::{comment, comment_report},
 };
 use lemmy_diesel_utils::connection::{DbPool, get_conn};

--- a/crates/db_schema/src/impls/community.rs
+++ b/crates/db_schema/src/impls/community.rs
@@ -1,6 +1,5 @@
 use crate::{
   diesel::{DecoratableTarget, JoinOnDsl, OptionalExtension},
-  newtypes::CommunityId,
   source::{
     actor_language::CommunityLanguage,
     community::{
@@ -34,6 +33,7 @@ use diesel_uplete::{UpleteCount, uplete};
 use lemmy_db_schema_file::{
   PersonId,
   enums::{CommunityFollowerState, CommunityNotificationsMode, CommunityVisibility, ListingType},
+  newtypes::CommunityId,
   schema::{comment, community, community_actions, instance, local_user, post},
 };
 use lemmy_diesel_utils::{

--- a/crates/db_schema/src/impls/community_community_follow.rs
+++ b/crates/db_schema/src/impls/community_community_follow.rs
@@ -1,11 +1,10 @@
 use crate::{
   diesel::{ExpressionMethods, QueryDsl},
-  newtypes::CommunityId,
   source::community_community_follow::CommunityCommunityFollow,
 };
 use diesel::{delete, dsl::insert_into};
 use diesel_async::RunQueryDsl;
-use lemmy_db_schema_file::schema::community_community_follow;
+use lemmy_db_schema_file::{newtypes::CommunityId, schema::community_community_follow};
 use lemmy_diesel_utils::connection::{DbPool, get_conn};
 use lemmy_utils::error::LemmyResult;
 

--- a/crates/db_schema/src/impls/community_report.rs
+++ b/crates/db_schema/src/impls/community_report.rs
@@ -1,5 +1,4 @@
 use crate::{
-  newtypes::{CommunityId, CommunityReportId},
   source::community_report::{CommunityReport, CommunityReportForm, UpdateCommunityReportForm},
   traits::Reportable,
 };
@@ -11,7 +10,11 @@ use diesel::{
   dsl::{insert_into, update},
 };
 use diesel_async::RunQueryDsl;
-use lemmy_db_schema_file::{PersonId, schema::community_report};
+use lemmy_db_schema_file::{
+  PersonId,
+  newtypes::{CommunityId, CommunityReportId},
+  schema::community_report,
+};
 use lemmy_diesel_utils::connection::{DbPool, get_conn};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 

--- a/crates/db_schema/src/impls/community_tag.rs
+++ b/crates/db_schema/src/impls/community_tag.rs
@@ -1,6 +1,5 @@
 use crate::{
   diesel::SelectableHelper,
-  newtypes::{CommunityId, CommunityTagId, PostId},
   source::{
     community_tag::{
       CommunityTag,
@@ -25,7 +24,10 @@ use diesel::{
   upsert::excluded,
 };
 use diesel_async::{RunQueryDsl, scoped_futures::ScopedFutureExt};
-use lemmy_db_schema_file::schema::{community_tag, post_community_tag};
+use lemmy_db_schema_file::{
+  newtypes::{CommunityId, CommunityTagId, PostId},
+  schema::{community_tag, post_community_tag},
+};
 use lemmy_diesel_utils::{
   connection::{DbPool, get_conn},
   dburl::DbUrl,

--- a/crates/db_schema/src/impls/custom_emoji.rs
+++ b/crates/db_schema/src/impls/custom_emoji.rs
@@ -1,15 +1,15 @@
-use crate::{
-  newtypes::CustomEmojiId,
-  source::{
-    custom_emoji::{CustomEmoji, CustomEmojiInsertForm, CustomEmojiUpdateForm},
-    custom_emoji_keyword::{CustomEmojiKeyword, CustomEmojiKeywordInsertForm},
-  },
+use crate::source::{
+  custom_emoji::{CustomEmoji, CustomEmojiInsertForm, CustomEmojiUpdateForm},
+  custom_emoji_keyword::{CustomEmojiKeyword, CustomEmojiKeywordInsertForm},
 };
 use diesel::{ExpressionMethods, QueryDsl, dsl::insert_into};
 use diesel_async::RunQueryDsl;
-use lemmy_db_schema_file::schema::{
-  custom_emoji::dsl::custom_emoji,
-  custom_emoji_keyword::dsl::{custom_emoji_id, custom_emoji_keyword},
+use lemmy_db_schema_file::{
+  newtypes::CustomEmojiId,
+  schema::{
+    custom_emoji::dsl::custom_emoji,
+    custom_emoji_keyword::dsl::{custom_emoji_id, custom_emoji_keyword},
+  },
 };
 use lemmy_diesel_utils::{
   connection::{DbPool, get_conn},

--- a/crates/db_schema/src/impls/email_verification.rs
+++ b/crates/db_schema/src/impls/email_verification.rs
@@ -1,10 +1,7 @@
-use crate::{
-  newtypes::LocalUserId,
-  source::email_verification::{EmailVerification, EmailVerificationForm},
-};
+use crate::source::email_verification::{EmailVerification, EmailVerificationForm};
 use diesel::{ExpressionMethods, QueryDsl, dsl::IntervalDsl, insert_into};
 use diesel_async::RunQueryDsl;
-use lemmy_db_schema_file::schema::email_verification;
+use lemmy_db_schema_file::{newtypes::LocalUserId, schema::email_verification};
 use lemmy_diesel_utils::{
   connection::{DbPool, get_conn},
   utils::now,

--- a/crates/db_schema/src/impls/keyword_block.rs
+++ b/crates/db_schema/src/impls/keyword_block.rs
@@ -1,10 +1,7 @@
-use crate::{
-  newtypes::LocalUserId,
-  source::keyword_block::{LocalUserKeywordBlock, LocalUserKeywordBlockForm},
-};
+use crate::source::keyword_block::{LocalUserKeywordBlock, LocalUserKeywordBlockForm};
 use diesel::{ExpressionMethods, QueryDsl, delete, insert_into};
 use diesel_async::{RunQueryDsl, scoped_futures::ScopedFutureExt};
-use lemmy_db_schema_file::schema::local_user_keyword_block;
+use lemmy_db_schema_file::{newtypes::LocalUserId, schema::local_user_keyword_block};
 use lemmy_diesel_utils::connection::{DbPool, get_conn};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 

--- a/crates/db_schema/src/impls/language.rs
+++ b/crates/db_schema/src/impls/language.rs
@@ -1,8 +1,11 @@
 use super::actor_language::UNDETERMINED_ID;
-use crate::{diesel::ExpressionMethods, newtypes::LanguageId, source::language::Language};
+use crate::{diesel::ExpressionMethods, source::language::Language};
 use diesel::{QueryDsl, dsl::count};
 use diesel_async::RunQueryDsl;
-use lemmy_db_schema_file::schema::{language, post};
+use lemmy_db_schema_file::{
+  newtypes::LanguageId,
+  schema::{language, post},
+};
 use lemmy_diesel_utils::connection::{DbPool, get_conn};
 use lemmy_utils::{
   CacheLock,

--- a/crates/db_schema/src/impls/local_user.rs
+++ b/crates/db_schema/src/impls/local_user.rs
@@ -1,10 +1,7 @@
-use crate::{
-  newtypes::{CommunityId, LanguageId, LocalUserId},
-  source::{
-    actor_language::LocalUserLanguage,
-    local_user::{LocalUser, LocalUserInsertForm, LocalUserUpdateForm},
-    site::Site,
-  },
+use crate::source::{
+  actor_language::LocalUserLanguage,
+  local_user::{LocalUser, LocalUserInsertForm, LocalUserUpdateForm},
+  site::Site,
 };
 use bcrypt::{DEFAULT_COST, hash};
 use diesel::{
@@ -18,6 +15,7 @@ use diesel::{
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema_file::{
   PersonId,
+  newtypes::{CommunityId, LanguageId, LocalUserId},
   schema::{community_actions, local_user, person, registration_application},
 };
 use lemmy_diesel_utils::{

--- a/crates/db_schema/src/impls/local_user_invite.rs
+++ b/crates/db_schema/src/impls/local_user_invite.rs
@@ -1,15 +1,12 @@
-use crate::{
-  newtypes::InvitationId,
-  source::local_user_invite::{
-    LocalUserInvite,
-    LocalUserInviteInsertForm,
-    LocalUserInviteUpdateForm,
-  },
+use crate::source::local_user_invite::{
+  LocalUserInvite,
+  LocalUserInviteInsertForm,
+  LocalUserInviteUpdateForm,
 };
 use chrono::Utc;
 use diesel::{ExpressionMethods, QueryDsl, insert_into};
 use diesel_async::RunQueryDsl;
-use lemmy_db_schema_file::schema::local_user_invite;
+use lemmy_db_schema_file::{newtypes::InvitationId, schema::local_user_invite};
 use lemmy_diesel_utils::{
   connection::{DbPool, get_conn},
   pagination::{CursorData, PaginationCursorConversion},
@@ -94,16 +91,14 @@ impl LocalUserInvite {
 
 #[cfg(test)]
 mod tests {
-  use crate::{
-    newtypes::{InvitationId, LocalUserId},
-    source::{
-      instance::Instance,
-      local_user::{LocalUser, LocalUserInsertForm},
-      local_user_invite::{LocalUserInvite, LocalUserInviteInsertForm, LocalUserInviteUpdateForm},
-      person::{Person, PersonInsertForm},
-    },
+  use crate::source::{
+    instance::Instance,
+    local_user::{LocalUser, LocalUserInsertForm},
+    local_user_invite::{LocalUserInvite, LocalUserInviteInsertForm, LocalUserInviteUpdateForm},
+    person::{Person, PersonInsertForm},
   };
   use chrono::{Duration, Utc};
+  use lemmy_db_schema_file::newtypes::{InvitationId, LocalUserId};
   use lemmy_diesel_utils::{connection::build_db_pool_for_tests, traits::Crud};
   use lemmy_utils::{error::LemmyResult, settings::structs::Settings};
   use pretty_assertions::assert_eq;

--- a/crates/db_schema/src/impls/login_token.rs
+++ b/crates/db_schema/src/impls/login_token.rs
@@ -1,11 +1,13 @@
 use crate::{
   diesel::{ExpressionMethods, QueryDsl},
-  newtypes::LocalUserId,
   source::login_token::{LoginToken, LoginTokenCreateForm},
 };
 use diesel::{delete, dsl::exists, insert_into, select};
 use diesel_async::RunQueryDsl;
-use lemmy_db_schema_file::schema::login_token::{dsl::login_token, user_id};
+use lemmy_db_schema_file::{
+  newtypes::LocalUserId,
+  schema::login_token::{dsl::login_token, user_id},
+};
 use lemmy_diesel_utils::connection::{DbPool, get_conn};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 

--- a/crates/db_schema/src/impls/modlog.rs
+++ b/crates/db_schema/src/impls/modlog.rs
@@ -1,18 +1,20 @@
-use crate::{
-  newtypes::{CommunityId, ModlogId},
-  source::{
-    comment::Comment,
-    modlog::{Modlog, ModlogInsertForm},
-    person::Person,
-    post::Post,
-  },
+use crate::source::{
+  comment::Comment,
+  modlog::{Modlog, ModlogInsertForm},
+  person::Person,
+  post::Post,
 };
 use chrono::{DateTime, Utc};
 use diesel::{QueryDsl, dsl::insert_into};
 use diesel_async::RunQueryDsl;
 #[cfg(feature = "full")]
 use lemmy_db_schema_file::schema::modlog;
-use lemmy_db_schema_file::{InstanceId, PersonId, enums::ModlogKind};
+use lemmy_db_schema_file::{
+  InstanceId,
+  PersonId,
+  enums::ModlogKind,
+  newtypes::{CommunityId, ModlogId},
+};
 use lemmy_diesel_utils::connection::{DbPool, get_conn};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 

--- a/crates/db_schema/src/impls/multi_community.rs
+++ b/crates/db_schema/src/impls/multi_community.rs
@@ -1,6 +1,5 @@
 use crate::{
   diesel::{BoolExpressionMethods, OptionalExtension, PgExpressionMethods, SelectableHelper},
-  newtypes::{CommunityId, MultiCommunityId},
   source::{
     community::Community,
     multi_community::{
@@ -26,6 +25,7 @@ use diesel::{
 use diesel_async::RunQueryDsl;
 use lemmy_db_schema_file::{
   PersonId,
+  newtypes::{CommunityId, MultiCommunityId},
   schema::{
     community,
     instance,

--- a/crates/db_schema/src/impls/notification.rs
+++ b/crates/db_schema/src/impls/notification.rs
@@ -1,7 +1,4 @@
-use crate::{
-  newtypes::{CommentId, NotificationId, PostId},
-  source::notification::{Notification, NotificationInsertForm},
-};
+use crate::source::notification::{Notification, NotificationInsertForm};
 use diesel::{
   ExpressionMethods,
   QueryDsl,
@@ -9,7 +6,11 @@ use diesel::{
   dsl::{insert_into, update},
 };
 use diesel_async::RunQueryDsl;
-use lemmy_db_schema_file::{PersonId, schema::notification};
+use lemmy_db_schema_file::{
+  PersonId,
+  newtypes::{CommentId, NotificationId, PostId},
+  schema::notification,
+};
 use lemmy_diesel_utils::connection::{DbPool, get_conn};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 

--- a/crates/db_schema/src/impls/oauth_account.rs
+++ b/crates/db_schema/src/impls/oauth_account.rs
@@ -1,10 +1,10 @@
-use crate::{
-  newtypes::LocalUserId,
-  source::oauth_account::{OAuthAccount, OAuthAccountInsertForm},
-};
+use crate::source::oauth_account::{OAuthAccount, OAuthAccountInsertForm};
 use diesel::{ExpressionMethods, QueryDsl, insert_into};
 use diesel_async::RunQueryDsl;
-use lemmy_db_schema_file::schema::{oauth_account, oauth_account::dsl::local_user_id};
+use lemmy_db_schema_file::{
+  newtypes::LocalUserId,
+  schema::{oauth_account, oauth_account::dsl::local_user_id},
+};
 use lemmy_diesel_utils::connection::{DbPool, get_conn};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 

--- a/crates/db_schema/src/impls/oauth_provider.rs
+++ b/crates/db_schema/src/impls/oauth_provider.rs
@@ -1,15 +1,12 @@
-use crate::{
-  newtypes::OAuthProviderId,
-  source::oauth_provider::{
-    AdminOAuthProvider,
-    OAuthProviderInsertForm,
-    OAuthProviderUpdateForm,
-    PublicOAuthProvider,
-  },
+use crate::source::oauth_provider::{
+  AdminOAuthProvider,
+  OAuthProviderInsertForm,
+  OAuthProviderUpdateForm,
+  PublicOAuthProvider,
 };
 use diesel::{QueryDsl, dsl::insert_into};
 use diesel_async::RunQueryDsl;
-use lemmy_db_schema_file::schema::oauth_provider;
+use lemmy_db_schema_file::{newtypes::OAuthProviderId, schema::oauth_provider};
 use lemmy_diesel_utils::{
   connection::{DbPool, get_conn},
   traits::Crud,

--- a/crates/db_schema/src/impls/password_reset_request.rs
+++ b/crates/db_schema/src/impls/password_reset_request.rs
@@ -1,7 +1,4 @@
-use crate::{
-  newtypes::LocalUserId,
-  source::password_reset_request::{PasswordResetRequest, PasswordResetRequestForm},
-};
+use crate::source::password_reset_request::{PasswordResetRequest, PasswordResetRequestForm};
 use diesel::{
   ExpressionMethods,
   IntoSql,
@@ -10,7 +7,7 @@ use diesel::{
   sql_types::Timestamptz,
 };
 use diesel_async::RunQueryDsl;
-use lemmy_db_schema_file::schema::password_reset_request;
+use lemmy_db_schema_file::{newtypes::LocalUserId, schema::password_reset_request};
 use lemmy_diesel_utils::connection::{DbPool, get_conn};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 

--- a/crates/db_schema/src/impls/person.rs
+++ b/crates/db_schema/src/impls/person.rs
@@ -1,6 +1,5 @@
 use crate::{
   diesel::{BoolExpressionMethods, NullableExpressionMethods, OptionalExtension},
-  newtypes::{CommunityId, LocalUserId},
   source::person::{
     Person,
     PersonActions,
@@ -26,6 +25,7 @@ use diesel_uplete::{UpleteCount, uplete};
 use lemmy_db_schema_file::{
   InstanceId,
   PersonId,
+  newtypes::{CommunityId, LocalUserId},
   schema::{instance, instance_actions, local_user, person, person_actions},
 };
 use lemmy_diesel_utils::{

--- a/crates/db_schema/src/impls/post.rs
+++ b/crates/db_schema/src/impls/post.rs
@@ -1,5 +1,4 @@
 use crate::{
-  newtypes::{CommunityId, PostId},
   source::post::{
     Post,
     PostActions,
@@ -32,6 +31,7 @@ use lemmy_db_schema_file::{
   InstanceId,
   PersonId,
   enums::PostNotificationsMode,
+  newtypes::{CommunityId, PostId},
   schema::{community, local_user, person, post, post_actions},
 };
 use lemmy_diesel_utils::{

--- a/crates/db_schema/src/impls/post_report.rs
+++ b/crates/db_schema/src/impls/post_report.rs
@@ -1,5 +1,4 @@
 use crate::{
-  newtypes::{PostId, PostReportId},
   source::post_report::{PostReport, PostReportForm, UpdatePostReportForm},
   traits::Reportable,
 };
@@ -11,7 +10,11 @@ use diesel::{
   dsl::{insert_into, update},
 };
 use diesel_async::RunQueryDsl;
-use lemmy_db_schema_file::{PersonId, schema::post_report};
+use lemmy_db_schema_file::{
+  PersonId,
+  newtypes::{PostId, PostReportId},
+  schema::post_report,
+};
 use lemmy_diesel_utils::connection::{DbPool, get_conn};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 

--- a/crates/db_schema/src/impls/private_message.rs
+++ b/crates/db_schema/src/impls/private_message.rs
@@ -1,6 +1,5 @@
 use crate::{
   diesel::{DecoratableTarget, OptionalExtension},
-  newtypes::PrivateMessageId,
   source::{
     person::Person,
     private_message::{PrivateMessage, PrivateMessageInsertForm, PrivateMessageUpdateForm},
@@ -9,7 +8,7 @@ use crate::{
 use chrono::{DateTime, Utc};
 use diesel::{ExpressionMethods, QueryDsl, dsl::insert_into};
 use diesel_async::RunQueryDsl;
-use lemmy_db_schema_file::{PersonId, schema::private_message};
+use lemmy_db_schema_file::{PersonId, newtypes::PrivateMessageId, schema::private_message};
 use lemmy_diesel_utils::{
   connection::{DbPool, get_conn},
   dburl::DbUrl,

--- a/crates/db_schema/src/impls/private_message_report.rs
+++ b/crates/db_schema/src/impls/private_message_report.rs
@@ -1,5 +1,4 @@
 use crate::{
-  newtypes::{PrivateMessageId, PrivateMessageReportId},
   source::private_message_report::{
     PrivateMessageReport,
     PrivateMessageReportForm,
@@ -15,7 +14,11 @@ use diesel::{
   dsl::{insert_into, update},
 };
 use diesel_async::RunQueryDsl;
-use lemmy_db_schema_file::{PersonId, schema::private_message_report};
+use lemmy_db_schema_file::{
+  PersonId,
+  newtypes::{PrivateMessageId, PrivateMessageReportId},
+  schema::private_message_report,
+};
 use lemmy_diesel_utils::connection::{DbPool, get_conn};
 use lemmy_utils::error::{LemmyErrorExt, LemmyErrorType, LemmyResult};
 

--- a/crates/db_schema/src/impls/registration_application.rs
+++ b/crates/db_schema/src/impls/registration_application.rs
@@ -1,14 +1,14 @@
-use crate::{
-  newtypes::{LocalUserId, RegistrationApplicationId},
-  source::registration_application::{
-    RegistrationApplication,
-    RegistrationApplicationInsertForm,
-    RegistrationApplicationUpdateForm,
-  },
+use crate::source::registration_application::{
+  RegistrationApplication,
+  RegistrationApplicationInsertForm,
+  RegistrationApplicationUpdateForm,
 };
 use diesel::{ExpressionMethods, QueryDsl, insert_into};
 use diesel_async::RunQueryDsl;
-use lemmy_db_schema_file::schema::registration_application;
+use lemmy_db_schema_file::{
+  newtypes::{LocalUserId, RegistrationApplicationId},
+  schema::registration_application,
+};
 use lemmy_diesel_utils::{
   connection::{DbPool, get_conn},
   traits::Crud,

--- a/crates/db_schema/src/impls/site.rs
+++ b/crates/db_schema/src/impls/site.rs
@@ -1,13 +1,10 @@
-use crate::{
-  newtypes::SiteId,
-  source::{
-    actor_language::SiteLanguage,
-    site::{Site, SiteInsertForm, SiteUpdateForm},
-  },
+use crate::source::{
+  actor_language::SiteLanguage,
+  site::{Site, SiteInsertForm, SiteUpdateForm},
 };
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, dsl::insert_into};
 use diesel_async::RunQueryDsl;
-use lemmy_db_schema_file::{InstanceId, schema::site};
+use lemmy_db_schema_file::{InstanceId, newtypes::SiteId, schema::site};
 use lemmy_diesel_utils::{
   connection::{DbPool, get_conn},
   dburl::DbUrl,

--- a/crates/db_schema/src/impls/tagline.rs
+++ b/crates/db_schema/src/impls/tagline.rs
@@ -1,12 +1,11 @@
 use crate::{
-  newtypes::TaglineId,
   source::tagline::{Tagline, TaglineInsertForm, TaglineUpdateForm, tagline_keys as key},
   utils::limit_fetch,
 };
 use diesel::{QueryDsl, insert_into};
 use diesel_async::RunQueryDsl;
 use i_love_jesus::SortDirection;
-use lemmy_db_schema_file::schema::tagline;
+use lemmy_db_schema_file::{newtypes::TaglineId, schema::tagline};
 use lemmy_diesel_utils::{
   connection::{DbPool, get_conn},
   pagination::{

--- a/crates/db_schema/src/lib.rs
+++ b/crates/db_schema/src/lib.rs
@@ -1,13 +1,9 @@
 #[cfg(feature = "full")]
 #[macro_use]
 extern crate diesel;
-#[cfg(feature = "full")]
-#[macro_use]
-extern crate diesel_derive_newtype;
 
 #[cfg(feature = "full")]
 pub mod impls;
-pub mod newtypes;
 pub mod source;
 #[cfg(feature = "full")]
 pub mod test_data;

--- a/crates/db_schema/src/source/activity.rs
+++ b/crates/db_schema/src/source/activity.rs
@@ -1,8 +1,8 @@
-use crate::newtypes::{ActivityId, CommunityId};
 use chrono::{DateTime, Utc};
 use diesel::Queryable;
 use lemmy_db_schema_file::{
   enums::ActorType,
+  newtypes::{ActivityId, CommunityId},
   schema::{received_activity, sent_activity},
 };
 use lemmy_diesel_utils::dburl::DbUrl;

--- a/crates/db_schema/src/source/actor_language.rs
+++ b/crates/db_schema/src/source/actor_language.rs
@@ -1,4 +1,4 @@
-use crate::newtypes::{CommunityId, LanguageId, LocalUserId, SiteId};
+use lemmy_db_schema_file::newtypes::{CommunityId, LanguageId, LocalUserId, SiteId};
 #[cfg(feature = "full")]
 use lemmy_db_schema_file::schema::local_user_language;
 use serde::{Deserialize, Serialize};

--- a/crates/db_schema/src/source/combined/person_content.rs
+++ b/crates/db_schema/src/source/combined/person_content.rs
@@ -1,10 +1,12 @@
-use crate::newtypes::{CommentId, CommunityId, PersonContentCombinedId, PostId};
 use chrono::{DateTime, Utc};
 #[cfg(feature = "full")]
 use i_love_jesus::CursorKeysModule;
-use lemmy_db_schema_file::PersonId;
 #[cfg(feature = "full")]
 use lemmy_db_schema_file::schema::person_content_combined;
+use lemmy_db_schema_file::{
+  PersonId,
+  newtypes::{CommentId, CommunityId, PersonContentCombinedId, PostId},
+};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 

--- a/crates/db_schema/src/source/combined/person_liked.rs
+++ b/crates/db_schema/src/source/combined/person_liked.rs
@@ -1,10 +1,12 @@
-use crate::newtypes::{CommentId, CommunityId, PersonLikedCombinedId, PostId};
 use chrono::{DateTime, Utc};
 #[cfg(feature = "full")]
 use i_love_jesus::CursorKeysModule;
-use lemmy_db_schema_file::PersonId;
 #[cfg(feature = "full")]
 use lemmy_db_schema_file::schema::person_liked_combined;
+use lemmy_db_schema_file::{
+  PersonId,
+  newtypes::{CommentId, CommunityId, PersonLikedCombinedId, PostId},
+};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 

--- a/crates/db_schema/src/source/combined/person_saved.rs
+++ b/crates/db_schema/src/source/combined/person_saved.rs
@@ -1,10 +1,12 @@
-use crate::newtypes::{CommentId, CommunityId, PersonSavedCombinedId, PostId};
 use chrono::{DateTime, Utc};
 #[cfg(feature = "full")]
 use i_love_jesus::CursorKeysModule;
-use lemmy_db_schema_file::PersonId;
 #[cfg(feature = "full")]
 use lemmy_db_schema_file::schema::person_saved_combined;
+use lemmy_db_schema_file::{
+  PersonId,
+  newtypes::{CommentId, CommunityId, PersonSavedCombinedId, PostId},
+};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 

--- a/crates/db_schema/src/source/combined/report.rs
+++ b/crates/db_schema/src/source/combined/report.rs
@@ -1,20 +1,22 @@
-use crate::newtypes::{
-  CommentId,
-  CommentReportId,
-  CommunityId,
-  CommunityReportId,
-  PostId,
-  PostReportId,
-  PrivateMessageId,
-  PrivateMessageReportId,
-  ReportCombinedId,
-};
 use chrono::{DateTime, Utc};
 #[cfg(feature = "full")]
 use i_love_jesus::CursorKeysModule;
-use lemmy_db_schema_file::PersonId;
 #[cfg(feature = "full")]
 use lemmy_db_schema_file::schema::report_combined;
+use lemmy_db_schema_file::{
+  PersonId,
+  newtypes::{
+    CommentId,
+    CommentReportId,
+    CommunityId,
+    CommunityReportId,
+    PostId,
+    PostReportId,
+    PrivateMessageId,
+    PrivateMessageReportId,
+    ReportCombinedId,
+  },
+};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 

--- a/crates/db_schema/src/source/comment.rs
+++ b/crates/db_schema/src/source/comment.rs
@@ -1,12 +1,13 @@
-use crate::newtypes::{CommentId, CommunityId, LanguageId, PostId};
 use chrono::{DateTime, Utc};
-use lemmy_db_schema_file::PersonId;
+use lemmy_db_schema_file::{
+  PersonId,
+  newtypes::{CommentId, CommunityId, LanguageId, LtreeDef, PostId},
+};
 use lemmy_diesel_utils::dburl::DbUrl;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 #[cfg(feature = "full")]
 use {
-  crate::newtypes::LtreeDef,
   diesel_ltree::Ltree,
   i_love_jesus::CursorKeysModule,
   lemmy_db_schema_file::schema::{comment, comment_actions},

--- a/crates/db_schema/src/source/comment.rs
+++ b/crates/db_schema/src/source/comment.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use lemmy_db_schema_file::{
   PersonId,
-  newtypes::{CommentId, CommunityId, LanguageId, LtreeDef, PostId},
+  newtypes::{CommentId, CommunityId, LanguageId, PostId},
 };
 use lemmy_diesel_utils::dburl::DbUrl;
 use serde::{Deserialize, Serialize};
@@ -10,6 +10,7 @@ use serde_with::skip_serializing_none;
 use {
   diesel_ltree::Ltree,
   i_love_jesus::CursorKeysModule,
+  lemmy_db_schema_file::newtypes::LtreeDef,
   lemmy_db_schema_file::schema::{comment, comment_actions},
 };
 

--- a/crates/db_schema/src/source/comment_report.rs
+++ b/crates/db_schema/src/source/comment_report.rs
@@ -1,8 +1,10 @@
-use crate::newtypes::{CommentId, CommentReportId};
 use chrono::{DateTime, Utc};
-use lemmy_db_schema_file::PersonId;
 #[cfg(feature = "full")]
 use lemmy_db_schema_file::schema::comment_report;
+use lemmy_db_schema_file::{
+  PersonId,
+  newtypes::{CommentId, CommentReportId},
+};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 

--- a/crates/db_schema/src/source/community.rs
+++ b/crates/db_schema/src/source/community.rs
@@ -1,9 +1,10 @@
-use crate::{newtypes::CommunityId, source::placeholder_apub_url};
+use crate::source::placeholder_apub_url;
 use chrono::{DateTime, Utc};
 use lemmy_db_schema_file::{
   InstanceId,
   PersonId,
   enums::{CommunityFollowerState, CommunityNotificationsMode, CommunityVisibility},
+  newtypes::CommunityId,
 };
 use lemmy_diesel_utils::{dburl::DbUrl, sensitive::SensitiveString};
 use serde::{Deserialize, Serialize};

--- a/crates/db_schema/src/source/community_community_follow.rs
+++ b/crates/db_schema/src/source/community_community_follow.rs
@@ -1,5 +1,4 @@
-use crate::newtypes::CommunityId;
-use lemmy_db_schema_file::schema::community_community_follow;
+use lemmy_db_schema_file::{newtypes::CommunityId, schema::community_community_follow};
 
 #[derive(Clone, Debug, PartialEq, Queryable, Selectable)]
 #[diesel(belongs_to(crate::source::community::Community))]

--- a/crates/db_schema/src/source/community_report.rs
+++ b/crates/db_schema/src/source/community_report.rs
@@ -1,8 +1,10 @@
-use crate::newtypes::{CommunityId, CommunityReportId};
 use chrono::{DateTime, Utc};
-use lemmy_db_schema_file::PersonId;
 #[cfg(feature = "full")]
 use lemmy_db_schema_file::schema::community_report;
+use lemmy_db_schema_file::{
+  PersonId,
+  newtypes::{CommunityId, CommunityReportId},
+};
 use lemmy_diesel_utils::dburl::DbUrl;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;

--- a/crates/db_schema/src/source/community_tag.rs
+++ b/crates/db_schema/src/source/community_tag.rs
@@ -1,10 +1,12 @@
-use crate::newtypes::{CommunityId, CommunityTagId, PostId};
 use chrono::{DateTime, Utc};
 #[cfg(feature = "full")]
 use diesel::{AsExpression, FromSqlRow, sql_types::Nullable};
-use lemmy_db_schema_file::enums::TagColor;
 #[cfg(feature = "full")]
 use lemmy_db_schema_file::schema::{community_tag, post_community_tag};
+use lemmy_db_schema_file::{
+  enums::TagColor,
+  newtypes::{CommunityId, CommunityTagId, PostId},
+};
 use lemmy_diesel_utils::dburl::DbUrl;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;

--- a/crates/db_schema/src/source/custom_emoji.rs
+++ b/crates/db_schema/src/source/custom_emoji.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
+use lemmy_db_schema_file::newtypes::CustomEmojiId;
 #[cfg(feature = "full")]
-use lemmy_db_schema_file::{newtypes::CustomEmojiId, schema::custom_emoji};
+use lemmy_db_schema_file::schema::custom_emoji;
 use lemmy_diesel_utils::dburl::DbUrl;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;

--- a/crates/db_schema/src/source/custom_emoji.rs
+++ b/crates/db_schema/src/source/custom_emoji.rs
@@ -1,7 +1,6 @@
-use crate::newtypes::CustomEmojiId;
 use chrono::{DateTime, Utc};
 #[cfg(feature = "full")]
-use lemmy_db_schema_file::schema::custom_emoji;
+use lemmy_db_schema_file::{newtypes::CustomEmojiId, schema::custom_emoji};
 use lemmy_diesel_utils::dburl::DbUrl;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;

--- a/crates/db_schema/src/source/custom_emoji_keyword.rs
+++ b/crates/db_schema/src/source/custom_emoji_keyword.rs
@@ -1,5 +1,6 @@
+use lemmy_db_schema_file::newtypes::CustomEmojiId;
 #[cfg(feature = "full")]
-use lemmy_db_schema_file::{newtypes::CustomEmojiId, schema::custom_emoji_keyword};
+use lemmy_db_schema_file::schema::custom_emoji_keyword;
 use serde::{Deserialize, Serialize};
 
 #[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]

--- a/crates/db_schema/src/source/custom_emoji_keyword.rs
+++ b/crates/db_schema/src/source/custom_emoji_keyword.rs
@@ -1,6 +1,5 @@
-use crate::newtypes::CustomEmojiId;
 #[cfg(feature = "full")]
-use lemmy_db_schema_file::schema::custom_emoji_keyword;
+use lemmy_db_schema_file::{newtypes::CustomEmojiId, schema::custom_emoji_keyword};
 use serde::{Deserialize, Serialize};
 
 #[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]

--- a/crates/db_schema/src/source/email_verification.rs
+++ b/crates/db_schema/src/source/email_verification.rs
@@ -1,5 +1,5 @@
-use crate::newtypes::LocalUserId;
 use chrono::{DateTime, Utc};
+use lemmy_db_schema_file::newtypes::LocalUserId;
 #[cfg(feature = "full")]
 use lemmy_db_schema_file::schema::email_verification;
 

--- a/crates/db_schema/src/source/federation_queue_state.rs
+++ b/crates/db_schema/src/source/federation_queue_state.rs
@@ -1,8 +1,7 @@
-use crate::newtypes::ActivityId;
 use chrono::{DateTime, Utc};
 #[cfg(feature = "full")]
 use diesel::prelude::*;
-use lemmy_db_schema_file::InstanceId;
+use lemmy_db_schema_file::{InstanceId, newtypes::ActivityId};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 

--- a/crates/db_schema/src/source/images.rs
+++ b/crates/db_schema/src/source/images.rs
@@ -1,6 +1,5 @@
-use crate::newtypes::PostId;
 use chrono::{DateTime, Utc};
-use lemmy_db_schema_file::PersonId;
+use lemmy_db_schema_file::{PersonId, newtypes::PostId};
 use lemmy_diesel_utils::dburl::DbUrl;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;

--- a/crates/db_schema/src/source/keyword_block.rs
+++ b/crates/db_schema/src/source/keyword_block.rs
@@ -1,4 +1,4 @@
-use crate::newtypes::LocalUserId;
+use lemmy_db_schema_file::newtypes::LocalUserId;
 #[cfg(feature = "full")]
 use lemmy_db_schema_file::schema::local_user_keyword_block;
 use serde::{Deserialize, Serialize};

--- a/crates/db_schema/src/source/language.rs
+++ b/crates/db_schema/src/source/language.rs
@@ -1,4 +1,4 @@
-use crate::newtypes::LanguageId;
+use lemmy_db_schema_file::newtypes::LanguageId;
 #[cfg(feature = "full")]
 use lemmy_db_schema_file::schema::language;
 use serde::{Deserialize, Serialize};

--- a/crates/db_schema/src/source/local_site.rs
+++ b/crates/db_schema/src/source/local_site.rs
@@ -1,4 +1,3 @@
-use crate::newtypes::{LocalSiteId, MultiCommunityId, SiteId};
 use chrono::{DateTime, Utc};
 #[cfg(feature = "full")]
 use lemmy_db_schema_file::schema::local_site;
@@ -13,6 +12,7 @@ use lemmy_db_schema_file::{
     PostSortType,
     RegistrationMode,
   },
+  newtypes::{LocalSiteId, MultiCommunityId, SiteId},
 };
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;

--- a/crates/db_schema/src/source/local_site_rate_limit.rs
+++ b/crates/db_schema/src/source/local_site_rate_limit.rs
@@ -1,5 +1,5 @@
-use crate::newtypes::LocalSiteId;
 use chrono::{DateTime, Utc};
+use lemmy_db_schema_file::newtypes::LocalSiteId;
 #[cfg(feature = "full")]
 use lemmy_db_schema_file::schema::local_site_rate_limit;
 use serde::{Deserialize, Serialize};

--- a/crates/db_schema/src/source/local_user.rs
+++ b/crates/db_schema/src/source/local_user.rs
@@ -1,10 +1,10 @@
-use crate::newtypes::LocalUserId;
 use chrono::{DateTime, Utc};
 #[cfg(feature = "full")]
 use lemmy_db_schema_file::schema::local_user;
 use lemmy_db_schema_file::{
   PersonId,
   enums::{CommentSortType, ListingType, PostListingMode, PostSortType, VoteShow},
+  newtypes::LocalUserId,
 };
 use lemmy_diesel_utils::sensitive::SensitiveString;
 use serde::{Deserialize, Serialize};

--- a/crates/db_schema/src/source/local_user_invite.rs
+++ b/crates/db_schema/src/source/local_user_invite.rs
@@ -1,7 +1,7 @@
-use crate::newtypes::{InvitationId, LocalUserId};
 use chrono::{DateTime, Utc};
 #[cfg(feature = "full")]
 use i_love_jesus::CursorKeysModule;
+use lemmy_db_schema_file::newtypes::{InvitationId, LocalUserId};
 #[cfg(feature = "full")]
 use lemmy_db_schema_file::schema::local_user_invite;
 use serde::{Deserialize, Serialize};

--- a/crates/db_schema/src/source/login_token.rs
+++ b/crates/db_schema/src/source/login_token.rs
@@ -1,5 +1,5 @@
-use crate::newtypes::LocalUserId;
 use chrono::{DateTime, Utc};
+use lemmy_db_schema_file::newtypes::LocalUserId;
 #[cfg(feature = "full")]
 use lemmy_db_schema_file::schema::login_token;
 use lemmy_diesel_utils::sensitive::SensitiveString;

--- a/crates/db_schema/src/source/modlog.rs
+++ b/crates/db_schema/src/source/modlog.rs
@@ -1,10 +1,14 @@
-use crate::newtypes::{CommentId, CommunityId, ModlogId, PostId};
 use chrono::{DateTime, Utc};
 #[cfg(feature = "full")]
 use i_love_jesus::CursorKeysModule;
 #[cfg(feature = "full")]
 use lemmy_db_schema_file::schema::modlog;
-use lemmy_db_schema_file::{InstanceId, PersonId, enums::ModlogKind};
+use lemmy_db_schema_file::{
+  InstanceId,
+  PersonId,
+  enums::ModlogKind,
+  newtypes::{CommentId, CommunityId, ModlogId, PostId},
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]

--- a/crates/db_schema/src/source/multi_community.rs
+++ b/crates/db_schema/src/source/multi_community.rs
@@ -1,7 +1,4 @@
-use crate::{
-  newtypes::{CommunityId, MultiCommunityId},
-  source::placeholder_apub_url,
-};
+use crate::source::placeholder_apub_url;
 use chrono::{DateTime, Utc};
 #[cfg(feature = "full")]
 use i_love_jesus::CursorKeysModule;
@@ -11,7 +8,12 @@ use lemmy_db_schema_file::schema::{
   multi_community_entry,
   multi_community_follow,
 };
-use lemmy_db_schema_file::{InstanceId, PersonId, enums::CommunityFollowerState};
+use lemmy_db_schema_file::{
+  InstanceId,
+  PersonId,
+  enums::CommunityFollowerState,
+  newtypes::{CommunityId, MultiCommunityId},
+};
 use lemmy_diesel_utils::{dburl::DbUrl, sensitive::SensitiveString};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;

--- a/crates/db_schema/src/source/notification.rs
+++ b/crates/db_schema/src/source/notification.rs
@@ -1,13 +1,20 @@
-use crate::{
-  newtypes::{CommentId, CommunityId, ModlogId, NotificationId, PostId, PrivateMessageId},
-  source::{comment::Comment, modlog::Modlog, post::Post, private_message::PrivateMessage},
+use crate::source::{
+  comment::Comment,
+  modlog::Modlog,
+  post::Post,
+  private_message::PrivateMessage,
 };
 use chrono::{DateTime, Utc};
 #[cfg(feature = "full")]
 use i_love_jesus::CursorKeysModule;
 #[cfg(feature = "full")]
 use lemmy_db_schema_file::schema::notification;
-use lemmy_db_schema_file::{InstanceId, PersonId, enums::NotificationType};
+use lemmy_db_schema_file::{
+  InstanceId,
+  PersonId,
+  enums::NotificationType,
+  newtypes::{CommentId, CommunityId, ModlogId, NotificationId, PostId, PrivateMessageId},
+};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 

--- a/crates/db_schema/src/source/oauth_account.rs
+++ b/crates/db_schema/src/source/oauth_account.rs
@@ -1,5 +1,5 @@
-use crate::newtypes::{LocalUserId, OAuthProviderId};
 use chrono::{DateTime, Utc};
+use lemmy_db_schema_file::newtypes::{LocalUserId, OAuthProviderId};
 #[cfg(feature = "full")]
 use lemmy_db_schema_file::schema::oauth_account;
 use serde::{Deserialize, Serialize};

--- a/crates/db_schema/src/source/oauth_provider.rs
+++ b/crates/db_schema/src/source/oauth_provider.rs
@@ -1,5 +1,5 @@
-use crate::newtypes::OAuthProviderId;
 use chrono::{DateTime, Utc};
+use lemmy_db_schema_file::newtypes::OAuthProviderId;
 #[cfg(feature = "full")]
 use lemmy_db_schema_file::schema::oauth_provider;
 use lemmy_diesel_utils::{dburl::DbUrl, sensitive::SensitiveString};

--- a/crates/db_schema/src/source/password_reset_request.rs
+++ b/crates/db_schema/src/source/password_reset_request.rs
@@ -1,5 +1,5 @@
-use crate::newtypes::LocalUserId;
 use chrono::{DateTime, Utc};
+use lemmy_db_schema_file::newtypes::LocalUserId;
 #[cfg(feature = "full")]
 use lemmy_db_schema_file::schema::password_reset_request;
 use lemmy_diesel_utils::sensitive::SensitiveString;

--- a/crates/db_schema/src/source/post.rs
+++ b/crates/db_schema/src/source/post.rs
@@ -1,6 +1,9 @@
-use crate::newtypes::{CommunityId, LanguageId, PostId};
 use chrono::{DateTime, Utc};
-use lemmy_db_schema_file::{PersonId, enums::PostNotificationsMode};
+use lemmy_db_schema_file::{
+  PersonId,
+  enums::PostNotificationsMode,
+  newtypes::{CommunityId, LanguageId, PostId},
+};
 use lemmy_diesel_utils::dburl::DbUrl;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;

--- a/crates/db_schema/src/source/post_report.rs
+++ b/crates/db_schema/src/source/post_report.rs
@@ -1,8 +1,10 @@
-use crate::newtypes::{PostId, PostReportId};
 use chrono::{DateTime, Utc};
-use lemmy_db_schema_file::PersonId;
 #[cfg(feature = "full")]
 use lemmy_db_schema_file::schema::post_report;
+use lemmy_db_schema_file::{
+  PersonId,
+  newtypes::{PostId, PostReportId},
+};
 use lemmy_diesel_utils::dburl::DbUrl;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;

--- a/crates/db_schema/src/source/private_message.rs
+++ b/crates/db_schema/src/source/private_message.rs
@@ -1,8 +1,7 @@
-use crate::newtypes::PrivateMessageId;
 use chrono::{DateTime, Utc};
-use lemmy_db_schema_file::PersonId;
 #[cfg(feature = "full")]
 use lemmy_db_schema_file::schema::private_message;
+use lemmy_db_schema_file::{PersonId, newtypes::PrivateMessageId};
 use lemmy_diesel_utils::dburl::DbUrl;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;

--- a/crates/db_schema/src/source/private_message_report.rs
+++ b/crates/db_schema/src/source/private_message_report.rs
@@ -1,8 +1,10 @@
-use crate::newtypes::{PrivateMessageId, PrivateMessageReportId};
 use chrono::{DateTime, Utc};
-use lemmy_db_schema_file::PersonId;
 #[cfg(feature = "full")]
 use lemmy_db_schema_file::schema::private_message_report;
+use lemmy_db_schema_file::{
+  PersonId,
+  newtypes::{PrivateMessageId, PrivateMessageReportId},
+};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 

--- a/crates/db_schema/src/source/registration_application.rs
+++ b/crates/db_schema/src/source/registration_application.rs
@@ -1,6 +1,8 @@
-use crate::newtypes::{LocalUserId, RegistrationApplicationId};
 use chrono::{DateTime, Utc};
-use lemmy_db_schema_file::PersonId;
+use lemmy_db_schema_file::{
+  PersonId,
+  newtypes::{LocalUserId, RegistrationApplicationId},
+};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 #[cfg(feature = "full")]

--- a/crates/db_schema/src/source/site.rs
+++ b/crates/db_schema/src/source/site.rs
@@ -1,8 +1,7 @@
-use crate::newtypes::SiteId;
 use chrono::{DateTime, Utc};
-use lemmy_db_schema_file::InstanceId;
 #[cfg(feature = "full")]
 use lemmy_db_schema_file::schema::site;
+use lemmy_db_schema_file::{InstanceId, newtypes::SiteId};
 use lemmy_diesel_utils::{dburl::DbUrl, sensitive::SensitiveString};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;

--- a/crates/db_schema/src/source/tagline.rs
+++ b/crates/db_schema/src/source/tagline.rs
@@ -1,10 +1,9 @@
-use crate::newtypes::TaglineId;
 use chrono::{DateTime, Utc};
+use lemmy_db_schema_file::newtypes::TaglineId;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 #[cfg(feature = "full")]
 use {i_love_jesus::CursorKeysModule, lemmy_db_schema_file::schema::tagline};
-
 #[skip_serializing_none]
 #[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(

--- a/crates/db_schema/src/traits.rs
+++ b/crates/db_schema/src/traits.rs
@@ -1,6 +1,5 @@
-use crate::newtypes::CommunityId;
 use diesel_uplete::UpleteCount;
-use lemmy_db_schema_file::PersonId;
+use lemmy_db_schema_file::{PersonId, newtypes::CommunityId};
 use lemmy_diesel_utils::{connection::DbPool, dburl::DbUrl};
 use lemmy_utils::{error::LemmyResult, settings::structs::Settings};
 use std::future::Future;

--- a/crates/db_schema_file/src/joins.rs
+++ b/crates/db_schema_file/src/joins.rs
@@ -1,5 +1,4 @@
 use crate::{
-  CommunityId,
   InstanceId,
   PersonId,
   aliases::{
@@ -10,6 +9,7 @@ use crate::{
     creator_local_user,
     my_instance_persons_actions,
   },
+  newtypes::CommunityId,
   schema::{
     comment,
     comment_actions,

--- a/crates/db_schema_file/src/lib.rs
+++ b/crates/db_schema_file/src/lib.rs
@@ -1,11 +1,17 @@
+#[cfg(feature = "full")]
+extern crate diesel;
+#[cfg(feature = "full")]
+#[macro_use]
+extern crate diesel_derive_newtype;
+
 use core::default::Default;
 #[cfg(feature = "full")]
 use diesel_derive_newtype::DieselNewType;
 use serde::{Deserialize, Serialize};
-
 pub mod enums;
 #[cfg(feature = "full")]
 pub mod joins;
+pub mod newtypes;
 #[cfg(feature = "full")]
 pub mod schema;
 #[cfg(feature = "full")]
@@ -32,13 +38,6 @@ pub mod aliases {
 #[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
 /// The person id.
 pub struct PersonId(pub i32);
-
-#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Default, Serialize, Deserialize)]
-#[cfg_attr(feature = "full", derive(DieselNewType))]
-#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
-#[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
-/// The community id.
-pub struct CommunityId(pub i32);
 
 #[derive(
   Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize, Default, Ord, PartialOrd,

--- a/crates/db_schema_file/src/newtypes.rs
+++ b/crates/db_schema_file/src/newtypes.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "full")]
 use diesel_ltree::Ltree;
-pub use lemmy_db_schema_file::CommunityId;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -202,3 +201,10 @@ pub struct MultiCommunityId(pub i32);
 #[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
 /// The community tag id
 pub struct CommunityTagId(pub i32);
+
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "full", derive(DieselNewType))]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
+/// The community id.
+pub struct CommunityId(pub i32);

--- a/crates/db_views/comment/src/api.rs
+++ b/crates/db_views/comment/src/api.rs
@@ -1,8 +1,8 @@
 use crate::CommentView;
-use lemmy_db_schema::newtypes::{CommentId, CommunityId, LanguageId, PostId};
 use lemmy_db_schema_file::{
   PersonId,
   enums::{CommentSortType, ListingType},
+  newtypes::{CommentId, CommunityId, LanguageId, PostId},
 };
 use lemmy_diesel_utils::pagination::PaginationCursor;
 use serde::{Deserialize, Serialize};

--- a/crates/db_views/comment/src/impls.rs
+++ b/crates/db_views/comment/src/impls.rs
@@ -12,7 +12,6 @@ use diesel_ltree::{Ltree, LtreeExtensions, nlevel};
 use i_love_jesus::asc_if;
 use lemmy_db_schema::{
   impls::local_user::LocalUserOptionHelper,
-  newtypes::{CommentId, CommunityId, PostId},
   source::{
     actor_language::LocalUserLanguage,
     comment::{Comment, comment_keys as key},
@@ -53,6 +52,7 @@ use lemmy_db_schema_file::{
     my_local_user_admin_join,
     my_person_actions_join,
   },
+  newtypes::{CommentId, CommunityId, PostId},
   schema::{comment, community, person, post},
 };
 use lemmy_diesel_utils::{
@@ -372,7 +372,6 @@ mod tests {
   use lemmy_db_schema::{
     assert_length,
     impls::actor_language::UNDETERMINED_ID,
-    newtypes::CommentId,
     source::{
       actor_language::LocalUserLanguage,
       comment::{Comment, CommentActions, CommentInsertForm, CommentLikeForm, CommentUpdateForm},
@@ -396,7 +395,7 @@ mod tests {
     test_data::TestData,
     traits::{Bannable, Blockable, Followable, Likeable},
   };
-  use lemmy_db_schema_file::enums::CommunityFollowerState;
+  use lemmy_db_schema_file::{enums::CommunityFollowerState, newtypes::CommentId};
   use lemmy_db_views_local_user::LocalUserView;
   use lemmy_diesel_utils::{
     connection::{DbPool, build_db_pool_for_tests},

--- a/crates/db_views/community/src/api.rs
+++ b/crates/db_views/community/src/api.rs
@@ -3,12 +3,12 @@ use lemmy_db_schema::{
   CommunitySortType,
   MultiCommunityListingType,
   MultiCommunitySortType,
-  newtypes::{CommunityId, CommunityTagId, LanguageId, MultiCommunityId},
   source::site::Site,
 };
 use lemmy_db_schema_file::{
   PersonId,
   enums::{CommunityNotificationsMode, CommunityVisibility, ListingType, TagColor},
+  newtypes::{CommunityId, CommunityTagId, LanguageId, MultiCommunityId},
 };
 use lemmy_db_views_community_moderator::CommunityModeratorView;
 use lemmy_diesel_utils::pagination::PaginationCursor;

--- a/crates/db_views/community/src/impls.rs
+++ b/crates/db_views/community/src/impls.rs
@@ -13,7 +13,6 @@ use lemmy_db_schema::{
   MultiCommunityListingType,
   MultiCommunitySortType,
   impls::local_user::LocalUserOptionHelper,
-  newtypes::{CommunityId, MultiCommunityId},
   source::{
     community::{Community, community_keys as key},
     local_site::LocalSite,
@@ -32,6 +31,7 @@ use lemmy_db_schema_file::{
     my_local_user_admin_join,
     my_multi_community_follower_join,
   },
+  newtypes::{CommunityId, MultiCommunityId},
   schema::{
     community,
     community_actions,

--- a/crates/db_views/community_follower/src/impls.rs
+++ b/crates/db_views/community_follower/src/impls.rs
@@ -9,11 +9,11 @@ use diesel::{
   select,
 };
 use diesel_async::RunQueryDsl;
-use lemmy_db_schema::newtypes::CommunityId;
 use lemmy_db_schema_file::{
   InstanceId,
   PersonId,
   enums::CommunityFollowerState,
+  newtypes::CommunityId,
   schema::{community, community_actions, person},
 };
 use lemmy_diesel_utils::{

--- a/crates/db_views/community_follower_approval/src/impls.rs
+++ b/crates/db_views/community_follower_approval/src/impls.rs
@@ -13,7 +13,6 @@ use diesel::{
 use diesel_async::RunQueryDsl;
 use i_love_jesus::SortDirection;
 use lemmy_db_schema::{
-  newtypes::CommunityId,
   source::{
     community::{Community, CommunityActions, community_actions_keys as key},
     person::Person,
@@ -25,6 +24,7 @@ use lemmy_db_schema_file::{
   PersonId,
   aliases,
   enums::{CommunityFollowerState, CommunityVisibility},
+  newtypes::CommunityId,
   schema::{community, community_actions, person},
 };
 use lemmy_diesel_utils::{

--- a/crates/db_views/community_moderator/src/impls.rs
+++ b/crates/db_views/community_moderator/src/impls.rs
@@ -9,13 +9,10 @@ use diesel::{
   select,
 };
 use diesel_async::RunQueryDsl;
-use lemmy_db_schema::{
-  impls::local_user::LocalUserOptionHelper,
-  newtypes::CommunityId,
-  source::local_user::LocalUser,
-};
+use lemmy_db_schema::{impls::local_user::LocalUserOptionHelper, source::local_user::LocalUser};
 use lemmy_db_schema_file::{
   PersonId,
+  newtypes::CommunityId,
   schema::{community, community_actions, person},
 };
 use lemmy_diesel_utils::connection::{DbPool, get_conn};

--- a/crates/db_views/custom_emoji/src/api.rs
+++ b/crates/db_views/custom_emoji/src/api.rs
@@ -1,5 +1,5 @@
 use crate::CustomEmojiView;
-use lemmy_db_schema::newtypes::CustomEmojiId;
+use lemmy_db_schema_file::newtypes::CustomEmojiId;
 use lemmy_diesel_utils::dburl::DbUrl;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;

--- a/crates/db_views/custom_emoji/src/impls.rs
+++ b/crates/db_views/custom_emoji/src/impls.rs
@@ -1,11 +1,14 @@
 use crate::CustomEmojiView;
 use diesel::{ExpressionMethods, JoinOnDsl, NullableExpressionMethods, QueryDsl, dsl::Nullable};
 use diesel_async::RunQueryDsl;
-use lemmy_db_schema::{
-  newtypes::CustomEmojiId,
-  source::{custom_emoji::CustomEmoji, custom_emoji_keyword::CustomEmojiKeyword},
+use lemmy_db_schema::source::{
+  custom_emoji::CustomEmoji,
+  custom_emoji_keyword::CustomEmojiKeyword,
 };
-use lemmy_db_schema_file::schema::{custom_emoji, custom_emoji_keyword};
+use lemmy_db_schema_file::{
+  newtypes::CustomEmojiId,
+  schema::{custom_emoji, custom_emoji_keyword},
+};
 use lemmy_diesel_utils::connection::{DbPool, get_conn};
 use lemmy_utils::error::{LemmyErrorType, LemmyResult};
 use std::collections::HashMap;

--- a/crates/db_views/local_user/src/impls.rs
+++ b/crates/db_views/local_user/src/impls.rs
@@ -11,7 +11,6 @@ use diesel_async::RunQueryDsl;
 use i_love_jesus::asc_if;
 use lemmy_db_schema::{
   LocalUserSortType,
-  newtypes::{LocalUserId, OAuthProviderId},
   source::{
     instance::Instance,
     local_user::{LocalUser, LocalUserInsertForm},
@@ -22,6 +21,7 @@ use lemmy_db_schema_file::{
   PersonId,
   aliases::creator_home_instance_actions,
   joins::creator_home_instance_actions_join,
+  newtypes::{LocalUserId, OAuthProviderId},
   schema::{instance_actions, local_user, oauth_account, person},
 };
 use lemmy_diesel_utils::{

--- a/crates/db_views/local_user_invite/src/impls.rs
+++ b/crates/db_views/local_user_invite/src/impls.rs
@@ -2,11 +2,10 @@ use diesel::{ExpressionMethods, QueryDsl, SelectableHelper};
 use diesel_async::RunQueryDsl;
 use i_love_jesus::SortDirection;
 use lemmy_db_schema::{
-  newtypes::LocalUserId,
   source::local_user_invite::{LocalUserInvite, invitation_keys as key},
   utils::limit_fetch,
 };
-use lemmy_db_schema_file::schema::local_user_invite;
+use lemmy_db_schema_file::{newtypes::LocalUserId, schema::local_user_invite};
 use lemmy_diesel_utils::{
   connection::{DbPool, get_conn},
   pagination::{PagedResponse, PaginationCursor, PaginationCursorConversion, paginate_response},
@@ -63,15 +62,13 @@ impl LocalUserInviteQuery {
 #[cfg(test)]
 mod tests {
   use crate::impls::LocalUserInviteQuery;
-  use lemmy_db_schema::{
-    newtypes::LocalUserId,
-    source::{
-      instance::Instance,
-      local_user::{LocalUser, LocalUserInsertForm},
-      local_user_invite::{LocalUserInvite, LocalUserInviteInsertForm},
-      person::{Person, PersonInsertForm},
-    },
+  use lemmy_db_schema::source::{
+    instance::Instance,
+    local_user::{LocalUser, LocalUserInsertForm},
+    local_user_invite::{LocalUserInvite, LocalUserInviteInsertForm},
+    person::{Person, PersonInsertForm},
   };
+  use lemmy_db_schema_file::newtypes::LocalUserId;
   use lemmy_diesel_utils::{
     connection::{DbPool, build_db_pool_for_tests},
     traits::Crud,

--- a/crates/db_views/modlog/src/api.rs
+++ b/crates/db_views/modlog/src/api.rs
@@ -1,8 +1,9 @@
-use lemmy_db_schema::{
-  ModlogKindFilter,
+use lemmy_db_schema::ModlogKindFilter;
+use lemmy_db_schema_file::{
+  PersonId,
+  enums::ListingType,
   newtypes::{CommentId, CommunityId, ModlogId, PostId},
 };
-use lemmy_db_schema_file::{PersonId, enums::ListingType};
 use lemmy_diesel_utils::pagination::PaginationCursor;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;

--- a/crates/db_views/modlog/src/impls.rs
+++ b/crates/db_views/modlog/src/impls.rs
@@ -12,7 +12,6 @@ use i_love_jesus::SortDirection;
 use lemmy_db_schema::{
   ModlogKindFilter,
   impls::local_user::LocalUserOptionHelper,
-  newtypes::{CommentId, CommunityId, ModlogId, PostId},
   source::{
     local_site::LocalSite,
     local_user::LocalUser,
@@ -25,6 +24,7 @@ use lemmy_db_schema_file::{
   PersonId,
   aliases,
   enums::{CommunityFollowerState, CommunityVisibility, ListingType},
+  newtypes::{CommentId, CommunityId, ModlogId, PostId},
   schema::{comment, community, community_actions, instance, modlog, person, post},
 };
 use lemmy_diesel_utils::{

--- a/crates/db_views/notification/src/api.rs
+++ b/crates/db_views/notification/src/api.rs
@@ -1,4 +1,4 @@
-use lemmy_db_schema::newtypes::NotificationId;
+use lemmy_db_schema_file::newtypes::NotificationId;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, Default, PartialEq, Eq, Hash)]

--- a/crates/db_views/notification/src/impls.rs
+++ b/crates/db_views/notification/src/impls.rs
@@ -10,7 +10,6 @@ use diesel_async::RunQueryDsl;
 use i_love_jesus::SortDirection;
 use lemmy_db_schema::{
   NotificationTypeFilter,
-  newtypes::NotificationId,
   source::{
     notification::{Notification, notification_keys},
     person::Person,
@@ -20,6 +19,7 @@ use lemmy_db_schema::{
 use lemmy_db_schema_file::{
   PersonId,
   enums::NotificationType,
+  newtypes::NotificationId,
   schema::{comment, modlog, notification, person, post, private_message},
 };
 use lemmy_db_views_modlog::ModlogView;

--- a/crates/db_views/person/src/api.rs
+++ b/crates/db_views/person/src/api.rs
@@ -1,11 +1,6 @@
 use crate::PersonView;
-use lemmy_db_schema::{
-  PersonListingType,
-  PersonSortType,
-  newtypes::CommunityId,
-  source::site::Site,
-};
-use lemmy_db_schema_file::PersonId;
+use lemmy_db_schema::{PersonListingType, PersonSortType, source::site::Site};
+use lemmy_db_schema_file::{PersonId, newtypes::CommunityId};
 use lemmy_db_views_community::MultiCommunityView;
 use lemmy_db_views_community_moderator::CommunityModeratorView;
 use lemmy_diesel_utils::pagination::PaginationCursor;

--- a/crates/db_views/person/src/impls.rs
+++ b/crates/db_views/person/src/impls.rs
@@ -12,7 +12,6 @@ use lemmy_db_schema::{
   PersonListingType,
   PersonSortType,
   impls::local_user::LocalUserOptionHelper,
-  newtypes::CommunityId,
   source::{
     local_user::LocalUser,
     person::{Person, person_keys as key},
@@ -30,6 +29,7 @@ use lemmy_db_schema_file::{
     my_person_actions_join,
     person_community_actions_join,
   },
+  newtypes::CommunityId,
   schema::{community_actions, local_user, person},
 };
 use lemmy_diesel_utils::{

--- a/crates/db_views/person_content_combined/src/impls.rs
+++ b/crates/db_views/person_content_combined/src/impls.rs
@@ -6,7 +6,6 @@ use lemmy_db_schema::{
   self,
   PersonContentType,
   impls::local_user::LocalUserOptionHelper,
-  newtypes::CommunityId,
   source::combined::person_content::{PersonContentCombined, person_content_combined_keys as key},
   traits::InternalToCombinedView,
   utils::{limit_fetch, queries::filters::filter_private_or_followed},
@@ -27,6 +26,7 @@ use lemmy_db_schema_file::{
     my_person_actions_join,
     my_post_actions_join,
   },
+  newtypes::CommunityId,
   schema::{comment, community, person, person_content_combined, post, post_actions},
 };
 use lemmy_db_views_post_comment_combined::{

--- a/crates/db_views/person_content_combined/src/lib.rs
+++ b/crates/db_views/person_content_combined/src/lib.rs
@@ -1,5 +1,5 @@
-use lemmy_db_schema::{PersonContentType, newtypes::CommunityId};
-use lemmy_db_schema_file::PersonId;
+use lemmy_db_schema::PersonContentType;
+use lemmy_db_schema_file::{PersonId, newtypes::CommunityId};
 #[cfg(feature = "full")]
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_diesel_utils::pagination::PaginationCursor;

--- a/crates/db_views/post/src/api.rs
+++ b/crates/db_views/post/src/api.rs
@@ -1,11 +1,9 @@
 use crate::PostView;
-use lemmy_db_schema::{
-  PostFeatureType,
-  newtypes::{CommentId, CommunityId, CommunityTagId, LanguageId, MultiCommunityId, PostId},
-};
+use lemmy_db_schema::PostFeatureType;
 use lemmy_db_schema_file::{
   PersonId,
   enums::{ListingType, PostNotificationsMode, PostSortType},
+  newtypes::{CommentId, CommunityId, CommunityTagId, LanguageId, MultiCommunityId, PostId},
 };
 use lemmy_db_views_community::CommunityView;
 use lemmy_db_views_community_moderator::CommunityModeratorView;

--- a/crates/db_views/post/src/impls.rs
+++ b/crates/db_views/post/src/impls.rs
@@ -18,7 +18,6 @@ use diesel_async::RunQueryDsl;
 use i_love_jesus::{SortDirection, asc_if};
 use lemmy_db_schema::{
   impls::local_user::LocalUserOptionHelper,
-  newtypes::{CommunityId, CommunityTagId, MultiCommunityId, PostId},
   source::{
     actor_language::LocalUserLanguage,
     community::CommunityActions,
@@ -52,6 +51,7 @@ use lemmy_db_schema_file::{
     my_person_actions_join,
     my_post_actions_join,
   },
+  newtypes::{CommunityId, CommunityTagId, MultiCommunityId, PostId},
   schema::{community, person, post, post_actions, post_community_tag},
 };
 use lemmy_diesel_utils::{

--- a/crates/db_views/post/src/test.rs
+++ b/crates/db_views/post/src/test.rs
@@ -7,7 +7,6 @@ use diesel_uplete::UpleteCount;
 use lemmy_db_schema::{
   assert_length,
   impls::actor_language::UNDETERMINED_ID,
-  newtypes::{LanguageId, PostId},
   source::{
     actor_language::LocalUserLanguage,
     comment::{Comment, CommentInsertForm},
@@ -41,12 +40,9 @@ use lemmy_db_schema::{
   test_data::TestData,
   traits::{Bannable, Blockable, Followable, Likeable},
 };
-use lemmy_db_schema_file::enums::{
-  CommunityFollowerState,
-  CommunityVisibility,
-  ListingType,
-  PostSortType,
-  TagColor,
+use lemmy_db_schema_file::{
+  enums::{CommunityFollowerState, CommunityVisibility, ListingType, PostSortType, TagColor},
+  newtypes::{LanguageId, PostId},
 };
 use lemmy_db_views_local_user::LocalUserView;
 use lemmy_diesel_utils::{

--- a/crates/db_views/private_message/src/api.rs
+++ b/crates/db_views/private_message/src/api.rs
@@ -1,6 +1,5 @@
 use crate::PrivateMessageView;
-use lemmy_db_schema::newtypes::PrivateMessageId;
-use lemmy_db_schema_file::PersonId;
+use lemmy_db_schema_file::{PersonId, newtypes::PrivateMessageId};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, Eq, Hash)]

--- a/crates/db_views/private_message/src/impls.rs
+++ b/crates/db_views/private_message/src/impls.rs
@@ -1,9 +1,10 @@
 use crate::PrivateMessageView;
 use diesel::{BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl, SelectableHelper};
 use diesel_async::RunQueryDsl;
-use lemmy_db_schema::{newtypes::PrivateMessageId, source::person::Person};
+use lemmy_db_schema::source::person::Person;
 use lemmy_db_schema_file::{
   aliases,
+  newtypes::PrivateMessageId,
   schema::{instance_actions, person, person_actions, private_message},
 };
 use lemmy_diesel_utils::connection::{DbPool, get_conn};

--- a/crates/db_views/registration_applications/src/api.rs
+++ b/crates/db_views/registration_applications/src/api.rs
@@ -1,6 +1,5 @@
 use crate::RegistrationApplicationView;
-use lemmy_db_schema::newtypes::RegistrationApplicationId;
-use lemmy_db_schema_file::PersonId;
+use lemmy_db_schema_file::{PersonId, newtypes::RegistrationApplicationId};
 use lemmy_diesel_utils::{pagination::PaginationCursor, sensitive::SensitiveString};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;

--- a/crates/db_views/registration_applications/src/impls.rs
+++ b/crates/db_views/registration_applications/src/impls.rs
@@ -10,7 +10,6 @@ use diesel::{
 use diesel_async::RunQueryDsl;
 use i_love_jesus::SortDirection;
 use lemmy_db_schema::{
-  newtypes::RegistrationApplicationId,
   source::registration_application::{
     RegistrationApplication,
     registration_application_keys as key,
@@ -20,6 +19,7 @@ use lemmy_db_schema::{
 use lemmy_db_schema_file::{
   PersonId,
   aliases,
+  newtypes::RegistrationApplicationId,
   schema::{local_user, person, registration_application},
 };
 use lemmy_diesel_utils::{

--- a/crates/db_views/report_combined/src/api.rs
+++ b/crates/db_views/report_combined/src/api.rs
@@ -1,17 +1,14 @@
 use crate::{CommentReportView, CommunityReportView, PostReportView, PrivateMessageReportView};
-use lemmy_db_schema::{
-  ReportSortType,
-  ReportType,
-  newtypes::{
-    CommentId,
-    CommentReportId,
-    CommunityId,
-    CommunityReportId,
-    PostId,
-    PostReportId,
-    PrivateMessageId,
-    PrivateMessageReportId,
-  },
+use lemmy_db_schema::{ReportSortType, ReportType};
+use lemmy_db_schema_file::newtypes::{
+  CommentId,
+  CommentReportId,
+  CommunityId,
+  CommunityReportId,
+  PostId,
+  PostReportId,
+  PrivateMessageId,
+  PrivateMessageReportId,
 };
 use lemmy_diesel_utils::pagination::PaginationCursor;
 use serde::{Deserialize, Serialize};

--- a/crates/db_views/report_combined/src/impls.rs
+++ b/crates/db_views/report_combined/src/impls.rs
@@ -21,6 +21,14 @@ use i_love_jesus::{SortDirection, asc_if};
 use lemmy_db_schema::{
   ReportSortType,
   ReportType,
+  source::{
+    combined::report::{ReportCombined, report_combined_keys as key},
+    person::Person,
+  },
+  traits::InternalToCombinedView,
+  utils::limit_fetch,
+};
+use lemmy_db_schema_file::{
   newtypes::{
     CommentReportId,
     CommunityId,
@@ -29,18 +37,7 @@ use lemmy_db_schema::{
     PostReportId,
     PrivateMessageReportId,
   },
-  source::{
-    combined::report::{ReportCombined, report_combined_keys as key},
-    person::Person,
-  },
-  traits::InternalToCombinedView,
-  utils::limit_fetch,
-};
-use lemmy_db_schema_file::schema::{
-  comment_report,
-  community_actions,
-  post_report,
-  report_combined,
+  schema::{comment_report, community_actions, post_report, report_combined},
 };
 use lemmy_db_views_report_combined_sql::report_combined_joins;
 use lemmy_diesel_utils::{

--- a/crates/db_views/site/src/api.rs
+++ b/crates/db_views/site/src/api.rs
@@ -3,7 +3,6 @@ use crate::{ResolveObjectView, SiteView};
 use activitypub_federation::protocol::helpers::deserialize_skip_error;
 use lemmy_db_schema::{
   SearchType,
-  newtypes::{CommunityId, LanguageId, MultiCommunityId, OAuthProviderId, TaglineId},
   source::{
     comment::Comment,
     community::Community,
@@ -32,6 +31,7 @@ use lemmy_db_schema_file::{
     RegistrationMode,
     VoteShow,
   },
+  newtypes::{CommunityId, LanguageId, MultiCommunityId, OAuthProviderId, TaglineId},
 };
 use lemmy_db_views_comment::CommentView;
 use lemmy_db_views_community::{CommunityView, MultiCommunityView};

--- a/crates/db_views/vote/src/impls.rs
+++ b/crates/db_views/vote/src/impls.rs
@@ -3,7 +3,6 @@ use diesel::{BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl, Sele
 use diesel_async::RunQueryDsl;
 use i_love_jesus::SortDirection;
 use lemmy_db_schema::{
-  newtypes::{CommentId, PostId},
   source::{comment::CommentActions, post::PostActions},
   utils::limit_fetch,
 };
@@ -12,6 +11,7 @@ use lemmy_db_schema_file::{
   PersonId,
   aliases::creator_community_actions,
   joins::{creator_home_instance_actions_join, creator_local_instance_actions_join},
+  newtypes::{CommentId, PostId},
   schema::{comment, comment_actions, community_actions, person, post, post_actions},
 };
 use lemmy_diesel_utils::{

--- a/crates/db_views/vote/src/lib.rs
+++ b/crates/db_views/vote/src/lib.rs
@@ -1,7 +1,5 @@
-use lemmy_db_schema::{
-  newtypes::{CommentId, PostId},
-  source::person::Person,
-};
+use lemmy_db_schema::source::person::Person;
+use lemmy_db_schema_file::newtypes::{CommentId, PostId};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 #[cfg(feature = "full")]

--- a/crates/routes/src/middleware/idempotency.rs
+++ b/crates/routes/src/middleware/idempotency.rs
@@ -7,7 +7,7 @@ use actix_web::{
   http::Method,
 };
 use futures_util::future::LocalBoxFuture;
-use lemmy_db_schema::newtypes::LocalUserId;
+use lemmy_db_schema_file::newtypes::LocalUserId;
 use lemmy_db_views_local_user::LocalUserView;
 use std::{
   collections::HashSet,


### PR DESCRIPTION
fixes #6634 

**Changes:**
- moved `newtypes.rs` from `lemmy_db_schema` to `lemmy_db_schema_file`
- moved `CommunityId` back to `newtypes.rs`

`PersonId` and `InstanceId` are still in [db_schema_file/src/lib.rs](https://github.com/LemmyNet/lemmy/blob/main/crates/db_schema_file/src/lib.rs), I propose to move it to `newtypes.rs` as well.