### PR TITLE
Fix link metadata test dess

### DIFF
--- a/api_tests/prepare-drone-federation-test.sh
+++ b/api_tests/prepare-drone-federation-test.sh
@@ -13,15 +13,18 @@ export RUST_LOG="warn,lemmy_server=$LEMMY_LOG_LEVEL,lemmy_federate=$LEMMY_LOG_LE
 export LEMMY_TEST_FAST_FEDERATION=1 # by default, the persistent federation queue has delays in the scale of 30s-5min
 
 PICTRS_PATH="api_tests/pict-rs"
-PICTRS_EXPECTED_HASH="7f7ac2a45ef9b13403ee139b7512135be6b060ff2f6460e0c800e18e1b49d2fd  api_tests/pict-rs"
+# Asonix.dog version
+# PICTRS_EXPECTED_HASH="7f7ac2a45ef9b13403ee139b7512135be6b060ff2f6460e0c800e18e1b49d2fd  api_tests/pict-rs"
+# Codeberg version
+PICTRS_EXPECTED_HASH="d5e6ceb49d955e9f839a191f88ae86d744c291fbca295bba0029518770634e38  api_tests/pict-rs"
 
 # Pictrs setup. Download file with hash check and up to 3 retries.
 if [ ! -f "$PICTRS_PATH" ]; then
   count=0
   while [ ! -f "$PICTRS_PATH" ] && [ "$count" -lt 3 ]; do
     # This one sometimes goes down
-    curl "https://git.asonix.dog/asonix/pict-rs/releases/download/v0.5.17-pre.9/pict-rs-linux-amd64" -o "$PICTRS_PATH"
-    # curl "https://codeberg.org/asonix/pict-rs/releases/download/v0.5.5/pict-rs-linux-amd64" -o "$PICTRS_PATH"
+    # curl "https://git.asonix.dog/asonix/pict-rs/releases/download/v0.5.17-pre.9/pict-rs-linux-amd64" -o "$PICTRS_PATH"
+    curl "https://codeberg.org/asonix/pict-rs/releases/download/v0.5.5/pict-rs-linux-amd64" -o "$PICTRS_PATH"
     PICTRS_HASH=$(sha256sum "$PICTRS_PATH")
     if [[ "$PICTRS_HASH" != "$PICTRS_EXPECTED_HASH" ]]; then
       echo "Pictrs binary hash mismatch, was $PICTRS_HASH but expected $PICTRS_EXPECTED_HASH"

--- a/crates/api/api_utils/src/request.rs
+++ b/crates/api/api_utils/src/request.rs
@@ -588,6 +588,7 @@ mod tests {
   // These helped with testing
   #[tokio::test]
   #[serial]
+  #[expect(clippy::unwrap_used)]
   async fn test_link_metadata() -> LemmyResult<()> {
     let context = LemmyContext::init_test_context().await;
     let sample_url = Url::parse("https://gitlab.com/IzzyOnDroid/repo/-/wikis/FAQ")?;
@@ -600,12 +601,13 @@ mod tests {
       Some("The F-Droid compatible repo at https://apt.izzysoft.de/fdroid/".to_string()),
       sample_res.opengraph_data.description
     );
-    assert_eq!(
-      Some(
-        Url::parse("https://gitlab.com/uploads/-/system/project/avatar/4877469/iod_logo.png")?
-          .into()
-      ),
-      sample_res.opengraph_data.image
+    assert!(
+      sample_res
+        .opengraph_data
+        .image
+        .unwrap()
+        .to_string()
+        .starts_with("https://gitlab.com/uploads/-/system/project/avatar/")
     );
     assert_eq!(None, sample_res.opengraph_data.embed_video_url);
     assert_eq!(


### PR DESCRIPTION
This now uses the codeberg hosted pictrs binary.